### PR TITLE
[docs] Drop retired claims from README and app description

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 </p>
 
 <p align="center">
-  Secure large file transfer. No cloud. No middleman.
+  Secure large file transfer. No cloud. No accounts.
   <br>
   <a href="https://mirall.app"><strong>mirall.app »</strong></a>
   <br>
@@ -29,9 +29,9 @@
 ---
 
 Mirall moves terabyte-scale files directly between devices. You and the people you share with
-form private **spaces**; files transfer peer-to-peer over end-to-end encrypted connections —
-no third-party servers, no cloud storage, GDPR-compliant by architecture. Built for workflows
-where files are huge and privacy is non-negotiable.
+form private **spaces**; files transfer peer-to-peer over end-to-end encrypted connections — no
+cloud storage, no accounts, no telemetry. Built for workflows where files are huge and privacy
+is non-negotiable.
 
 <picture>
   <source media="(prefers-color-scheme: dark)" srcset="docs/media/hero-dark.png">

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "mirall",
   "productName": "Mirall",
   "version": "1.8.0",
-  "description": "Mirall - secure data transfer without middleman",
+  "description": "Secure large file transfer. No cloud. No accounts.",
   "license": "AGPL-3.0-or-later",
   "author": "Oliver Kohl",
   "type": "commonjs",


### PR DESCRIPTION
"No middleman" and "no third-party servers" are absolute topology claims, and hyperdht honours a relay advertised by the remote peer, so a connection may traverse one the user never chose. "GDPR-compliant by architecture" is a legal conclusion no test can pass; that discussion stays in the privacy policy. Wording now matches the website. The package description also ships as the AppImage .desktop Comment, so it is user-visible on Linux.

<!-- See .claude/testing.md for the layers, the change-type → coverage matrix, and the a11y bar. -->

## What & why


## Test coverage
Pick the layer(s) this change touches (not all of them always — see the matrix).

- [ ] **Unit** (`test/unit`) — pure logic / validators / encoders / IPC dispatch
- [ ] **Integration** (`test/integration`) — single-peer data layer (corestore / hyperdrive / swarm)
- [ ] **Flow / two-peer** (`test/flow`) — P2P behavior (sync, transfer, membership, mirror, leave)
- [ ] **Frontend** (`test/frontend`, local) — user-facing UI flow
- [x] **N/A** — docs / comments / config only (no runtime surface)

- [ ] Bug fix? A red-first `REGRESSION (FIX-N: …)` test was added at the bug's layer.
- [ ] `npm test` (unit + integration) and `npm run build` (lint + typecheck) pass locally.

## Accessibility (required for any UI change)
- [ ] `npm run lint` clean (eslint-plugin-jsx-a11y).
- [ ] Dev `@axe-core/react` adds no new serious/critical violations.
- [ ] Every new/changed control has an accessible name + role + state (keyboard-reachable; status uses `aria-live`/`role`).
- [ ] `npm run test:fe` run locally for UI-affecting changes (headless CI can't) — flows exercised: _____
- [x] N/A — no UI change.
