### PR TITLE
[chore] Simplify the PR template to what CI can't check

### DIFF
--- a/.claude/testing.md
+++ b/.claude/testing.md
@@ -53,7 +53,7 @@ When a fix's precise guarantee isn't cleanly observable at a higher layer (e.g. 
 
 - **CI (automatic, every PR):** `.github/workflows/test.yml` runs three jobs: **node** (`typecheck` + `lint:ci` [jsx-a11y + a `--max-warnings` ceiling + comment-hygiene] + `knip` [advisory] + `test:node:core` = unit + `test/raw`), **flow** (`test:flow` sharded 6×), and **bare** (`test:bare` = integration). Green CI is required to merge.
 - **Local (you run it — not optional):** `npm run test:fe` is **required** for any UI-affecting change and runs fine on a dev machine (only CI can't drive the AX tree). Run it, confirm it's green, plus the manual a11y spot-check. Capture the evidence (the suite writes screenshots to `test/frontend/evidence/`) and note which UI flows were exercised.
-- **PR checklist (humans):** `.github/pull_request_template.md` reproduces the coverage + a11y checklist so non-AI PRs confirm the same bar.
+- **PR body:** `.github/pull_request_template.md` asks only for what CI cannot check — which layers the change touches (and why an obvious one is skipped), plus the local-only runs: `test:fe` and which flows it exercised, dev axe, VoiceOver. Everything CI already enforces is deliberately absent from it; restating a machine-verified fact in prose is noise, and a checklist of them trains people to tick without reading.
 - **AI-assisted work:** adding the appropriate-layer tests + a11y check is part of the change itself (see `CLAUDE.md` → Testing & Accessibility Discipline), not a follow-up.
 
 ## 5. Frontend scenario authoring (agent-desktop)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,12 @@
-<!-- See .claude/testing.md for the layers, the change-type → coverage matrix, and the a11y bar. -->
+<!-- Layers, the change-type → coverage matrix, and the a11y bar: .claude/testing.md -->
 
 ## What & why
 
 
-## Test coverage
-Pick the layer(s) this change touches (not all of them always — see the matrix).
+## Coverage
+Which layers this change touches — and why any obvious one is skipped.
 
-- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
-- [ ] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
-- [ ] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
-- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
-- [ ] **N/A** — docs / comments / config only (no runtime surface)
 
-- [ ] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
-- [ ] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.
-
-## Accessibility (required for any UI change)
-- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
-- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
-- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
-- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
-- [ ] N/A — no UI change.
+## Ran locally
+CI covers typecheck, lint, unit, integration and flow. Say only what it can't:
+`test:fe` (which flows), dev axe, VoiceOver — or why none applied.


### PR DESCRIPTION
## What & why

The layer and a11y checkboxes mostly restated gates CI already enforces on every PR (`test.yml`: typecheck + `lint:ci` + `test:node` + `test:bare`). Ticking a box to confirm a machine-verified fact adds nothing and trains people to tick without reading — which devalues the boxes that do matter. The layer list also duplicated the matrix in `.claude/testing.md`, free to drift.

What's left is three prose prompts asking only for what no machine can supply: **why an obvious layer was skipped**, and the local-only runs — `test:fe` and which flows it exercised, dev axe, VoiceOver. Shorter than before, and strictly more useful to a reviewer.

`.claude/testing.md` §4 is updated in the same commit so the two don't contradict each other.

## Coverage

Docs/config only — no runtime surface, no test layer applies.

## Ran locally

Nothing to run.