### PR TITLE
[test] Raise join-wait budget for impaired-link setup

### DIFF
--- a/test/helpers/peer.js
+++ b/test/helpers/peer.js
@@ -224,8 +224,8 @@ export async function launchPeer (t, { bootstrap, displayName = 'Peer', debug = 
 export async function connectInSpace (t, A, B, name = 'Test Space') {
   const space = await A.request('space:create', { name })
   const inviteCode = await A.request('space:invite', { spaceId: space.spaceId })
-  const aSawB = A.waitFor('event:member-joined', (m) => m.spaceId === space.spaceId)
-  const bSawA = B.waitFor('event:member-joined', (m) => m.spaceId === space.spaceId)
+  const aSawB = A.waitFor('event:member-joined', (m) => m.spaceId === space.spaceId, 120000)
+  const bSawA = B.waitFor('event:member-joined', (m) => m.spaceId === space.spaceId, 120000)
   await B.request('space:join', { inviteCode })
   await Promise.all([aSawB, bSawA])
 
@@ -253,8 +253,8 @@ export async function connectInSpace (t, A, B, name = 'Test Space') {
 export async function connectInSpaceWithApproval (t, A, B, name = 'Secure Space') {
   const space = await A.request('space:create', { name })
   const inviteCode = await A.request('space:invite', { spaceId: space.spaceId })
-  const aGotRequest = A.waitFor('event:member-join-request', (m) => m.spaceId === space.spaceId)
-  const bGranted = B.waitFor('event:membership-granted', (m) => m.spaceId === space.spaceId)
+  const aGotRequest = A.waitFor('event:member-join-request', (m) => m.spaceId === space.spaceId, 120000)
+  const bGranted = B.waitFor('event:membership-granted', (m) => m.spaceId === space.spaceId, 120000)
   await B.request('space:join', { inviteCode })
   const req = await aGotRequest
   await A.request('space:approve-member', { spaceId: space.spaceId, publicKey: req.publicKey })


### PR DESCRIPTION
connectInSpaceWithApproval and connectInSpace left their join waits on waitFor's 20s default, but a join over a flapping link can lose a frame and wait out the 15s convergence tick — so setup timed out before the test under test began. Give all four waits the same 120s budget addApprovedPeer already uses for the identical waits.

Closes #11

## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [ ] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [ ] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [x] **N/A** — docs / comments / config only (no runtime surface)

- [ ] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [x] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [x] N/A — no UI change.
