### PR TITLE
[fix] Allowlist renovate-bot in CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -39,6 +39,11 @@ jobs:
           path-to-signatures: 'signatures/cla.json'
           path-to-document: 'https://github.com/ok/mirall-app/blob/main/CLA.md'
           branch: 'cla-signatures'
-          allowlist: 'ok,dependabot[bot],renovate[bot]'
+          # `renovate-bot` is the identity our self-hosted Renovate actually
+          # commits as: renovatebot/github-action signs commits as
+          # `Renovate Bot <renovate@whitesourcesoftware.com>`, which GitHub
+          # resolves to that user. `renovate[bot]` is the hosted GitHub App
+          # and is kept only in case we ever switch to it.
+          allowlist: 'ok,dependabot[bot],renovate[bot],renovate-bot'
           custom-pr-sign-comment: 'I have read the CLA Document and I hereby sign the CLA'
           custom-allsigned-prcomment: 'All contributors have signed the CLA. Thank you!'


### PR DESCRIPTION
The CLA allowlist named `renovate[bot]` (the hosted Renovate GitHub App), but this repo self-hosts Renovate via `renovatebot/github-action` with a PAT. It commits as `Renovate Bot <renovate@whitesourcesoftware.com>`, which GitHub resolves to the user account `renovate-bot`.

The action matches `commit.author.user.login` against the allowlist, so it saw `renovate-bot`, found no entry, and blocked all five open Renovate PRs (#17–#21) on a signature a bot cannot give.

Adds `renovate-bot` to the allowlist. `renovate[bot]` stays in case we ever move to the hosted App.

Because the CLA workflow runs on `pull_request_target`, this has to be on `staging` before it takes effect; the five PRs then need a `recheck` comment to clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)