### PR TITLE
[fix] Clear owner download indicator when a paused mirror unmounts

### DIFF
--- a/src/renderer/hooks/usePeerDownloadDetail.ts
+++ b/src/renderer/hooks/usePeerDownloadDetail.ts
@@ -4,6 +4,12 @@ import { SpeedSampler, decayedSpeed } from '../speedSampler.js'
 import { SERVE_TTL_MS } from './usePeerDownloads.js'
 import type { PeerDownloadPeer } from '../types.js'
 
+// A paused peer is kept far longer than an active one — the worker holds paused rows for
+// PAUSED_DROP_MS (300s) and re-announces every ~10s — but not forever: if those re-announces
+// stop (a worker ledger reset emits no clear, a dropped frame, an overlay restart) the row must
+// still age out. Above the worker's PAUSED_DROP_MS so the authoritative clear wins in the normal path.
+const PAUSED_SERVE_TTL_MS = 330000
+
 interface DetailPeer {
   peerKey: string
   bytes: number
@@ -65,9 +71,10 @@ export function usePeerDownloadDetail(spaceId: string, path: string): PeerDownlo
       const now = Date.now()
       setPeers((prev) => {
         if (prev.length === 0) return prev
-        // Soft-state expiry: a peer whose authoritative snapshot went silent past the TTL is dropped
-        // (a paused peer is kept — the worker holds paused rows far longer). Backstops a missed frame.
-        const live = prev.filter((p) => p.paused || (lastSeen.get(p.peerKey) ?? 0) + SERVE_TTL_MS >= now)
+        // Soft-state expiry: a peer whose authoritative snapshot went silent past the TTL is dropped.
+        // A paused peer gets the longer PAUSED_SERVE_TTL_MS (the worker holds paused rows far longer)
+        // but still ages out, so a missed clearing frame can't strand it forever.
+        const live = prev.filter((p) => (lastSeen.get(p.peerKey) ?? 0) + (p.paused ? PAUSED_SERVE_TTL_MS : SERVE_TTL_MS) >= now)
         for (const p of prev) if (!live.includes(p)) { samplers.delete(p.peerKey); lastSeen.delete(p.peerKey) }
         let changed = live.length !== prev.length
         const next = live.map((p) => {

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -401,6 +401,10 @@ const cancelGen = new Map()
 // strictly sequential): contentHash so stopForeignLoop can abort the in-flight overlay
 // download, relPath so foreignFetchActive can identify the row.
 const activeOverlayFetches = new Map()
+// contentHash a pause left holders showing us paused for, after its in-flight fetch slot was
+// released — lets a later unmount tell the holder we stopped rather than leaving its "who is
+// downloading" row paused until the 5-min sweep. Mirrors overlay-download's pausedHashes.
+const pausedMirrorHashes = new Map()
 function mirrorGen(key) { return cancelGen.get(key) || 0 }
 
 // Is the mirror loop actively fetching THIS row? Consulted by the worker's share:list-files
@@ -520,6 +524,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   let res
   const streamKey = loopKey(mount.spaceId, mount.shareId)
   activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath })
+  pausedMirrorHashes.delete(streamKey) // a fresh/resumed fetch supersedes any paused-stop marker
   // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.
   ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
   try {
@@ -671,11 +676,19 @@ export function stopForeignLoop(spaceId, shareId, { discardPartial = false } = {
   // Overlay-catalog in-flight fetch: cancel by content hash. discardPartial:false
   // (pause) keeps the .partial + journal so the next tick resumes; true (unmount)
   // unlinks it. cancelFetch also tells the holder we paused/stopped, so its
-  // "who is downloading" indicator clears now rather than on the idle sweep.
+  // "who is downloading" indicator clears now rather than on the idle sweep. A pause
+  // releases the fetch slot while the holder still shows us paused, so remember the hash
+  // and, on a later unmount with no live fetch, notify the holder we stopped.
   const inflight = activeOverlayFetches.get(key)
   if (inflight) {
     try { getOverlay()?.cancelFetch(inflight.contentHash, { discardPartial }) } catch {}
     activeOverlayFetches.delete(key)
+    if (discardPartial) pausedMirrorHashes.delete(key)
+    else pausedMirrorHashes.set(key, inflight.contentHash)
+  } else if (discardPartial) {
+    const paused = pausedMirrorHashes.get(key)
+    if (paused) { try { getOverlay()?.notifyTransferStopped(paused) } catch {} }
+    pausedMirrorHashes.delete(key)
   }
   tickDirty.delete(key)
   const handle = activeLoops.get(key)

--- a/test/flow/foreign-mirror-unmount-clears-serving.test.js
+++ b/test/flow/foreign-mirror-unmount-clears-serving.test.js
@@ -1,0 +1,56 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
+
+const FLAGS = { overlayEnabled: true }
+
+// REGRESSION (FIX-MIRROR-STOP): end-to-end proof that a mirror paused mid-download and then
+// unmounted while still online clears the OWNER's "who is downloading" indicator promptly. Before
+// the fix the pause released the in-flight fetch slot, so the unmount signalled nothing and the
+// owner kept showing the peer 'paused' until the 5-min PAUSED_DROP_MS sweep.
+test('mirror paused then unmounted clears the owner serve ledger without waiting for the sweep',
+  { timeout: scaled(120000) }, async (t) => {
+    const bootstrap = await localTestnet(t)
+    const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: mkTmpDir(t), flags: FLAGS })
+    const B = await launchPeer(t, { bootstrap, displayName: 'Bob', flags: FLAGS })
+    const spaceId = await connectInSpace(t, A, B)
+    const aKey = (await A.request('profile:get')).publicKey
+    const bKey = (await B.request('profile:get')).publicKey
+
+    const share = await A.request('share:create', { spaceId, name: 'Vault', contentMode: 'overlay' })
+    const folder = mkTmpDir(t)
+    fs.writeFileSync(path.join(folder, 'big.bin'), patternedBytes(48 * 1024 * 1024, 29))
+    const scanDone = A.waitFor('event:owned-folder-scan-completed', (m) => m.shareId === share.id)
+    await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })
+    await scanDone
+
+    await B.until('share:list', { spaceId }, (list) => list.some((s) => s.id === share.id))
+
+    const servesB = (rows) => Array.isArray(rows) && rows.some((r) => r.peers?.includes(bKey))
+    const pausesB = (rows) => Array.isArray(rows) && rows.some((r) => r.pausedKeys?.includes(bKey))
+
+    // The mount request returns before the initial scan finishes, so the fetch is still in flight.
+    const mirrorDir = mkTmpDir(t)
+    await B.request('foreign-folder:mount', { spaceId, shareId: share.id, ownerKey: aKey, mountPath: mirrorDir })
+
+    // The owner sees B pulling the file — proves the fetch reached A and is in flight.
+    await A.until('serving:summary-list', { spaceId }, servesB, { ms: scaled(60000) })
+
+    // B pauses mid-download → the owner's row flips to paused (CONTROL_PAUSED).
+    await B.request('foreign-folder:set-enabled', { spaceId, shareId: share.id, enabled: false })
+    await A.until('serving:summary-list', { spaceId }, pausesB, { ms: scaled(30000) })
+
+    // B unmounts while still online → notifyTransferStopped drops B from the owner's ledger now,
+    // not after the 5-min sweep. Without the fix this poll times out.
+    await B.request('foreign-folder:unmount', { spaceId, shareId: share.id })
+    await A.until('serving:summary-list', { spaceId }, (rows) => !servesB(rows), { ms: scaled(20000) })
+
+    const finalRows = await A.request('serving:summary-list', { spaceId })
+    t.absent(servesB(finalRows), 'owner no longer shows the unmounted mirror as downloading')
+
+    A.kill()
+  })

--- a/test/integration/foreign-unmount-signals-stop.test.js
+++ b/test/integration/foreign-unmount-signals-stop.test.js
@@ -1,0 +1,109 @@
+import test from 'brittle'
+import { freshPeer } from '../helpers/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
+import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
+import { saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { runMaterializeTick, setForeignEnabled, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+
+// REGRESSION (FIX-MIRROR-STOP): a mirror paused mid-download and then unmounted while online
+// left the holder's "who is downloading" row stuck at 'paused'. The pause released the in-flight
+// fetch slot (activeOverlayFetches cleared), so the subsequent unmount had no inflight to cancel
+// and signalled nothing — the holder only reaped the paused row after the 5-min PAUSED_DROP_MS
+// sweep. The fix remembers the paused hash and broadcasts CONTROL_STOPPED (notifyTransferStopped)
+// on unmount. Deterministic + network-free: the overlay's fetchFile/cancelFetch/notifyTransferStopped
+// are stubbed to record calls.
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function waitUntil (pred, ms = 5000) {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await delay(20)
+  }
+  throw new Error('condition not met within ' + ms + 'ms')
+}
+
+async function setupOverlayMirror (t, { relPath = 'big.bin', contentHash = 'a'.repeat(64), size = 96 * 1024 * 1024 } = {}) {
+  const ctx = await freshPeer(t)
+  setRuntimeConfig({ ...getRuntimeConfig(), overlayEnabled: true })
+  await initOverlay()
+  t.teardown(async () => { await teardownOverlay() })
+
+  const space = await createSpace('Aurora')
+  const spaceId = space.spaceId
+  const shareId = generateShareId()
+  await publishShare(spaceId, {
+    id: shareId, type: 'owned-folder', name: 'Mirror', owner: getLocalPublicKeyHex(),
+    contentMode: 'overlay', catalogKey: 'c'.repeat(64), createdAt: Date.now(),
+  })
+
+  const origListPeer = overlayBackend.listPeer
+  overlayBackend.listPeer = async () => [{ relPath, contentHash, size }]
+  t.teardown(() => { overlayBackend.listPeer = origListPeer })
+
+  const overlay = getOverlay()
+  const origFetch = overlay.fetchFile
+  const origCancel = overlay.cancelFetch
+  const origNotify = overlay.notifyTransferStopped
+  t.teardown(() => { overlay.fetchFile = origFetch; overlay.cancelFetch = origCancel; overlay.notifyTransferStopped = origNotify })
+  const spy = { startedHash: null, rejectFetch: null, cancel: null, stopped: [] }
+  overlay.fetchFile = (hash) => { spy.startedHash = hash; return new Promise((_res, rej) => { spy.rejectFetch = rej }) }
+  overlay.cancelFetch = (hash, opts) => {
+    spy.cancel = { hash, opts }
+    const err = new Error('cancelled'); err.code = 'ECANCELLED'
+    spy.rejectFetch?.(err)
+    return true
+  }
+  overlay.notifyTransferStopped = (hash) => { spy.stopped.push(hash); return true }
+
+  await saveForeignMount({
+    spaceId, shareId, ownerKey: getLocalPublicKeyHex(), mountPath: ctx.tmpDir('mirror'),
+    enabled: true, attachedAt: Date.now(), status: 'active', syncedPaths: [],
+  })
+  return { spaceId, shareId, contentHash, spy }
+}
+
+test('FIX-MIRROR-STOP: unmount after pause tells holders we stopped', async (t) => {
+  const { spaceId, shareId, contentHash, spy } = await setupOverlayMirror(t)
+
+  const tickP = runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.startedHash === contentHash)
+
+  await setForeignEnabled(spaceId, shareId, false)
+  t.is(spy.cancel?.opts?.discardPartial, false, 'pause kept the partial (CONTROL_PAUSED)')
+  t.alike(spy.stopped, [], 'no STOP yet — still paused')
+
+  await unmountForeignFolder(spaceId, shareId)
+  t.alike(spy.stopped, [contentHash], 'unmount broadcast STOPPED for the paused hash')
+
+  await tickP
+  t.is(await getForeignMount(spaceId, shareId), null, 'mount removed')
+})
+
+test('FIX-MIRROR-STOP: unmount mid-download stops via cancelFetch, not a second notify', async (t) => {
+  const { spaceId, shareId, contentHash, spy } = await setupOverlayMirror(t)
+
+  const tickP = runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.startedHash === contentHash)
+
+  await unmountForeignFolder(spaceId, shareId)
+  t.is(spy.cancel?.hash, contentHash, 'in-flight fetch cancelled by content hash')
+  t.is(spy.cancel?.opts?.discardPartial, true, 'unmount discards the partial (CONTROL_STOPPED)')
+  t.alike(spy.stopped, [], 'no separate notifyTransferStopped — cancelFetch already signalled')
+
+  await tickP
+  t.is(await getForeignMount(spaceId, shareId), null, 'mount removed')
+})
+
+test('FIX-MIRROR-STOP: unmounting an idle mirror sends no stray STOP', async (t) => {
+  const { spaceId, shareId, spy } = await setupOverlayMirror(t)
+
+  await unmountForeignFolder(spaceId, shareId)
+  t.alike(spy.stopped, [], 'nothing was in flight or paused — nothing to stop')
+  t.absent(spy.cancel, 'no fetch to cancel')
+})

--- a/test/integration/serve-ledger.test.js
+++ b/test/integration/serve-ledger.test.js
@@ -3,7 +3,7 @@ import { createFakeIpc } from '../helpers/fake-ipc.js'
 import { serveIndex } from '../../src/shared/transfer/backends/overlay/overlay-serve-index.js'
 import {
   initContentBackendOverlay, _resetContentBackendOverlay, _sweepServeLedgerNow,
-  onServeStart, onServePaused,
+  onServeStart, onServePaused, onServeControl,
   subscribeServeDetail, getServeDetail, unsubscribeServeDetail, listServeSummaries,
 } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
 
@@ -59,6 +59,22 @@ test('the sweep re-announces active rows too (missed-frame recovery for the rend
   const after = summaries(fake)
   t.ok(after.length > before, 'a live active row re-announces on the sweep')
   t.alike(after[after.length - 1].payload.pausedKeys, [], 'active row carries no paused marker')
+})
+
+// The downloader→holder contract the mirror-unmount fix relies on: a STOPPED control drops a
+// previously-paused peer from the ledger at once (no waiting on the 5-min PAUSED_DROP_MS sweep),
+// emitting an authoritative empty summary.
+test('a STOPPED control drops a previously-paused peer from the ledger', (t) => {
+  const fake = setup(t)
+  onServeStart({ from: PEER, contentHash: HASH, total: 1000 })
+  onServePaused({ from: PEER, contentHash: HASH })
+  t.is(listServeSummaries(SID).length, 1, 'precondition: one paused row present')
+
+  onServeControl({ from: PEER, contentHash: HASH, state: 'stopped' })
+
+  t.is(listServeSummaries(SID).length, 0, 'STOPPED cleared the row immediately')
+  const last = summaries(fake).pop().payload
+  t.alike(last.peers, [], 'and emitted an authoritative empty summary')
 })
 
 test('getServeDetail reads the snapshot without touching the detailSubs refcount', (t) => {


### PR DESCRIPTION
Pausing a mirror mid-download released the in-flight fetch slot, so a later unmount had nothing to cancel and told the holder nothing — the owner's "who is downloading" row stayed stuck on the paused peer until the 5-min sweep (or indefinitely in the expanded dropdown). The mirror now remembers the paused hash and broadcasts STOPPED on unmount, and a finite renderer TTL backstops a missed clear frame.

## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [x] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [x] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [ ] **N/A** — docs / comments / config only (no runtime surface)

- [x] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [ ] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [x] N/A — no UI change.
