### PR TITLE
[feat] Split bulk content onto its own transport plane

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+../feat-mirror-participation-record/node_modules

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -671,6 +671,9 @@ function getWorker(specifier) {
     overlayEnabled: readFeatureFlags().overlay === true || readFeatureFlags().inPlaceFiles === true,
     inPlaceFilesEnabled: readFeatureFlags().inPlaceFiles === true,
     sharePrepareProgressEnabled: readFeatureFlags().sharePrepareProgress === true,
+    // Bulk content rides its own transport by default when overlay is on; feature-flags.json
+    // can set separateContentPlane:false to revert to the single-plane overlay.
+    separateContentPlane: readFeatureFlags().separateContentPlane !== false,
     identityKEK: identityKEKHex,
   }
   worker.write(Buffer.from(JSON.stringify(bootstrap) + '\n'))

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -121,6 +121,9 @@ function buildConfig(next) {
   // `false` override degrades shares to UNSUPPORTED.
   out.overlayEnabled = next?.overlayEnabled !== false
   out.inPlaceFilesEnabled = next?.inPlaceFilesEnabled !== false
+  // Bulk content rides its own transport by default; only an explicit `false` reverts to the
+  // single-plane overlay (control + content on one stream).
+  out.separateContentPlane = next?.separateContentPlane !== false
   return out
 }
 
@@ -156,6 +159,10 @@ export function isInPlaceFilesEnabled() {
 
 export function isSharePrepareProgressEnabled() {
   return config.sharePrepareProgressEnabled
+}
+
+export function isSeparateContentPlaneEnabled() {
+  return config.separateContentPlane
 }
 
 export function getOverlayServeLimit() {

--- a/src/shared/transfer/backends/overlay/overlay-authorize.js
+++ b/src/shared/transfer/backends/overlay/overlay-authorize.js
@@ -1,8 +1,8 @@
 // THE SERVE GATE decision, as a pure factory over its collaborators — NO bare/
 // swarm imports, so the truth table unit-tests under brittle-node with fakes.
 // overlay-instance.js wires in the real helpers: socket identity auth
-// (senderAuthorizedOnSocket), membership (isApprovedMember), and the
-// per-requester rate limiter.
+// (socketAuthorized — control or content plane), membership (isApprovedMember),
+// and the per-requester rate limiter.
 //
 // Deny is surfaced to the protocol as a silent drop — observationally
 // identical to "I don't hold it", so a non-member learns nothing (no oracle).
@@ -10,18 +10,18 @@
 /**
  * @param {object} deps
  * @param {{ get(peer): any }} deps.peerSocket overlay peer → swarm socket
- * @param {(socket, fromHex) => boolean} deps.senderAuthorizedOnSocket is this profile key Noise-authenticated on this socket?
+ * @param {(socket, fromHex) => boolean} deps.socketAuthorized is this profile key Noise-authenticated on this socket?
  * @param {(spaceId, fromHex) => Promise<boolean>} deps.isApprovedMember approved-membership check for a space
  * @param {{ take(key): { ok: boolean } }} deps.serveLimiter per-requester serve rate limit
  * @param {{ spacesFor(hash): Iterable<string> }} deps.serveIndex
  * @returns {(peer, from, contentHash) => Promise<boolean>}
  */
-export function makeServeAuthorizer({ peerSocket, senderAuthorizedOnSocket, isApprovedMember, serveLimiter, serveIndex }) {
+export function makeServeAuthorizer({ peerSocket, socketAuthorized, isApprovedMember, serveLimiter, serveIndex }) {
   return async function authorizeServe(peer, from, contentHash) {
     const socket = peerSocket.get(peer)
     if (!socket) return false                                          // peer not attached on a live socket
     // 1) socket auth: the claimed profileKey must be Noise-authenticated on THIS socket.
-    if (!from || !senderAuthorizedOnSocket(socket, from)) return false
+    if (!from || !socketAuthorized(socket, from)) return false
     // 2) rate limit: per-requester serve budget, keyed on the asker identity.
     if (!serveLimiter.take(from).ok) return false
     // 3) membership: the asker must be an approved member of a space advertising this hash.

--- a/src/shared/transfer/backends/overlay/overlay-instance.js
+++ b/src/shared/transfer/backends/overlay/overlay-instance.js
@@ -13,8 +13,9 @@ import path from 'bare-path'
 import b4a from 'b4a'
 import { getLocalPublicKeyHex } from '../../../spaces/profile.js'
 import { senderAuthorizedOnSocket, isApprovedMember } from '../../swarm.js'
+import { contentSenderAuthorizedOnSocket } from '../../content-swarm.js'
 import { createRateLimiter } from '../../handshake-guard.js'
-import { getOverlayServeLimit } from '../../../core/runtime-config.js'
+import { getOverlayServeLimit, isSeparateContentPlaneEnabled } from '../../../core/runtime-config.js'
 import { createLogger } from '../../../core/logger.js'
 
 const log = createLogger('overlay')
@@ -75,8 +76,11 @@ export function getJournalDir() {
 export async function initOverlay() {
   if (overlay) return overlay
   serveLimiter = createRateLimiter(getOverlayServeLimit())
+  // With the content plane on, the overlay channel rides the content connection, so serve
+  // authorization keys on that socket's content-hello; otherwise on the control handshake.
+  const socketAuthorized = isSeparateContentPlaneEnabled() ? contentSenderAuthorizedOnSocket : senderAuthorizedOnSocket
   const serveAuthorizer = makeServeAuthorizer({
-    peerSocket, senderAuthorizedOnSocket, isApprovedMember, serveLimiter, serveIndex,
+    peerSocket, socketAuthorized, isApprovedMember, serveLimiter, serveIndex,
   })
   const enc = useEncryptedOverlay()
   overlay = new HyperOverlayV2(getStore(), {
@@ -106,8 +110,9 @@ export async function initOverlay() {
  * Bind this swarm connection to the overlay protocol. Called SYNCHRONOUSLY inside
  * swarm.on('connection') — protomux will not pair a channel opened after the
  * remote's. The overlay channel never serves to an unauthenticated peer because
- * authorizeServe reads `peerSocket` + `senderAuthorizedOnSocket`, both empty until
- * the mirall/handshake authenticates the sender on this socket.
+ * authorizeServe reads `peerSocket` + `socketAuthorized`, both empty until the
+ * connection's handshake (mirall/handshake or mirall/content-hello) authenticates
+ * the sender on this socket.
  */
 export function attachOverlay(mux, socket) {
   if (!overlay) return

--- a/src/shared/transfer/content-swarm.js
+++ b/src/shared/transfer/content-swarm.js
@@ -1,0 +1,174 @@
+// The bulk-content transport plane. A second Hyperswarm with its own Noise identity that shares
+// the control swarm's DHT node and carries ONLY the overlay content channel. Bulk file bytes get
+// their own Noise-over-UDX stream (independent ordered buffer + congestion window), so a large
+// download can no longer head-of-line-block the Corestore replication + mirall/handshake traffic
+// on the control plane — the reason a newly shared folder stayed invisible to a downloading peer
+// until it paused. Each content connection authenticates independently via a signed
+// mirall/content-hello (profileKey bound to this connection's Noise key), reusing the control
+// handshake's identity-binding primitive; serving stays gated on space membership, which the
+// control plane maintains.
+import Hyperswarm from 'hyperswarm'
+import Protomux from 'protomux'
+import c from 'compact-encoding'
+import b4a from 'b4a'
+import crypto from 'hypercore-crypto'
+import { getResourceCaps, getHandshakeRateLimit } from '../core/runtime-config.js'
+import { getIdentitySigner, getProfileKey } from '../spaces/profile.js'
+import { signNoiseBinding, verifyIdentityBinding, createRateLimiter } from './handshake-guard.js'
+import { applyNetImpairment } from './net-impair.js'
+import { createLogger } from '../core/logger.js'
+
+const log = createLogger('content-swarm')
+
+// The content plane joins a topic DERIVED from the space topic so its DHT lookups only find other
+// content-plane peers, never the control-plane identity announced on the space topic — otherwise
+// each swarm would cross-dial the other's identity and pair no channels.
+const CONTENT_TOPIC_LABEL = b4a.from('mirall/content-plane/v1')
+function deriveContentTopic(topicHex) {
+  return crypto.hash(b4a.concat([b4a.from(topicHex, 'hex'), CONTENT_TOPIC_LABEL]))
+}
+
+let contentSwarm = null
+const contentSpaceTopics = new Map() // spaceId → derived content topic buffer
+const contentDiscoveries = new Map() // spaceId → PeerDiscovery (kept for reconnect refresh)
+const contentSocketToPeers = new Map() // content socket → Set<profileKey> authenticated on it
+const bannedContentKeys = new Set()    // Noise keys evicted for content-hello flooding
+let helloLimiter = null
+let contentAttachHook = null
+let contentResumeHook = null
+let contentBinding = null
+
+export function setContentAttachHook(fn) { contentAttachHook = fn }
+export function setContentResumeHook(fn) { contentResumeHook = fn }
+
+export function contentSenderAuthorizedOnSocket(socket, profileKeyHex) {
+  return !!contentSocketToPeers.get(socket)?.has(profileKeyHex)
+}
+
+function getContentBinding() {
+  if (contentBinding) return contentBinding
+  const signer = getIdentitySigner()
+  const noiseKey = contentSwarm?.keyPair?.publicKey
+  if (!signer || !noiseKey) return null
+  contentBinding = {
+    sig: signNoiseBinding(noiseKey, signer.secretKey),
+    signerKey: b4a.toString(signer.publicKey, 'hex'),
+    signerNs: b4a.toString(signer.namespace, 'hex'),
+  }
+  return contentBinding
+}
+
+function sendContentHello(helloMsg) {
+  const binding = getContentBinding()
+  if (!binding) return
+  const profileKey = b4a.toString(getProfileKey(), 'hex')
+  try { helloMsg.send(JSON.stringify({ type: 'content-hello', profileKey, ...binding })) } catch {}
+}
+
+function onContentConnection(socket, peerInfo) {
+  const remoteKeyHex = peerInfo.publicKey ? b4a.toString(peerInfo.publicKey, 'hex') : ''
+  const remoteKey = remoteKeyHex.slice(0, 16) || 'unknown'
+  if (contentSpaceTopics.size === 0) { socket.destroy(); return }
+  applyNetImpairment(socket) // TEST-ONLY: no-op unless runtime-config.netImpair is set
+
+  const mux = Protomux.from(socket)
+  const channel = mux.createChannel({
+    protocol: 'mirall/content-hello',
+    onopen() { sendContentHello(helloMsg) },
+  })
+  const helloMsg = channel.addMessage({
+    encoding: c.string,
+    onmessage(str) {
+      // Rate-limit BEFORE the ed25519 verify so a flood can't spend unbounded CPU. A peer sends
+      // one content-hello per connection, so a burst is abusive — ban + evict on sustained abuse.
+      if (helloLimiter) {
+        const verdict = helloLimiter.take(remoteKeyHex)
+        if (!verdict.ok) { if (verdict.ban) { bannedContentKeys.add(remoteKeyHex); socket.destroy() } return }
+      }
+      let msg
+      try { msg = JSON.parse(str) } catch { return }
+      if (!msg || msg.type !== 'content-hello') return
+      // Same verifier as the control handshake: proves the signer manifest-hashes to
+      // msg.profileKey AND signed this socket's Noise key, so a replay onto another
+      // connection (a different Noise key) fails.
+      if (!verifyIdentityBinding(peerInfo, msg)) { log.warn('content-hello rejected from', remoteKey + '...'); return }
+      let set = contentSocketToPeers.get(socket)
+      if (!set) { set = new Set(); contentSocketToPeers.set(socket, set) }
+      set.add(msg.profileKey)
+      // The plane can now serve/fetch this owner → resume its paused/interrupted downloads.
+      contentResumeHook?.(msg.profileKey)
+    },
+  })
+
+  // Bind the overlay channel on THIS mux, synchronous + before channel.open() (protomux won't
+  // pair a channel opened after the remote's). Serving stays denied until content-hello verifies.
+  try { contentAttachHook?.(mux, socket) } catch (err) { log.warn('content attach hook failed:', err.message) }
+  channel.open()
+
+  socket.on('close', () => contentSocketToPeers.delete(socket))
+}
+
+export function initContentSwarm(sharedDht) {
+  if (contentSwarm) return contentSwarm
+  if (!sharedDht) { log.warn('no shared DHT — content plane not started'); return null }
+  const caps = getResourceCaps()
+  helloLimiter = createRateLimiter(getHandshakeRateLimit().matched)
+  // Distinct identity (fresh keyPair, ephemeral per process like the control swarm) so the remote
+  // sees a different key and hyperswarm's per-(swarm, remoteKey) dedup keeps this connection
+  // separate from the control one. Share the control swarm's DHT node.
+  contentSwarm = new Hyperswarm({
+    dht: sharedDht,
+    maxServerConnections: caps.serverConnections || Infinity,
+    maxClientConnections: caps.clientConnections || Infinity,
+    firewall: (remoteKey) => bannedContentKeys.has(b4a.toString(remoteKey, 'hex')),
+  })
+  contentBinding = null
+  contentSwarm.on('connection', onContentConnection)
+  log.info('initialized')
+  return contentSwarm
+}
+
+export function joinContentTopic(spaceId, topicHex) {
+  if (!contentSwarm || contentDiscoveries.has(spaceId)) return
+  const topic = deriveContentTopic(topicHex)
+  contentSpaceTopics.set(spaceId, topic)
+  const discovery = contentSwarm.join(topic, { server: true, client: true })
+  contentDiscoveries.set(spaceId, discovery)
+  discovery.flushed().catch(() => {})
+}
+
+export async function leaveContentTopic(spaceId) {
+  const topic = contentSpaceTopics.get(spaceId)
+  if (!contentSwarm || !topic) return
+  try { await contentSwarm.leave(topic) } catch {}
+  contentSpaceTopics.delete(spaceId)
+  contentDiscoveries.delete(spaceId)
+}
+
+export async function refreshContentDiscoveries() {
+  if (!contentSwarm) return
+  for (const [, discovery] of contentDiscoveries) {
+    try { await discovery.refresh({ client: true, server: true }) } catch {}
+  }
+}
+
+export async function destroyContentSwarm() {
+  if (!contentSwarm) return
+  // We SHARE the control swarm's DHT node; hyperswarm.destroy() would destroy that shared node
+  // (via dht.destroy()) and tear the control plane down with us. So leave topics + close our
+  // server + drop EVERY connection ourselves (destroy() would have relied on dht.destroy() for
+  // that), and let destroySwarm() own the DHT teardown.
+  for (const topic of contentSpaceTopics.values()) {
+    try { await contentSwarm.leave(topic) } catch {}
+  }
+  try { await contentSwarm.server?.close?.() } catch {}
+  for (const socket of contentSwarm.connections) { try { socket.destroy() } catch {} }
+  contentSpaceTopics.clear()
+  contentDiscoveries.clear()
+  contentSocketToPeers.clear()
+  bannedContentKeys.clear()
+  helloLimiter = null
+  contentBinding = null
+  contentSwarm = null
+  log.info('destroyed')
+}

--- a/src/shared/transfer/net-impair.js
+++ b/src/shared/transfer/net-impair.js
@@ -1,0 +1,48 @@
+// TEST-ONLY link shaper (runtime-config `netImpair`; production never sets it). Reproduces bad
+// real-world links in flow tests by degrading a connection in place — no Duplex wrapping, so the
+// socket's Noise/peer properties survive. Latency delays every outbound app frame (both peers
+// impairing → a symmetric high-RTT link); flap periodically destroys the live connection so
+// Hyperswarm re-dials (the connection handler re-runs and re-impairs the fresh socket). Applied
+// on both the control and content planes so an impaired-link test shapes the bulk path too.
+import { getNetImpair } from '../core/runtime-config.js'
+
+export function applyNetImpairment(socket) {
+  const cfg = getNetImpair()
+  if (!cfg) return
+  const latencyMs = cfg.latencyMs | 0
+  const jitterMs = cfg.jitterMs | 0
+  if (latencyMs > 0 || jitterMs > 0) {
+    const realWrite = socket.write.bind(socket)
+    // Ordered release queue: this is a RELIABLE, in-order stream (Protomux framing), so frames
+    // MUST leave in FIFO order — independent per-frame timers with jitter would reorder and
+    // corrupt it. Each frame's release time is max(now+latency+jitter, previous release).
+    const q = []
+    let pumping = false
+    const pump = () => {
+      if (pumping) return
+      pumping = true
+      const step = () => {
+        while (q.length && q[0].at <= Date.now()) { const it = q.shift(); try { realWrite(it.data, ...it.rest) } catch {} }
+        if (!q.length) { pumping = false; return }
+        const timer = setTimeout(step, Math.max(0, q[0].at - Date.now()))
+        timer.unref?.()
+      }
+      step()
+    }
+    socket.write = (data, ...rest) => {
+      const delay = latencyMs + (jitterMs > 0 ? Math.floor(Math.random() * jitterMs) : 0)
+      const prevAt = q.length ? q[q.length - 1].at : 0
+      q.push({ data, rest, at: Math.max(Date.now() + delay, prevAt) })
+      pump()
+      return true
+    }
+    socket.once('close', () => { q.length = 0 })
+  }
+  if ((cfg.flapEveryMs | 0) > 0) {
+    const jitter = cfg.flapJitterMs | 0
+    const timer = setTimeout(() => { try { socket.destroy() } catch {} },
+      cfg.flapEveryMs + (jitter > 0 ? Math.floor(Math.random() * jitter) : 0))
+    timer.unref?.()
+    socket.once('close', () => clearTimeout(timer))
+  }
+}

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -25,11 +25,13 @@ import {
   recordJoinRequest, listJoinRequests, getJoinRequestDriveKey, clearJoinRequest,
   pinCreatorKey, markCreatorDivergence, clearCreatorDivergence, ownLooseCatalogPublish, persistLeftTombstone,
 } from '../spaces/space.js'
-import { getRuntimeConfig, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow, getNetImpair } from '../core/runtime-config.js'
+import { getRuntimeConfig, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow } from '../core/runtime-config.js'
 import { catalogKeyField } from '../shares/share-catalog.js'
 import { HEX64 } from '../invite-envelope.js'
 import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, leaveFrameBound } from './handshake-guard.js'
 import { createAnnounceLedger, escalationDue, announceStatus } from './announce-ledger.js'
+import { joinContentTopic, leaveContentTopic, refreshContentDiscoveries } from './content-swarm.js'
+import { applyNetImpairment } from './net-impair.js'
 import { takeIncompleteListSpaces, clearListDeficits } from './list-deficits.js'
 import { LOOSE_SHARE_ID } from './transfer-id.js'
 import { shareDecoKey } from './decoration-key.js'
@@ -141,54 +143,6 @@ function isBenignSocketError (err) {
 let corruptionDiagnosed = false
 
 // === Connection intake & frame dispatch ===
-
-// TEST-ONLY link shaper (runtime-config `netImpair`; production never sets it). Reproduces bad
-// real-world links in flow tests by degrading THIS peer's connections in place — no Duplex
-// wrapping, so the socket's Noise/peer properties survive. Latency delays every outbound app
-// frame (both peers impairing → a symmetric high-RTT link); flap periodically destroys the live
-// connection so Hyperswarm re-dials (this handler re-runs and re-impairs the fresh socket),
-// exercising reconnect churn + any state not re-established on reconnect. See netImpair docs.
-function applyNetImpairment(socket) {
-  const cfg = getNetImpair()
-  if (!cfg) return
-  const latencyMs = cfg.latencyMs | 0
-  const jitterMs = cfg.jitterMs | 0
-  if (latencyMs > 0 || jitterMs > 0) {
-    const realWrite = socket.write.bind(socket)
-    // Ordered release queue: this is a RELIABLE, in-order stream (Protomux framing), so frames
-    // MUST leave in FIFO order — independent per-frame timers with jitter would reorder and
-    // corrupt it. Each frame's release time is max(now+latency+jitter, previous release), so
-    // jitter varies the delay without ever letting a later frame overtake an earlier one.
-    const q = []
-    let pumping = false
-    const pump = () => {
-      if (pumping) return
-      pumping = true
-      const step = () => {
-        while (q.length && q[0].at <= Date.now()) { const it = q.shift(); try { realWrite(it.data, ...it.rest) } catch {} }
-        if (!q.length) { pumping = false; return }
-        const timer = setTimeout(step, Math.max(0, q[0].at - Date.now()))
-        timer.unref?.()
-      }
-      step()
-    }
-    socket.write = (data, ...rest) => {
-      const delay = latencyMs + (jitterMs > 0 ? Math.floor(Math.random() * jitterMs) : 0)
-      const prevAt = q.length ? q[q.length - 1].at : 0
-      q.push({ data, rest, at: Math.max(Date.now() + delay, prevAt) })
-      pump()
-      return true
-    }
-    socket.once('close', () => { q.length = 0 }) // drop pending frames when the link dies
-  }
-  if ((cfg.flapEveryMs | 0) > 0) {
-    const jitter = cfg.flapJitterMs | 0
-    const timer = setTimeout(() => { try { socket.destroy() } catch {} },
-      cfg.flapEveryMs + (jitter > 0 ? Math.floor(Math.random() * jitter) : 0))
-    timer.unref?.()
-    socket.once('close', () => clearTimeout(timer))
-  }
-}
 
 export function initSwarm(_ipc) {
   ipcRef = _ipc
@@ -1197,6 +1151,7 @@ export async function joinSpaceTopic(spaceId) {
 
   const discovery = swarm.join(topic, { server: true, client: true })
   spaceDiscoveries.set(spaceId, discovery)
+  joinContentTopic(spaceId, topicHex) // no-op unless the content plane is active
   discovery.flushed().then(
     () => {
       announced = true
@@ -1414,6 +1369,7 @@ export async function leaveSpaceTopic(spaceId) {
   await swarm.leave(topic)
   spaceTopics.delete(spaceId)
   spaceDiscoveries.delete(spaceId)
+  try { await leaveContentTopic(spaceId) } catch {} // no-op unless the content plane is active
   // The tick's cleanup only visits current spaceTopics, so a left space's escalation state
   // would dangle (and mistime escalation on a same-space rejoin) — drop it here. The announce
   // ledger self-prunes the left space on its next drain (status resolves null → settled).
@@ -1658,6 +1614,10 @@ export function setMembershipControlHandler(fn) {
 
 export function setConnectionAttachHook(fn) {
   connectionAttachHook = fn
+}
+
+export function getSwarmDht() {
+  return swarm?.dht || null
 }
 
 // A pending joiner has no handshake yet, so it isn't in connectedPeers — fall back to
@@ -1949,6 +1909,7 @@ export async function reconnectAll() {
       log.warn('refresh failed for', spaceId, err.message)
     }
   }
+  try { await refreshContentDiscoveries() } catch {} // content plane (no-op unless active)
   scheduleStatusEmit()
   return { ok: true }
 }

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -11,7 +11,7 @@ import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
 import { createIPC, getBootstrapPromise } from '../shared/core/ipc.js'
-import { setRuntimeConfig, getRuntimeConfig, setDownloadFolder, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, getListFilesCap } from '../shared/core/runtime-config.js'
+import { setRuntimeConfig, getRuntimeConfig, setDownloadFolder, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap } from '../shared/core/runtime-config.js'
 import { getDownloadDir } from '../shared/core/paths.js'
 import { createLogger } from '../shared/core/logger.js'
 import { installCrashBackstop } from '../shared/core/crash-backstop.js'
@@ -41,7 +41,8 @@ import {
 import { initSpaceKeys } from '../shared/spaces/space-keys.js'
 import { classifyInvite } from '../shared/spaces/invite-policy.js'
 import { encodeInvite, decodeInvite } from '../shared/invite-envelope.js'
-import { initSwarm, joinSpaceTopic, leaveSpaceTopic, cleanupSpaceDrives, compactStore, destroySwarm, broadcastDeparture, getConnectedPeers, isOwnerOnline, broadcastProfileUpdate, sendLeaveFrameToConnectedPeers, awaitLeaveAcks, getSwarmStatus, reconnectAll, setMembershipControlHandler, setConnectionAttachHook, setOverlayReconnectHook, sendMembershipGrant, sendMembershipDeny, broadcastMembershipCancel, reconcilePendingRequester, isApprovedMember, resolveInvite, markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving, getBoundSignerKey, broadcastSharePrepareProgress, configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, joinPendingLeaveTopic, leavePendingLeaveTopic, hasPendingLeave, takeLeaveAckedKeys, configurePendingCancels, registerPendingCancel, joinPendingCancelTopic, leavePendingCancelTopic, hasPendingCancel, sendPendingCancelToConnected } from '../shared/transfer/swarm.js'
+import { initSwarm, joinSpaceTopic, leaveSpaceTopic, cleanupSpaceDrives, compactStore, destroySwarm, broadcastDeparture, getConnectedPeers, isOwnerOnline, broadcastProfileUpdate, sendLeaveFrameToConnectedPeers, awaitLeaveAcks, getSwarmStatus, reconnectAll, setMembershipControlHandler, setConnectionAttachHook, getSwarmDht, setOverlayReconnectHook, sendMembershipGrant, sendMembershipDeny, broadcastMembershipCancel, reconcilePendingRequester, isApprovedMember, resolveInvite, markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving, getBoundSignerKey, broadcastSharePrepareProgress, configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, joinPendingLeaveTopic, leavePendingLeaveTopic, hasPendingLeave, takeLeaveAckedKeys, configurePendingCancels, registerPendingCancel, joinPendingCancelTopic, leavePendingCancelTopic, hasPendingCancel, sendPendingCancelToConnected } from '../shared/transfer/swarm.js'
+import { initContentSwarm, destroyContentSwarm, setContentAttachHook, setContentResumeHook } from '../shared/transfer/content-swarm.js'
 import { clampDisplayName, checkGrantAssertion } from '../shared/transfer/handshake-guard.js'
 import { openSealedSck } from '../shared/transfer/sck-seal.js'
 import { reconcileAssertedRoot } from '../shared/spaces/creator-root.js'
@@ -123,6 +124,7 @@ async function safeShutdown(reason) {
   try { await new Promise((resolve) => { const to = setTimeout(resolve, 150); to.unref?.() }) } catch {}
   try { closeAllMemberViews() } catch {}
   try { await teardownBackends() } catch {}
+  try { await destroyContentSwarm() } catch {}
   try { await destroySwarm() } catch {}
   log.info('shutdown complete')
   Bare.exit(0)
@@ -251,17 +253,36 @@ try { await flagUnverifiedJoinedCreators() } catch (err) {
 await initBackends(ipc) // overlay instance + IPC ref when the flag is on
 initLooseOverlay(ipc)
 if (isInPlaceFilesEnabled()) rehydrateLooseFiles().catch((err) => log.debug('loose rehydrate failed:', err.message))
+const useContentPlane = isOverlayEnabled() && isSeparateContentPlaneEnabled()
 if (isOverlayEnabled()) {
   // Auto-resume overlay downloads (loose + folder) when their owner (re)connects.
-  setOverlayReconnectHook((ownerKey, spaceId) => {
+  const autoResume = (ownerKey, spaceId) => {
     if (isInPlaceFilesEnabled()) resumeLooseForOwner(ownerKey, spaceId).catch((err) => log.debug('loose auto-resume failed:', err.message))
     resumeOverlayForOwner(ownerKey, spaceId).catch((err) => log.debug('overlay folder auto-resume failed:', err.message))
-  })
+  }
+  if (useContentPlane) {
+    // The content plane authenticates per owner with no space, so fan the resume across our
+    // spaces — coalesced per owner so reconnect churn doesn't re-run listSpaces() each time.
+    const resumePending = new Map()
+    setContentResumeHook((ownerKey) => {
+      if (resumePending.has(ownerKey)) return
+      const timer = setTimeout(() => {
+        resumePending.delete(ownerKey)
+        listSpaces().then((spaces) => { for (const s of spaces) if (!s.leaving) autoResume(ownerKey, s.spaceId) }).catch(() => {})
+      }, 250)
+      timer.unref?.()
+      resumePending.set(ownerKey, timer)
+    })
+  } else {
+    setOverlayReconnectHook(autoResume)
+  }
 }
 setMembershipControlHandler(handleMembershipControl)
-setConnectionAttachHook(fanoutAttach) // lets overlay bind its channel per connection
+if (useContentPlane) setContentAttachHook(fanoutAttach) // overlay binds its channel on content connections
+else setConnectionAttachHook(fanoutAttach) // lets overlay bind its channel per connection
 setSharePrepareBroadcast((spaceId, p) => { if (isSharePrepareProgressEnabled()) broadcastSharePrepareProgress(spaceId, p) })
 initSwarm(ipc)
+if (useContentPlane) initContentSwarm(getSwarmDht())
 
 // Deferred past the core-opening init above so the one-time compaction (which
 // scrubs the migrated plaintext from old SSTs) doesn't contend with boot I/O.

--- a/test/flow/content-plane-hol.test.js
+++ b/test/flow/content-plane-hol.test.js
@@ -1,0 +1,71 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
+import { LINKS } from '../helpers/impair.js'
+
+const FLAGS = (netImpair) => ({ overlayEnabled: true, separateContentPlane: true, ...(netImpair ? { netImpair } : {}) })
+
+// Bulk content rides its own transport, so control-plane replication (a peer's newly shared
+// folder) is not blocked behind an in-flight download. Both peers run an impaired link so the
+// 48 MB download stays in flight for the whole assertion window (t.absent(completed) proves the
+// download had NOT finished when the share surfaced). This is a behavior gate, not a red-first
+// repro: the original "invisible until pause" starvation only bites on a bandwidth-constrained
+// real link the hermetic testnet can't reproduce, and the existing sender-drain / receiver-yield
+// dampeners keep control-plane latency low here (measured ~1.3s with or without the split). See
+// the plan for the real-link verification.
+test('a newly shared folder surfaces on a peer while a download is in flight over the content plane',
+  { timeout: scaled(180000) }, async (t) => {
+    const bootstrap = await localTestnet(t)
+    const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: mkTmpDir(t), flags: FLAGS(LINKS.transcontinental) })
+    const B = await launchPeer(t, { bootstrap, displayName: 'Bob', downloads: mkTmpDir(t), flags: FLAGS(LINKS.transcontinental) })
+    const spaceId = await connectInSpace(t, A, B)
+    const aKey = (await A.request('profile:get')).publicKey
+
+    const src = path.join(mkTmpDir(t), 'big.bin')
+    const bytes = patternedBytes(48 * 1024 * 1024, 41)
+    fs.writeFileSync(src, bytes)
+    await A.request('files:add', { spaceId, filePath: src, fileName: 'big.bin', fileSize: bytes.length })
+    await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.status === 'remote'), { ms: scaled(120000) })
+
+    let completed = false
+    B.on('event:transfer-complete', (m) => { if (m.path === '/big.bin') completed = true })
+    const flowing = new Promise((resolve, reject) => {
+      const to = setTimeout(() => reject(new Error('download never started flowing')), scaled(90000))
+      B.on('event:decoration', (m) => { if (m.channel === 'transfer' && m.key === '/big.bin' && m.bytes > 0 && !m.done) { clearTimeout(to); resolve() } })
+    })
+    await B.request('files:download', { spaceId, path: '/big.bin', inPlace: true, ownerKey: aKey })
+    await flowing
+
+    const fresh = await A.request('share:create', { spaceId, name: 'Fresh', contentMode: 'overlay' })
+    await B.until('share:list', { spaceId }, (shares) => Array.isArray(shares) && shares.some((s) => s.id === fresh.id), { ms: scaled(20000) })
+    t.absent(completed, 'the download was still in flight when the new folder surfaced')
+    t.pass('new folder surfaced on the downloading peer without pausing the transfer')
+
+    A.kill()
+  })
+
+test('a download completes byte-exact over the content plane', { timeout: scaled(120000) }, async (t) => {
+  const bootstrap = await localTestnet(t)
+  const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: mkTmpDir(t), flags: FLAGS() })
+  const B = await launchPeer(t, { bootstrap, displayName: 'Bob', downloads: mkTmpDir(t), flags: FLAGS() })
+  const spaceId = await connectInSpace(t, A, B)
+  const aKey = (await A.request('profile:get')).publicKey
+
+  const src = path.join(mkTmpDir(t), 'file.bin')
+  const bytes = patternedBytes(4 * 1024 * 1024, 23)
+  fs.writeFileSync(src, bytes)
+  await A.request('files:add', { spaceId, filePath: src, fileName: 'file.bin', fileSize: bytes.length })
+  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/file.bin' && e.status === 'remote'), { ms: scaled(60000) })
+
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/file.bin', scaled(90000))
+  await B.request('files:download', { spaceId, path: '/file.bin', inPlace: true, ownerKey: aKey })
+  const completion = await done
+  t.ok(fs.readFileSync(completion.localPath).equals(bytes), 'downloaded bytes match source over the content plane')
+  t.ok(!completion.localPath.endsWith('.overlay-partial'), 'finalised, not a partial')
+
+  A.kill()
+})

--- a/test/unit/content-hello-binding.test.js
+++ b/test/unit/content-hello-binding.test.js
@@ -1,0 +1,57 @@
+import test from 'brittle'
+import b4a from 'b4a'
+import crypto from 'hypercore-crypto'
+import Hypercore from 'hypercore'
+import { signNoiseBinding, verifyIdentityBinding } from '../../src/shared/transfer/handshake-guard.js'
+
+// The content plane authenticates each connection with a mirall/content-hello frame that binds
+// the profileKey to THIS connection's Noise key, reusing signNoiseBinding / verifyIdentityBinding.
+// A content-hello carries no spaceTopic and no driveKey, so it rides the V1 binding
+// (context || noiseKey). These assert the exact frame content-swarm builds and its anti-replay.
+function contentHello () {
+  const signer = crypto.keyPair()
+  const namespace = crypto.randomBytes(32)
+  const noise = crypto.keyPair()
+  const manifest = {
+    version: 1, hash: 'blake2b', allowPatch: false, quorum: 1,
+    signers: [{ signature: 'ed25519', namespace, publicKey: signer.publicKey }],
+    prologue: null, linked: null, userData: null,
+  }
+  const profileKey = b4a.toString(Hypercore.key(manifest), 'hex')
+  const msg = {
+    type: 'content-hello',
+    profileKey,
+    sig: signNoiseBinding(noise.publicKey, signer.secretKey),
+    signerKey: b4a.toString(signer.publicKey, 'hex'),
+    signerNs: b4a.toString(namespace, 'hex'),
+  }
+  return { signer, namespace, noise, profileKey, msg }
+}
+
+test('content-hello verifies against the Noise key it was signed for', (t) => {
+  const { noise, msg } = contentHello()
+  t.ok(verifyIdentityBinding({ publicKey: noise.publicKey }, msg))
+})
+
+test('content-hello replayed onto another content connection is rejected', (t) => {
+  const { msg } = contentHello()
+  // The attacker's content connection has a different Noise key (Noise proves possession); the
+  // signature is over the victim's content Noise key, so it does not verify here.
+  t.absent(verifyIdentityBinding({ publicKey: crypto.keyPair().publicKey }, msg))
+})
+
+test('content-hello with a signer that does not hash to profileKey is rejected', (t) => {
+  const victim = contentHello()
+  const attacker = contentHello()
+  const forged = { ...attacker.msg, profileKey: victim.profileKey }
+  t.absent(verifyIdentityBinding({ publicKey: attacker.noise.publicKey }, forged))
+})
+
+test('content-hello with malformed / missing binding fields is rejected', (t) => {
+  const { noise, msg } = contentHello()
+  const peerInfo = { publicKey: noise.publicKey }
+  t.absent(verifyIdentityBinding(peerInfo, { ...msg, sig: undefined }))
+  t.absent(verifyIdentityBinding(peerInfo, { ...msg, signerKey: 'not-hex' }))
+  t.absent(verifyIdentityBinding(peerInfo, { ...msg, signerNs: undefined }))
+  t.absent(verifyIdentityBinding({}, msg))
+})

--- a/test/unit/overlay-authorize.test.js
+++ b/test/unit/overlay-authorize.test.js
@@ -9,7 +9,7 @@ function build (overrides = {}) {
   const peerSocket = new Map([[peer, socket]])
   const deps = {
     peerSocket,
-    senderAuthorizedOnSocket: overrides.senderAuthorizedOnSocket || (() => true),
+    socketAuthorized: overrides.socketAuthorized || (() => true),
     isApprovedMember: overrides.isApprovedMember || (async () => true),
     serveLimiter: overrides.serveLimiter || { take: () => ({ ok: true }) },
     serveIndex: overrides.serveIndex || { spacesFor: () => ['space1'] },
@@ -23,7 +23,7 @@ test('(a) unknown peer (not attached on a socket) → deny', async (t) => {
 })
 
 test('(b) from not Noise-authenticated on the socket → deny', async (t) => {
-  const { peer, auth } = build({ senderAuthorizedOnSocket: () => false })
+  const { peer, auth } = build({ socketAuthorized: () => false })
   t.is(await auth(peer, 'fromKey', 'hash'), false)
 })
 


### PR DESCRIPTION
A large download no longer head-of-line-blocks control-plane replication: the overlay content channel now rides a second Hyperswarm (its own Noise/UDX stream, sharing the control DHT), so a newly shared folder reaches a downloading peer without waiting for the transfer to be paused. Each content connection authenticates with a signed content-hello and serving stays gated on space membership; the plane is rate-limited, firewalled, and on by default when overlay is enabled.

## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [x] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [ ] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [x] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [ ] **N/A** — docs / comments / config only (no runtime surface)

- [x] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [ ] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [x] N/A — no UI change.
