### PR TITLE
[chore] Gate major updates behind dashboard approval

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,7 +11,7 @@
   "rebaseWhen": "behind-base-branch",
   "packageRules": [
     {
-      "description": "Routine dependency updates auto-merge once CI passes; with rebaseWhen above, Renovate keeps them rebased so package-lock conflicts resolve without manual cycles. The smoke-test groups below come after and override this back to manual for their packages.",
+      "description": "Routine updates are flagged for automerge, but be aware this has never actually fired — every dependency PR so far was merged by hand. GitHub's auto-merge is only offered on PRs blocked by something (required status checks or reviews) and this repo has neither, so Renovate falls back to its own automerge, which only runs when the weekly workflow runs. By then rebaseWhen has usually just rebased the branch and CI is pending again. The flag is kept because the intent is right: it starts working the moment either a more frequent Renovate cron or required status checks exist. The smoke-test groups below come after and override this back to manual for their packages.",
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeStrategy": "squash"

--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
   "schedule": ["before 8am on Monday"],
   "baseBranchPatterns": ["staging"],
   "labels": ["dependencies"],
-  "prConcurrentLimit": 5,
+  "prConcurrentLimit": 10,
   "prHourlyLimit": 0,
   "rangeStrategy": "bump",
   "rebaseWhen": "behind-base-branch",
@@ -15,6 +15,11 @@
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
       "automerge": true,
       "automergeStrategy": "squash"
+    },
+    {
+      "description": "Majors are adopted deliberately, and several are blocked upstream for months at a time (eslint 10 on eslint-plugin-jsx-a11y's peer range, typescript 7 on typescript-eslint's). An open PR for one of those sits untouched indefinitely, occupying a prConcurrentLimit slot and getting rebased plus fully re-tested every run. Queue them on the dependency dashboard instead: they stay visible as checkboxes and only become a branch when someone ticks one.",
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     },
     {
       "description": "Pear runtime hosts the worker process; bump deliberately and smoke-test OTA, DMG, MSIX, AppImage, and native modules before merging",


### PR DESCRIPTION
Config-only hotfix to `main`, identical to #47 which carries the staging half. The Renovate workflow checks out the default branch, so `renovate.json` has to be here to take effect.

Raises `prConcurrentLimit` 5 → 10 and gates majors behind `dependencyDashboardApproval`, so the four majors we are deliberately holding (eslint 10, typescript 7, electron 43, setup-node v7) queue as dashboard checkboxes rather than opening PRs that squat on concurrency slots indefinitely.

Tests: SKIP — config-only, touches no runtime code. `renovate-config-validator` passes.