### PR TITLE
[feat] Add bandwidth limits for file transfers

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -598,6 +598,15 @@ The dispatch seam is `getContentBackend(share)` (`transfer/content-backends.js`)
 
 The generic v2 serve/fetch engine is a vendored subset of the `hyper-overlay` project; `backends/overlay/vendor/PROVENANCE.md` documents what was vendored and every local modification. Mirall-specific policy (authorization, catalogs, lifecycle) lives **outside** `vendor/`.
 
+#### Bandwidth limiting
+
+User-set transfer caps (`transfer/bandwidth-limiter.js`) are byte-denominated token buckets — one for each direction, created in `overlay-instance.js` and **injected** into the protocol so `vendor/` keeps no app imports. Both read their rate through a getter on every call, so a settings change applies to **in-flight** transfers with nothing to re-plumb.
+
+- **Upload** is charged in `_onChunkNeed` before each `chunkData.send`. The wait opens a revocation window just like the existing drain boundary, so the serve grant is re-checked on the far side of it.
+- **Download** is charged in `ChunkScheduler._assign`. It is a *pull* protocol, so inbound bytes are paced by pacing chunk **requests** — by arrival the bytes are already spent.
+- **Two invariants.** A chunk larger than one second of budget (tier-3 chunks reach 4 MB; a cap may be 64 KB/s) is released on a full bucket and the deficit repaid, or it could never be afforded. And a gated `_assign` **re-arms the idle watchdog**: that timer measures *silence*, and time spent waiting on our own limiter is not silence — without the re-arm a low cap fails a healthy transfer as "stalled".
+- Caps govern the **content plane only**. Catalog/profile replication, handshakes and DHT traffic stay unthrottled — throttling them would starve the convergence that `test/flow/content-plane-hol.test.js` guards. A corrupt cap value fails **open** (unlimited), the inverse of the protective bounds in `runtime-config.js`.
+
 ---
 
 ## 8. IPC Protocol
@@ -631,6 +640,7 @@ The generic v2 serve/fetch engine is a vendored subset of the `hyper-overlay` pr
 | `onMainLog(fn)` | Main-process log lines (only while the debug gate is on); the dev console mirrors them as `[main]` |
 | `deepLink.subscribe(fn)` | `mirall://join/<code>` links. First subscribe drains the cold-start queue via `deeplink:flush`. Returns an unsubscribe fn. §5.2 |
 | `browseShareFolder()` | OS folder picker (`share:browseFolder`) → absolute dir path or `null` |
+| `getBandwidth()` / `setBandwidth(patch)` | Read/persist the content-plane transfer caps (`network.downloadKBps` / `network.uploadKBps` in `config.json`, `0` = unlimited). Main validates and returns the stored value; the renderer then forwards it to the worker as `settings:set-bandwidth` — the same two-step the download folder uses |
 | `startOwnedFolderWatcher(shareId, mountPath, ignore)` / `stopOwnedFolderWatcher(shareId)` | Start/stop the chokidar watcher in main (§2 step 12) |
 
 ### Renderer ↔ Worker (NDJSON)
@@ -658,6 +668,7 @@ One JSON object per line. Requests carry an `id`; events don't. Default request 
 | `storage:info` | `{}` | `{ totalDiskUsage, storagePath, spaces[], otherBytes }` |
 | `storage:cleanup` / `storage:free-space` | `{}` | `{ purged }` / `{ freedBytes }` — `free-space` reclaims resident-cache bytes across every space (called by `StorageSettings.tsx`) |
 | `settings:set-download-folder` | `{ path }` | `{ ok:true }` — relocate the loose-file download dir |
+| `settings:set-bandwidth` | `{ downloadKBps, uploadKBps }` | `{ ok:true }` — content-plane transfer caps, `0` = unlimited. Applies to **in-flight** transfers: the limiters read their rate per call (§ below) |
 | `network:status:get` / `network:reconnect` | `{}` | `{ online, … }` / `{ ok:true }` |
 | `feedback:send` | `{ comment, screenshot? }` | `{ ok:true }` — POSTs to `feedback.mirall.app` |
 | `ping` | `{}` | `{ pong:true, timestamp }` |

--- a/src/main/config-store.js
+++ b/src/main/config-store.js
@@ -22,6 +22,8 @@ function defaults() {
     appearance: { theme: 'system', locale: null },
     general: { minimizeToTray: true, openAtLogin: false, firstHideNoticeShown: false, appMenuAutoHide: false },
     downloads: { folder: null },
+    // Shared group: plan-blind-relay-client-adoption adds relayMode/relays here.
+    network: { downloadKBps: 0, uploadKBps: 0 },
     storage: { cacheBudgetBytes: 0 },
     notifications: null,
     ui: { lastSeenVersion: null, feedbackEmail: '' },
@@ -142,6 +144,20 @@ class ConfigStore {
       notifications: d.notifications,
       ui: { lastSeenVersion: d.ui.lastSeenVersion, feedbackEmail: d.ui.feedbackEmail },
     }
+  }
+
+  // Non-negative finite KB/s only; 0 means unlimited. Anything else leaves the stored
+  // value untouched rather than persisting a cap the worker would reject anyway.
+  setBandwidth(patch) {
+    if (!isPlainObject(patch)) return this._data.network
+    for (const key of ['downloadKBps', 'uploadKBps']) {
+      const next = patch[key]
+      if (typeof next === 'number' && Number.isFinite(next) && next >= 0) {
+        this._data.network[key] = Math.floor(next)
+      }
+    }
+    this._schedule()
+    return this._data.network
   }
 
   setRenderer(patch) {

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -602,6 +602,14 @@ function readDownloadFolder() {
   return getDefaultDownloadFolder()
 }
 
+function readBandwidth() {
+  const network = config().get('network')
+  return {
+    downloadKBps: network?.downloadKBps ?? 0,
+    uploadKBps: network?.uploadKBps ?? 0,
+  }
+}
+
 function writeDownloadFolder(folder) {
   config().set('downloads.folder', folder)
 }
@@ -659,6 +667,7 @@ function getWorker(specifier) {
     dev: isDev,
     verbose,
     downloadFolder: readDownloadFolder(),
+    ...readBandwidth(),
     dhtBootstrap: process.env.MIRALL_DHT_BOOTSTRAP ? JSON.parse(process.env.MIRALL_DHT_BOOTSTRAP) : null,
     // Test/debug override for the share:list-files row cap (undefined → omitted by JSON →
     // the runtime-config default). Lets the frontend suite exercise the truncation banner
@@ -905,6 +914,10 @@ ipcMain.handle('downloads:set', (_evt, folder) => {
   writeDownloadFolder(folder)
   return folder
 })
+
+ipcMain.handle('bandwidth:get', () => readBandwidth())
+
+ipcMain.handle('bandwidth:set', (_evt, patch) => config().setBandwidth(patch))
 
 ipcMain.handle('prefs:get', () => prefs)
 

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -75,6 +75,10 @@ contextBridge.exposeInMainWorld('bridge', {
   getDownloadFolder: () => ipcRenderer.invoke('downloads:get'),
   setDownloadFolder: (folder) => ipcRenderer.invoke('downloads:set', folder),
   browseDownloadFolder: () => ipcRenderer.invoke('downloads:browse'),
+
+  getBandwidth: () => ipcRenderer.invoke('bandwidth:get'),
+  setBandwidth: (patch) => ipcRenderer.invoke('bandwidth:set', patch),
+
   browseShareFolder: () => ipcRenderer.invoke('share:browseFolder'),
   startOwnedFolderWatcher: (shareId, mountPath, ignore) =>
     ipcRenderer.invoke('owned-folder:start-watcher', { shareId, mountPath, ignore }),

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -47,6 +47,7 @@ const SCREEN_TITLE_KEYS: Record<string, string> = {
   'appearance-settings': 'a11y.screens.appearance',
   'notification-settings': 'a11y.screens.notifications',
   'general-settings': 'a11y.screens.general',
+  'network-settings': 'a11y.screens.networkSettings',
   'network-status': 'a11y.screens.network',
   'activity-log': 'a11y.screens.activityLog',
   'activity-log-settings': 'a11y.screens.activityLogSettings',

--- a/src/renderer/components/layout/ScreenRouter.tsx
+++ b/src/renderer/components/layout/ScreenRouter.tsx
@@ -9,6 +9,7 @@ import AboutSettings from '../../screens/AboutSettings.js'
 import NotificationSettings from '../../screens/NotificationSettings.js'
 import AppearanceSettings from '../../screens/AppearanceSettings.js'
 import GeneralSettings from '../../screens/GeneralSettings.js'
+import NetworkSettings from '../../screens/NetworkSettings.js'
 import NetworkStatus from '../../screens/NetworkStatus.js'
 import Account from '../../screens/Account.js'
 import ActivityLog from '../../screens/ActivityLog.js'
@@ -95,6 +96,8 @@ export default function ScreenRouter({ nav, profile, onSaveProfile, onOpenFeedba
       return <NotificationSettings onBack={() => nav.setCurrentScreen('settings')} />
     case 'general-settings':
       return <GeneralSettings onBack={() => nav.setCurrentScreen('settings')} />
+    case 'network-settings':
+      return <NetworkSettings onBack={() => nav.setCurrentScreen('settings')} />
     case 'network-status':
       return <NetworkStatus onBack={() => nav.setCurrentScreen('account')} />
     case 'activity-log':

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -14,6 +14,12 @@ export interface WindowBounds {
   height: number
 }
 
+// Content-plane transfer caps in KB/s; 0 = unlimited.
+export interface BandwidthLimits {
+  downloadKBps: number
+  uploadKBps: number
+}
+
 export type PearEventName = 'updating' | 'updated'
 
 export type NotificationUrgency = 'normal' | 'critical' | 'low'
@@ -115,6 +121,8 @@ export interface MirallBridge {
   getDownloadFolder(): Promise<string>
   setDownloadFolder(folder: string): Promise<string>
   browseDownloadFolder(): Promise<string | null>
+  getBandwidth(): Promise<BandwidthLimits>
+  setBandwidth(patch: BandwidthLimits): Promise<BandwidthLimits>
   browseShareFolder(): Promise<string | null>
   startOwnedFolderWatcher(shareId: string, mountPath: string, ignore: string[]): Promise<{ ok: boolean; reason?: string }>
   stopOwnedFolderWatcher(shareId: string): Promise<{ ok: boolean }>

--- a/src/renderer/hooks/useAppNavigation.ts
+++ b/src/renderer/hooks/useAppNavigation.ts
@@ -84,6 +84,7 @@ export function useAppNavigation(): AppNavigation {
       case 'about': setCurrentScreen(preAboutScreen); break
       case 'appearance-settings':
       case 'notification-settings':
+      case 'network-settings':
       case 'general-settings': setCurrentScreen('settings'); break
       case 'network-status': setCurrentScreen('account'); break
       // The viewer hangs off Account and the config off Settings, so each backs out to its own

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -439,6 +439,8 @@
     "generalDescMac": "Menüleiste, beim Anmelden starten.",
     "notifications": "Benachrichtigungen",
     "notificationsDesc": "Lege fest, welche Ereignisse einen Hinweis zeigen.",
+    "network": "Netzwerk",
+    "networkDesc": "Limits für Uploads und Downloads.",
     "storage": "Speicher",
     "storageDesc": "Mirall-Datennutzung auf diesem Gerät.",
     "about": "Über",
@@ -637,6 +639,27 @@
     "restoredToast": "Wieder online",
     "showDetails": "Details anzeigen"
   },
+  "networkSettings": {
+    "title": "Netzwerk",
+    "intro": "Limits für Uploads und Downloads.",
+    "transferLimits": "Übertragungslimits",
+    "download": "Download",
+    "upload": "Upload",
+    "unlimited": "Unbegrenzt",
+    "custom": "Eigenes",
+    "downloadCustomLabel": "Download-Limit in KB/s",
+    "uploadCustomLabel": "Upload-Limit in KB/s",
+    "customEcho": "Etwa {{rate}}. Gib 0 ein für kein Limit.",
+    "customUnlimited": "Kein Limit.",
+    "floorAdvisory": "Sehr niedrige Limits können Übertragungen blockieren. Mirall nutzt mindestens {{min}} KB/s.",
+    "scopeNote": "Limits gelten für Dateiübertragungen. Das Synchronisieren deiner Räume und Mitglieder wird nicht begrenzt — es braucht sehr wenig Daten, und eine Drosselung würde verhindern, dass neue Ordner erscheinen.",
+    "a11y": {
+      "downloadPreset": "Download-Limit: {{rate}}",
+      "uploadPreset": "Upload-Limit: {{rate}}",
+      "downloadCustom": "Download-Limit: eigenes",
+      "uploadCustom": "Upload-Limit: eigenes"
+    }
+  },
   "networkStatus": {
     "title": "Netzwerkstatus",
     "intro": "Verbindungsdetails und Diagnose.",
@@ -717,7 +740,8 @@
       "general": "Allgemein",
       "network": "Netzwerkstatus",
       "activityLog": "Aktivitätsprotokoll",
-      "activityLogSettings": "Einstellungen für das Aktivitätsprotokoll"
+      "activityLogSettings": "Einstellungen für das Aktivitätsprotokoll",
+      "networkSettings": "Netzwerkeinstellungen"
     }
   },
   "avatar": {

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -34,7 +34,8 @@
       "general": "General",
       "network": "Network status",
       "activityLog": "Activity log",
-      "activityLogSettings": "Activity log settings"
+      "activityLogSettings": "Activity log settings",
+      "networkSettings": "Network settings"
     }
   },
   "avatar": {
@@ -462,6 +463,8 @@
     "generalDescMac": "Menu bar, launch at login.",
     "notifications": "Notifications",
     "notificationsDesc": "Choose what triggers a desktop alert.",
+    "network": "Network",
+    "networkDesc": "Limits for uploads and downloads.",
     "storage": "Storage",
     "storageDesc": "View Mirall data usage on this device.",
     "about": "About",
@@ -673,6 +676,27 @@
     "connectingToast": "Reconnecting…",
     "restoredToast": "Back online",
     "showDetails": "Show details"
+  },
+  "networkSettings": {
+    "title": "Network",
+    "intro": "Limits for uploads and downloads.",
+    "transferLimits": "Transfer limits",
+    "download": "Download",
+    "upload": "Upload",
+    "unlimited": "Unlimited",
+    "custom": "Custom",
+    "downloadCustomLabel": "Download limit in KB/s",
+    "uploadCustomLabel": "Upload limit in KB/s",
+    "customEcho": "About {{rate}}. Enter 0 for no limit.",
+    "customUnlimited": "No limit.",
+    "floorAdvisory": "Very low limits can stall transfers. Mirall will use at least {{min}} KB/s.",
+    "scopeNote": "Limits apply to file transfers. Keeping your spaces and members in sync is not limited — it uses very little data, and slowing it down would stop new folders from appearing.",
+    "a11y": {
+      "downloadPreset": "Download limit: {{rate}}",
+      "uploadPreset": "Upload limit: {{rate}}",
+      "downloadCustom": "Download limit: custom",
+      "uploadCustom": "Upload limit: custom"
+    }
   },
   "networkStatus": {
     "title": "Network status",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -439,6 +439,8 @@
     "generalDescMac": "Barra de menús, iniciar al iniciar sesión.",
     "notifications": "Notificaciones",
     "notificationsDesc": "Elige qué eventos muestran una alerta de escritorio.",
+    "network": "Red",
+    "networkDesc": "Límites de subida y bajada.",
     "storage": "Almacenamiento",
     "storageDesc": "Consulta el uso de datos de Mirall en este dispositivo.",
     "about": "Acerca de",
@@ -637,6 +639,27 @@
     "restoredToast": "De nuevo en línea",
     "showDetails": "Ver detalles"
   },
+  "networkSettings": {
+    "title": "Red",
+    "intro": "Límites de subida y bajada.",
+    "transferLimits": "Límites de transferencia",
+    "download": "Descarga",
+    "upload": "Subida",
+    "unlimited": "Sin límite",
+    "custom": "Personalizado",
+    "downloadCustomLabel": "Límite de descarga en KB/s",
+    "uploadCustomLabel": "Límite de subida en KB/s",
+    "customEcho": "Aproximadamente {{rate}}. Escribe 0 para no poner límite.",
+    "customUnlimited": "Sin límite.",
+    "floorAdvisory": "Los límites muy bajos pueden detener las transferencias. Mirall usará al menos {{min}} KB/s.",
+    "scopeNote": "Los límites se aplican a las transferencias de archivos. La sincronización de tus espacios y sus miembros no se limita — usa muy pocos datos, y ralentizarla impediría que aparezcan carpetas nuevas.",
+    "a11y": {
+      "downloadPreset": "Límite de descarga: {{rate}}",
+      "uploadPreset": "Límite de subida: {{rate}}",
+      "downloadCustom": "Límite de descarga: personalizado",
+      "uploadCustom": "Límite de subida: personalizado"
+    }
+  },
   "networkStatus": {
     "title": "Estado de la red",
     "intro": "Detalles de conexión y diagnóstico.",
@@ -717,7 +740,8 @@
       "general": "General",
       "network": "Estado de la red",
       "activityLog": "Registro de actividad",
-      "activityLogSettings": "Ajustes del registro de actividad"
+      "activityLogSettings": "Ajustes del registro de actividad",
+      "networkSettings": "Ajustes de red"
     }
   },
   "avatar": {

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -439,6 +439,8 @@
     "generalDescMac": "Barre des menus, lancer à l'ouverture de session.",
     "notifications": "Notifications",
     "notificationsDesc": "Choisissez ce qui déclenche une alerte de bureau.",
+    "network": "Réseau",
+    "networkDesc": "Limites d'envoi et de téléchargement.",
     "storage": "Stockage",
     "storageDesc": "Voir l'utilisation des données Mirall sur cet appareil.",
     "about": "À propos",
@@ -637,6 +639,27 @@
     "restoredToast": "De nouveau en ligne",
     "showDetails": "Voir les détails"
   },
+  "networkSettings": {
+    "title": "Réseau",
+    "intro": "Limites d'envoi et de téléchargement.",
+    "transferLimits": "Limites de transfert",
+    "download": "Téléchargement",
+    "upload": "Envoi",
+    "unlimited": "Illimité",
+    "custom": "Personnalisé",
+    "downloadCustomLabel": "Limite de téléchargement en Ko/s",
+    "uploadCustomLabel": "Limite d'envoi en Ko/s",
+    "customEcho": "Environ {{rate}}. Saisissez 0 pour aucune limite.",
+    "customUnlimited": "Aucune limite.",
+    "floorAdvisory": "Des limites très basses peuvent bloquer les transferts. Mirall utilisera au moins {{min}} Ko/s.",
+    "scopeNote": "Les limites s'appliquent aux transferts de fichiers. La synchronisation de vos espaces et de leurs membres n'est pas limitée — elle consomme très peu de données, et la ralentir empêcherait les nouveaux dossiers d'apparaître.",
+    "a11y": {
+      "downloadPreset": "Limite de téléchargement : {{rate}}",
+      "uploadPreset": "Limite d'envoi : {{rate}}",
+      "downloadCustom": "Limite de téléchargement : personnalisée",
+      "uploadCustom": "Limite d'envoi : personnalisée"
+    }
+  },
   "networkStatus": {
     "title": "État du réseau",
     "intro": "Détails de connexion et diagnostics.",
@@ -717,7 +740,8 @@
       "general": "Général",
       "network": "État du réseau",
       "activityLog": "Journal d'activité",
-      "activityLogSettings": "Réglages du journal d'activité"
+      "activityLogSettings": "Réglages du journal d'activité",
+      "networkSettings": "Paramètres réseau"
     }
   },
   "avatar": {

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -439,6 +439,8 @@
     "generalDescMac": "Barra dei menu, avvia all'accesso.",
     "notifications": "Notifiche",
     "notificationsDesc": "Scegli quali eventi mostrano un avviso sul desktop.",
+    "network": "Rete",
+    "networkDesc": "Limiti di caricamento e download.",
     "storage": "Archiviazione",
     "storageDesc": "Visualizza l'utilizzo dei dati di Mirall su questo dispositivo.",
     "about": "Informazioni",
@@ -637,6 +639,27 @@
     "restoredToast": "Di nuovo online",
     "showDetails": "Mostra dettagli"
   },
+  "networkSettings": {
+    "title": "Rete",
+    "intro": "Limiti di caricamento e download.",
+    "transferLimits": "Limiti di trasferimento",
+    "download": "Download",
+    "upload": "Caricamento",
+    "unlimited": "Nessun limite",
+    "custom": "Personalizzato",
+    "downloadCustomLabel": "Limite di download in KB/s",
+    "uploadCustomLabel": "Limite di caricamento in KB/s",
+    "customEcho": "Circa {{rate}}. Inserisci 0 per nessun limite.",
+    "customUnlimited": "Nessun limite.",
+    "floorAdvisory": "Limiti molto bassi possono bloccare i trasferimenti. Mirall userà almeno {{min}} KB/s.",
+    "scopeNote": "I limiti si applicano ai trasferimenti di file. La sincronizzazione dei tuoi spazi e dei loro membri non è limitata — usa pochissimi dati, e rallentarla impedirebbe la comparsa di nuove cartelle.",
+    "a11y": {
+      "downloadPreset": "Limite di download: {{rate}}",
+      "uploadPreset": "Limite di caricamento: {{rate}}",
+      "downloadCustom": "Limite di download: personalizzato",
+      "uploadCustom": "Limite di caricamento: personalizzato"
+    }
+  },
   "networkStatus": {
     "title": "Stato della rete",
     "intro": "Dettagli di connessione e diagnostica.",
@@ -717,7 +740,8 @@
       "general": "Generale",
       "network": "Stato della rete",
       "activityLog": "Registro attività",
-      "activityLogSettings": "Impostazioni del registro attività"
+      "activityLogSettings": "Impostazioni del registro attività",
+      "networkSettings": "Impostazioni di rete"
     }
   },
   "avatar": {

--- a/src/renderer/screens/NetworkSettings.tsx
+++ b/src/renderer/screens/NetworkSettings.tsx
@@ -1,0 +1,210 @@
+// Network settings: content-plane transfer caps. Settings only — live connection status
+// lives on the account screen.
+import { useState, useEffect, useCallback, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { request } from '../ipc.js'
+import { formatSpeed } from '../utils.js'
+import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import PageHeader from '../components/layout/PageHeader.js'
+import SectionHeading from '../components/layout/SectionHeading.js'
+import type { BandwidthLimits } from '../global.js'
+
+interface NetworkSettingsProps {
+  onBack: () => void
+}
+
+type Direction = 'download' | 'upload'
+
+// Below this a single chunk can outlive the transfer watchdog; the worker clamps to the
+// same floor (bandwidth-limiter.js).
+const MIN_KBPS = 32
+const PRESET_KBPS = [0, 1024, 5120, 25600]
+const COMMIT_DEBOUNCE_MS = 400
+
+const SEGMENT_BASE =
+  'flex items-center px-4 py-2 rounded-full text-sm transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30'
+const SEGMENT_ON = 'bg-surface-container-lowest shadow-sm text-accent font-semibold'
+const SEGMENT_OFF = 'text-on-surface-variant hover:text-accent font-medium'
+
+function LimitRow({
+  direction,
+  kbps,
+  custom,
+  onPreset,
+  onCustom,
+  onValue,
+}: {
+  direction: Direction
+  kbps: number
+  custom: boolean
+  onPreset: (next: number) => void
+  onCustom: () => void
+  onValue: (next: number) => void
+}) {
+  const { t } = useTranslation()
+  const inputId = `${direction}-limit`
+  const helpId = `${direction}-limit-help`
+  // The field is a draft until it settles: persisting per keystroke would push "1", then
+  // "12", then "120" to the worker, and each write is an IPC round-trip.
+  const [draft, setDraft] = useState(String(kbps))
+  useEffect(() => { setDraft(String(kbps)) }, [kbps])
+  const parsed = Math.max(0, Math.floor(Number(draft) || 0))
+  const belowFloor = parsed > 0 && parsed < MIN_KBPS
+
+  const latest = useRef({ parsed, kbps, onValue })
+  latest.current = { parsed, kbps, onValue }
+  const commit = useCallback(() => {
+    const now = latest.current
+    if (now.parsed !== now.kbps) now.onValue(now.parsed)
+  }, [])
+
+  useEffect(() => {
+    if (!custom) return undefined
+    const id = setTimeout(commit, COMMIT_DEBOUNCE_MS)
+    return () => clearTimeout(id)
+  }, [draft, custom, commit])
+
+  // Navigating away must not silently discard what was typed — a click that never blurs
+  // the field (or a keyboard-driven back) would otherwise lose it.
+  useEffect(() => () => commit(), [commit])
+
+  return (
+    <div>
+      <div className="flex items-center justify-between gap-4">
+        <p className="font-semibold text-accent">{t(`networkSettings.${direction}`)}</p>
+        <div className="flex bg-surface-container-high dark:bg-surface-container-highest p-1 rounded-full shrink-0">
+          {PRESET_KBPS.map((preset) => {
+            const label = preset === 0 ? t('networkSettings.unlimited') : `${preset / 1024} MB/s`
+            const active = !custom && kbps === preset
+            return (
+              <button
+                key={preset}
+                type="button"
+                onClick={() => onPreset(preset)}
+                aria-label={t(`networkSettings.a11y.${direction}Preset`, { rate: label })}
+                aria-pressed={active}
+                className={`${SEGMENT_BASE} ${active ? SEGMENT_ON : SEGMENT_OFF}`}
+              >
+                {label}
+              </button>
+            )
+          })}
+          <button
+            type="button"
+            onClick={onCustom}
+            aria-label={t(`networkSettings.a11y.${direction}Custom`)}
+            aria-pressed={custom}
+            className={`${SEGMENT_BASE} ${custom ? SEGMENT_ON : SEGMENT_OFF}`}
+          >
+            {t('networkSettings.custom')}
+          </button>
+        </div>
+      </div>
+
+      {custom && (
+        <div className="mt-4 space-y-2">
+          <label htmlFor={inputId} className="font-headline text-sm font-bold text-accent px-1 block">
+            {t(`networkSettings.${direction}CustomLabel`)}
+          </label>
+          <input
+            id={inputId}
+            type="number"
+            inputMode="numeric"
+            min={0}
+            step={1}
+            value={draft}
+            aria-describedby={helpId}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commit}
+            onKeyDown={(e) => { if (e.key === 'Enter') commit() }}
+            className="w-full bg-surface-container-lowest border-none rounded-xl px-4 py-4 text-on-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30 transition-all text-lg tabular-nums"
+          />
+          {belowFloor ? (
+            <div id={helpId} role="status" className="rounded-xl bg-warning px-5 py-3 text-sm font-medium text-on-warning">
+              {t('networkSettings.floorAdvisory', { min: MIN_KBPS })}
+            </div>
+          ) : (
+            <p id={helpId} className="text-xs text-on-surface-variant px-1">
+              {parsed > 0
+                ? t('networkSettings.customEcho', { rate: formatSpeed(parsed * 1024) })
+                : t('networkSettings.customUnlimited')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default function NetworkSettings({ onBack }: NetworkSettingsProps) {
+  const { t } = useTranslation()
+  const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
+  const [limits, setLimits] = useState<BandwidthLimits>({ downloadKBps: 0, uploadKBps: 0 })
+  // Which rows show the number input. Derived from the stored value on load, then owned by
+  // the user: picking Custom must not discard the cap they already have.
+  const [custom, setCustom] = useState<Record<Direction, boolean>>({ download: false, upload: false })
+
+  useEffect(() => {
+    let cancelled = false
+    window.bridge.getBandwidth()
+      .then((stored) => {
+        if (cancelled) return
+        setLimits(stored)
+        setCustom({
+          download: !PRESET_KBPS.includes(stored.downloadKBps),
+          upload: !PRESET_KBPS.includes(stored.uploadKBps),
+        })
+      })
+      .catch(() => {})
+    return () => { cancelled = true }
+  }, [])
+
+  const apply = useCallback(async (next: BandwidthLimits) => {
+    setLimits(next)
+    try {
+      const persisted = await window.bridge.setBandwidth(next)
+      await request('settings:set-bandwidth', { ...persisted })
+    } catch {
+      // A failed write leaves the worker on its previous cap; the next change retries.
+    }
+  }, [])
+
+  const rowProps = (direction: Direction) => {
+    const key = direction === 'download' ? 'downloadKBps' : 'uploadKBps'
+    return {
+      direction,
+      kbps: limits[key],
+      custom: custom[direction],
+      onPreset: (next: number) => {
+        setCustom((prev) => ({ ...prev, [direction]: false }))
+        apply({ ...limits, [key]: next })
+      },
+      onCustom: () => setCustom((prev) => ({ ...prev, [direction]: true })),
+      onValue: (next: number) => apply({ ...limits, [key]: next }),
+    }
+  }
+
+  return (
+    <div
+      ref={ref}
+      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+    >
+      <div className="pt-8 px-8 max-w-2xl mx-auto">
+        <PageHeader title={t('networkSettings.title')} subtitle={t('networkSettings.intro')} onBack={onBack} />
+
+        <div className="space-y-10">
+          <section>
+            <SectionHeading>{t('networkSettings.transferLimits')}</SectionHeading>
+            <div className="bg-surface-container-low rounded-xl p-6 space-y-6">
+              <LimitRow {...rowProps('download')} />
+              <LimitRow {...rowProps('upload')} />
+              <p className="text-sm text-on-surface-variant leading-relaxed pt-1">
+                {t('networkSettings.scopeNote')}
+              </p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/screens/Settings.tsx
+++ b/src/renderer/screens/Settings.tsx
@@ -19,6 +19,7 @@ export default function Settings({ onBack, onNavigate }: SettingsProps) {
     { icon: 'desktop_windows', label: t('settings.general'),       desc: generalDesc,                  bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'general-settings' },
     { icon: 'palette',         label: t('settings.appearance'),    desc: t('settings.appearanceDesc'), bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'appearance-settings' },
     { icon: 'notifications',   label: t('settings.notifications'), desc: t('settings.notificationsDesc'), bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'notification-settings' },
+    { icon: 'hub',             label: t('settings.network'),       desc: t('settings.networkDesc'),    bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'network-settings' },
     { icon: 'database',        label: t('settings.storage'),       desc: t('settings.storageDesc'),    bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'storage-settings' },
     { icon: 'history',         label: t('settings.activityLog'),  desc: t('settings.activityLogDesc'), bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'activity-log-settings' },
     { icon: 'info',            label: t('settings.about'),         desc: t('settings.aboutDesc'),      bg: 'bg-icon-tile', fg: 'text-on-icon-tile', screen: 'about' },

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -125,6 +125,10 @@ const DEFAULTED = {
   //   { flapEveryMs, flapJitterMs }  periodically destroy each live connection (a flaky link →
   //                                  reconnect churn, handshake re-rate-limiting, state re-sync)
   netImpair: null,
+  // User-facing content-plane transfer caps, KB/s, 0 = unlimited (the default). Unlike the
+  // protective bounds above these fail OPEN — see getBandwidthLimits.
+  downloadKBps: 0,
+  uploadKBps: 0,
 }
 
 function buildConfig(next) {
@@ -156,6 +160,19 @@ export function setRuntimeConfig(next) {
 
 export function setDownloadFolder(folder) {
   config = { ...config, downloadFolder: folder }
+}
+
+export function setBandwidthLimits({ downloadKBps, uploadKBps } = {}) {
+  config = {
+    ...config,
+    downloadKBps: coerceKBps(downloadKBps, config.downloadKBps),
+    uploadKBps: coerceKBps(uploadKBps, config.uploadKBps),
+  }
+}
+
+function coerceKBps(next, fallback) {
+  if (next === undefined || next === null) return fallback
+  return typeof next === 'number' && Number.isFinite(next) && next >= 0 ? next : fallback
 }
 
 export function getRuntimeConfig() {
@@ -214,6 +231,20 @@ export function getMaxFilesPerShare() {
   if (n === 0 || n === Infinity) return Infinity
   if (typeof n === 'number' && Number.isFinite(n) && n > 0) return n
   return DEFAULT_MAX_FILES_PER_SHARE
+}
+
+// Bytes per second, 0 = unlimited. The fail-safe polarity is INVERTED relative to
+// getListFilesCap: those guard against resource exhaustion, so a bad value must keep the
+// cap; this is a user convenience, so a bad value must return to unlimited rather than
+// throttle every transfer to a crawl.
+export function getBandwidthLimits() {
+  const c = config
+  return { download: toBytesPerSecond(c.downloadKBps), upload: toBytesPerSecond(c.uploadKBps) }
+}
+
+function toBytesPerSecond(kbps) {
+  if (typeof kbps !== 'number' || !Number.isFinite(kbps) || kbps <= 0) return 0
+  return kbps * 1024
 }
 
 export function getCaptureMemberRecordMs() {

--- a/src/shared/transfer/backends/overlay/overlay-instance.js
+++ b/src/shared/transfer/backends/overlay/overlay-instance.js
@@ -18,7 +18,8 @@ import { getLocalPublicKeyHex } from '../../../spaces/profile.js'
 import { senderAuthorizedOnSocket, isApprovedMember } from '../../swarm.js'
 import { contentSenderAuthorizedOnSocket } from '../../content-swarm.js'
 import { createRateLimiter } from '../../handshake-guard.js'
-import { getOverlayServeLimit, isSeparateContentPlaneEnabled } from '../../../core/runtime-config.js'
+import { getOverlayServeLimit, isSeparateContentPlaneEnabled, getBandwidthLimits } from '../../../core/runtime-config.js'
+import { createBandwidthLimiter } from '../../bandwidth-limiter.js'
 import { createLogger } from '../../../core/logger.js'
 
 const log = createLogger('overlay')
@@ -79,6 +80,10 @@ export function getJournalDir() {
 export async function initOverlay() {
   if (overlay) return overlay
   serveLimiter = createRateLimiter(getOverlayServeLimit())
+  // Rates are read per call, so a settings change reaches in-flight transfers without
+  // rebuilding anything.
+  const uploadLimiter = createBandwidthLimiter(() => getBandwidthLimits().upload)
+  const downloadLimiter = createBandwidthLimiter(() => getBandwidthLimits().download)
   // With the content plane on, the overlay channel rides the content connection, so serve
   // authorization keys on that socket's content-hello; otherwise on the control handshake.
   const socketAuthorized = isSeparateContentPlaneEnabled() ? contentSenderAuthorizedOnSocket : senderAuthorizedOnSocket
@@ -116,6 +121,8 @@ export async function initOverlay() {
     onServeControl: ({ from, path, state }) => ledgerServeControl({ from, contentHash: contentHashOf(path), state }),
     // Resume baseline: the downloader's true on-disk have-bytes raise its ledger row.
     onServeProgress: ({ from, path, have }) => ledgerServeBaseline({ from, contentHash: contentHashOf(path), have }),
+    uploadLimiter,
+    downloadLimiter,
   })
   await overlay.ready() // builds protocol/index/sync cores; REQUIRED before attach
   log.info('instance ready')

--- a/src/shared/transfer/backends/overlay/vendor/PROVENANCE.md
+++ b/src/shared/transfer/backends/overlay/vendor/PROVENANCE.md
@@ -331,6 +331,21 @@ re-diffable against upstream. Categories:
     (`test/unit/partial-suffix.test.js`); the opt itself is covered by
     `test/integration/partial-suffix-injection.test.js`.
 
+19. **Host-injected bandwidth limiters (`overlay-v2.js` + `protocol-v2.js` + `chunk-scheduler.js`).**
+    User-set transfer caps are enforced inside the serve/fetch engine, but the limiter itself lives
+    in app code (`src/shared/transfer/bandwidth-limiter.js`) and is **injected** as
+    `uploadLimiter` / `downloadLimiter` constructor opts, so `vendor/` gains no app imports and an
+    embedder that injects nothing is unthrottled. `overlay-v2.js` forwards both to
+    `OverlayProtocolV2`; `protocol-v2._onChunkNeed` awaits `uploadLimiter.take(bytes)` before each
+    `chunkData.send` — and, because that wait opens a revocation window, re-checks the serve grant
+    on the far side of it exactly as the existing drain boundary does. `protocol-v2.fetchContent`
+    passes `downloadLimiter` through as the scheduler's `limiter` opt;
+    `chunk-scheduler._assign` charges each chunk with `tryTake` and, when gated, **re-arms the idle
+    watchdog** before `whenAvailable(bytes, …)` — the watchdog measures silence, and time spent
+    waiting on our own limiter is not silence, so without the re-arm a low cap fails a healthy
+    transfer as "stalled". Covered by `test/unit/bandwidth-limiter.test.js` and the two download-cap
+    cases in `test/unit/overlay-vendor-scheduler.test.js`.
+
 ## Re-diffing against upstream
 
 ```

--- a/src/shared/transfer/backends/overlay/vendor/chunk-scheduler.js
+++ b/src/shared/transfer/backends/overlay/vendor/chunk-scheduler.js
@@ -92,6 +92,7 @@ export class ChunkScheduler {
     this._reject = null
     this._onEnd = opts.onEnd || null
     this._contentHash = opts.contentHash || null   // [mirall] enables incremental whole-file verify
+    this._limiter = opts.limiter || null           // [mirall] download cap; absent → unthrottled
     this._startedAt = Date.now()
     // [mirall] idle timeout — re-armed on each progress signal (see _armIdleTimer).
     this._idleTimeout = opts.timeout || DEFAULT_IDLE_TIMEOUT
@@ -337,6 +338,10 @@ export class ChunkScheduler {
   /** Assign needed-but-not-inflight chunks to peers with spare capacity. */
   _assign () {
     if (this._done || !this._chunks) return
+    // [mirall] A pull protocol paces its inbound bytes by pacing its REQUESTS, so the
+    // download cap is charged here rather than on arrival (by then the bytes are spent).
+    const limiter = this._limiter && !this._limiter.isUnlimited() ? this._limiter : null
+    let gatedBytes = 0
     // Per peer, batch the indices we hand it this round.
     const batches = new Map()
     for (const peer of this._peers) {
@@ -345,15 +350,23 @@ export class ChunkScheduler {
       for (const index of this._needed) {
         if (slots <= 0) break
         if (this._inflight.has(index)) continue
+        if (limiter && !limiter.tryTake(this._chunks[index].length)) { gatedBytes = this._chunks[index].length; break }
         this._inflight.set(index, peer)
         this._peerInflight.set(peer, (this._peerInflight.get(peer) || 0) + 1)
         if (!batches.has(peer)) batches.set(peer, [])
         batches.get(peer).push(index)
         slots--
       }
+      if (gatedBytes) break
     }
     for (const [peer, indices] of batches) {
       if (indices.length) this._sendNeed(peer, indices)
+    }
+    // [mirall] Deliberate pacing is not idleness: re-arm the watchdog and retry on refill,
+    // or a low cap would trip the no-progress timeout and fail a healthy transfer.
+    if (gatedBytes) {
+      this._armIdleTimer()
+      limiter.whenAvailable(gatedBytes, () => this._assign())
     }
   }
 }

--- a/src/shared/transfer/backends/overlay/vendor/overlay-v2.js
+++ b/src/shared/transfer/backends/overlay/vendor/overlay-v2.js
@@ -82,6 +82,10 @@ export class HyperOverlayV2 extends ReadyResource {
     this._onServeControl = opts.onServeControl || null
     this._onServeProgress = opts.onServeProgress || null
 
+    // [mirall] content-plane transfer caps, injected by the app layer.
+    this._uploadLimiter = opts.uploadLimiter || null
+    this._downloadLimiter = opts.downloadLimiter || null
+
     // Shared maps the protocol reads: overlayPath → diskPath (for serving an
     // offered/known path), contentHash → diskPath (fast path for content
     // requests). Both populated by registerFile.
@@ -138,7 +142,9 @@ export class HyperOverlayV2 extends ReadyResource {
         onChunkServe: this._onChunkServe,
         onServeEnd: this._onServeEnd,
         onServeControl: this._onServeControl,
-        onServeProgress: this._onServeProgress
+        onServeProgress: this._onServeProgress,
+        uploadLimiter: this._uploadLimiter,
+        downloadLimiter: this._downloadLimiter
       })
       try { fs.mkdirSync(this._destDir, { recursive: true }) } catch {}
       if (this._journalDir) { try { fs.mkdirSync(this._journalDir, { recursive: true }) } catch {} }

--- a/src/shared/transfer/backends/overlay/vendor/protocol-v2.js
+++ b/src/shared/transfer/backends/overlay/vendor/protocol-v2.js
@@ -78,6 +78,10 @@ export class OverlayProtocolV2 {
     this._serveStartCb = opts.onServeStart || null
     this._chunkServeCb = opts.onChunkServe || null
     this._serveEndCb = opts.onServeEnd || null
+    // [mirall] Content-plane transfer caps, injected by the app layer so this module keeps
+    // no app imports. Absent → unthrottled.
+    this._uploadLimiter = opts.uploadLimiter || null
+    this._downloadLimiter = opts.downloadLimiter || null
     // [mirall] Serve grants are cached per (peer, syntheticPath) at request time and every later
     // chunkNeed is checked against that cache alone, so a request-time authorization would
     // otherwise be trusted forever. The epoch moves on any membership/space mutation, which
@@ -151,7 +155,8 @@ export class OverlayProtocolV2 {
       onVerify: opts.onVerify,
       onEnd: opts.onEnd,
       onBaseline: (have) => this.sendTransferProgress(contentHash, have),
-      contentHash   // [mirall] verify the whole-file hash incrementally during the transfer
+      contentHash,   // [mirall] verify the whole-file hash incrementally during the transfer
+      limiter: this._downloadLimiter   // [mirall] download cap
     })
     this._schedulers.set(p, sched)
     // [mirall] shared promise so joiners (above) can await the same completion —
@@ -666,6 +671,13 @@ export class OverlayProtocolV2 {
       const c = chunkMap[index]
       const data = this._transferManager.readChunk(diskPath, c.offset, c.length)
       if (!data) continue
+      // [mirall] Upload cap. The wait opens a revocation window exactly like the drain
+      // boundary below, so the grant is re-checked on the far side of it.
+      if (this._uploadLimiter && !this._uploadLimiter.isUnlimited()) {
+        await this._uploadLimiter.take(data.length)
+        if (peer.channel?.closed) return
+        if (this._serveAuthorizer && !(await this._serveStillAuthorized(peer, msg.path))) return
+      }
       const flushed = peer.msgs.chunkData.send({ path: msg.path, index, data })
       if (this._chunkServeCb) {
         try { this._chunkServeCb({ path: msg.path, index, bytes: data.length, peer, from: peer.authorizedServe.get(msg.path)?.from ?? null }) } catch {}

--- a/src/shared/transfer/bandwidth-limiter.js
+++ b/src/shared/transfer/bandwidth-limiter.js
@@ -1,0 +1,108 @@
+// Byte-denominated token bucket pacing content-plane transfers. Distinct from
+// handshake-guard's createRateLimiter, which counts EVENTS per peer for abuse control:
+// this one counts BYTES, is global, and delays rather than drops.
+//
+// The rate is read through a getter on every call, so a settings change applies to
+// in-flight transfers with no re-plumbing.
+
+// A cap below this would let a single chunk outlive ChunkScheduler's 30s idle watchdog,
+// failing the transfer as if the network had stalled. Clamped here as well as in the UI.
+export const MIN_BYTES_PER_SECOND = 32 * 1024
+
+export function createBandwidthLimiter(getBytesPerSecond, { now = Date.now } = {}) {
+  let tokens = 0
+  let last = now()
+  let timer = null
+  const waiters = []
+
+  // 0 / negative / non-finite all mean unlimited: a corrupt value must never throttle to
+  // a crawl, so this fails OPEN (the inverse of the protective caps in runtime-config).
+  function ratePerSecond() {
+    const n = getBytesPerSecond()
+    if (typeof n !== 'number' || !Number.isFinite(n) || n <= 0) return 0
+    return Math.max(n, MIN_BYTES_PER_SECOND)
+  }
+
+  function refill(bps) {
+    const t = now()
+    const elapsed = t - last
+    if (elapsed <= 0) return
+    last = t
+    tokens = Math.min(bps, tokens + (bps * elapsed) / 1000)
+  }
+
+  function consume(bytes) {
+    const bps = ratePerSecond()
+    if (bps === 0) return true
+    refill(bps)
+    if (tokens >= bytes) {
+      tokens -= bytes
+      return true
+    }
+    // A chunk larger than one second of budget never fits the bucket. Releasing it on a
+    // full bucket and repaying the deficit keeps the long-run rate correct; refusing it
+    // would stall the transfer permanently.
+    if (bytes > bps && tokens >= bps) {
+      tokens -= bytes
+      return true
+    }
+    return false
+  }
+
+  function delayFor(bytes) {
+    const bps = ratePerSecond()
+    if (bps === 0) return 0
+    const needed = Math.min(bytes, bps) - tokens
+    if (needed <= 0) return 0
+    return Math.ceil((needed / bps) * 1000)
+  }
+
+  function wake() {
+    timer = null
+    const pending = waiters.splice(0, waiters.length)
+    for (const cb of pending) {
+      try { cb() } catch {}
+    }
+  }
+
+  // Deliberately NOT unref'd: a pending take() resolves only when this fires, so an
+  // unref'd timer would let an otherwise-idle loop hang the serve loop forever. The timer
+  // is sub-second and exists only while a transfer is actively throttled.
+  function schedule(ms) {
+    if (timer) return
+    timer = setTimeout(wake, Math.max(1, ms))
+  }
+
+  return {
+    // Non-blocking — for the synchronous download-assign loop.
+    tryTake(bytes) {
+      return consume(bytes)
+    },
+
+    // Awaited before serving a chunk. Resolves once the bytes are paid for.
+    async take(bytes) {
+      while (!consume(bytes)) {
+        const ms = delayFor(bytes)
+        await new Promise((resolve) => {
+          waiters.push(resolve)
+          schedule(ms)
+        })
+      }
+    },
+
+    // Retry hook for tryTake callers: fires once `bytes` should be affordable.
+    whenAvailable(bytes, cb) {
+      waiters.push(cb)
+      schedule(delayFor(bytes))
+    },
+
+    isUnlimited() {
+      return ratePerSecond() === 0
+    },
+
+    destroy() {
+      if (timer) { clearTimeout(timer); timer = null }
+      waiters.length = 0
+    },
+  }
+}

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -11,7 +11,7 @@ import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
 import { createIPC, getBootstrapPromise } from '../shared/core/ipc.js'
-import { setRuntimeConfig, getRuntimeConfig, setDownloadFolder, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap } from '../shared/core/runtime-config.js'
+import { setRuntimeConfig, getRuntimeConfig, setDownloadFolder, setBandwidthLimits, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap } from '../shared/core/runtime-config.js'
 import { getDownloadDir } from '../shared/core/paths.js'
 import { createLogger } from '../shared/core/logger.js'
 import { installCrashBackstop } from '../shared/core/crash-backstop.js'
@@ -2166,6 +2166,13 @@ ipc.handle('storage:free-space', async () => {
 ipc.handle('settings:set-download-folder', async (msg) => {
   const folder = validateDownloadFolder(msg?.folder)
   setDownloadFolder(folder)
+  return { ok: true }
+})
+
+// The limiters read their rate per call, so this reaches in-flight transfers with no
+// further plumbing.
+ipc.handle('settings:set-bandwidth', async (msg) => {
+  setBandwidthLimits({ downloadKBps: msg?.downloadKBps, uploadKBps: msg?.uploadKBps })
   return { ok: true }
 })
 

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -78,6 +78,7 @@ import s76 from './scenarios/s76-invite-create-flow.mjs'
 import s77 from './scenarios/s77-folder-listing-no-flicker.mjs'
 import s78 from './scenarios/s78-folder-truncated-listing.mjs'
 import s104 from './scenarios/s104-add-folder-over-limit.mjs'
+import s105 from './scenarios/s105-network-limits.mjs'
 import s79 from './scenarios/s79-folder-source-missing.mjs'
 import s80 from './scenarios/s80-space-switch-roster.mjs'
 import s81 from './scenarios/s81-space-card-facepile.mjs'
@@ -156,7 +157,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s105-network-limits.mjs
+++ b/test/frontend/scenarios/s105-network-limits.mjs
@@ -1,0 +1,70 @@
+import { mkdirSync } from 'node:fs'
+import { Instance } from '../instance.mjs'
+import { makeReport, waitFor } from '../assert.mjs'
+
+// Settings ▸ Network: transfer caps. Covers the preset control, the Custom input and its
+// floor advisory, persistence across a reopen, and the rule that this screen carries NO
+// live network state (status lives on the account screen).
+export default async function s105 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 1 })
+
+  try {
+    await r.ok('launch + open Network settings', async () => {
+      await A.launch()
+      await A.gotoSettings('Network')
+      await A.waitText('Transfer limits', 8000)
+    })
+
+    await r.ok('defaults to Unlimited in both directions', async () => {
+      await waitFor(async () => (await A.nodeValue({ name: 'Download limit: Unlimited' })) === '1', 8000, 'download unlimited')
+      await waitFor(async () => (await A.nodeValue({ name: 'Upload limit: Unlimited' })) === '1', 8000, 'upload unlimited')
+      await A.shot('s105-default', runDir)
+    })
+
+    // §7.0 — a settings screen answers "what did I choose", not "what is true now".
+    await r.ok('carries no live network state', async () => {
+      if (await A.hasText('peers connected')) throw new Error('peer count leaked onto the settings screen')
+      if (await A.has({ name: 'Network status' })) throw new Error('diagnostics link leaked onto the settings screen')
+    })
+
+    await r.ok('selecting a preset marks it pressed', async () => {
+      await A.click({ name: 'Download limit: 5 MB/s' })
+      await waitFor(async () => (await A.nodeValue({ name: 'Download limit: 5 MB/s' })) === '1', 8000, '5 MB/s pressed')
+      await waitFor(async () => (await A.nodeValue({ name: 'Download limit: Unlimited' })) === '0', 8000, 'Unlimited released')
+    })
+
+    await r.ok('Custom reveals the KB/s input', async () => {
+      await A.click({ name: 'Upload limit: custom' })
+      await A.waitText('Upload limit in KB/s', 8000)
+      await A.shot('s105-custom', runDir)
+    })
+
+    // Targeted by accessible name (from its <label for>), not by role: that is the
+    // contract the a11y bar actually requires of the control.
+    await r.ok('a below-floor value surfaces the clamp advisory', async () => {
+      await A.type({ name: 'Upload limit in KB/s' }, '12')
+      await A.waitText('at least 32 KB/s', 8000)
+      await A.shot('s105-advisory', runDir)
+    })
+
+    await r.ok('a valid custom value echoes its MB/s equivalent', async () => {
+      await A.type({ name: 'Upload limit in KB/s' }, '768')
+      await A.waitText('About', 8000)
+    })
+
+    await r.ok('both the preset and the committed custom value survive a reopen', async () => {
+      // Leaving the field commits the draft; the screen change also proves it persisted.
+      await A.click({ name: 'Back' })
+      await A.waitText('Manage your experience', 8000)
+      await A.click({ name: 'Network' })
+      await A.waitText('Transfer limits', 8000)
+      await waitFor(async () => (await A.nodeValue({ name: 'Download limit: 5 MB/s' })) === '1', 8000, '5 MB/s still pressed')
+      await waitFor(async () => (await A.nodeValue({ name: 'Upload limit: custom' })) === '1', 8000, 'custom still pressed')
+      await A.waitText('Upload limit in KB/s', 8000)
+      await A.shot('s105-persisted', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/unit/bandwidth-limiter.test.js
+++ b/test/unit/bandwidth-limiter.test.js
@@ -1,0 +1,103 @@
+import test from 'brittle'
+import { createBandwidthLimiter, MIN_BYTES_PER_SECOND } from '../../src/shared/transfer/bandwidth-limiter.js'
+
+// A manual clock so refill is deterministic — drive the bucket, never sleep.
+function clock (start = 1_000_000) {
+  let t = start
+  return { now: () => t, advance: (ms) => { t += ms } }
+}
+
+const KB = 1024
+
+test('0 is unlimited: every take passes and no bucket is consulted', (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 0, { now: c.now })
+  t.ok(l.isUnlimited(), 'reports unlimited')
+  for (let i = 0; i < 100; i++) t.ok(l.tryTake(64 * KB), `take ${i + 1} passes`)
+})
+
+test('a full bucket grants one second of budget, then throttles', (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 100 * KB, { now: c.now })
+  c.advance(1000) // fill
+  t.ok(l.tryTake(100 * KB), 'one second of budget passes')
+  t.absent(l.tryTake(1 * KB), 'bucket is now empty')
+})
+
+test('refill is proportional to elapsed time', (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 100 * KB, { now: c.now })
+  c.advance(1000)
+  t.ok(l.tryTake(100 * KB), 'drain the bucket')
+  c.advance(500)
+  t.ok(l.tryTake(50 * KB), 'half a second refills half the budget')
+  t.absent(l.tryTake(1 * KB), 'and no more')
+})
+
+test('the bucket never accumulates more than one second of burst', (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 100 * KB, { now: c.now })
+  c.advance(60_000) // idle for a minute
+  t.ok(l.tryTake(100 * KB), 'one second of budget is available')
+  t.absent(l.tryTake(1 * KB), 'the other 59 seconds did NOT bank')
+})
+
+// The starvation guard: a chunk can exceed one second of budget (tier-3 chunks reach 4 MB
+// while a cap may be 64 KB/s). Refusing it forever would stall the transfer.
+test('a chunk larger than the bucket is released on a full bucket and repaid', (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 64 * KB, { now: c.now })
+  c.advance(1000)
+  t.ok(l.tryTake(4 * 1024 * KB), 'oversized chunk passes rather than starving')
+  c.advance(1000)
+  t.absent(l.tryTake(1 * KB), 'the deficit is still being repaid a second later')
+  c.advance(70_000)
+  t.ok(l.tryTake(1 * KB), 'once repaid, normal service resumes')
+})
+
+test('rate is re-read on every call, so a live change applies immediately', (t) => {
+  const c = clock()
+  let kbps = 0
+  const l = createBandwidthLimiter(() => kbps, { now: c.now })
+  t.ok(l.tryTake(10 * 1024 * KB), 'unlimited while the cap is 0')
+  kbps = 100 * KB
+  t.absent(l.tryTake(100 * KB), 'the new cap binds without rebuilding the limiter')
+})
+
+test('a cap below the floor is clamped, not honoured', (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 1, { now: c.now })
+  c.advance(1000)
+  t.ok(l.tryTake(MIN_BYTES_PER_SECOND), 'the floor is granted despite a 1 B/s request')
+  t.absent(l.isUnlimited(), 'still a limit, just not an unusable one')
+})
+
+// Fail-safe polarity: a corrupt value must return to UNLIMITED, never throttle to a crawl.
+for (const bad of [-1, NaN, Infinity, '5000', null, undefined]) {
+  test(`a non-positive or non-numeric rate (${String(bad)}) falls back to unlimited`, (t) => {
+    const c = clock()
+    const l = createBandwidthLimiter(() => bad, { now: c.now })
+    t.ok(l.isUnlimited(), 'treated as unlimited')
+    t.ok(l.tryTake(100 * 1024 * KB), 'nothing is throttled')
+  })
+}
+
+test('take() resolves once the bytes are paid for', async (t) => {
+  const l = createBandwidthLimiter(() => 256 * KB)
+  await l.take(256 * KB)
+  const startedAt = Date.now()
+  await l.take(64 * KB)
+  t.ok(Date.now() - startedAt >= 100, 'the second take waited for a refill')
+  l.destroy()
+})
+
+test('whenAvailable waits only as long as the requested bytes need', async (t) => {
+  const l = createBandwidthLimiter(() => 128 * KB)
+  l.tryTake(128 * KB)
+  const startedAt = Date.now()
+  await new Promise((resolve) => l.whenAvailable(8 * KB, resolve))
+  const waited = Date.now() - startedAt
+  t.ok(l.tryTake(8 * KB), 'budget is available by the time the callback runs')
+  t.ok(waited < 500, `waited ${waited}ms for 1/16th of a second of budget, not a full second`)
+  l.destroy()
+})

--- a/test/unit/config-store.test.js
+++ b/test/unit/config-store.test.js
@@ -137,3 +137,51 @@ test('setRenderer applies valid patches and rejects bad values', (t) => {
   store.setRenderer({ notifications: null })
   t.is(store.get('notifications'), null)
 })
+
+test('network defaults to unlimited and self-heals onto a config written before it existed', (t) => {
+  const dir = tmpDir()
+  const store = new ConfigStore(dir).load()
+  t.is(store.get('network.downloadKBps'), 0, 'download unlimited by default')
+  t.is(store.get('network.uploadKBps'), 0, 'upload unlimited by default')
+
+  // A config.json from a build that predates the network group must gain it via
+  // mergeDefaults, without losing what that build did set.
+  writeJson(path.join(dir, 'config.json'), { version: CONFIG_VERSION, appearance: { theme: 'dark' } })
+  const reopened = new ConfigStore(dir).load()
+  t.is(reopened.get('network.downloadKBps'), 0, 'missing group filled with defaults')
+  t.is(reopened.get('appearance.theme'), 'dark', 'existing values preserved')
+})
+
+test('setBandwidth stores non-negative integers and ignores anything else', (t) => {
+  const dir = tmpDir()
+  const store = new ConfigStore(dir).load()
+
+  store.setBandwidth({ downloadKBps: 5120, uploadKBps: 1024 })
+  t.is(store.get('network.downloadKBps'), 5120)
+  t.is(store.get('network.uploadKBps'), 1024)
+
+  store.setBandwidth({ downloadKBps: 512.7 })
+  t.is(store.get('network.downloadKBps'), 512, 'floored to a whole KB/s')
+
+  for (const bad of [-1, NaN, Infinity, '900', null, {}]) {
+    store.setBandwidth({ downloadKBps: bad })
+    t.is(store.get('network.downloadKBps'), 512, `rejects ${String(bad)}`)
+  }
+
+  store.setBandwidth({ uploadKBps: 0 })
+  t.is(store.get('network.uploadKBps'), 0, '0 is valid — it means unlimited')
+
+  store.setBandwidth(null)
+  t.is(store.get('network.downloadKBps'), 512, 'a non-object patch is a no-op')
+})
+
+test('network survives a persist/reload round-trip', (t) => {
+  const dir = tmpDir()
+  const store = new ConfigStore(dir).load()
+  store.setBandwidth({ downloadKBps: 2048, uploadKBps: 256 })
+  store.flush()
+  t.alike(readConfig(dir).network, { downloadKBps: 2048, uploadKBps: 256 })
+  const reopened = new ConfigStore(dir).load()
+  t.is(reopened.get('network.downloadKBps'), 2048)
+  t.is(reopened.get('network.uploadKBps'), 256)
+})

--- a/test/unit/overlay-vendor-scheduler.test.js
+++ b/test/unit/overlay-vendor-scheduler.test.js
@@ -338,3 +338,77 @@ test('a _fail with a transfer lacking pause() does not throw', async (t) => {
   await sched.onChunkHashes(peer, chunkList(2))
   await t.exception(done, /stalled/, 'stall still rejects cleanly without a pause method')
 })
+
+// --- download cap -----------------------------------------------------------
+// The limiter is injected, so these drive the gate without a live overlay.
+
+function fakeLimiter (allowance) {
+  let left = allowance
+  const waiters = []
+  return {
+    isUnlimited: () => false,
+    tryTake (bytes) {
+      if (left < bytes) return false
+      left -= bytes
+      return true
+    },
+    whenAvailable (bytes, cb) { waiters.push(cb) },
+    release (amount) {
+      left += amount
+      const pending = waiters.splice(0, waiters.length)
+      for (const cb of pending) cb()
+    },
+    pendingWaiters: () => waiters.length,
+  }
+}
+
+test('download cap: chunks are requested only as budget allows', async (t) => {
+  const requested = []
+  const limiter = fakeLimiter(20) // room for exactly 2 of the 4 ten-byte chunks
+  const sched = new ChunkScheduler({
+    path: 'content:capped', destPath: '/tmp/capped', transfer: fakeTransfer(),
+    sendNeed: (_peer, indices) => requested.push(...indices), timeout: 5000, cap: 8, limiter,
+  })
+  const done = sched.promise()
+  await sched.onChunkHashes(peer, chunkList(4))
+  t.is(requested.length, 2, 'only the affordable chunks were asked for')
+  t.is(limiter.pendingWaiters(), 1, 'the scheduler registered a retry for the rest')
+
+  limiter.release(20)
+  await wait(0)
+  t.is(requested.length, 4, 'the rest are requested once budget refills')
+
+  for (let i = 0; i < 4; i++) sched.onChunkData(peer, i, Buffer.alloc(10))
+  await done
+  t.pass('capped transfer still completes')
+})
+
+// REGRESSION (FIX: bandwidth cap must not look like a stall): the idle watchdog measures
+// SILENCE. Time spent waiting on our own limiter is not silence, so a cap low enough to
+// hold every chunk longer than the window must not fail the transfer.
+test('download cap: waiting on the limiter does not trip the idle watchdog', async (t) => {
+  const limiter = fakeLimiter(10) // one chunk, then gated for the rest of the test
+  const sched = new ChunkScheduler({
+    path: 'content:slow', destPath: '/tmp/slow', transfer: fakeTransfer(),
+    sendNeed: () => {}, timeout: 120, cap: 8, limiter,
+  })
+  const done = sched.promise()
+  await sched.onChunkHashes(peer, chunkList(4))
+
+  // Stay gated for well over the idle window, re-arming as a real refill loop would.
+  for (let i = 0; i < 4; i++) {
+    await wait(60)
+    limiter.release(0)
+  }
+
+  let failed = false
+  done.catch(() => { failed = true })
+  await wait(0)
+  t.absent(failed, 'no stall failure while the transfer was merely paced')
+
+  limiter.release(1000)
+  await wait(0)
+  for (let i = 0; i < 4; i++) sched.onChunkData(peer, i, Buffer.alloc(10))
+  await done
+  t.pass('completes once the cap allows')
+})

--- a/test/unit/runtime-config.test.js
+++ b/test/unit/runtime-config.test.js
@@ -1,5 +1,5 @@
 import {
-  setRuntimeConfig, setDownloadFolder, getRuntimeConfig,
+  setRuntimeConfig, setDownloadFolder, setBandwidthLimits, getBandwidthLimits, getRuntimeConfig,
   getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow,
 } from '../../src/shared/core/runtime-config.js'
 import test from 'brittle'
@@ -158,5 +158,38 @@ test('REGRESSION (FIX-MIR-12): avatar cap default matches AVATAR_MAX_BYTES', (t)
   t.is(getResourceCaps().avatarMaxBytes, 1024, 'override applied')
   setRuntimeConfig({ maxAvatarBytes: 0 })
   t.is(getResourceCaps().avatarMaxBytes, 0, '0 disables the bound')
+  setRuntimeConfig({})
+})
+
+test('bandwidth limits default to unlimited and convert KB/s to bytes/s', (t) => {
+  setRuntimeConfig({})
+  t.alike(getBandwidthLimits(), { download: 0, upload: 0 }, '0 = unlimited on both directions')
+  setRuntimeConfig({ downloadKBps: 5120, uploadKBps: 1024 })
+  t.alike(getBandwidthLimits(), { download: 5120 * 1024, upload: 1024 * 1024 }, 'converted to bytes/s')
+  setRuntimeConfig({})
+})
+
+// Inverted fail-safe: these are a user convenience, not a protective bound, so a corrupt
+// value must return to UNLIMITED rather than throttle every transfer to a crawl.
+test('a corrupt bandwidth value fails OPEN, not closed', (t) => {
+  for (const bad of [-1, NaN, Infinity, '5000', {}, null]) {
+    setRuntimeConfig({ downloadKBps: bad, uploadKBps: bad })
+    t.alike(getBandwidthLimits(), { download: 0, upload: 0 }, `${String(bad)} falls back to unlimited`)
+  }
+  setRuntimeConfig({})
+})
+
+test('setBandwidthLimits updates live and leaves the rest of the config alone', (t) => {
+  setRuntimeConfig({ downloadFolder: '/tmp/dl', downloadKBps: 100 })
+  setBandwidthLimits({ downloadKBps: 2048, uploadKBps: 512 })
+  t.alike(getBandwidthLimits(), { download: 2048 * 1024, upload: 512 * 1024 }, 'new caps applied')
+  t.is(getRuntimeConfig().downloadFolder, '/tmp/dl', 'unrelated config preserved')
+
+  setBandwidthLimits({ uploadKBps: 0 })
+  t.is(getBandwidthLimits().upload, 0, '0 is honoured — it means unlimited')
+  t.is(getBandwidthLimits().download, 2048 * 1024, 'an omitted direction keeps its value')
+
+  setBandwidthLimits({ downloadKBps: 'nonsense' })
+  t.is(getBandwidthLimits().download, 2048 * 1024, 'an invalid value keeps the previous cap')
   setRuntimeConfig({})
 })


### PR DESCRIPTION
Global download and upload caps for file transfers, 0 = unlimited.

A byte token bucket per direction, charged at chunk boundaries: the pull side
paces chunk **requests** (by arrival the bytes are spent), the serve side paces
sends. The limiter lives in app code and is injected into the vendored overlay
engine, so `vendor/` gains no app imports. Rates are read per call, so a change
reaches in-flight transfers with nothing to re-plumb.

Caps govern the **content plane only** — catalog/profile replication and
handshakes stay unthrottled, since throttling them would starve the propagation
`content-plane-hol.test.js` guards. A corrupt cap value fails **open**, the
inverse of the protective bounds in `runtime-config.js`.

Settings gains a Network screen for the caps. It carries no live status by
design: status stays on the account screen.

### Three cases that needed guarding
- **Idle watchdog.** `ChunkScheduler` fails after 30s with no accepted chunk. A
  gated assign re-arms it — that timer measures silence, and waiting on our own
  limiter is not silence. Without this a low cap fails a healthy transfer as a
  stall. Verified by removing the guard and watching the test fail.
- **Revocation window.** The new serve-side `await` opens a gap in which a
  removed member could keep pulling bytes, so the grant is re-checked after it,
  mirroring the existing drain boundary.
- **Oversized chunks.** A chunk can exceed one second of budget (tier-3 reaches
  4 MB, a cap may be 64 KB/s). It is released on a full bucket and the deficit
  repaid, rather than starving forever.

### Testing
`typecheck` clean · unit 887/887 · `test:bare` 632/632 · `test:flow` 187/187 ·
`lint:ci` 0 errors · `build` (jsx-a11y) clean · frontend `s105` 8/8 (new) plus
`s8`/`s15`/`s17` as regression checks.

New coverage: `bandwidth-limiter.test.js` (bucket math, fail-open, clamp),
config-store + runtime-config round-trips, two download-cap cases in
`overlay-vendor-scheduler.test.js`, and `s105-network-limits.mjs` — which also
asserts the screen exposes no live-state row.

Locale keys added to all five languages. `PROVENANCE.md` entry 19 documents the
vendored-file changes.
