### PR TITLE
[chore] Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,38 @@ behaves are intentionally omitted. Releases that contained only such
 changes do not appear here.
 
 
+## v1.8.0
+### 2026-08-11
+
+#### Added
+
+- **A record of what happened in your spaces.** The new Activity Log
+  gathers what's gone on — who joined, left, or was approved, files
+  shared and downloaded, folders shared and mirrored, and requests that
+  were refused. It's kept on your device only and never leaves it. Open
+  it from your Account page, then search it or narrow it down by space,
+  person, category, or date. Entries stay readable even for spaces
+  you've since left. Settings → Activity Log turns recording off, sets
+  how long events are kept (30, 90, or 365 days), exports everything as
+  JSON, or deletes the log outright.
+- **Limit how much bandwidth Mirall uses.** A new Network page in
+  Settings caps download and upload speed — pick 1, 5, or 25 MB/s,
+  type your own figure, or leave it unlimited. A change takes effect
+  straight away, including on transfers already running. The cap
+  covers file transfers only: keeping your spaces and members in sync
+  is left alone, since it uses very little data and slowing it down
+  would stop new folders from appearing.
+
+#### Fixed
+
+- **A shared folder that comes back is no longer flagged as missing.**
+  If the folder you shared went away and returned quickly — an external
+  drive reconnecting, a network share remounting — the "source missing"
+  warning on the folder and on its card stayed up even though
+  everything was working again. The warning now clears as soon as the
+  folder is back.
+
+
 ## v1.7.1
 ### 2026-08-05
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mirall",
   "productName": "Mirall",
-  "version": "1.7.1",
+  "version": "1.8.0",
   "description": "Mirall - secure data transfer without middleman",
   "license": "AGPL-3.0-or-later",
   "author": "Oliver Kohl",


### PR DESCRIPTION
Bumps `package.json` to 1.8.0 and adds the changelog entry.

Covered since v1.7.1:
- On-device activity log
- Bandwidth limits for file transfers
- Fix: source-missing banner stayed up after the folder returned

The blind-relay client is intentionally undocumented — its feature flag ships absent, so the Relays section is not reachable in a release build.

Ships on the staging channel as `1.8.0-beta.<run#>`; no tag is cut by this PR.