### PR TITLE
[fix] Clear the source-missing banner when the folder returns

### DIFF
--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -26,12 +26,19 @@ export { shouldIgnore, DEFAULT_IGNORE }
 const log = createLogger('owned-folders')
 
 let ipcRef = null
+// Injected by the worker: maps a scan/reconcile outcome onto the mount's durable status, the
+// live UI event, and (for a missing root) the watcher/timer teardown. This module reports
+// outcomes; the policy for acting on one belongs to the process that owns the watcher and the
+// mount-point probe. Unset outside the worker (integration helpers), which keeps the old
+// fire-and-forget behaviour.
+let settleScanRef = null
 
 const reconcileTimers = new Map()
 const POST_EVENT_RECONCILE_MS = 2000
 
-export function initOwnedFolders(_ipc) {
+export function initOwnedFolders(_ipc, { settleScan = null } = {}) {
   ipcRef = _ipc
+  settleScanRef = settleScan
 }
 
 // Chokidar can drop `add` events when several files land in a new subfolder at
@@ -43,8 +50,12 @@ function scheduleCatchupReconcile(mount) {
   clearTimeout(reconcileTimers.get(key))
   const timer = setTimeout(() => {
     reconcileTimers.delete(key)
-    periodicReconcile(mount.spaceId, mount.shareId, mount.mountPath, mount.ignore || DEFAULT_IGNORE)
-      .catch((err) => log.debug('catch-up reconcile failed:', err.message))
+    const scan = periodicReconcile(mount.spaceId, mount.shareId, mount.mountPath, mount.ignore || DEFAULT_IGNORE)
+    // Settle the OUTCOME rather than swallowing it. This reconcile is the fastest signal that a
+    // vanished source is back — or still gone — and running it silently repaired the catalog while
+    // leaving the durable status (and the "source missing" banner) latched on the last bad value.
+    if (settleScanRef) settleScanRef(scan, mount.spaceId, mount.shareId)
+    else scan.catch((err) => log.debug('catch-up reconcile failed:', err.message))
   }, POST_EVENT_RECONCILE_MS)
   timer.unref?.()
   reconcileTimers.set(key, timer)

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -256,7 +256,12 @@ try { didMigrateOverlayIndex = (await migrateOverlayIndexToEncrypted())?.migrate
   log.warn('overlay-index at-rest migration failed:', err.message)
 }
 await initMounts()
-initOwnedFolders(ipc)
+// settleScanStatus (hoisted, defined with the reconcile scheduling below) also settles the
+// trailing catch-up reconcile a watcher event schedules, so a source that disappears or returns
+// between probe ticks still updates the durable status and notifies the UI. Forward-referencing it
+// here is safe: the hook can only fire off a watcher event, and no frame is dispatched until
+// ipc.start() at the end of this module — well after the state it touches is initialised.
+initOwnedFolders(ipc, { settleScan: settleScanStatus })
 initForeignFolders(ipc)
 const knownSpaces = await listSpaces()
 // Finish any leave a prior process interrupted (durable `leaving` marker still present) BEFORE
@@ -792,6 +797,21 @@ async function setOwnedStatus(spaceId, shareId, status, error) {
   ipc.emit('event:owned-folder-mount-status', { spaceId, shareId, status, ...(error ? { error } : {}) })
 }
 
+// Everything that must happen once an owned source folder is known to be missing, from whichever
+// signal noticed first: the mount-point probe, or a scan/reconcile that bailed on the absent root.
+// Recording the absence in `lastMountPointStatus` is what lets the probe read the RETURN as a
+// gone→present edge. Without it, a folder that vanished and came back inside a single 60s probe
+// window produced no transition at all — so no status event, and every derived-from-event UI
+// (the FolderView banner, the share card badge) stayed latched on "source missing" indefinitely.
+async function handleOwnedMountGone(spaceId, shareId) {
+  lastMountPointStatus.set('owned-folder:' + shareId, false)
+  // Stop pointing a watcher at a dead path and stop reconciling. The published snapshot and the
+  // mount config are left untouched — a missing root is ambiguous, never a delete.
+  ipc.emit('main-request', { command: 'owned-folder:stop-watcher', args: { shareId } })
+  cancelPeriodicReconcile(spaceId, shareId)
+  await setOwnedStatus(spaceId, shareId, 'mount-point-gone')
+}
+
 // Map a reconcile/scan outcome to the durable owned-mount status. A scan RESOLVES (not rejects)
 // with { skipped } when it couldn't run — a missing root or a content mode this build can't serve
 // — so treating any resolution as 'active' would durably record a healthy scan that never ran.
@@ -799,7 +819,7 @@ async function setOwnedStatus(spaceId, shareId, status, error) {
 async function settleScanStatus(promise, spaceId, shareId) {
   try {
     const result = await promise
-    if (result?.skipped === 'mount-point-gone') await setOwnedStatus(spaceId, shareId, 'mount-point-gone')
+    if (result?.skipped === 'mount-point-gone') await handleOwnedMountGone(spaceId, shareId)
     else if (result?.skipped) await setOwnedStatus(spaceId, shareId, 'paused-error', result.skipped)
     else await setOwnedStatus(spaceId, shareId, 'active')
     return result
@@ -914,12 +934,8 @@ async function probeMountPoints() {
 
     if (mount.role === 'owned-folder') {
       if (!exists) {
-        // Source folder just disappeared — tear down the live machinery so we stop pointing a
-        // watcher at a dead path and stop reconciling, and persist the gone status. The
-        // published snapshot and mount config are left untouched.
-        ipc.emit('main-request', { command: 'owned-folder:stop-watcher', args: { shareId: mount.shareId } })
-        cancelPeriodicReconcile(mount.spaceId, mount.shareId)
-        await setOwnedStatus(mount.spaceId, mount.shareId, 'mount-point-gone')
+        // Source folder just disappeared — same teardown the watcher-driven path runs.
+        await handleOwnedMountGone(mount.spaceId, mount.shareId)
       } else if (wasGone) {
         // Source folder came back (USB replugged, network mount up, moved back). Resume: restart
         // the watcher, run one catch-up reconcile whose OUTCOME sets the durable status (so a

--- a/test/frontend/scenarios/s28-subfolder.mjs
+++ b/test/frontend/scenarios/s28-subfolder.mjs
@@ -7,8 +7,8 @@ import { workDir } from '../paths.mjs'
 
 // P0 / G3 — the owner creates a nested subfolder with a file inside a shared
 // folder. The nested path must replicate (slash-keyed), show in the peer's
-// (flat, recursive) folder view, and materialize at the right nested path on a
-// mirror's disk via mkdir -p. Nesting is exactly where path-handling bugs hide.
+// folder view, and materialize at the right nested path on a mirror's disk via
+// mkdir -p. Nesting is exactly where path-handling bugs hide.
 export default async function s28 ({ runDir, bootstrap }) {
   mkdirSync(runDir, { recursive: true })
   const r = makeReport()
@@ -40,6 +40,12 @@ export default async function s28 ({ runDir, bootstrap }) {
     })
     await r.ok('the nested file shows in B’s folder view', async () => {
       await B.openFolder('Media')
+      // FolderView is a collapsible tree (s103): top-level folders open by default, deeper
+      // ones stay collapsed, and leaves render their basename — so the replicated nesting
+      // shows as a "trips" row containing a "2024" row, and the leaf appears once it's opened.
+      await B.waitText('trips', 20000)
+      assert(await B.hasText('2024'), 'the nested subfolder replicated as its own tree level')
+      await B.click({ role: 'button', name: '2024' })
       await B.waitText('lake.txt', 20000)
     })
   } catch {}

--- a/test/integration/owned-source-return.test.js
+++ b/test/integration/owned-source-return.test.js
@@ -1,0 +1,111 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { setupOwnedShare } from '../helpers/owned.js'
+import { initOwnedFolders, onFsEvent } from '../../src/shared/folders/owned-folders.js'
+import { setOwnedMountStatus, getOwnedMount } from '../../src/shared/folders/mount-store.js'
+
+// A watcher event schedules a trailing catch-up reconcile (2s debounce). That reconcile used to
+// run fire-and-forget: it healed the catalog but its OUTCOME went nowhere, so nothing persisted a
+// status and nothing emitted event:owned-folder-mount-status. The renderer only re-derives the
+// owned-mount status on that event, and the 60s mount-point probe only emits on a present↔gone
+// EDGE — so a source folder that vanished and came back inside one probe window produced no
+// signal at all and the "source folder moved" banner stayed up forever (frontend s79).
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+const CATCHUP_SETTLED_MS = 4000   // POST_EVENT_RECONCILE_MS (2s) plus room for the scan itself
+
+// Stand-in for the worker's settleScanStatus: records every settled outcome and applies the same
+// outcome → status mapping (durable write + live event) the worker installs in production.
+function recordingSettle (ctx) {
+  const settled = []
+  const settleScan = async (scan, spaceId, shareId) => {
+    let status = 'active'
+    let outcome
+    try {
+      const result = await scan
+      if (result?.skipped === 'mount-point-gone') status = 'mount-point-gone'
+      else if (result?.skipped) status = 'paused-error'
+      outcome = { spaceId, shareId, result }
+    } catch (err) {
+      status = 'paused-error'
+      outcome = { spaceId, shareId, error: err }
+    }
+    await setOwnedMountStatus(spaceId, shareId, status, null)
+    ctx.fake.ipc.emit('event:owned-folder-mount-status', { spaceId, shareId, status })
+    // Recorded last: waitForSettle keys off this array, so publishing the status first keeps
+    // the assertions that follow it free of a race with our own settle.
+    settled.push(outcome)
+  }
+  initOwnedFolders(ctx.fake.ipc, { settleScan })
+  return settled
+}
+
+// Returns whether an outcome landed. Callers bail out on false: with nothing recorded, every
+// assertion after it would throw on an empty array and bury the real failure.
+async function waitForSettle (settled, timeout = CATCHUP_SETTLED_MS) {
+  const deadline = Date.now() + timeout
+  while (Date.now() < deadline && settled.length === 0) await delay(50)
+  return settled.length > 0
+}
+
+test('REGRESSION (FIX-S79: a watcher event’s catch-up reconcile settles its outcome)', async (t) => {
+  const ctx = await setupOwnedShare(t)
+  const settled = recordingSettle(ctx)
+
+  const abs = path.join(ctx.mountPath, 'doc.txt')
+  fs.writeFileSync(abs, 'v1')
+  await onFsEvent(ctx.spaceId, ctx.share.id, 'add', 'doc.txt', abs)
+
+  const landed = await waitForSettle(settled)
+  t.ok(landed, 'the trailing catch-up reconcile reported its outcome')
+  if (!landed) return
+  t.is(settled[0].shareId, ctx.share.id, 'settled against the share that saw the event')
+  t.absent(settled[0].result?.skipped, 'a present root reconciles for real')
+  t.is(ctx.fake.lastStatus(ctx.share.id), 'active', 'and the UI is told the mount is healthy')
+})
+
+// The s79 timeline at the data layer: the source vanishes (watcher unlink), the banner goes up,
+// and the folder is restored moments later — well inside one probe window, so the probe never
+// sees an edge. The catch-up reconcile is the only thing that can clear it.
+test('REGRESSION (FIX-S79: a source restored before the catch-up reconcile clears the gone status)', async (t) => {
+  const ctx = await setupOwnedShare(t)
+  const settled = recordingSettle(ctx)
+  const abs = path.join(ctx.mountPath, 'doc.txt')
+  fs.writeFileSync(abs, 'v1')
+
+  // Source folder moved away: the watcher fires unlink against an absent root.
+  fs.rmSync(ctx.mountPath, { recursive: true, force: true })
+  await onFsEvent(ctx.spaceId, ctx.share.id, 'unlink', 'doc.txt', abs)
+  t.is(ctx.fake.lastStatus(ctx.share.id), 'mount-point-gone', 'the missing source surfaces immediately')
+
+  // Moved back, before the 2s catch-up reconcile fires.
+  fs.mkdirSync(ctx.mountPath, { recursive: true })
+  fs.writeFileSync(abs, 'v1')
+
+  const landed = await waitForSettle(settled)
+  t.ok(landed, 'the catch-up reconcile still settles after the round trip')
+  if (!landed) return
+  t.absent(settled[0].result?.skipped, 'it ran against the restored root')
+  t.is(ctx.fake.lastStatus(ctx.share.id), 'active', 'the gone status is cleared without a probe edge')
+  t.is((await getOwnedMount(ctx.spaceId, ctx.share.id)).status, 'active', 'and the durable status recovers')
+})
+
+// The other half: when the source is STILL gone at catch-up time, the settled outcome is what
+// drives the durable gone status — and, in the worker, marks the probe's presence baseline so the
+// eventual return registers as a gone→present edge.
+test('REGRESSION (FIX-S79: a source still missing at catch-up time settles as mount-point-gone)', async (t) => {
+  const ctx = await setupOwnedShare(t)
+  const settled = recordingSettle(ctx)
+  const abs = path.join(ctx.mountPath, 'doc.txt')
+  fs.writeFileSync(abs, 'v1')
+
+  fs.rmSync(ctx.mountPath, { recursive: true, force: true })
+  await onFsEvent(ctx.spaceId, ctx.share.id, 'unlink', 'doc.txt', abs)
+
+  const landed = await waitForSettle(settled)
+  t.ok(landed, 'the catch-up reconcile reports even when it could not run')
+  if (!landed) return
+  t.is(settled[0].result?.skipped, 'mount-point-gone', 'the outcome names the missing root')
+  t.is((await getOwnedMount(ctx.spaceId, ctx.share.id)).status, 'mount-point-gone', 'persisted, so a reload re-derives it')
+})


### PR DESCRIPTION
Fixes two failing frontend scenarios.

**s79 — product bug.** The "source folder moved" banner could be raised by the
watcher's unlink path but only cleared by the 60s mount-point probe, which is a
pure edge detector. A source that vanished and returned inside one probe window
produced no transition, so no `event:owned-folder-mount-status` — and every
surface that derives from it (FolderView banner, share card badge) stayed
latched until the view was remounted.

- The catch-up reconcile a watcher event schedules now settles its outcome
  through an injected `settleScan` seam instead of running fire-and-forget.
- `handleOwnedMountGone()` is now the single teardown path for a missing
  source, used by both the probe and scan outcomes. It records the absence in
  the probe's presence map, so the return always registers as an edge.

**s28 — stale test.** FolderView has been a collapsible tree since s103; the
scenario still asserted the old flat recursive listing, so a leaf two levels
deep was never rendered. Updated to expand the nested folder.

## Coverage
- 3 red-first `REGRESSION (FIX-S79: …)` integration tests — 0/3 before the fix, 3/3 after.
- Local `test:fe`: s79 3/3, s28 3/3, plus s23 / s9 / s103 as a regression sweep.
- typecheck + lint clean, `test:bare` 650/650, `test:node` 187/187.

No renderer UI changed, so no a11y surface.
