### PR TITLE
[chore] Complete the CLA Assistant one-time setup

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,14 +1,13 @@
 name: CLA Assistant
 
-# Requires a one-time setup:
-#  - Decide where signatures are stored. Simplest: a private repo, referenced
-#    via a PERSONAL_ACCESS_TOKEN secret (repo scope). To store them in THIS
-#    repo instead, drop the PERSONAL_ACCESS_TOKEN line below.
-#  - Replace <owner> in path-to-document with the real GitHub org/user.
-#  - Pin `contributor-assistant/github-action` to the latest release tag.
+# Signatures are stored in signatures/cla.json on the orphan `cla-signatures`
+# branch of this repo. That branch must exist and must NOT be protected — the
+# action commits to it but will not create it.
 #
-# Alternative: the hosted CLA Assistant app at https://cla-assistant.io
-# (zero CI config, but grants a third-party app access to your org).
+# Because this runs on pull_request_target, GitHub reads this file from the
+# PR's BASE branch. Edits on a feature branch have no effect until merged.
+#
+# Maintainers who hold copyright are allowlisted; a CLA licenses work TO them.
 
 on:
   issue_comment:
@@ -38,8 +37,8 @@ jobs:
           # PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         with:
           path-to-signatures: 'signatures/cla.json'
-          path-to-document: 'https://github.com/<owner>/mirall/blob/main/CLA.md'
+          path-to-document: 'https://github.com/ok/mirall-app/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],renovate[bot]'
+          allowlist: 'ok,dependabot[bot],renovate[bot]'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'


### PR DESCRIPTION
Replace the unsubstituted <owner> placeholder with the real repo, allowlist the copyright-holding maintainer, and document that pull_request_target reads this file from the base branch. Pairs with the new cla-signatures branch.

## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [ ] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [ ] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [x] **N/A** — docs / comments / config only (no runtime surface)

- [ ] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [ ] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [ ] N/A — no UI change.
