### PR TITLE
[fix] Resume downloads after a dropped connection

### DIFF
--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -906,6 +906,9 @@ const folderEngine = createOverlayDownloadEngine({
 // write to the downloads folder. No second copy stored (reSeed:false). When the
 // hash is not yet advertised (owner still hashing), report queued.
 export async function overlayRequestDownload(spaceId, share, relPath) {
+  // Doubles as the manual resume, so retire any pause marker before the guards below can return
+  // early — a marker left set suppresses every later auto-resume for this row.
+  folderEngine.clearPauseMarker(transferIdFor(spaceId, share.id, relPath))
   if (!getOverlay()) return { queued: true }
   const { keyHex, sck, encrypted, readable } = await resolvePeerCatalog(spaceId, share)
   if (!readable) return { queued: true }

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -220,9 +220,13 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       // Record the pending row up front (carrying ownerKey + the content hash it is fetching) so
       // the download survives an owner-offline gap and auto-resumes on reconnect, and so a later
       // reconcile can tell a re-added-identical entry (drop) from changed content (restart).
+      // recordPending OVERWRITES the row, so the resumed byte count has to be carried through
+      // explicitly: a start() that then bails (owner offline) would otherwise reset a part-
+      // downloaded row's progress to zero.
       await recordPending(job.spaceId, job.pendingKey, {
         total: job.size, inPlace: channel.inPlace, ownerKey: job.ownerPublicKey,
-        finalPath: job.finalPath, sourceSeq: job.sourceSeq, contentHash: job.contentHash, ...channel.pendingExtra(job),
+        finalPath: job.finalPath, sourceSeq: job.sourceSeq, contentHash: job.contentHash,
+        bytesTransferred: job.prevBytes || 0, ...channel.pendingExtra(job),
       })
 
       // A pause/cancel/supersede may have landed during the await above, before any
@@ -233,7 +237,12 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
         return { queued: true } // cancelByKey already cleared the row + emitted
       }
       if (slot.paused) { registry.delete(transferId); channel.emitUpdated(job.spaceId); return { queued: true } }
-      if (!ownerOnline(job.ownerPublicKey)) { registry.delete(transferId); channel.emitUpdated(job.spaceId); return { queued: true } }
+      if (!ownerOnline(job.ownerPublicKey)) {
+        registry.delete(transferId)
+        log.debug('overlay download queued — owner not present on the control plane:', job.relPath)
+        channel.emitUpdated(job.spaceId)
+        return { queued: true }
+      }
 
       // Preflight: the size is known up front, so refuse a download the volume cannot hold
       // BEFORE any scheduler/holder work. On NTFS the receive path's full-size preallocation
@@ -274,15 +283,27 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     }
   }
 
-  // Stop the fetch but KEEP the partial + pending row so a later start() resumes it.
+  // Stop the fetch but KEEP the partial + pending row so a later start() resumes it. With no
+  // slot the fetch already settled (a dropped connection beat the click) — the row is still
+  // pending, so record the intent anyway: without the marker the next reconnect auto-resumes a
+  // download the user just paused.
   function pause (transferId) {
     const tr = registry.get(transferId)
-    if (!tr) return false
+    if (!tr) {
+      pausedHashes.set(transferId, null)
+      return true
+    }
     tr.paused = true
     pausedHashes.set(transferId, tr.contentHash) // remember the hash so a later discard can signal STOPPED
     if (tr.fetching) getOverlay()?.cancelFetch(tr.contentHash, { discardPartial: false })
     return true
   }
+
+  // A user's explicit download/resume click outranks a manual-pause marker. Cleared HERE rather
+  // than only in start(), because an attempt that dies before start() (an unreadable catalog, an
+  // owner that just went offline) would otherwise leave the marker set — and a set marker makes
+  // runReconcile skip the row as "manually paused" forever, so no reconnect ever resumes it.
+  function clearPauseMarker (transferId) { pausedHashes.delete(transferId) }
 
   // Discard: stop + drop the partial + pending row. Works in-flight (the slot is left
   // for start()'s guard / the fetch IIFE to honor `cancelled`) and on a paused/restart-
@@ -446,5 +467,5 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     if (pending) channel.emitRemovedByOwner?.(spaceId, pendingKey, pending, transferId)
   }
 
-  return { start, pause, cancel, cancelByKey, resumeForOwner, reconcileOnAppend, dropRemoved, supersede, releaseForRepublish, has, activeSlots: () => registry.entries(), _registry: registry }
+  return { start, pause, clearPauseMarker, cancel, cancelByKey, resumeForOwner, reconcileOnAppend, dropRemoved, supersede, releaseForRepublish, has, activeSlots: () => registry.entries(), _registry: registry }
 }

--- a/src/shared/transfer/backends/overlay/vendor/chunk-scheduler.js
+++ b/src/shared/transfer/backends/overlay/vendor/chunk-scheduler.js
@@ -72,6 +72,12 @@ export class ChunkScheduler {
     this._sinceYield = 0   // [mirall] §HOL event-loop yield counter
 
     this._peers = new Set()
+    // [mirall] Peers we have sent a content-request to but not yet heard a chunk list from. A peer
+    // only enters _peers once its list arrives, so without this a holder that dies inside that
+    // window is invisible to removePeer and the fetch waits out the whole idle timeout instead of
+    // failing fast — 30s in which the transfer still holds its slot and every reconnect-driven
+    // resume is skipped as "already downloading".
+    this._requested = new Set()
     this._started = false
     this._settingUp = false
     this._finalizing = false
@@ -171,6 +177,7 @@ export class ChunkScheduler {
 
   /** A peer responded with the chunk list. First response starts the transfer. */
   async onChunkHashes (peer, chunks) {
+    this._requested.delete(peer) // it answered — from here on its loss is handled by _peers
     if (this._done) return
     this._peers.add(peer)
     if (!this._peerInflight.has(peer)) this._peerInflight.set(peer, 0)
@@ -282,16 +289,30 @@ export class ChunkScheduler {
     if (now - this._lastReportAt >= this._reportInterval) this._reportHave(now)
   }
 
+  // [mirall] We asked this peer for the content; it has not answered yet. Tracked so its loss is
+  // still a loss (see _requested).
+  noteRequested (peer) {
+    if (!this._done) this._requested.add(peer)
+  }
+
   /** A peer went away — return its inflight chunks to the pool. */
   removePeer (peer) {
-    if (!this._peers.has(peer)) return
+    const wasRequested = this._requested.delete(peer)
+    if (!this._peers.has(peer)) {
+      // [mirall] It died before its chunk list arrived. If it was the last holder we were waiting
+      // on, the fetch is already doomed — fail now rather than idling for the full timeout.
+      if (wasRequested && !this._done && this._peers.size === 0 && this._requested.size === 0) {
+        return this._fail(new Error('all peers gone before any chunk list arrived'))
+      }
+      return
+    }
     this._peers.delete(peer)
     this._peerInflight.delete(peer)
     for (const [index, p] of this._inflight) {
       if (p === peer) this._inflight.delete(index) // back to needed (still in _needed)
     }
     if (this._done) return
-    if (this._peers.size === 0 && this._needed.size > 0) {
+    if (this._peers.size === 0 && this._requested.size === 0 && this._needed.size > 0) {
       return this._fail(new Error('all peers gone with ' + this._needed.size + ' chunk(s) outstanding'))
     }
     this._assign()

--- a/src/shared/transfer/backends/overlay/vendor/protocol-v2.js
+++ b/src/shared/transfer/backends/overlay/vendor/protocol-v2.js
@@ -159,7 +159,10 @@ export class OverlayProtocolV2 {
     sched.shared = sched.promise().finally(() => this._schedulers.delete(p))
     // [mirall] honor a cancel/pause that arrived before this scheduler existed.
     if (this._cancelPending.delete(p)) { sched.cancel(); return sched.shared }
-    for (const peer of peers) this.requestContent(peer, contentHash, null)
+    for (const peer of peers) {
+      sched.noteRequested(peer) // [mirall] so losing it before its chunk list arrives fails the fetch fast
+      this.requestContent(peer, contentHash, null)
+    }
     return sched.shared
   }
 

--- a/src/shared/transfer/content-peer-sockets.js
+++ b/src/shared/transfer/content-peer-sockets.js
@@ -25,6 +25,13 @@ export function createContentPeerSockets() {
       return !!socketToPeers.get(socket)?.has(profileKeyHex)
     },
 
+    // Is this peer reachable on ANY live content socket? Distinct from authorized(), which asks
+    // about one socket: this is the "can the bulk plane still talk to them at all" question.
+    hasPeer(profileKeyHex) {
+      for (const keys of socketToPeers.values()) if (keys.has(profileKeyHex)) return true
+      return false
+    },
+
     // Destroy every socket this profile is authenticated on. Returns how many were dropped.
     destroyFor(profileKeyHex) {
       let dropped = 0

--- a/src/shared/transfer/content-swarm.js
+++ b/src/shared/transfer/content-swarm.js
@@ -71,6 +71,8 @@ function onContentConnection(socket, peerInfo) {
   const remoteKey = remoteKeyHex.slice(0, 16) || 'unknown'
   if (contentSpaceTopics.size === 0) { socket.destroy(); return }
   applyNetImpairment(socket) // TEST-ONLY: no-op unless runtime-config.netImpair is set
+  log.debug('connection', remoteKey + '...', peerInfo.client ? '(we dialed)' : '(they dialed)')
+  socket.on('close', () => log.debug('connection closed', remoteKey + '...'))
 
   const mux = Protomux.from(socket)
   const channel = mux.createChannel({
@@ -94,6 +96,7 @@ function onContentConnection(socket, peerInfo) {
       // connection (a different Noise key) fails.
       if (!verifyIdentityBinding(peerInfo, msg)) { log.warn('content-hello rejected from', remoteKey + '...'); return }
       contentPeerSockets.add(socket, msg.profileKey)
+      log.debug('content-hello verified from', msg.profileKey.slice(0, 12) + '... — resuming its downloads')
       // The plane can now serve/fetch this owner → resume its paused/interrupted downloads.
       contentResumeHook?.(msg.profileKey)
     },
@@ -158,6 +161,22 @@ export async function refreshContentDiscoveries() {
   if (!contentSwarm) return
   for (const [, discovery] of contentDiscoveries) {
     try { await discovery.refresh({ client: true, server: true }) } catch {}
+  }
+}
+
+// Is this owner reachable on the bulk plane at all? A pending download from an owner with no
+// content socket is a stalled transfer — swarm.js escalates that into a discovery refresh.
+export function contentPlaneHasPeer(profileKeyHex) {
+  return contentPeerSockets.hasPeer(profileKeyHex)
+}
+
+export function getContentPlaneStatus() {
+  if (!contentSwarm) return { active: false, connections: 0, authedPeers: 0, topics: 0 }
+  return {
+    active: true,
+    connections: contentSwarm.connections?.size || 0,
+    authedPeers: contentPeerSockets.size,
+    topics: contentSpaceTopics.size,
   }
 }
 

--- a/src/shared/transfer/loose-overlay.js
+++ b/src/shared/transfer/loose-overlay.js
@@ -14,7 +14,7 @@ import {
 } from '../shares/share-catalog.js'
 import { markListIncomplete } from './list-deficits.js'
 import { markOwnedSource, getOwnedSourcePath, clearOwnedSource } from './files.js'
-import { getPendingFor } from './pending-transfers.js'
+import { getPendingFor, recordPending } from './pending-transfers.js'
 import { resolveDest } from './download-dest.js'
 import { getDownloadDir } from '../core/paths.js'
 import { listSpaces, getSpace } from '../spaces/space.js'
@@ -360,9 +360,22 @@ export function looseHasTransfer (transferId) { return looseEngine.has(transferI
 export function looseTransferActive (spaceId, relPath) { return looseEngine.has(looseTransferIdFor(spaceId, relPath)) }
 
 export async function looseDownload (spaceId, member, drivePath) {
+  const relPath = rel(drivePath)
+  // This is the manual resume path too, so retire any pause marker up front — start() clears it
+  // as well, but the guards below can return before we ever reach start().
+  looseEngine.clearPauseMarker(looseTransferIdFor(spaceId, relPath))
   if (!getOverlay() || !(member?.looseCatalogKey || member?.looseCatalogKeyEnc)) return { queued: true }
   const job = await buildLooseJob(spaceId, member, drivePath)
-  if (!job) return { queued: true }
+  if (!job) {
+    // The catalog entry is unreadable right now (owner offline, or the read budget expired under
+    // reconnect churn). Record the intent so the reconnect machinery owns the retry: with no row,
+    // nothing would ever retry and the click is silently lost.
+    await recordPending(spaceId, drivePath, {
+      inPlace: true, shareId: LOOSE_SHARE_ID, relPath, ownerKey: member.publicKey, total: 0,
+    }).catch((err) => log.debug('loose intent row failed:', relPath, err.message))
+    ipcRef?.emit('event:files-updated', { spaceId })
+    return { queued: true }
+  }
   return looseEngine.start(job)
 }
 

--- a/src/shared/transfer/pending-transfers.js
+++ b/src/shared/transfer/pending-transfers.js
@@ -82,6 +82,17 @@ export async function listPendingForSpace(spaceId) {
   return out
 }
 
+// Owners we are still waiting on bytes from, deduped. Read on every convergence tick, so it stays
+// a bee scan with no per-row resolution.
+export async function listPendingOwnerKeys() {
+  const owners = new Set()
+  for await (const entry of bee.createReadStream()) {
+    const ownerKey = entry.value?.ownerKey
+    if (typeof ownerKey === 'string' && ownerKey) owners.add(ownerKey)
+  }
+  return owners
+}
+
 export async function clearPendingForSpace(spaceId) {
   const batch = bee.batch()
   for await (const entry of bee.createReadStream({ gte: spaceId + ':', lt: spaceId + ';' })) {

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -30,7 +30,7 @@ import { catalogKeyField } from '../shares/share-catalog.js'
 import { HEX64 } from '../invite-envelope.js'
 import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, leaveFrameBound } from './handshake-guard.js'
 import { createAnnounceLedger, escalationDue, announceStatus } from './announce-ledger.js'
-import { joinContentTopic, leaveContentTopic, refreshContentDiscoveries, destroyContentPeerSockets } from './content-swarm.js'
+import { joinContentTopic, leaveContentTopic, refreshContentDiscoveries, destroyContentPeerSockets, contentPlaneHasPeer, getContentPlaneStatus } from './content-swarm.js'
 import { applyNetImpairment } from './net-impair.js'
 import { takeIncompleteListSpaces, clearListDeficits } from './list-deficits.js'
 import { LOOSE_SHARE_ID } from './transfer-id.js'
@@ -1353,6 +1353,64 @@ async function runConvergenceTick() {
   // short-lived session heals here on a later one. Throttled per key inside the
   // scheduler; retired keys (complete or past the sweep cap) never come back.
   for (const key of await captureDeficits()) scheduleCapture(key)
+  try { await rescueStalledTransfers() } catch (err) { log.debug('stalled-transfer rescue failed:', err.message) }
+}
+
+// Hyperswarm stops re-dialing a peer whose connections keep dying young: a link that drops inside
+// its prove-yourself window never resets the peer's attempt counter, and after the fourth such
+// close the peer loses its retry timer altogether — the next automatic dial is a topic re-lookup
+// ten minutes out. The escalation above cannot save us: it is gated on a ROSTER deficit, and a
+// two-peer space whose roster is fully replicated never has one, so a download can sit dead while
+// the swarm believes it is converged.
+//
+// A pending download whose owner we hold no socket for is exactly that state, and a discovery
+// refresh is the one lever that clears it (rediscovering a peer resets its attempts). Both planes
+// need it: the bulk plane carries the bytes, but the control plane carries the presence lease the
+// download's resume gate reads — rescuing only one leaves the transfer gated behind the other.
+// Refresh eagerly at first — a flapping link brings the peer back within a second or two, and every
+// cycle we sit out is a cycle the transfer makes no progress. But an owner who is simply offline
+// would then have us re-announce forever, so each fruitless attempt backs the next one off, up to a
+// quiet ceiling. Any attempt that finds every owner reachable resets it.
+const STALL_RESCUE_MIN_MS = 10_000
+const STALL_RESCUE_MAX_MS = 300_000
+let stalledOwnersHook = null
+let lastStallRescueAt = 0
+let stallRescueBackoffMs = STALL_RESCUE_MIN_MS
+let stallRescueInFlight = false
+
+export function setStalledOwnersHook(fn) { stalledOwnersHook = fn }
+
+export async function rescueStalledTransfers() {
+  if (!swarm || !stalledOwnersHook || stallRescueInFlight) return false
+
+  stallRescueInFlight = true
+  try {
+    const contentActive = getContentPlaneStatus().active
+    let controlDown = false
+    let contentDown = false
+    for (const ownerKey of await stalledOwnersHook()) {
+      if (!connectedPeers.has(ownerKey)) controlDown = true
+      if (contentActive && !contentPlaneHasPeer(ownerKey)) contentDown = true
+    }
+    if (!controlDown && !contentDown) {
+      stallRescueBackoffMs = STALL_RESCUE_MIN_MS // everyone we are waiting on is reachable
+      return false
+    }
+    if (Date.now() - lastStallRescueAt < stallRescueBackoffMs) return false
+
+    lastStallRescueAt = Date.now()
+    stallRescueBackoffMs = Math.min(stallRescueBackoffMs * 2, STALL_RESCUE_MAX_MS)
+    log.info('stalled transfer — refreshing discovery:', controlDown ? 'control' : '', contentDown ? 'content' : '')
+    if (controlDown) {
+      for (const [spaceId, discovery] of spaceDiscoveries) {
+        try { await discovery.refresh({ client: true, server: true }) } catch (err) { log.debug('stall refresh failed for', spaceId, err.message) }
+      }
+    }
+    if (contentDown) await refreshContentDiscoveries()
+    return true
+  } finally {
+    stallRescueInFlight = false
+  }
 }
 
 function startConvergenceTick() {
@@ -1852,6 +1910,7 @@ export function getSwarmStatus() {
       tableSize: safeRoutingTableSize(),
     },
     topics: spaceTopics.size,
+    contentPlane: getContentPlaneStatus(),
     stats: snapshotStats(),
     versions: { dht: DHT_VERSION },
   }

--- a/src/shared/transfer/transfer-id.js
+++ b/src/shared/transfer/transfer-id.js
@@ -3,3 +3,7 @@
 export const LOOSE_SHARE_ID = '__loose__'
 export const transferIdFor = (spaceId, shareId, relPath) => spaceId + '|' + shareId + '|' + relPath
 export const looseTransferIdFor = (spaceId, relPath) => transferIdFor(spaceId, LOOSE_SHARE_ID, relPath)
+// Which engine owns an id, decided from the id alone — a caller must not have to ask whether a
+// transfer is still live (it may have settled) to route a pause/resume to the right backend.
+export const isLooseTransferId = (transferId) =>
+  typeof transferId === 'string' && transferId.split('|')[1] === LOOSE_SHARE_ID

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -41,7 +41,7 @@ import {
 import { initSpaceKeys } from '../shared/spaces/space-keys.js'
 import { classifyInvite } from '../shared/spaces/invite-policy.js'
 import { encodeInvite, decodeInvite } from '../shared/invite-envelope.js'
-import { initSwarm, joinSpaceTopic, leaveSpaceTopic, cleanupSpaceDrives, compactStore, destroySwarm, broadcastDeparture, getConnectedPeers, isOwnerOnline, broadcastProfileUpdate, sendLeaveFrameToConnectedPeers, awaitLeaveAcks, getSwarmStatus, reconnectAll, setMembershipControlHandler, setConnectionAttachHook, getSwarmDht, setOverlayReconnectHook, setRevokeServesForSpaceHook, sendMembershipGrant, sendMembershipDeny, broadcastMembershipCancel, reconcilePendingRequester, isApprovedMember, resolveInvite, markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving, getBoundSignerKey, broadcastSharePrepareProgress, configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, joinPendingLeaveTopic, leavePendingLeaveTopic, hasPendingLeave, takeLeaveAckedKeys, configurePendingCancels, registerPendingCancel, joinPendingCancelTopic, leavePendingCancelTopic, hasPendingCancel, sendPendingCancelToConnected } from '../shared/transfer/swarm.js'
+import { initSwarm, joinSpaceTopic, leaveSpaceTopic, cleanupSpaceDrives, compactStore, destroySwarm, broadcastDeparture, getConnectedPeers, isOwnerOnline, broadcastProfileUpdate, sendLeaveFrameToConnectedPeers, awaitLeaveAcks, getSwarmStatus, reconnectAll, setMembershipControlHandler, setConnectionAttachHook, getSwarmDht, setOverlayReconnectHook, setRevokeServesForSpaceHook, setStalledOwnersHook, rescueStalledTransfers, sendMembershipGrant, sendMembershipDeny, broadcastMembershipCancel, reconcilePendingRequester, isApprovedMember, resolveInvite, markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving, getBoundSignerKey, broadcastSharePrepareProgress, configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, joinPendingLeaveTopic, leavePendingLeaveTopic, hasPendingLeave, takeLeaveAckedKeys, configurePendingCancels, registerPendingCancel, joinPendingCancelTopic, leavePendingCancelTopic, hasPendingCancel, sendPendingCancelToConnected } from '../shared/transfer/swarm.js'
 import { initContentSwarm, destroyContentSwarm, setContentAttachHook, setContentResumeHook } from '../shared/transfer/content-swarm.js'
 import { clampDisplayName, checkGrantAssertion } from '../shared/transfer/handshake-guard.js'
 import { openSealedSck } from '../shared/transfer/sck-seal.js'
@@ -60,9 +60,9 @@ import { getJournalDir, revokeServesForSpace, bumpServeEpoch } from '../shared/t
 import { cleanupOrphanedJournals } from '../shared/transfer/backends/overlay/vendor/transfer.js'
 import { cleanupOrphanedOverlayPartials } from '../shared/transfer/partial-sweep.js'
 import { pausedStatusFor, unhashedStatusFor } from '../shared/transfer/transfer-status.js'
-import { transferIdFor } from '../shared/transfer/transfer-id.js'
+import { transferIdFor, isLooseTransferId } from '../shared/transfer/transfer-id.js'
 import { makeKeyedCoalescer } from '../shared/state/coalesce.js'
-import { initPendingTransfers, clearPendingForSpace, listPendingForSpace } from '../shared/transfer/pending-transfers.js'
+import { initPendingTransfers, clearPendingForSpace, listPendingForSpace, listPendingOwnerKeys } from '../shared/transfer/pending-transfers.js'
 import { getStorageInfo, cleanupOrphanedData, getSpaceCacheBytes, freeSpace } from '../shared/storage/storage.js'
 import { spaceStorageSummary } from '../shared/storage/space-storage.js'
 import { reclaimLegacyPeerCaches } from '../shared/storage/legacy-peer-cache.js'
@@ -263,26 +263,35 @@ if (isOverlayEnabled()) {
     if (isInPlaceFilesEnabled()) resumeLooseForOwner(ownerKey, spaceId).catch((err) => log.debug('loose auto-resume failed:', err.message))
     resumeOverlayForOwner(ownerKey, spaceId).catch((err) => log.debug('overlay folder auto-resume failed:', err.message))
   }
+  // BOTH planes drive the resume. The control handshake marks the owner's presence lease
+  // synchronously before firing this hook, so a resume it triggers can never observe the stale
+  // "owner offline" that start()'s gate reads — whereas a content-plane hello routinely lands
+  // while the control socket is still re-handshaking, and its resume is dropped. With only the
+  // content hook installed, out-of-phase flapping starves the download of every trigger it has.
+  setOverlayReconnectHook(autoResume)
   if (useContentPlane) {
     // The content plane authenticates per owner with no space, so fan the resume across our
     // spaces — coalesced per owner so reconnect churn doesn't re-run listSpaces() each time.
+    // Still needed alongside the control hook: a content-only flap re-runs no handshake.
     const resumePending = new Map()
     setContentResumeHook((ownerKey) => {
       if (resumePending.has(ownerKey)) return
       const timer = setTimeout(() => {
         resumePending.delete(ownerKey)
-        listSpaces().then((spaces) => { for (const s of spaces) if (!s.leaving) autoResume(ownerKey, s.spaceId) }).catch(() => {})
+        listSpaces()
+          .then((spaces) => { for (const s of spaces) if (!s.leaving) autoResume(ownerKey, s.spaceId) })
+          .catch((err) => log.debug('content-hello resume fan-out failed:', err.message))
       }, 250)
       timer.unref?.()
       resumePending.set(ownerKey, timer)
     })
-  } else {
-    setOverlayReconnectHook(autoResume)
   }
 }
 setMembershipControlHandler(handleMembershipControl)
 if (useContentPlane) setContentAttachHook(fanoutAttach) // overlay binds its channel on content connections
 else setConnectionAttachHook(fanoutAttach) // lets overlay bind its channel per connection
+// Lets the convergence tick see a download whose owner has dropped off either plane.
+setStalledOwnersHook(listPendingOwnerKeys)
 setSharePrepareBroadcast((spaceId, p) => { if (isSharePrepareProgressEnabled()) broadcastSharePrepareProgress(spaceId, p) })
 // A peer left a space we are still in: stop serving THAT PEER the space's bytes. Scoped to the
 // leaver — a space-wide revoke here would also cut off every other member still legitimately
@@ -1849,7 +1858,11 @@ ipc.handle('files:add', async (msg) => {
 ipc.handle('files:download', async (msg) => {
   const space = await getSpace(msg.spaceId)
   const member = (space?.members || []).find((m) => m.publicKey === msg.ownerKey)
-  return await looseDownload(msg.spaceId, member, msg.path)
+  const res = await looseDownload(msg.spaceId, member, msg.path)
+  // Couldn't start: the owner may simply be unreachable on the bulk plane. Don't make the user
+  // wait for the next tick to find that out — the rescue throttles itself, so clicks stay cheap.
+  if (res?.queued) rescueStalledTransfers().catch((err) => log.debug('stalled-transfer rescue failed:', err.message))
+  return res
 })
 ipc.handle('files:cancel-download', async (msg) => {
   const id = msg.transferId
@@ -1859,8 +1872,11 @@ ipc.handle('files:cancel-download', async (msg) => {
 })
 ipc.handle('files:pause-download', async (msg) => {
   const id = msg.transferId
-  if (looseHasTransfer(id)) loosePause(id)
-  else if (overlayHasTransfer(id)) overlayPause(id)
+  // Route on the id's shape, not on a live transfer: a dropped connection can settle the fetch a
+  // moment before the click lands, and gating on has() would silently pause nothing — leaving the
+  // row to auto-resume on the next reconnect against the user's intent.
+  if (isLooseTransferId(id)) loosePause(id)
+  else overlayPause(id)
   return { ok: true }
 })
 ipc.handle('files:cancel-publish', async (msg) => {

--- a/test/flow/content-plane-rescue.test.js
+++ b/test/flow/content-plane-rescue.test.js
@@ -1,0 +1,72 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
+import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
+
+// REGRESSION (FIX-9: a download interrupted by a dropped connection never resumed).
+//
+// Both halves of the bug are exercised here, because a link this hostile hits both:
+//   1. every reconnect used to fire a resume that the presence gate silently dropped (the trigger
+//      rode the bulk plane, the gate read the control plane, and the two are never up together
+//      right after a drop);
+//   2. hyperswarm stops re-dialing a peer whose connections keep dying young, and the bulk plane
+//      had no way back — its only discovery refresh hung off a manual Reconnect.
+//
+// Sizing matters. The flap interval sits BELOW hyperswarm's prove-yourself window, so the dialer
+// burns through its retries within a few cycles; the payload is large enough that the transfer is
+// still unfinished by then, so finishing REQUIRES surviving the cliff. The test asserts the drops
+// actually landed mid-transfer — a payload that slipped through between flaps would otherwise pass
+// while testing nothing. The shrunk convergence tick keeps the rescue inside the budget; production
+// uses the 15s default.
+
+const kekHex = () => crypto.randomBytes(32).toString('hex')
+const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
+
+const FLAP_MS = 6000
+const HOSTILE_LINK = { latencyMs: 200, jitterMs: 150, flapEveryMs: FLAP_MS, flapJitterMs: 1000 }
+const flags = () => ({
+  overlayEnabled: true,
+  inPlaceFilesEnabled: true,
+  membershipApprovalEnabled: true,
+  identityKEK: kekHex(),
+  netImpair: HOSTILE_LINK,
+  convergenceTickMs: 3000,
+})
+
+test('a download survives a link that flaps until hyperswarm gives up re-dialing', { timeout: scaled(420000) }, async (t) => {
+  const bootstrap = await localTestnet(t)
+  const aSrc = mkTmpDir(t)
+  const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), flags: flags() })
+  const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
+  const spaceId = await connectInSpaceWithApproval(t, A, B)
+  const aKey = (await A.request('profile:get')).publicKey
+
+  // Big enough that it cannot complete inside the handful of flap cycles hyperswarm tolerates
+  // before it stops re-dialing — so the download can only finish by being rescued and resumed.
+  // Not bigger: each recovery cycle only moves a few MB on this link, so a larger payload measures
+  // throughput-under-adversity (and races the budget) instead of the recovery this test is for.
+  const bytes = patternedBytes(32 * 1024 * 1024, 91)
+  fs.writeFileSync(path.join(aSrc, 'churn.bin'), bytes)
+  await A.request('files:add', { spaceId, filePath: path.join(aSrc, 'churn.bin'), fileName: 'churn.bin', fileSize: bytes.length })
+  await B.until('files:list', { spaceId },
+    (f) => Array.isArray(f) && f.some((e) => e.path === '/churn.bin' && e.status === 'remote'), { ms: 180000 })
+
+  let interruptions = 0
+  B.on('event:transfer-paused', (m) => { if (m.path === '/churn.bin') interruptions++ })
+
+  const started = Date.now()
+  const done = B.waitFor('event:transfer-complete', (m) => m.path === '/churn.bin', 300000)
+  await B.request('files:download', { spaceId, path: '/churn.bin', inPlace: true, ownerKey: aKey })
+  const completion = await done
+  const elapsed = Date.now() - started
+
+  t.comment(`completed in ${elapsed}ms across ${interruptions} interruption(s)`)
+  t.ok(interruptions > 0, 'the link actually dropped mid-transfer — the scenario under test really happened')
+  t.ok(elapsed > FLAP_MS, 'the transfer outlived at least one flap cycle (it did not slip through between drops)')
+  t.ok(fs.readFileSync(completion.localPath).equals(bytes), 'the interrupted download resumed and landed byte-exact')
+  A.kill()
+})

--- a/test/integration/content-plane-rescue.test.js
+++ b/test/integration/content-plane-rescue.test.js
@@ -1,0 +1,59 @@
+import test from 'brittle'
+import { createContentPeerSockets } from '../../src/shared/transfer/content-peer-sockets.js'
+
+// REGRESSION (FIX-9, second root cause: the bulk plane stops re-dialing and never recovers).
+//
+// Hyperswarm only keeps re-dialing a peer whose connections live long enough to prove themselves.
+// On a link that keeps dropping inside that window the attempt counter never resets, and after the
+// fourth short-lived close the peer loses its retry timer outright — the next automatic dial is a
+// topic re-lookup ten minutes later. The control plane survives that because the convergence tick
+// can refresh its discovery; the content plane had no such lever at all (its only refresh hung off
+// the user pressing Reconnect), so a stalled transfer stayed dead.
+//
+// hasPeer is what lets the tick SEE the stall: a pending download whose owner has no content socket
+// left is the signal to refresh discovery, which resets hyperswarm's attempts and re-dials now.
+
+const fakeSocket = (name) => ({ name, destroyed: false, destroy () { this.destroyed = true } })
+
+test('hasPeer reports whether an owner is still reachable on any content socket', (t) => {
+  const reg = createContentPeerSockets()
+  const sock = fakeSocket('alice')
+
+  t.absent(reg.hasPeer('alice-key'), 'unknown peer is not reachable')
+  reg.add(sock, 'alice-key')
+  t.ok(reg.hasPeer('alice-key'), 'reachable once authenticated on a socket')
+  t.absent(reg.hasPeer('bob-key'), 'a different peer is still not reachable')
+})
+
+test('a dropped content socket makes its owner unreachable — the stall the tick must see', (t) => {
+  const reg = createContentPeerSockets()
+  const sock = fakeSocket('alice')
+  reg.add(sock, 'alice-key')
+
+  reg.forget(sock) // what the socket's own 'close' does
+  t.absent(reg.hasPeer('alice-key'),
+    'after the link drops, the owner has no content socket — a transfer pending on them is stalled')
+})
+
+test('hasPeer survives a peer authenticated on several sockets until the last one goes', (t) => {
+  const reg = createContentPeerSockets()
+  const first = fakeSocket('first')
+  const second = fakeSocket('second')
+  reg.add(first, 'alice-key')
+  reg.add(second, 'alice-key')
+
+  reg.forget(first)
+  t.ok(reg.hasPeer('alice-key'), 'still reachable on the surviving socket — not a stall')
+  reg.forget(second)
+  t.absent(reg.hasPeer('alice-key'), 'the last socket is gone — now it is a stall')
+})
+
+test('destroyFor (a peer we no longer share a space with) leaves them unreachable', (t) => {
+  const reg = createContentPeerSockets()
+  reg.add(fakeSocket('alice'), 'alice-key')
+  reg.add(fakeSocket('bob'), 'bob-key')
+
+  reg.destroyFor('alice-key')
+  t.absent(reg.hasPeer('alice-key'), 'the departed peer is unreachable')
+  t.ok(reg.hasPeer('bob-key'), 'a peer we still share a space with stays reachable')
+})

--- a/test/integration/overlay-resume-gate.test.js
+++ b/test/integration/overlay-resume-gate.test.js
@@ -1,0 +1,195 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import url from 'bare-url'
+import { freshPeer } from '../helpers/store.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { initPendingTransfers, recordPending, getPendingFor } from '../../src/shared/transfer/pending-transfers.js'
+import { initDownloads } from '../../src/shared/transfer/files.js'
+import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
+
+// REGRESSION (FIX-9: a download interrupted by a dropped connection never resumed).
+//
+// The resume trigger and the resume gate read DIFFERENT network planes. With the content plane on,
+// the only trigger was a content-hello (bulk plane), while start()'s gate asks whether the owner is
+// present on the CONTROL plane. The bulk socket reconnects faster than the control handshake
+// completes, so on a flapping link every trigger landed inside a control-down window and was
+// dropped silently — leaving a fully recoverable transfer parked forever.
+//
+// The fix fires the resume from BOTH planes' reconnects: the control handshake marks presence
+// synchronously before firing, so its trigger can never observe the stale "offline" the bulk-plane
+// trigger races. These tests pin the engine half of that contract — the trigger must survive a
+// gate-closed attempt, the resumed byte count must not be wiped by the attempt that bails, and a
+// manual resume must never leave a pause marker that suppresses every later reconnect.
+
+const SPACE = 'space1'
+const OWNER = 'ownerpub'
+const HASH = 'a'.repeat(64)
+
+function testChannel (events, over = {}) {
+  return {
+    diagLabel: 'test download',
+    inPlace: false,
+    ownsPendingRow: (row) => row.overlayShare === true,
+    pendingExtra: (job) => ({ overlayShare: true, shareId: job.shareId, relPath: job.relPath }),
+    emitProgress: () => {},
+    emitError: (...a) => events.push(['error', ...a]),
+    emitComplete: () => {},
+    emitCancelled: (...a) => events.push(['cancelled', ...a]),
+    emitSuperseded: () => {},
+    emitPaused: (job, reason) => events.push(['paused', job, reason]),
+    emitUpdated: (spaceId) => events.push(['updated', spaceId]),
+    emitDecorationDone: () => {},
+    transferIdForRow: (spaceId, row) => spaceId + '|folder1|' + row.relPath,
+    ...over,
+  }
+}
+
+async function setup (t) {
+  const ctx = await freshPeer(t)
+  await initDownloads()
+  await initPendingTransfers()
+  await initOverlay()
+  t.teardown(async () => { await teardownOverlay() })
+  return ctx
+}
+
+function makeJob (ctx, over = {}) {
+  return {
+    spaceId: SPACE, pendingKey: '/Photos/doc.bin', path: '/Photos/doc.bin', relPath: 'doc.bin',
+    shareId: 'folder1', transferId: SPACE + '|folder1|doc.bin',
+    contentHash: HASH, size: 4096, ownerPublicKey: OWNER, verifyKey: 'folder1|doc.bin',
+    finalPath: path.join(ctx.tmpDir('dl'), 'doc.bin'), ...over,
+  }
+}
+
+// Seeds the row a dropped connection leaves behind: intent recorded, partial on disk, no live slot.
+async function seedInterruptedRow (job, bytesTransferred) {
+  await recordPending(SPACE, job.pendingKey, {
+    total: job.size, inPlace: false, ownerKey: OWNER, finalPath: job.finalPath,
+    contentHash: HASH, bytesTransferred, overlayShare: true, shareId: 'folder1', relPath: job.relPath,
+  })
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 400)) // past the 250ms resume coalescer
+
+// The bug lives in which hooks the worker installs, and the engine cannot observe that — so pin it
+// structurally, the way FIX-D2 pins the completion write order. The control-plane hook must be
+// installed unconditionally: putting it in the `else` of the content-plane branch (the old wiring)
+// left the control handshake firing into null, and with it the only trigger that cannot race the
+// presence gate it is checked against.
+test('REGRESSION (FIX-9: the control-plane resume hook is installed even when the content plane is on)', (t) => {
+  const here = path.dirname(url.fileURLToPath(import.meta.url))
+  const src = fs.readFileSync(path.join(here, '..', '..', 'src', 'worker', 'main.js'), 'utf8')
+
+  const controlAt = src.indexOf('setOverlayReconnectHook(autoResume)')
+  const contentAt = src.indexOf('setContentResumeHook(')
+  t.ok(controlAt > -1, 'the control-plane resume hook is wired')
+  t.ok(contentAt > -1, 'the content-plane resume hook is wired')
+  t.ok(controlAt < contentAt,
+    'the control hook is installed before (i.e. outside) the content-plane branch — not as its else')
+  t.absent(/else\s*\{\s*setOverlayReconnectHook/.test(src),
+    'the control hook is not gated behind the content plane being off')
+})
+
+test('REGRESSION (FIX-9: a resume trigger arriving while the owner looks offline does not consume the intent)', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  let ownerOnline = false
+  let fetches = 0
+
+  const job = makeJob(ctx)
+  const channel = testChannel(events, {
+    isOwnerOnline: () => ownerOnline,
+    resolvePendingRow: async () => ({ removed: false, seq: undefined, job }),
+  })
+  const engine = createOverlayDownloadEngine(channel)
+  getOverlay().fetchFile = async () => { fetches++; return job.finalPath }
+
+  await seedInterruptedRow(job, 1024)
+
+  // The bulk plane reconnects first and fires its resume — but the control handshake has not
+  // landed yet, so presence still reads offline and the gate holds.
+  await engine.resumeForOwner(OWNER, SPACE)
+  await settle()
+  t.is(fetches, 0, 'the gate held the doomed fetch while the owner was not present')
+  t.absent(engine.has(job.transferId), 'no slot left registered')
+
+  // The control handshake completes: presence flips, and the hook it fires must still find a live
+  // intent to act on. Before the fix, this second trigger did not exist.
+  ownerOnline = true
+  await engine.resumeForOwner(OWNER, SPACE)
+  await settle()
+  t.is(fetches, 1, 'the later trigger restarted the fetch — the intent was not consumed by the gate')
+})
+
+test('REGRESSION (FIX-9: a start() that bails at the gate keeps the partial byte count)', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  const job = makeJob(ctx, { prevBytes: 14_155_776, size: 16_777_216 })
+  const channel = testChannel(events, { isOwnerOnline: () => false })
+  const engine = createOverlayDownloadEngine(channel)
+
+  await seedInterruptedRow(job, 14_155_776)
+  const res = await engine.start(job)
+
+  t.ok(res.queued, 'start reports queued — the owner is not reachable')
+  const row = await getPendingFor(SPACE, job.pendingKey)
+  t.is(row.bytesTransferred, 14_155_776, 'the resumed progress survived the bailed start (row not reset to 0)')
+})
+
+test('REGRESSION (FIX-9: a manual resume that fails before start() clears the pause marker)', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  let ownerOnline = true
+  let fetches = 0
+
+  const job = makeJob(ctx)
+  const channel = testChannel(events, {
+    isOwnerOnline: () => ownerOnline,
+    resolvePendingRow: async () => ({ removed: false, seq: undefined, job }),
+  })
+  const engine = createOverlayDownloadEngine(channel)
+  getOverlay().fetchFile = async () => { fetches++; return job.finalPath }
+  getOverlay().cancelFetch = () => {}
+
+  await seedInterruptedRow(job, 2048)
+  engine.pause(job.transferId) // no live slot: records the intent as a marker
+  ownerOnline = false
+
+  // The user hits resume while the owner is unreachable. The attempt cannot start — but it MUST
+  // still retire the pause marker, or every later reconnect skips this row as "manually paused".
+  engine.clearPauseMarker(job.transferId)
+  await engine.start(job)
+  t.is(fetches, 0, 'the manual attempt could not start')
+
+  ownerOnline = true
+  await engine.resumeForOwner(OWNER, SPACE)
+  await settle()
+  t.is(fetches, 1, 'the next reconnect resumed it — no stale pause marker suppressing the row')
+})
+
+test('REGRESSION (FIX-9: pausing a transfer whose fetch already settled still sticks)', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  let fetches = 0
+
+  const job = makeJob(ctx)
+  const channel = testChannel(events, {
+    isOwnerOnline: () => true,
+    resolvePendingRow: async () => ({ removed: false, seq: undefined, job }),
+  })
+  const engine = createOverlayDownloadEngine(channel)
+  getOverlay().fetchFile = async () => { fetches++; return job.finalPath }
+
+  await seedInterruptedRow(job, 4096)
+  t.absent(engine.has(job.transferId), 'the dropped connection already settled the fetch — no slot')
+
+  // The click lands after the drop settled it. With no slot to flag, the pause used to do nothing
+  // at all and the row auto-resumed on the next reconnect, against the user's explicit intent.
+  t.ok(engine.pause(job.transferId), 'pause records the intent even with no live slot')
+
+  await engine.resumeForOwner(OWNER, SPACE)
+  await settle()
+  t.is(fetches, 0, 'the reconnect did not auto-resume a user-paused row')
+})


### PR DESCRIPTION
A download interrupted mid-transfer could stall forever: the resume trigger rode the content plane while the gate that admits it read the control plane, so on a flapping link every trigger landed in a window where the owner looked offline. Fire the resume from both planes, keep pause/resume intent durable across a settle race, and escalate a stalled transfer to a discovery refresh — the only way back once hyperswarm has stopped re-dialing a peer whose connections keep dying young.

Closes #9

## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [x] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [x] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [ ] **N/A** — docs / comments / config only (no runtime surface)

- [x] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [x] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [x] N/A — no UI change.
