### PR TITLE
[test] Fix double-scaled deadlines and event taxonomy gap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-node_modules/
+node_modules
 assets/dist/
 .DS_Store
 .claude/settings.local.json

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:css": "npx @tailwindcss/cli -i src/renderer/styles/tailwind.css -o assets/dist/app.css --minify",
     "build:clean": "node -e \"require('fs').rmSync('assets/dist',{recursive:true,force:true})\"",
     "lint": "eslint src",
-    "lint:ci": "eslint src --max-warnings 28 && bash scripts/check-comment-hygiene.sh --strict",
+    "lint:ci": "eslint src --max-warnings 28 && bash scripts/check-comment-hygiene.sh --strict && bash scripts/check-test-timing.sh",
     "knip": "knip",
     "build": "npm run build:clean && npm run lint && tsc --noEmit && npm run build:js && npm run build:css",
     "start": "npm run build && electron-forge start -- --no-updates",

--- a/scripts/check-test-timing.sh
+++ b/scripts/check-test-timing.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Test-deadline hygiene for test/: the poll/wait helpers scale the `ms` they receive
+# (peer.waitFor, peer.until, fixtures.waitForFile all do `scaled(ms)` internally), so a
+# call site must pass a BASE value. Passing scaled() in as well squares the scale factor:
+# under CI's MIRALL_TEST_TIMEOUT_SCALE=3 a scaled(120000) deadline becomes 1,080,000ms,
+# far past brittle's per-test timeout — so the helper's diagnostic (which carries the
+# worker stderr tail) can never fire and a hang degrades into a bare "timed out" with no
+# indication of what it was waiting for.
+#
+# Only brittle's per-test `{ timeout: scaled(...) }` takes a scaled value; it is not a helper.
+#
+# Usage: scripts/check-test-timing.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+# `ms:` options feed until()/waitForFile(); the third arg of waitFor() is its deadline.
+hits="$(grep -rnE "ms: scaled\(|\.waitFor\([^)]*\)[^)]*, *scaled\(" test/ || true)"
+# The waitFor pattern above misses predicates containing parens, so catch those too.
+hits="$hits$(grep -rnE "\.waitFor\(.*scaled\(" test/ || true)"
+
+if [ -n "$(printf '%s' "$hits" | tr -d '[:space:]')" ]; then
+  echo "ERROR: double-scaled test deadline — helpers already scale, pass a base value:" >&2
+  printf '%s\n' "$hits" | sort -u >&2
+  echo >&2
+  echo "  fix: B.waitFor(type, pred, scaled(60000))  ->  B.waitFor(type, pred, 60000)" >&2
+  echo "       { ms: scaled(60000) }                 ->  { ms: 60000 }" >&2
+  echo "  (keep scaled() on brittle's per-test { timeout: scaled(...) })" >&2
+  exit 1
+fi
+
+echo "test-timing: clean."

--- a/test/flow/concurrent-download.test.js
+++ b/test/flow/concurrent-download.test.js
@@ -33,12 +33,12 @@ test('REGRESSION (GAP #10): concurrent downloaders of one file each land byte-ex
     // Both peers wait until they see the file as `remote` (owner finished hashing).
     const seeRemote = (P) => P.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
     await Promise.all([seeRemote(B), seeRemote(C)])
 
     // Fire both downloads at the same time — the owner serves both concurrently.
-    const doneB = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', scaled(90000))
-    const doneC = C.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', scaled(90000))
+    const doneB = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', 90000)
+    const doneC = C.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', 90000)
     const [resB, resC] = await Promise.all([
       B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'big.bin' }),
       C.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'big.bin' }),

--- a/test/flow/content-plane-hol.test.js
+++ b/test/flow/content-plane-hol.test.js
@@ -29,7 +29,7 @@ test('a newly shared folder surfaces on a peer while a download is in flight ove
     const bytes = patternedBytes(48 * 1024 * 1024, 41)
     fs.writeFileSync(src, bytes)
     await A.request('files:add', { spaceId, filePath: src, fileName: 'big.bin', fileSize: bytes.length })
-    await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.status === 'remote'), { ms: scaled(120000) })
+    await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.status === 'remote'), { ms: 120000 })
 
     let completed = false
     B.on('event:transfer-complete', (m) => { if (m.path === '/big.bin') completed = true })
@@ -41,7 +41,7 @@ test('a newly shared folder surfaces on a peer while a download is in flight ove
     await flowing
 
     const fresh = await A.request('share:create', { spaceId, name: 'Fresh', contentMode: 'overlay' })
-    await B.until('share:list', { spaceId }, (shares) => Array.isArray(shares) && shares.some((s) => s.id === fresh.id), { ms: scaled(20000) })
+    await B.until('share:list', { spaceId }, (shares) => Array.isArray(shares) && shares.some((s) => s.id === fresh.id), { ms: 20000 })
     t.absent(completed, 'the download was still in flight when the new folder surfaced')
     t.pass('new folder surfaced on the downloading peer without pausing the transfer')
 
@@ -59,9 +59,9 @@ test('a download completes byte-exact over the content plane', { timeout: scaled
   const bytes = patternedBytes(4 * 1024 * 1024, 23)
   fs.writeFileSync(src, bytes)
   await A.request('files:add', { spaceId, filePath: src, fileName: 'file.bin', fileSize: bytes.length })
-  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/file.bin' && e.status === 'remote'), { ms: scaled(60000) })
+  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/file.bin' && e.status === 'remote'), { ms: 60000 })
 
-  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/file.bin', scaled(90000))
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/file.bin', 90000)
   await B.request('files:download', { spaceId, path: '/file.bin', inPlace: true, ownerKey: aKey })
   const completion = await done
   t.ok(fs.readFileSync(completion.localPath).equals(bytes), 'downloaded bytes match source over the content plane')

--- a/test/flow/folder-delete-mid-mirror.test.js
+++ b/test/flow/folder-delete-mid-mirror.test.js
@@ -24,7 +24,7 @@ async function ownedShareWithScan (A, spaceId, name, folder) {
 async function mirror (t, A, B, spaceId, share, aKey) {
   await B.until('share:list', { spaceId }, (l) => l.some((s) => s.id === share.id))
   const mirrorDir = mkTmpDir(t)
-  const active = B.waitFor('event:foreign-folder-mount-status', (m) => m.shareId === share.id && m.status === 'active', scaled(90000))
+  const active = B.waitFor('event:foreign-folder-mount-status', (m) => m.shareId === share.id && m.status === 'active', 90000)
   await B.request('foreign-folder:mount', { spaceId, shareId: share.id, ownerKey: aKey, mountPath: mirrorDir })
   await active
   return mirrorDir
@@ -48,7 +48,7 @@ test('owner deletes the share mid-mirror: the share tombstones on the mirroring 
     // Delete right after the mount goes active — the 64 MB file is still materializing.
     await A.request('owned-folder:delete', { spaceId, shareId: share.id })
 
-    await B.until('share:list', { spaceId }, (l) => !l.some((s) => s.id === share.id), { ms: scaled(60000) })
+    await B.until('share:list', { spaceId }, (l) => !l.some((s) => s.id === share.id), { ms: 60000 })
     t.pass('share tombstone reached the mirroring peer')
 
     await sleep(3000)
@@ -77,8 +77,8 @@ test('owner deletes a file mid-mirror: it is removed from the mirror, the siblin
     fs.rmSync(path.join(folder, 'big.bin'))
     await A.request('event:owned-folder-fs-event', { shareId: share.id, action: 'unlink', relPath: 'big.bin', absPath: path.join(folder, 'big.bin') })
 
-    await waitForFile(path.join(mirrorDir, 'big.bin'), { present: false, ms: scaled(120000) })
-    await waitForFile(path.join(mirrorDir, 'keep.txt'), { present: true, ms: scaled(90000) })
+    await waitForFile(path.join(mirrorDir, 'big.bin'), { present: false, ms: 120000 })
+    await waitForFile(path.join(mirrorDir, 'keep.txt'), { present: true, ms: 90000 })
     t.absent(fs.existsSync(path.join(mirrorDir, 'big.bin')), 'the deleted file is removed from the mirror')
     t.ok(fs.existsSync(path.join(mirrorDir, 'keep.txt')), 'the sibling file is preserved')
     A.kill()

--- a/test/flow/folder-mirror-status.test.js
+++ b/test/flow/folder-mirror-status.test.js
@@ -31,12 +31,12 @@ test('REGRESSION (FIX-EDA-7): a materializing mirror row reports downloading, th
 
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Arm the downloading observation BEFORE the mount so no window is missed.
     const sawDownloading = B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'downloading'),
-      { ms: scaled(120000) })
+      { ms: 120000 })
 
     const mirrorDir = mkTmpDir(t)
     await B.request('foreign-folder:mount', { spaceId, shareId: share.id, ownerKey: aKey, mountPath: mirrorDir })
@@ -45,7 +45,7 @@ test('REGRESSION (FIX-EDA-7): a materializing mirror row reports downloading, th
 
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'synced'),
-      { ms: scaled(180000) })
+      { ms: 180000 })
     t.ok(fs.readFileSync(path.join(mirrorDir, 'big.bin')).equals(bytes), 'mirror landed byte-exact')
 
     A.kill()

--- a/test/flow/folder-overlay-pause-resume.test.js
+++ b/test/flow/folder-overlay-pause-resume.test.js
@@ -31,7 +31,7 @@ test('overlay folder: pause mid-flight surfaces paused-interrupted; resume compl
 
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     const flowing = new Promise((resolve) => {
       B.on('event:decoration', (m) => {
@@ -50,7 +50,7 @@ test('overlay folder: pause mid-flight surfaces paused-interrupted; resume compl
       (list) => {
         const e = Array.isArray(list?.entries) ? list.entries.find((x) => x.relPath === 'big.bin') : null
         return e && e.status === 'paused-interrupted' && typeof e.pendingBytes === 'number' && e.pendingBytes > 0
-      }, { ms: scaled(60000) })
+      }, { ms: 60000 })
 
     const paused = await B.request('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id })
     const pausedRow = paused.entries.find((e) => e.relPath === 'big.bin')
@@ -58,7 +58,7 @@ test('overlay folder: pause mid-flight surfaces paused-interrupted; resume compl
     t.ok(pausedRow.pendingBytes > 0, 'pendingBytes preserved through pause (partial kept)')
 
     // Resume = the same share:read-file IPC the Resume button triggers.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', 120000)
     await B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'big.bin' })
     const completion = await done
 
@@ -89,14 +89,14 @@ test('overlay folder: a queued download auto-resumes when the owner returns',
 
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'resume.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     A.kill()
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
     const queued = await B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'resume.bin' })
     t.ok(queued && queued.queued, 'overlay folder download queued while owner offline')
 
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Docs/resume.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Docs/resume.bin', 120000)
     A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, flags: FLAGS })
     const completed = await done
 
@@ -127,7 +127,7 @@ test('REGRESSION (FIX-EDA-15: a manual folder pause survives an owner catalog ap
 
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     const flowing = new Promise((resolve) => {
       B.on('event:decoration', (m) => {
@@ -143,7 +143,7 @@ test('REGRESSION (FIX-EDA-15: a manual folder pause survives an owner catalog ap
       (list) => {
         const e = Array.isArray(list?.entries) ? list.entries.find((x) => x.relPath === 'big.bin') : null
         return !!e && e.status === 'paused-interrupted'
-      }, { ms: scaled(60000) })
+      }, { ms: 60000 })
 
     // Owner appends an UNRELATED file → B's peer-catalog watch fires resumeForOwner on the
     // folder channel. A MANUAL pause must not be resurrected — and (FIX-EDA-14) the gated row
@@ -156,7 +156,7 @@ test('REGRESSION (FIX-EDA-15: a manual folder pause survives an owner catalog ap
       { shareId: share.id, action: 'add', relPath: 'small.txt', absPath: path.join(folder, 'small.txt') })
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'small.txt'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Give resumeForOwner ample time to (wrongly) restart, then assert it did not.
     await new Promise((r) => setTimeout(r, scaled(6000)))

--- a/test/flow/foreign-mirror-unmount-clears-serving.test.js
+++ b/test/flow/foreign-mirror-unmount-clears-serving.test.js
@@ -38,16 +38,16 @@ test('mirror paused then unmounted clears the owner serve ledger without waiting
     await B.request('foreign-folder:mount', { spaceId, shareId: share.id, ownerKey: aKey, mountPath: mirrorDir })
 
     // The owner sees B pulling the file — proves the fetch reached A and is in flight.
-    await A.until('serving:summary-list', { spaceId }, servesB, { ms: scaled(60000) })
+    await A.until('serving:summary-list', { spaceId }, servesB, { ms: 60000 })
 
     // B pauses mid-download → the owner's row flips to paused (CONTROL_PAUSED).
     await B.request('foreign-folder:set-enabled', { spaceId, shareId: share.id, enabled: false })
-    await A.until('serving:summary-list', { spaceId }, pausesB, { ms: scaled(30000) })
+    await A.until('serving:summary-list', { spaceId }, pausesB, { ms: 30000 })
 
     // B unmounts while still online → notifyTransferStopped drops B from the owner's ledger now,
     // not after the 5-min sweep. Without the fix this poll times out.
     await B.request('foreign-folder:unmount', { spaceId, shareId: share.id })
-    await A.until('serving:summary-list', { spaceId }, (rows) => !servesB(rows), { ms: scaled(20000) })
+    await A.until('serving:summary-list', { spaceId }, (rows) => !servesB(rows), { ms: 20000 })
 
     const finalRows = await A.request('serving:summary-list', { spaceId })
     t.absent(servesB(finalRows), 'owner no longer shows the unmounted mirror as downloading')

--- a/test/flow/impaired-interaction.test.js
+++ b/test/flow/impaired-interaction.test.js
@@ -17,7 +17,7 @@ const v2flags = (netImpair) => ({ overlayEnabled: true, inPlaceFilesEnabled: tru
 const sleep = (ms) => new Promise((r) => setTimeout(r, scaled(ms)))
 
 async function seeRemote (B, spaceId, name) {
-  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: scaled(120000) })
+  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: 120000 })
 }
 async function startAndFlow (B, spaceId, name, aKey) {
   const flowing = new Promise((resolve) => {
@@ -42,7 +42,7 @@ test('a transfer completes over a brutal link (high latency + periodic drops on 
   await seeRemote(B, spaceId, 'brutal.bin')
 
   const started = Date.now()
-  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/brutal.bin', scaled(300000))
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/brutal.bin', 300000)
   await B.request('files:download', { spaceId, path: '/brutal.bin', inPlace: true, ownerKey: aKey })
   const completion = await done
   t.comment(`brutal.bin: 16 MB completed in ${Date.now() - started}ms on the brutal link`)
@@ -68,7 +68,7 @@ test('a manual pause and resume survive a flaky link (connection churn while pau
   await startAndFlow(B, spaceId, 'churn.bin', aKey)
   const transferId = (await B.request('files:list', { spaceId })).find((e) => e.path === '/churn.bin')?.transferId
   await B.request('files:pause-download', { transferId })
-  await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/churn.bin'); return e && e.status === 'paused-interrupted' }, { ms: scaled(60000) })
+  await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/churn.bin'); return e && e.status === 'paused-interrupted' }, { ms: 60000 })
 
   // Let the flaky link drop + reconnect several times while paused.
   let autoResumed = false
@@ -80,7 +80,7 @@ test('a manual pause and resume survive a flaky link (connection churn while pau
   t.absent(fs.existsSync(path.join(B.downloads, 'churn.bin')), 'the paused file did not complete on its own')
 
   // A manual resume completes it despite the flaky link.
-  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/churn.bin', scaled(180000))
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/churn.bin', 180000)
   await B.request('files:download', { spaceId, path: '/churn.bin', inPlace: true, ownerKey: aKey })
   const completion = await done
   t.ok(fs.readFileSync(completion.localPath).equals(bytes), 'manual resume completes byte-exact over the flaky link')

--- a/test/flow/impaired-link.test.js
+++ b/test/flow/impaired-link.test.js
@@ -22,9 +22,9 @@ async function shareSeeDownload (t, A, B, spaceId, aKey, aSrc, name, mb, seed) {
   const bytes = patternedBytes(mb * 1024 * 1024, seed)
   fs.writeFileSync(path.join(aSrc, name), bytes)
   await A.request('files:add', { spaceId, filePath: path.join(aSrc, name), fileName: name, fileSize: bytes.length })
-  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: scaled(120000) })
+  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: 120000 })
   const started = Date.now()
-  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/' + name, scaled(240000))
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/' + name, 240000)
   await B.request('files:download', { spaceId, path: '/' + name, inPlace: true, ownerKey: aKey })
   const completion = await done
   t.comment(`${name}: ${mb} MB transferred in ${Date.now() - started}ms under the impaired link`)

--- a/test/flow/loose-cancel-discard.test.js
+++ b/test/flow/loose-cancel-discard.test.js
@@ -29,7 +29,7 @@ async function shareAndSee (A, B, spaceId, aSrc, name, seed) {
   const bytes = patternedBytes(8 * 1024 * 1024, seed)
   fs.writeFileSync(path.join(aSrc, name), bytes)
   await A.request('files:add', { spaceId, filePath: path.join(aSrc, name), fileName: name, fileSize: bytes.length })
-  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: scaled(60000) })
+  await B.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: 60000 })
   return bytes
 }
 async function startFlowGetTransfer (B, spaceId, name, aKey) {
@@ -51,7 +51,7 @@ test('loose cancel mid-download: partial discarded, row back to remote, nothing 
     t.ok(transferId, 'transferId derived')
 
     await B.request('files:cancel-download', { transferId })
-    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/lump.bin'); return e && e.status === 'remote' }, { ms: scaled(30000) })
+    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/lump.bin'); return e && e.status === 'remote' }, { ms: 30000 })
     await sleep(1000)
     t.ok(noResidue(B.downloads, 'lump'), 'no partial or final file left after cancel')
     A.kill()
@@ -65,9 +65,9 @@ test('loose pause then discard-partial: partial cleared, row back to remote',
     const transferId = await startFlowGetTransfer(B, spaceId, 'draft.bin', aKey)
 
     await B.request('files:pause-download', { transferId })
-    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/draft.bin'); return e && e.status === 'paused-interrupted' }, { ms: scaled(30000) })
+    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/draft.bin'); return e && e.status === 'paused-interrupted' }, { ms: 30000 })
     await B.request('files:discard-partial', { spaceId, path: '/draft.bin' })
-    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/draft.bin'); return e && e.status === 'remote' }, { ms: scaled(30000) })
+    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/draft.bin'); return e && e.status === 'remote' }, { ms: 30000 })
     await sleep(1000)
     t.ok(noResidue(B.downloads, 'draft'), 'no partial left after discard')
     A.kill()
@@ -81,9 +81,9 @@ test('loose cancel then re-download: completes byte-exact with no stale partial'
     const transferId = await startFlowGetTransfer(B, spaceId, 'retry.bin', aKey)
 
     await B.request('files:cancel-download', { transferId })
-    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/retry.bin'); return e && e.status === 'remote' }, { ms: scaled(30000) })
+    await B.until('files:list', { spaceId }, (list) => { const e = list.find((x) => x.path === '/retry.bin'); return e && e.status === 'remote' }, { ms: 30000 })
 
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/retry.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/retry.bin', 120000)
     await B.request('files:download', { spaceId, path: '/retry.bin', inPlace: true, ownerKey: aKey })
     const completion = await done
     t.ok(fs.readFileSync(completion.localPath).equals(bytes), 're-downloaded file is byte-exact')

--- a/test/flow/loose-crash-mid-index.test.js
+++ b/test/flow/loose-crash-mid-index.test.js
@@ -60,7 +60,7 @@ test('owner crash mid-index then restart: no permanent null-hash publishing zomb
       await A.until('files:list', { spaceId }, (list) => {
         const e = Array.isArray(list) ? list.find((x) => x.path === '/archive.bin') : null
         return !e || e.status === 'mine'
-      }, { ms: scaled(90000) })
+      }, { ms: 90000 })
       row = (await A.request('files:list', { spaceId })).find((e) => e.path === '/archive.bin')
     }
     t.ok(!row || row.status === 'mine', 'owner entry is absent or fully shared — not a permanent publishing zombie')
@@ -74,7 +74,7 @@ test('owner crash mid-index then restart: no permanent null-hash publishing zomb
       await B.until('files:list', { spaceId }, (list) => {
         const e = Array.isArray(list) ? list.find((x) => x.path === '/archive.bin') : null
         return !!e && e.status === 'remote'
-      }, { ms: scaled(60000) })
+      }, { ms: 60000 })
     }
     const bRow = (await B.request('files:list', { spaceId })).find((e) => e.path === '/archive.bin')
     t.comment(`post-restart peer row: ${bRow ? 'status=' + bRow.status : 'absent'}`)

--- a/test/flow/loose-inplace-seed-mode.test.js
+++ b/test/flow/loose-inplace-seed-mode.test.js
@@ -42,13 +42,13 @@ for (const mode of V1_MODES) {
       // that timed out before the fix.
       const listed = await B.until('files:list', { spaceId },
         (f) => Array.isArray(f) && f.some((e) => e.path === '/shared.txt' && e.inPlace && e.status === 'remote'),
-        { ms: scaled(60000) })
+        { ms: 60000 })
       const entry = listed.find((e) => e.path === '/shared.txt')
       t.is(entry.size, bytes.length, 'catalog carries the size')
       t.ok(entry.hash, 'catalog carries the content hash')
 
       // And can fetch it end-to-end — proves the looseCatalogKey actually opens the catalog + serves.
-      const done = B.waitFor('event:transfer-complete', (m) => m.path === '/shared.txt', scaled(60000))
+      const done = B.waitFor('event:transfer-complete', (m) => m.path === '/shared.txt', 60000)
       const res = await B.request('files:download', { spaceId, path: '/shared.txt', inPlace: true, ownerKey: aKey })
       t.ok(res?.transferId, 'in-place download returned a transferId')
       const completed = await done

--- a/test/flow/loose-inplace-two-peer.test.js
+++ b/test/flow/loose-inplace-two-peer.test.js
@@ -44,13 +44,13 @@ test('in-place loose file: owner shares with no drive copy; member fetches by co
     // Bob sees it in the flat list (from Alice's replicated loose catalog), marked in-place + remote.
     const listed = await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
     const entry = listed.find((e) => e.path === '/big.bin')
     t.is(entry.size, bytes.length, 'catalog carries the size')
     t.ok(entry.hash, 'catalog carries the content hash')
 
     // Bob fetches by content hash straight from Alice; completion arrives via event.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', scaled(60000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', 60000)
     const res = await B.request('files:download', { spaceId, path: '/big.bin', inPlace: true, ownerKey: aKey })
     t.ok(res?.transferId, 'in-place download returned a transferId (non-blocking)')
     const completed = await done
@@ -60,7 +60,7 @@ test('in-place loose file: owner shares with no drive copy; member fetches by co
     // hash byte-for-byte during the transfer).
     const bobList = await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.status === 'downloaded'),
-      { ms: scaled(30000) })
+      { ms: 30000 })
     t.is(bobList.find((e) => e.path === '/big.bin')?.verified, true, 'downloaded loose file shows the verified badge')
 
     // Still no drive blobs on Alice after serving — the fetch streamed from the source file.
@@ -84,10 +84,10 @@ test('in-place loose file is unavailable while the owner is offline',
 
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/note.txt' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     A.kill()
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
 
     const files = await B.request('files:list', { spaceId })
     t.is(files.find((e) => e.path === '/note.txt')?.status, 'unavailable', 'unavailable with the owner offline')

--- a/test/flow/loose-inplace-v2.test.js
+++ b/test/flow/loose-inplace-v2.test.js
@@ -48,10 +48,10 @@ test('REGRESSION (FIX-326): v2 loose file — pending joiner cannot list; approv
 
   const listed = await B.until('files:list', { spaceId: space.spaceId },
     (f) => Array.isArray(f) && f.some((e) => e.path === '/secret.txt' && e.inPlace),
-    { ms: scaled(60000) })
+    { ms: 60000 })
   t.ok(listed.find((e) => e.path === '/secret.txt')?.hash, 'approved member lists the encrypted loose file')
 
-  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/secret.txt', scaled(60000))
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/secret.txt', 60000)
   await B.request('files:download', { spaceId: space.spaceId, path: '/secret.txt', inPlace: true, ownerKey: aKey })
   const completed = await done
   t.ok(fs.readFileSync(completed.localPath).equals(bytes), 'approved member downloads matching bytes')

--- a/test/flow/loose-leave-mid-transfer.test.js
+++ b/test/flow/loose-leave-mid-transfer.test.js
@@ -31,7 +31,7 @@ async function share (A, spaceId, dir, name, seed) {
 }
 async function seeRemote (peer, spaceId, name) {
   await peer.until('files:list', { spaceId },
-    (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: scaled(60000) })
+    (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: 60000 })
 }
 
 // F2 — the OWNER leaves the space while a peer is downloading.

--- a/test/flow/loose-pause-resume.test.js
+++ b/test/flow/loose-pause-resume.test.js
@@ -35,7 +35,7 @@ test('loose download: pause mid-flight surfaces paused-interrupted; resume compl
 
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Capture the transferId from the first progress event; pause once real bytes flow.
     // REGRESSION (FIX-EDA-12): decoration frames carry spaceId — the bare drive path is
@@ -64,7 +64,7 @@ test('loose download: pause mid-flight surfaces paused-interrupted; resume compl
       (list) => {
         const e = Array.isArray(list) ? list.find((x) => x.path === '/big.bin') : null
         return e && e.status === 'paused-interrupted' && typeof e.pendingBytes === 'number' && e.pendingBytes > 0
-      }, { ms: scaled(60000) })
+      }, { ms: 60000 })
 
     const paused = await B.request('files:list', { spaceId })
     const pausedRow = paused.find((e) => e.path === '/big.bin')
@@ -72,7 +72,7 @@ test('loose download: pause mid-flight surfaces paused-interrupted; resume compl
     t.ok(pausedRow.pendingBytes > 0, 'pendingBytes preserved through pause (partial kept)')
 
     // Resume = the same files:download IPC the Resume button triggers.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', 120000)
     await B.request('files:download', { spaceId, path: '/big.bin', inPlace: true, ownerKey: aKey })
     const completion = await done
 
@@ -103,17 +103,17 @@ test('loose download auto-resumes when the owner returns (reconnect hook)',
 
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/resume.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Owner offline → the loose download queues (records a pending row carrying ownerKey).
     A.kill()
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
     const queued = await B.request('files:download', { spaceId, path: '/resume.bin', inPlace: true, ownerKey: aKey })
     t.ok(queued && queued.queued, 'loose download queued while owner offline')
 
     // Owner returns with the SAME storage (source still servable). On A's handshake,
     // B's reconnect hook (resumeLooseForOwner) re-triggers the download with NO manual click.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/resume.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/resume.bin', 120000)
     A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, flags: aFlags })
     const completed = await done
 
@@ -137,7 +137,7 @@ test('REGRESSION (FIX-EDA-2: a manual pause survives an owner catalog re-append 
     await A.request('files:add', { spaceId, filePath: srcPath, fileName: 'big.bin', fileSize: bytes.length })
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     const flowing = new Promise((resolve) => {
       B.on('event:decoration', (m) => { if (m.channel === 'transfer' && m.spaceId === spaceId && m.key === '/big.bin' && m.bytes > 0) resolve() })
@@ -148,7 +148,7 @@ test('REGRESSION (FIX-EDA-2: a manual pause survives an owner catalog re-append 
     await B.request('files:pause-download', { transferId })
     await B.until('files:list', { spaceId },
       (list) => { const e = Array.isArray(list) ? list.find((x) => x.path === '/big.bin') : null; return !!e && e.status === 'paused-interrupted' },
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Owner appends an UNRELATED file → B's peer-catalog watch fires resumeForOwner. A MANUAL pause
     // must NOT be resurrected by that (the bug: catalog re-append restarts user-paused downloads).
@@ -160,7 +160,7 @@ test('REGRESSION (FIX-EDA-2: a manual pause survives an owner catalog re-append 
     await A.request('files:add', { spaceId, filePath: smallPath, fileName: 'small.txt', fileSize: 9 })
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/small.txt'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
     // Give resumeForOwner ample time to (wrongly) restart, then assert it did not.
     await new Promise((r) => setTimeout(r, scaled(6000)))
     const row = (await B.request('files:list', { spaceId })).find((e) => e.path === '/big.bin')

--- a/test/flow/loose-preparing-offline.test.js
+++ b/test/flow/loose-preparing-offline.test.js
@@ -31,17 +31,17 @@ test('loose file caught mid-index degrades preparing→unavailable when owner qu
     // Catch the preparing window (the null-hash entry replicates to B before the hash lands).
     await B.until('files:list', { spaceId },
       (l) => Array.isArray(l) && l.find((e) => e.path === '/reel.bin')?.status === 'preparing',
-      { ms: scaled(60000), every: 100 })
+      { ms: 60000, every: 100 })
 
     // Owner quits mid-index — the graceful {type:'shutdown'} the Electron main sends.
     await A.request('shutdown').catch(() => {})
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
 
     // The mid-index file must NOT stay preparing — it degrades to unavailable like every other
     // file from an offline owner.
     const settled = await B.until('files:list', { spaceId },
       (l) => Array.isArray(l) && l.find((e) => e.path === '/reel.bin')?.status === 'unavailable',
-      { ms: scaled(30000), every: 200 })
+      { ms: 30000, every: 200 })
     t.is(settled.find((e) => e.path === '/reel.bin').status, 'unavailable',
       'mid-index file is unavailable while owner offline, not stuck preparing')
   })

--- a/test/flow/loose-preparing-status.test.js
+++ b/test/flow/loose-preparing-status.test.js
@@ -48,7 +48,7 @@ test('peer observes a loose file settle from indexing to remote while the owner 
     t.absent(preRemote.has('error'), 'the peer never observes a Failed/error state during owner indexing')
 
     // And it downloads cleanly once remote.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/reel.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/reel.bin', 120000)
     await B.request('files:download', { spaceId, path: '/reel.bin', inPlace: true, ownerKey: aKey })
     const completion = await done
     t.ok(fs.readFileSync(completion.localPath).equals(bytes), 'downloads byte-exact after settling to remote')

--- a/test/flow/loose-publish-lifecycle.test.js
+++ b/test/flow/loose-publish-lifecycle.test.js
@@ -32,9 +32,9 @@ test('owner cancels publish while indexing: the peer never sees the half-adverti
     A.request('files:add', { spaceId, filePath: path.join(aSrc, 'huge.bin'), fileName: 'huge.bin', fileSize: bytes.length }).catch(() => {})
 
     // Catch the still-indexing 'publishing' row, then cancel the publish.
-    await A.until('files:list', { spaceId }, (list) => Array.isArray(list) && list.some((e) => e.path === '/huge.bin' && e.status === 'publishing'), { ms: scaled(30000) })
+    await A.until('files:list', { spaceId }, (list) => Array.isArray(list) && list.some((e) => e.path === '/huge.bin' && e.status === 'publishing'), { ms: 30000 })
     await A.request('files:cancel-publish', { spaceId, path: '/huge.bin' })
-    await A.until('files:list', { spaceId }, (list) => !Array.isArray(list) || !list.some((e) => e.path === '/huge.bin'), { ms: scaled(30000) })
+    await A.until('files:list', { spaceId }, (list) => !Array.isArray(list) || !list.some((e) => e.path === '/huge.bin'), { ms: 30000 })
 
     // The peer must never observe it as an available (remote) share; any transient preparing row clears.
     await sleep(8000)
@@ -58,21 +58,21 @@ test('loose reshare after unshare: the file can be added again and downloads cle
     const src = path.join(aSrc, 'cycle.bin')
     fs.writeFileSync(src, bytes)
     await A.request('files:add', { spaceId, filePath: src, fileName: 'cycle.bin', fileSize: bytes.length })
-    await B.until('files:list', { spaceId }, (f) => f.some((e) => e.path === '/cycle.bin' && e.status === 'remote'), { ms: scaled(60000) })
+    await B.until('files:list', { spaceId }, (f) => f.some((e) => e.path === '/cycle.bin' && e.status === 'remote'), { ms: 60000 })
 
     // Unshare → it disappears for the peer.
     await A.request('files:remove', { spaceId, path: '/cycle.bin' })
-    await B.until('files:list', { spaceId }, (f) => !f.some((e) => e.path === '/cycle.bin'), { ms: scaled(60000) })
+    await B.until('files:list', { spaceId }, (f) => !f.some((e) => e.path === '/cycle.bin'), { ms: 60000 })
 
     // Re-add the same file; capture whatever path it re-shares under (tombstone must not block it).
     await A.request('files:add', { spaceId, filePath: src, fileName: 'cycle.bin', fileSize: bytes.length })
-    const reAdded = await A.until('files:list', { spaceId }, (list) => Array.isArray(list) && list.some((e) => e.path.includes('cycle') && e.status === 'mine'), { ms: scaled(30000) })
+    const reAdded = await A.until('files:list', { spaceId }, (list) => Array.isArray(list) && list.some((e) => e.path.includes('cycle') && e.status === 'mine'), { ms: 30000 })
     const rePath = reAdded.find((e) => e.path.includes('cycle') && e.status === 'mine').path
     t.comment(`re-shared under path: ${rePath}`)
 
     // The peer sees it again and can download it.
-    await B.until('files:list', { spaceId }, (f) => f.some((e) => e.path === rePath && e.status === 'remote'), { ms: scaled(60000) })
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === rePath, scaled(120000))
+    await B.until('files:list', { spaceId }, (f) => f.some((e) => e.path === rePath && e.status === 'remote'), { ms: 60000 })
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === rePath, 120000)
     await B.request('files:download', { spaceId, path: rePath, inPlace: true, ownerKey: aKey })
     const completion = await done
     t.ok(fs.readFileSync(completion.localPath).equals(bytes), 're-shared file downloads byte-exact')

--- a/test/flow/loose-remove-readd-no-resume.test.js
+++ b/test/flow/loose-remove-readd-no-resume.test.js
@@ -33,7 +33,7 @@ test('owner remove + re-add mid-download does NOT auto-resume; requires a manual
     const srcPath = path.join(aSrc, 'big.bin')
     fs.writeFileSync(srcPath, bytes)
     await A.request('files:add', { spaceId, filePath: srcPath, fileName: 'big.bin', fileSize: bytes.length })
-    await B.until('files:list', { spaceId }, (f) => statusOf(f, '/big.bin') === 'remote', { ms: scaled(60000) })
+    await B.until('files:list', { spaceId }, (f) => statusOf(f, '/big.bin') === 'remote', { ms: 60000 })
 
     let removed = false
     let completedBeforeRemove = false
@@ -53,7 +53,7 @@ test('owner remove + re-add mid-download does NOT auto-resume; requires a manual
 
     // Arm the removal-signal listener BEFORE the remove so the worker's event:transfer-removed
     // (which drives the mandatory toast, and proves the intent row was torn down) can't race us.
-    const removedSignal = B.waitFor('event:transfer-removed', (m) => m.path === '/big.bin', scaled(60000))
+    const removedSignal = B.waitFor('event:transfer-removed', (m) => m.path === '/big.bin', 60000)
     await A.request('files:remove', { spaceId, path: '/big.bin' })
     removed = true
     t.absent(completedBeforeRemove, 'the original did not complete before the removal (mid-transfer path exercised)')
@@ -61,13 +61,13 @@ test('owner remove + re-add mid-download does NOT auto-resume; requires a manual
     t.is((await removedSignal).fileName, 'big.bin', 'worker emitted event:transfer-removed for the torn-down download')
 
     // B observes the removal: the file leaves B's listing (tombstone hides it).
-    await B.until('files:list', { spaceId }, (f) => !Array.isArray(f) || !f.some((e) => e.path === '/big.bin'), { ms: scaled(60000) })
+    await B.until('files:list', { spaceId }, (f) => !Array.isArray(f) || !f.some((e) => e.path === '/big.bin'), { ms: 60000 })
 
     // A re-adds the SAME content (human-paced: after B saw the removal → distinct appends).
     await A.request('files:add', { spaceId, filePath: srcPath, fileName: 'big.bin', fileSize: bytes.length })
 
     // The file returns for B as 'remote' — NOT downloading/paused/downloaded — and STAYS so.
-    await B.until('files:list', { spaceId }, (f) => statusOf(f, '/big.bin') === 'remote', { ms: scaled(60000) })
+    await B.until('files:list', { spaceId }, (f) => statusOf(f, '/big.bin') === 'remote', { ms: 60000 })
     await new Promise((r) => setTimeout(r, scaled(8000))) // stability window: the buggy auto-resume would fire here
     const stable = await B.request('files:list', { spaceId })
     t.is(statusOf(stable, '/big.bin'), 'remote', 'file remains "remote" after re-add — intent terminated, no auto-resume')
@@ -75,7 +75,7 @@ test('owner remove + re-add mid-download does NOT auto-resume; requires a manual
 
     // A manual re-download works and lands the bytes.
     manualStarted = true
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', 120000)
     await B.request('files:download', { spaceId, path: '/big.bin', inPlace: true, ownerKey: aKey })
     const completion = await done
     t.is(sha(fs.readFileSync(completion.localPath)), sha(bytes), 'manual re-download landed the content byte-exact')

--- a/test/flow/loose-resume-reconnect.test.js
+++ b/test/flow/loose-resume-reconnect.test.js
@@ -34,7 +34,7 @@ test('manual pause survives an owner offline→online reconnect (no auto-resume)
     fs.writeFileSync(path.join(aSrc, 'held.bin'), bytes)
     await A.request('files:add', { spaceId, filePath: path.join(aSrc, 'held.bin'), fileName: 'held.bin', fileSize: bytes.length })
     await B.until('files:list', { spaceId },
-      (f) => Array.isArray(f) && f.some((e) => e.path === '/held.bin' && e.status === 'remote'), { ms: scaled(60000) })
+      (f) => Array.isArray(f) && f.some((e) => e.path === '/held.bin' && e.status === 'remote'), { ms: 60000 })
 
     // Start, prove mid-flight, then MANUALLY pause.
     const flowing = new Promise((resolve) => {
@@ -47,18 +47,18 @@ test('manual pause survives an owner offline→online reconnect (no auto-resume)
     await B.request('files:pause-download', { transferId })
     await B.until('files:list', { spaceId },
       (list) => { const e = Array.isArray(list) ? list.find((x) => x.path === '/held.bin') : null; return !!e && e.status === 'paused-interrupted' },
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Owner goes offline; B genuinely registers the outage.
     A.kill()
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
 
     // Owner returns → B's resumeForOwner reconnect hook fires. A MANUAL pause must NOT be resurrected.
     let autoResumed = false
     B.on('event:transfer-complete', (m) => { if (m.path === '/held.bin') autoResumed = true })
     B.on('event:decoration', (m) => { if (m.channel === 'transfer' && m.key === '/held.bin' && m.bytes > 0) autoResumed = true })
     A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, flags: aFlags })
-    await B.until('members:online', { spaceId }, (o) => o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => o.includes(aKey), { ms: 90000 })
     await sleep(8000) // give the reconnect hook ample time to (wrongly) auto-resume
 
     const row = (await B.request('files:list', { spaceId })).find((e) => e.path === '/held.bin')
@@ -68,7 +68,7 @@ test('manual pause survives an owner offline→online reconnect (no auto-resume)
     t.absent(fs.existsSync(path.join(B.downloads, 'held.bin')), 'the paused file did not complete on its own')
 
     // A manual resume still drives it to completion.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/held.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/held.bin', 120000)
     await B.request('files:download', { spaceId, path: '/held.bin', inPlace: true, ownerKey: aKey })
     const completion = await done
     t.ok(fs.readFileSync(completion.localPath).equals(bytes), 'manual resume completes byte-exact')

--- a/test/flow/loose-share-reconcile.test.js
+++ b/test/flow/loose-share-reconcile.test.js
@@ -29,7 +29,7 @@ test('a peer\'s loose share fans a files-scoped reconcile hint to the other peer
     const src = path.join(mkTmpDir(t), 'report.txt')
     fs.writeFileSync(src, Buffer.alloc(4096, 7))
 
-    const sawFilesHint = B.waitFor('event:reconcile', scopeIs('files', spaceId), scaled(60000))
+    const sawFilesHint = B.waitFor('event:reconcile', scopeIs('files', spaceId), 60000)
     await A.request('files:add', { spaceId, filePath: src, fileName: 'report.txt', fileSize: 4096 })
     await sawFilesHint
     t.pass('B received a files-scoped reconcile hint for A\'s loose share')

--- a/test/flow/loose-source-change-restart.test.js
+++ b/test/flow/loose-source-change-restart.test.js
@@ -39,7 +39,7 @@ test('loose download auto-restarts when the source changes mid-transfer',
 
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Track ordering: a transfer-complete for /big.bin BEFORE the supersede means the
     // original finished first and the restart was never exercised (the test would then
@@ -55,8 +55,8 @@ test('loose download auto-restarts when the source changes mid-transfer',
     const flowing = new Promise((resolve) => {
       B.on('event:decoration', (m) => { if (m.channel === 'transfer' && m.spaceId === spaceId && m.key === '/big.bin' && m.bytes > 0) resolve() })
     })
-    const supersededEvt = B.waitFor('event:transfer-superseded', (m) => m.path === '/big.bin', scaled(120000))
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin' && superseded, scaled(180000))
+    const supersededEvt = B.waitFor('event:transfer-superseded', (m) => m.path === '/big.bin', 120000)
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin' && superseded, 180000)
     await B.request('files:download', { spaceId, path: '/big.bin', inPlace: true, ownerKey: aKey })
     await flowing
 

--- a/test/flow/loose-unshare-mid-download.test.js
+++ b/test/flow/loose-unshare-mid-download.test.js
@@ -22,7 +22,7 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, scaled(ms)))
 async function seeRemote (peer, spaceId, name) {
   await peer.until('files:list', { spaceId },
     (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.inPlace && e.status === 'remote'),
-    { ms: scaled(60000) })
+    { ms: 60000 })
 }
 // Start a loose download and resolve once real bytes are flowing (genuinely mid-transfer).
 async function startAndFlow (peer, spaceId, name, ownerKey) {
@@ -81,7 +81,7 @@ test('loose unshare after a completed download: the peer keeps its downloaded co
     await A.request('files:add', { spaceId, filePath: path.join(aSrc, 'keep.bin'), fileName: 'keep.bin', fileSize: bytes.length })
     await seeRemote(B, spaceId, 'keep.bin')
 
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/keep.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/keep.bin', 120000)
     await B.request('files:download', { spaceId, path: '/keep.bin', inPlace: true, ownerKey: aKey })
     const localPath = (await done).localPath
     t.ok(fs.existsSync(localPath), 'peer downloaded the file')

--- a/test/flow/membership-cancel-convergence.test.js
+++ b/test/flow/membership-cancel-convergence.test.js
@@ -29,7 +29,7 @@ test('a withdrawn pending request clears on the member and stays cleared', { tim
   t.ok(showsB(await A.request('space:pending-requests', { spaceId: space.spaceId }), bKey), 'A shows B as a pending request')
 
   await B.request('space:leave', { spaceId: space.spaceId })
-  await A.until('space:pending-requests', { spaceId: space.spaceId }, (reqs) => !showsB(reqs, bKey), { ms: scaled(30000), every: 500 })
+  await A.until('space:pending-requests', { spaceId: space.spaceId }, (reqs) => !showsB(reqs, bKey), { ms: 30000, every: 500 })
   t.absent(showsB(await A.request('space:pending-requests', { spaceId: space.spaceId }), bKey), 'the withdrawn request is gone')
 
   // Durable: A restarts (same storage + KEK) and does NOT resurrect the withdrawn request.
@@ -67,6 +67,6 @@ test('a withdrawal reaches a member offline at withdrawal time (pending-cancel r
 
   // A returns; B's pending-cancel replay reaches it on the fresh connection and clears it durably.
   A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, downloads: mkTmpDir(t), flags: flagsFor(aKek) })
-  await A.until('space:pending-requests', { spaceId: space.spaceId }, (reqs) => !showsB(reqs, bKey), { ms: scaled(60000), every: 500 })
+  await A.until('space:pending-requests', { spaceId: space.spaceId }, (reqs) => !showsB(reqs, bKey), { ms: 60000, every: 500 })
   t.absent(showsB(await A.request('space:pending-requests', { spaceId: space.spaceId }), bKey), 'the offline-at-withdrawal member converged via replay')
 })

--- a/test/flow/mirror-pause.test.js
+++ b/test/flow/mirror-pause.test.js
@@ -45,7 +45,7 @@ test('REGRESSION (FIX-128): pausing a mirror aborts the in-flight download; resu
     await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })
     await scanDone
 
-    await B.until('share:list', { spaceId }, (l) => Array.isArray(l) && l.some((s) => s.id === share.id), { ms: scaled(60000) })
+    await B.until('share:list', { spaceId }, (l) => Array.isArray(l) && l.some((s) => s.id === share.id), { ms: 60000 })
 
     const dest = mkTmpDir(t)
     const destFile = path.join(dest, 'big.bin')

--- a/test/flow/overlay-mirror-sync.test.js
+++ b/test/flow/overlay-mirror-sync.test.js
@@ -43,15 +43,15 @@ test('overlay mirror: re-fetches on owner edit and removes on owner delete',
     await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })
     await scanDone
 
-    await B.until('share:list', { spaceId }, (l) => Array.isArray(l) && l.some((s) => s.id === share.id), { ms: scaled(60000) })
+    await B.until('share:list', { spaceId }, (l) => Array.isArray(l) && l.some((s) => s.id === share.id), { ms: 60000 })
     const dest = mkTmpDir(t)
-    const active = B.waitFor('event:foreign-folder-mount-status', (m) => m.shareId === share.id && m.status === 'active', scaled(90000))
+    const active = B.waitFor('event:foreign-folder-mount-status', (m) => m.shareId === share.id && m.status === 'active', 90000)
     await B.request('foreign-folder:mount', { spaceId, ownerKey: aKey, shareId: share.id, mountPath: dest })
     await active
 
     // Initial mirror: both files land via overlay fetch-to-mount.
     await waitForContent(path.join(dest, 'doc.txt'), v1)
-    await waitForFile(path.join(dest, 'keep.bin'), { present: true, ms: scaled(70000) })
+    await waitForFile(path.join(dest, 'keep.bin'), { present: true, ms: 70000 })
     t.ok(fs.readFileSync(path.join(dest, 'keep.bin')).equals(keep), 'keep.bin mirrored byte-exact')
 
     // Owner EDITS doc.txt → new content hash → mirror must re-fetch v2.
@@ -64,7 +64,7 @@ test('overlay mirror: re-fetches on owner edit and removes on owner delete',
     // Owner DELETES doc.txt → mirror removes it; keep.bin stays.
     fs.unlinkSync(path.join(folder, 'doc.txt'))
     await A.request('event:owned-folder-fs-event', { shareId: share.id, action: 'unlink', relPath: 'doc.txt', absPath: path.join(folder, 'doc.txt') })
-    await waitForFile(path.join(dest, 'doc.txt'), { present: false, ms: scaled(70000) })
+    await waitForFile(path.join(dest, 'doc.txt'), { present: false, ms: 70000 })
     t.absent(fs.existsSync(path.join(dest, 'doc.txt')), 'owner delete removed the file from the overlay mirror')
     t.ok(fs.existsSync(path.join(dest, 'keep.bin')), 'unrelated mirrored file kept')
   })

--- a/test/flow/overlay-no-store-growth.test.js
+++ b/test/flow/overlay-no-store-growth.test.js
@@ -46,10 +46,10 @@ test('overlay: publish imports no blob; download writes no content blocks into t
     // ── Consumer: measure the store right before the download ──
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
     const bBeforeDownload = dirSize(bStore)
 
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', scaled(60000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', 60000)
     const res = await B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'big.bin' })
     t.ok(res?.transferId, 'download returned a transferId (non-blocking)')
     const completed = await done

--- a/test/flow/overlay-owner-visibility.test.js
+++ b/test/flow/overlay-owner-visibility.test.js
@@ -24,7 +24,7 @@ test('overlay owner refreshes incrementally during the scan, not only at the end
     let scanCompleted = false
     let updatesDuringScan = 0
     A.on('event:share-files-updated', (m) => { if (m.shareId === share.id && !scanCompleted) updatesDuringScan++ })
-    const scanDone = A.waitFor('event:owned-folder-scan-completed', (m) => m.shareId === share.id, scaled(120000))
+    const scanDone = A.waitFor('event:owned-folder-scan-completed', (m) => m.shareId === share.id, 120000)
     scanDone.then(() => { scanCompleted = true }).catch(() => {})
 
     await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })

--- a/test/flow/overlay-two-peer.test.js
+++ b/test/flow/overlay-two-peer.test.js
@@ -44,14 +44,14 @@ test('overlay: owner publishes in place (no second copy); peer fetches by conten
     // B browses the catalog and waits until the file is `remote` (owner finished hashing).
     const listed = await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
     const entry = listed.entries.find((e) => e.relPath === 'big.bin')
     t.is(entry.size, bytes.length, 'catalog carries the size')
     t.ok(entry.hash, 'catalog carries the content hash')
 
     // B fetches by content hash straight from the owner; bytes match. The download
     // is non-blocking (returns a transferId immediately), completion via event.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', scaled(60000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/Vault/big.bin', 60000)
     const res = await B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'big.bin' })
     t.ok(res?.transferId, 'overlay download returned a transferId (non-blocking)')
     const completed = await done
@@ -87,10 +87,10 @@ test('overlay: a file is unavailable while the owner is offline',
     // Wait until B sees the hashed entry (remote) BEFORE the owner goes offline.
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'note.txt' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     A.kill()
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
 
     const files = await B.request('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id })
     t.is(files.entries.find((e) => e.relPath === 'note.txt')?.status, 'unavailable', 'file is unavailable with the owner offline')

--- a/test/flow/overlay-version-skew.test.js
+++ b/test/flow/overlay-version-skew.test.js
@@ -29,7 +29,7 @@ test('R14: an overlay share seen by a peer without overlay support degrades, nev
 
     // B replicates the share record (proves it SEES the overlay share)…
     await B.until('share:list', { spaceId }, (l) => Array.isArray(l) && l.some((s) => s.id === share.id),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // …but, lacking overlay support, it lists the share EMPTY (UNSUPPORTED → []),
     // not as a broken eager drive. No crash, no mis-route.

--- a/test/flow/paused-reason.test.js
+++ b/test/flow/paused-reason.test.js
@@ -33,13 +33,13 @@ test('FIX-REMOVE-1: an online owner removing mid-download terminates the transfe
 
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     const flowing = new Promise((resolve) => {
       B.on('event:decoration', (m) => { if (m.channel === 'transfer' && m.spaceId === spaceId && m.key === '/big.bin' && m.bytes > 0) resolve() })
     })
     // The removal is terminal → a 'removed' signal, NOT a lingering 'paused' event.
-    const removed = B.waitFor('event:transfer-removed', (m) => m.path === '/big.bin', scaled(120000))
+    const removed = B.waitFor('event:transfer-removed', (m) => m.path === '/big.bin', 120000)
     await B.request('files:download', { spaceId, path: '/big.bin', inPlace: true, ownerKey: aKey })
     await flowing
 

--- a/test/flow/quit-mid-index-conveyance.test.js
+++ b/test/flow/quit-mid-index-conveyance.test.js
@@ -27,14 +27,14 @@ test('quit mid-index: owner goes offline and the mid-index file degrades to unav
     fs.writeFileSync(src, bytes)
     A.request('files:add', { spaceId, filePath: src, fileName: 'reel.bin', fileSize: bytes.length }).catch(() => {})
     await B.until('files:list', { spaceId },
-      (l) => l.find((e) => e.path === '/reel.bin')?.status === 'preparing', { ms: scaled(60000), every: 100 })
+      (l) => l.find((e) => e.path === '/reel.bin')?.status === 'preparing', { ms: 60000, every: 100 })
 
     await A.request('shutdown').catch(() => {})
     // Bound stays under the un-scaled 15s PRESENCE_TTL_MS so a broken announce can't pass via
     // plain lease expiry under scaled CI.
     await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: Math.min(scaled(8000), 12000) })
     const settled = await B.until('files:list', { spaceId },
-      (l) => l.find((e) => e.path === '/reel.bin')?.status === 'unavailable', { ms: scaled(20000) })
+      (l) => l.find((e) => e.path === '/reel.bin')?.status === 'unavailable', { ms: 20000 })
     t.is(settled.find((e) => e.path === '/reel.bin').status, 'unavailable',
       'mid-index file resolves to unavailable, not stuck preparing')
   })

--- a/test/flow/quit-mid-index-preserves-share.test.js
+++ b/test/flow/quit-mid-index-preserves-share.test.js
@@ -32,7 +32,7 @@ test('graceful quit mid-index preserves the share: restart re-hashes to mine, no
     // Quit WHILE the owner is mid-index (advertised null-hash → own status 'publishing').
     await A.until('files:list', { spaceId },
       (l) => Array.isArray(l) && l.find((e) => e.path === '/archive.bin')?.status === 'publishing',
-      { ms: scaled(30000), every: 100 })
+      { ms: 30000, every: 100 })
     const aPid = A.sidecar._process.pid
     await A.request('shutdown').catch(() => {})
     // Barrier: the shutdown IPC settles before the process fully exits and releases the RocksDB
@@ -44,7 +44,7 @@ test('graceful quit mid-index preserves the share: restart re-hashes to mine, no
     A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, flags: aFlags })
     const row = await A.until('files:list', { spaceId },
       (l) => Array.isArray(l) && l.find((e) => e.path === '/archive.bin')?.status === 'mine',
-      { ms: scaled(120000), every: 500 })
+      { ms: 120000, every: 500 })
     t.is(row.find((e) => e.path === '/archive.bin').status, 'mine',
       'graceful quit mid-index left the share intact — restart re-hashed it, not reverted')
 

--- a/test/flow/reconcile-hints.test.js
+++ b/test/flow/reconcile-hints.test.js
@@ -20,17 +20,17 @@ test('REGRESSION (FIX-EDA-18): member and share transitions fan reconcile hints'
     const B = await launchPeer(t, { bootstrap, displayName: 'Bob', downloads: mkTmpDir(t), flags: FLAGS })
 
     // Arm before the join: the arrival hint fires during connect, when the spaceId is not yet known.
-    const sawJoinHint = A.waitFor('event:reconcile', scopeIs('members'), scaled(60000))
+    const sawJoinHint = A.waitFor('event:reconcile', scopeIs('members'), 60000)
     const spaceId = await connectInSpace(t, A, B)
     await sawJoinHint
     t.pass('handshake arrival fanned a members-scoped reconcile hint')
 
-    const sawShares = B.waitFor('event:reconcile', scopeIs('shares', spaceId), scaled(60000))
+    const sawShares = B.waitFor('event:reconcile', scopeIs('shares', spaceId), 60000)
     await A.request('share:create', { spaceId, name: 'Vault', contentMode: 'overlay' })
     await sawShares
     t.pass('share creation fanned a shares-scoped reconcile hint')
 
-    const sawLeave = A.waitFor('event:reconcile', scopeIs('members', spaceId), scaled(60000))
+    const sawLeave = A.waitFor('event:reconcile', scopeIs('members', spaceId), 60000)
     await B.request('space:leave', { spaceId })
     await sawLeave
     t.pass('leave fanned a members-scoped reconcile hint')

--- a/test/flow/seeder-quit-mid-download.test.js
+++ b/test/flow/seeder-quit-mid-download.test.js
@@ -35,7 +35,7 @@ test('seeder quitting mid-download surfaces paused-offline, then auto-resumes',
 
     await B.until('files:list', { spaceId },
       (f) => Array.isArray(f) && f.some((e) => e.path === '/big.bin' && e.inPlace && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     // Start the download; resolve once real bytes are flowing (genuinely mid-transfer).
     const flowing = new Promise((resolve) => {
@@ -46,19 +46,19 @@ test('seeder quitting mid-download surfaces paused-offline, then auto-resumes',
 
     // A quits — the only seeder goes away mid-download.
     A.kill()
-    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: scaled(90000) })
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
 
     // THE REGRESSION ASSERTION: the row settles at paused-offline, never 'error'. On the
     // bug this poll never resolves (status is stuck 'error') → red.
     const settled = await B.until('files:list', { spaceId },
       (l) => Array.isArray(l) && l.find((e) => e.path === '/big.bin')?.status === 'paused-offline',
-      { ms: scaled(90000) })
+      { ms: 90000 })
     const row = settled.find((e) => e.path === '/big.bin')
     t.is(row.status, 'paused-offline', 'owner-offline state, not a failure')
     t.absent(row.errorCode, 'no errorCode recorded for a quit seeder')
 
     // A returns with the SAME storage (source still servable) → auto-resume, no manual click.
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/big.bin', 120000)
     A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, flags: aFlags })
     const completed = await done
 

--- a/test/flow/serve-ledger-two-peer.test.js
+++ b/test/flow/serve-ledger-two-peer.test.js
@@ -21,7 +21,7 @@ async function shareAndSee (A, peers, spaceId, aSrc, name, seed, mb) {
   fs.writeFileSync(path.join(aSrc, name), bytes)
   await A.request('files:add', { spaceId, filePath: path.join(aSrc, name), fileName: name, fileSize: bytes.length })
   for (const P of peers) {
-    await P.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: scaled(60000) })
+    await P.until('files:list', { spaceId }, (f) => Array.isArray(f) && f.some((e) => e.path === '/' + name && e.status === 'remote'), { ms: 60000 })
   }
   return bytes
 }
@@ -48,18 +48,18 @@ test('owner serve ledger: reflects a downloading peer, its pause, and clears on 
     await shareAndSee(A, [B], spaceId, aSrc, 'feed.bin', 31, 16)
     await startAndFlow(B, spaceId, 'feed.bin', aKey)
 
-    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/feed.bin'); return !!s && s.peers.includes(bKey) }, { ms: scaled(30000) })
+    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/feed.bin'); return !!s && s.peers.includes(bKey) }, { ms: 30000 })
     t.pass('owner ledger shows the downloading peer')
 
     const transferId = (await B.request('files:list', { spaceId })).find((e) => e.path === '/feed.bin')?.transferId
     await B.request('files:pause-download', { transferId })
-    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/feed.bin'); return !!s && s.pausedKeys.includes(bKey) }, { ms: scaled(30000) })
+    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/feed.bin'); return !!s && s.pausedKeys.includes(bKey) }, { ms: 30000 })
     t.pass('owner ledger surfaces the peer as paused')
 
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/feed.bin', scaled(120000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/feed.bin', 120000)
     await B.request('files:download', { spaceId, path: '/feed.bin', inPlace: true, ownerKey: aKey }) // resume
     await done
-    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/feed.bin'); return !s || !s.peers.includes(bKey) }, { ms: scaled(45000) })
+    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/feed.bin'); return !s || !s.peers.includes(bKey) }, { ms: 45000 })
     t.pass('owner ledger clears the peer after completion')
 
     A.kill()
@@ -83,15 +83,15 @@ test('owner serve ledger: two peers download, one cancels → the canceller is d
     await startAndFlow(B, spaceId, 'shared.bin', aKey)
     await startAndFlow(C, spaceId, 'shared.bin', aKey)
 
-    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/shared.bin'); return !!s && s.peers.includes(bKey) && s.peers.includes(cKey) }, { ms: scaled(30000) })
+    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/shared.bin'); return !!s && s.peers.includes(bKey) && s.peers.includes(cKey) }, { ms: 30000 })
     t.pass('owner ledger shows both downloaders')
 
     const cTransfer = (await C.request('files:list', { spaceId })).find((e) => e.path === '/shared.bin')?.transferId
     await C.request('files:cancel-download', { transferId: cTransfer })
-    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/shared.bin'); return !s || !s.peers.includes(cKey) }, { ms: scaled(45000) })
+    await A.until('serving:summary-list', { spaceId }, (list) => { const s = summaryFor(list, '/shared.bin'); return !s || !s.peers.includes(cKey) }, { ms: 45000 })
     t.pass('owner ledger dropped the canceller')
 
-    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/shared.bin', scaled(180000))
+    const done = B.waitFor('event:transfer-complete', (m) => m.path === '/shared.bin', 180000)
     await done
     t.pass('the other peer completes its download')
 

--- a/test/flow/share-prepare-progress.test.js
+++ b/test/flow/share-prepare-progress.test.js
@@ -60,7 +60,7 @@ test('owner with the flag off never broadcasts prepare-progress',
     // frames would have been sent. None should have, with the owner's flag off.
     await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
       (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
-      { ms: scaled(60000) })
+      { ms: 60000 })
 
     t.is(prepareSeen, 0, 'no prepare-progress reached the receiver while the owner flag was off')
   })

--- a/test/flow/share-visibility.test.js
+++ b/test/flow/share-visibility.test.js
@@ -74,7 +74,7 @@ test('REGRESSION (HOL): a new share reaches a peer that is mid-download — no p
     await A.request('files:add', { spaceId, filePath: src, fileName: 'big.bin', fileSize: bytes.length })
 
     const entry = await waitForCatalogEntry(B, spaceId, '/big.bin')
-    const inFlight = B.waitFor('event:decoration', (m) => m.channel === 'transfer' && m.spaceId === spaceId && m.key === '/big.bin' && (m.bytes || 0) > 0, scaled(60000))
+    const inFlight = B.waitFor('event:decoration', (m) => m.channel === 'transfer' && m.spaceId === spaceId && m.key === '/big.bin' && (m.bytes || 0) > 0, 60000)
     const dl = B.request('files:download', { spaceId, path: entry.path, inPlace: true, ownerKey: entry.owner.publicKey })
     dl.catch(() => {})
     const firstProgress = await inFlight
@@ -83,7 +83,7 @@ test('REGRESSION (HOL): a new share reaches a peer that is mid-download — no p
     // Note: on fast loopback the transfer can finish before shares-updated arrives, so this
     // is an end-to-end guard, not the deterministic proof — that lives in
     // test/integration/overlay-vendor-backpressure.test.js (seeder backpressure red-first).
-    const sawShare = B.waitFor('event:shares-updated', (m) => m.spaceId === spaceId, scaled(15000))
+    const sawShare = B.waitFor('event:shares-updated', (m) => m.spaceId === spaceId, 15000)
     await A.request('share:create', { spaceId, name: 'Vault' })
     await sawShare
     t.pass('B received event:shares-updated while the download was active — no pause required')

--- a/test/unit/event-taxonomy.test.js
+++ b/test/unit/event-taxonomy.test.js
@@ -29,6 +29,7 @@ const TAXONOMY = {
   'event:shares-updated': 'poke',
   'event:share-files-updated': 'poke',
   'event:members-updated': 'poke',
+  'event:mirrors-updated': 'poke',
   'event:member-left': 'poke',
   'event:member-avatar-updated': 'poke',
   'event:member-join-request': 'poke',


### PR DESCRIPTION
The wait helpers scale the ms they receive, so call sites that also passed scaled() squared the CI factor and pushed their deadlines past brittle's per-test timeout — a hang then reported a bare timeout instead of what it was waiting for. Corrects 125 call sites, adds a lint tripwire, registers event:mirrors-updated in the taxonomy, and drops the trailing slash in .gitignore so a worktree node_modules symlink can no longer be committed.

## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [ ] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [x] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [x] **N/A** — docs / comments / config only (no runtime surface)

- [ ] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [ ] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [x] N/A — no UI change.
