### PR TITLE
[fix] Close readChunk's fd when the read throws

### DIFF
--- a/src/shared/transfer/backends/overlay/vendor/transfer.js
+++ b/src/shared/transfer/backends/overlay/vendor/transfer.js
@@ -286,15 +286,20 @@ export class TransferManager {
    * @returns {Buffer | null}
    */
   readChunk (filePath, offset, length) {
+    // [mirall] The fd is closed in `finally`, not on the success path: an allocation or
+    // read that throws must not escape through the catch below with the handle still open.
+    // This serves every chunk request, so a leak here compounds per request.
+    let fd = null
     try {
-      const fd = openSyncTracked(filePath, 'r')
+      fd = openSyncTracked(filePath, 'r')
       const buf = Buffer.alloc(length)
       const bytesRead = fs.readSync(fd, buf, 0, length, offset)
-      closeSyncTracked(fd)
       if (bytesRead !== length) return null
       return buf
     } catch {
       return null
+    } finally {
+      if (fd !== null) closeSyncTracked(fd)
     }
   }
 

--- a/test/integration/overlay-vendor-transfer.test.js
+++ b/test/integration/overlay-vendor-transfer.test.js
@@ -1002,6 +1002,30 @@ test('B1: fd count stays flat across a multi-chunk transfer and 20 transfers', a
   await index.close()
 })
 
+// REGRESSION (FIX-358: readChunk leaks its fd when the read fails): the open sat inside the
+// try and the close ran only on the success path, so any throw in between fell straight to
+// `catch { return null }` with the descriptor still open — leaked for the life of the
+// process. protocol-v2 calls readChunk once per chunk of every served request, so a disk
+// throwing EIO while seeding drains the fd table until the worker can open nothing at all.
+// Forced below with an out-of-range length, which throws in Buffer.alloc after the open —
+// the same shape as a readSync I/O error, and the same leak.
+test('REGRESSION (FIX-358): readChunk closes its fd when the read throws', async (t) => {
+  const { index, transfer } = await setup()
+  const p = writeTestFile(tmpDir('rc'), 'rc.bin', crypto.randomBytes(1024))
+
+  t.is(transfer.readChunk(p, 0, 16)?.length, 16, 'a good read still returns its bytes')
+
+  const ITERS = 5
+  const before = fdCount()
+  for (let i = 0; i < ITERS; i++) {
+    t.is(transfer.readChunk(p, 0, Number.MAX_SAFE_INTEGER), null, 'a failing read returns null')
+  }
+  const after = fdCount()
+  t.is(after, before, `no fd leaked across ${ITERS} failing reads (${before} -> ${after})`)
+
+  await index.close()
+})
+
 test('B1: pause closes the fd; a late chunk is refused codeless; resume completes', async (t) => {
   const { index, transfer } = await setup()
   const original = crypto.randomBytes(512 * 1024)


### PR DESCRIPTION
`TransferManager.readChunk` opened its file descriptor inside the `try` and closed it only on the success path. Any throw in between — an `fs.readSync` I/O error, or an allocation failure — fell straight through `catch { return null }` with the handle still open, leaking it for the life of the process.

`protocol-v2.js:667` calls `readChunk` once per chunk of every served request, so a disk throwing EIO while seeding would leak one fd per chunk until the worker could no longer open anything.

Not remotely triggerable: `offset`/`length` come from our own local chunk map, and the peer-supplied `indices` are bounds-checked at `protocol-v2.js:665`.

The close now runs in a `finally`.

## Test

Red-first. `REGRESSION (FIX-358)` fails on the unfixed code with `no fd leaked across 5 failing reads (0 -> 5)` — one descriptor per failing read — and reads `0 -> 0` after the fix. It asserts on the manager's own `openFdCount()`, not the process fd table.

The throw is forced with an out-of-range length, which throws in `Buffer.alloc` after the open. bare-fs's `readSync` is tolerant of bad arguments (negative offset, huge offset, over-long length all return without throwing), so that is the reachable way to exercise the path; it is the same code path and the same leak a genuine `readSync` EIO takes.

Gates: `test:bare` 604/604, `test:node:core` 760/760, `test:flow` 173/173, typecheck and lint clean.