### PR TITLE
[chore] Align branch model with main as default branch

### DIFF
--- a/.claude/build-process.md
+++ b/.claude/build-process.md
@@ -27,9 +27,10 @@ git push --tags ─→ matrix build (5 archs)
 
 ## Branches & promotion
 
-`staging` is the repo's **default branch** and the integration branch where the next
-release accumulates; `main` is **production**. Features and chores squash-merge into
-`staging`, so a merged PR becomes exactly one commit (PR title + PR body). A release
+`main` is the repo's **default branch** and is **production** — every commit on it is
+releasable, and it is what a visitor cloning the public repo gets. `staging` is the
+integration branch where the next release accumulates. Features and chores squash-merge
+into `staging`, so a merged PR becomes exactly one commit (PR title + PR body). A release
 promotes `staging → main` as a pure fast-forward:
 
 ```
@@ -45,9 +46,28 @@ land on `main` directly, then gets forward-ported to `staging`.
 > OTA* below). They are independent: a `workflow_dispatch` build can publish any branch to
 > any channel.
 
-Because GitHub always pre-selects the repo's default branch as a PR base, new PRs — and
-Renovate's — target `staging` automatically. The occasional `staging → main` release PR is
-the one case where the base must be switched to `main` by hand.
+Because GitHub always pre-selects the repo's default branch as a PR base, new PRs open
+against `main`. **Feature and chore PRs must have their base switched to `staging` by
+hand** — only a release promotion or a hotfix legitimately targets `main`.
+
+`.github/workflows/pr-base-guard.yml` enforces this: a PR based on `main` fails unless its
+head is `staging`, `hotfix/*` or `release/*`. It is an allowlist, so an unfamiliar branch
+prefix fails closed. A deliberate exception — an infrastructure change that must land on
+`main` first, like the `renovate.json` case below — is unblocked with the `base:main`
+label, which should be justified in the PR body.
+
+Renovate is exempt: `renovate.json` sets `"baseBranches": ["staging"]`, so its PRs target
+the integration branch regardless of the default. That key must stay on `main` — Renovate
+defaults to `useBaseBranchConfig: "none"`, meaning it reads its config **only from the
+repo's default branch**. A `renovate.json` that exists on `staging` but not on `main` is
+silently ignored.
+
+Long-lived branches are limited to `main` and `staging`. Feature (`feat/*`, `fix/*`) and
+release (`release/*`) branches are short-lived and deleted after merge. There is no
+permanent branch per version: the channels are build flavors of one commit lineage, not
+divergent code, and OTA clients roll forward within a channel, so no released version
+needs parallel maintenance. Cut a `release/x.y` branch from its tag only if a patch to an
+older line is ever actually needed after `staging` has moved on.
 
 ## CI build — `.github/workflows/build-electron.yml`
 

--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -47,14 +47,16 @@ jobs:
     steps:
       - id: ch
         run: |
+          # The only triggers are `push: tags: v*` and `workflow_dispatch`, so these
+          # two arms are exhaustive. Reaching the fallback means a trigger was added
+          # without deciding its channel — fail loudly rather than guess.
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
             CHANNEL="${{ inputs.channel }}"
           elif [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             CHANNEL="prod"
-          elif [[ "$GITHUB_REF" == refs/heads/release/* ]]; then
-            CHANNEL="staging"
           else
-            CHANNEL="dev"
+            echo "::error::No channel for ref '$GITHUB_REF' (event ${{ github.event_name }}); add an arm here or dispatch manually."
+            exit 1
           fi
           echo "channel=$CHANNEL" >> "$GITHUB_OUTPUT"
           echo "Channel: $CHANNEL"

--- a/.github/workflows/pr-base-guard.yml
+++ b/.github/workflows/pr-base-guard.yml
@@ -1,0 +1,45 @@
+name: PR Base Guard
+
+# Feature and chore work integrates on `staging`; `main` is production. Because
+# GitHub pre-selects the default branch (`main`) as the PR base, the easy mistake
+# is merging unintegrated work straight into production. This guard catches it.
+# See .claude/build-process.md → "Branches & promotion".
+on:
+  pull_request:
+    # `edited` catches a base switched after the PR was opened; the label events
+    # re-run the check when the bypass label is added or removed.
+    types: [opened, reopened, edited, synchronize, labeled, unlabeled]
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  base:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check head branch may target main
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+          LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          if echo "$LABELS" | jq -e 'index("base:main")' >/dev/null; then
+            echo "Bypassed by the \`base:main\` label — deliberate exception."
+            exit 0
+          fi
+          # Allowlist, not denylist: a branch prefix nobody thought about should
+          # fail closed and get a human decision, not slip into production.
+          case "$HEAD_REF" in
+            staging)      echo "Release promotion from staging — OK" ;;
+            hotfix/*)     echo "Hotfix — OK (remember to forward-port to staging)" ;;
+            release/*)    echo "Release branch — OK" ;;
+            *)
+              echo "::error::'$HEAD_REF' targets main, but feature and chore work integrates on staging."
+              echo ""
+              echo "Retarget this PR:  gh pr edit ${{ github.event.pull_request.number }} --base staging"
+              echo ""
+              echo "Only 'staging' (release promotion), 'hotfix/*' and 'release/*' may target main."
+              echo "For a deliberate exception, add the 'base:main' label and explain why in the PR body."
+              exit 1
+              ;;
+          esac

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": ["config:recommended", ":dependencyDashboard"],
   "timezone": "Europe/Berlin",
   "schedule": ["before 8am on Monday"],
+  "baseBranches": ["staging"],
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,


### PR DESCRIPTION
Follow-up to the default-branch switch (`staging` → `main`). Three fixes plus a guard.

**Renovate was silently repointed at production.** `renovate.json` had no `baseBranches`, so it follows the repo default — now `main`. Next run is scheduled `before 8am on Monday`. Pinned to `staging`.

**The key has to be on `main`.** Renovate defaults to `useBaseBranchConfig: "none"` and reads config only from the default branch, so a `renovate.json` that exists on `staging` but not `main` is ignored. This is why the PR is based on `main` rather than `staging`.

**Dead code in the channel resolver.** `build-electron.yml` triggers only on `push: tags: v*` and `workflow_dispatch`; the dispatch arm short-circuits on `inputs.channel` and the tag arm forces `prod`, so `refs/heads/release/* → staging` and the `else → dev` fallback were both unreachable. Removed. The fallback now errors instead of silently building `dev` — dropping it entirely would leave `CHANNEL` unset on an unexpected trigger.

**New guard.** `pr-base-guard.yml` fails a PR based on `main` unless its head is `staging`, `hotfix/*` or `release/*`, since GitHub now pre-selects `main` and unintegrated work could land in production by accident. Allowlist, so unfamiliar prefixes fail closed. Also a second line of defence if `baseBranches` ever regresses — a `renovate/*` head targeting `main` fails.

**This PR carries `base:main`**, the guard's own bypass label, because it must land on `main` first for the reason above.

Docs updated in `.claude/build-process.md`, including that there is no long-lived branch per version — channels are build flavors of one commit lineage and OTA clients roll forward, so no released version needs parallel maintenance.

Verification: JSON and YAML parse; resolver simulated across five ref/event combinations; guard simulated across nine branch/label combinations; `check-comment-hygiene.sh` clean. Docs/config/CI only — no runtime, UI or data-layer code, so no test-layer coverage applies.

Forward-port to `staging` after merge to keep `main` a strict ancestor.