### PR TITLE
[chore] Cap hyperdht below 6.33.0 in Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,7 @@
   "extends": ["config:recommended", ":dependencyDashboard"],
   "timezone": "Europe/Berlin",
   "schedule": ["before 8am on Monday"],
-  "baseBranches": ["staging"],
+  "baseBranchPatterns": ["staging"],
   "labels": ["dependencies"],
   "prConcurrentLimit": 5,
   "prHourlyLimit": 0,
@@ -51,6 +51,11 @@
       "groupName": "electron",
       "labels": ["dependencies", "needs-smoke-test"],
       "automerge": false
+    },
+    {
+      "description": "hyperdht 6.33.0 rewrote the LAN shortcut in lib/connect.js to race the LAN ping against holepunch, which degrades connection setup on the loopback testnet under Linux CI — every flow shard times out waiting for member-join-request while macOS passes (see issue #13). Cap below 6.33.0 so the known-bad version cannot land unattended, while patches on the 6.32 line still flow through the holepunch group. Raise this only after a Linux runner proves the newer version green.",
+      "matchPackageNames": ["hyperdht"],
+      "allowedVersions": "<6.33.0"
     }
   ],
   "lockFileMaintenance": {


### PR DESCRIPTION
Config-only hotfix to `main`. The Renovate workflow checks out the default branch, so `renovate.json` must be on `main` for the cap to take effect — landing it only on staging would leave hyperdht 6.33.0 free to return on the next scheduled run (Mon 2026-08-17) and undo the #28 split.

Identical change to #45, which carries the staging half (the forward-port the base guard's hotfix path asks for).

hyperdht 6.33.0 has failed all six flow shards on #28 for four consecutive weekly rebases with the connection-layer signature from #13. Holding it at 6.32.0 turned #28 green — 9/9 including all six shards — confirming it was the sole cause.

`allowedVersions: "<6.33.0"` rather than disabling the package, so 6.32.x patches still flow.

Tests: SKIP — config-only, touches no runtime code. `renovate-config-validator` passes.