### PR TITLE
[fix] Stop logging unheld file requests as refusals

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1123,6 +1123,8 @@ File bytes are served only when three gates pass (`transfer/backends/overlay/ove
 
 **A denial is observationally identical to "I don't hold this file"**, so membership cannot be probed.
 
+Locally the reasons are kept apart: only `UNAUTHENTICATED` and `NOT_A_MEMBER` are refusals, and only those reach the audit log as `security.serve_denied` (the Activity Log row names the reason). `NO_SOCKET` (teardown race), `RATE_LIMITED` (flow control) and `NOT_HELD` (gate 3 found no space advertising the hash) are ordinary operation and record nothing — a multi-source fetch broadcasts its content-request to every connected peer instead of asking holders first, so being asked for content this device does not advertise is the normal case, not an incident.
+
 ### Resource bounds
 
 `core/runtime-config.js` centralizes DoS/resource budgets: caps on peer-supplied data (e.g. avatar data-URI length), read timeouts bounding how long an offline peer can stall aggregation, and the serve-gate rate limiter.

--- a/src/renderer/auditRow.d.ts
+++ b/src/renderer/auditRow.d.ts
@@ -27,6 +27,7 @@ export function avatarKind(entry: AuditEntry): 'self' | 'peer' | 'system'
 export function actorInitials(entry: AuditEntry): string | null
 export function rowBadge(entry: AuditEntry): RowBadge | null
 export function isSystemRow(entry: AuditEntry): boolean
+export function denialReasonKey(entry: AuditEntry): string | null
 export function sentenceKey(entry: AuditEntry): string
 export function sentenceValues(entry: AuditEntry): SentenceValues
 

--- a/src/renderer/auditRow.js
+++ b/src/renderer/auditRow.js
@@ -49,6 +49,20 @@ export function isSystemRow(entry) {
   return !entry.actor || entry.actor.type === 'system'
 }
 
+// WHY a request was refused, as an i18n key for the meta line. Without it the two refusals a
+// reader can actually act on are indistinguishable: a peer asking for content it is not entitled
+// to, and a peer asking before its identity was verified (routine on a fresh connection, since the
+// content channel is bound before the hello that authenticates it).
+//
+// Closed set, not a passthrough: an unknown reason — a row written by another version, or a kind
+// whose subject.reason means something else entirely — renders nothing rather than a raw key.
+const DENIAL_REASONS = new Set(['not-a-member', 'unauthenticated'])
+
+export function denialReasonKey(entry) {
+  const reason = entry.outcome === 'denied' ? entry.subject?.reason : null
+  return DENIAL_REASONS.has(reason) ? 'activityLog.denialReason.' + reason : null
+}
+
 // The i18n key for the sentence. One key per kind keeps the whole sentence translatable as a
 // unit — a sentence assembled from fragments cannot be reordered for other languages.
 export function sentenceKey(entry) {

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -790,6 +790,10 @@
     "yesterday": "Gestern",
     "badgeDenied": "Abgelehnt",
     "badgeFailed": "Fehlgeschlagen",
+    "denialReason": {
+      "not-a-member": "Kein Mitglied dieses Raums",
+      "unauthenticated": "Identität nicht bestätigt"
+    },
     "actorSelf": "Du",
     "actorSystem": "Mirall",
     "logSettings": "Protokolleinstellungen",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -790,6 +790,10 @@
     "yesterday": "Yesterday",
     "badgeDenied": "Denied",
     "badgeFailed": "Failed",
+    "denialReason": {
+      "not-a-member": "Not a member of this space",
+      "unauthenticated": "Identity not verified"
+    },
     "actorSelf": "You",
     "actorSystem": "Mirall",
     "logSettings": "Log settings",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -790,6 +790,10 @@
     "yesterday": "Ayer",
     "badgeDenied": "Denegado",
     "badgeFailed": "Fallido",
+    "denialReason": {
+      "not-a-member": "No es miembro de este espacio",
+      "unauthenticated": "Identidad no verificada"
+    },
     "actorSelf": "Tú",
     "actorSystem": "Mirall",
     "logSettings": "Ajustes del registro",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -790,6 +790,10 @@
     "yesterday": "Hier",
     "badgeDenied": "Refusé",
     "badgeFailed": "Échec",
+    "denialReason": {
+      "not-a-member": "Pas membre de cet espace",
+      "unauthenticated": "Identité non vérifiée"
+    },
     "actorSelf": "Vous",
     "actorSystem": "Mirall",
     "logSettings": "Réglages du journal",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -790,6 +790,10 @@
     "yesterday": "Ieri",
     "badgeDenied": "Rifiutato",
     "badgeFailed": "Non riuscito",
+    "denialReason": {
+      "not-a-member": "Non è membro di questo spazio",
+      "unauthenticated": "Identità non verificata"
+    },
     "actorSelf": "Tu",
     "actorSystem": "Mirall",
     "logSettings": "Impostazioni del registro",

--- a/src/renderer/screens/ActivityLog.tsx
+++ b/src/renderer/screens/ActivityLog.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { useAuditLog, useAuditFacets, hasActiveFilters, EMPTY_FILTERS, AUDIT_CATEGORIES } from '../hooks/useAuditLog.js'
-import { actorInitials, avatarKind, groupByDay, metaParts, rowBadge, sentenceKey, sentenceValues, sentinelValues, splitSentence } from '../auditRow.js'
+import { actorInitials, avatarKind, denialReasonKey, groupByDay, metaParts, rowBadge, sentenceKey, sentenceValues, sentinelValues, splitSentence } from '../auditRow.js'
 import { AUDIT_KINDS } from '../auditKinds.js'
 import type { AuditCategory, AuditEntry, AuditFilters } from '../types.js'
 import Icon from '../components/primitives/Icon.js'
@@ -40,7 +40,10 @@ function selectItems(
 function AuditRow({ entry }: { entry: AuditEntry }) {
   const { t } = useTranslation()
   const badge = rowBadge(entry)
-  const meta = metaParts(entry).join(' · ')
+  // The reason trails the row's own context (space, totals): "DENIED" says something was refused,
+  // this says what a reader should do about it — nothing, if we simply had no verified identity yet.
+  const reasonKey = denialReasonKey(entry)
+  const meta = [...metaParts(entry), ...(reasonKey ? [t(reasonKey)] : [])].join(' · ')
   const avatar = avatarKind(entry)
   const badgeClasses = badge?.tone === 'error'
     ? 'bg-error-container text-on-error-container'

--- a/src/shared/transfer/backends/overlay/overlay-authorize.js
+++ b/src/shared/transfer/backends/overlay/overlay-authorize.js
@@ -16,15 +16,17 @@
  * @param {{ spacesFor(hash): Iterable<string> }} deps.serveIndex
  * @returns {(peer, from, contentHash, opts?: { rateLimit?: boolean }) => Promise<boolean>}
  */
-// Denial reasons. Only UNAUTHENTICATED and NOT_A_MEMBER mean "access refused"; the other two are
-// ordinary operation — NO_SOCKET is a teardown race, and RATE_LIMITED is flow control that fires
-// routinely mid-transfer when a peer asks for chunks faster than the budget allows. Conflating
-// them makes a busy mirror look like a stream of security incidents.
+// Denial reasons. Only UNAUTHENTICATED and NOT_A_MEMBER mean "access refused"; the other three are
+// ordinary operation — NO_SOCKET is a teardown race, RATE_LIMITED is flow control that fires
+// routinely mid-transfer when a peer asks for chunks faster than the budget allows, and NOT_HELD
+// is simply a request for content this device does not advertise. Conflating them makes a busy
+// mirror look like a stream of security incidents.
 export const DENY = {
   NO_SOCKET: 'no-socket',
   UNAUTHENTICATED: 'unauthenticated',
   RATE_LIMITED: 'rate-limited',
   NOT_A_MEMBER: 'not-a-member',
+  NOT_HELD: 'not-held',
 }
 
 export const SECURITY_DENIALS = new Set([DENY.UNAUTHENTICATED, DENY.NOT_A_MEMBER])
@@ -44,9 +46,15 @@ export function makeServeAuthorizer({ peerSocket, socketAuthorized, isApprovedMe
     //    that to the asker's budget would revoke healthy transfers for being numerous.
     if (rateLimit && !serveLimiter.take(from).ok) return deny(DENY.RATE_LIMITED)
     // 3) membership: the asker must be an approved member of a space advertising this hash.
+    //    A hash NO space advertises is not a refusal of anyone — we hold nothing to refuse. A
+    //    multi-source fetch broadcasts its content-request to EVERY connected peer rather than
+    //    querying holders first, so a non-holder is asked as a matter of course; answering that
+    //    with NOT_A_MEMBER turned an ordinary folder mirror into one security row per file.
+    let advertised = false
     for (const spaceId of serveIndex.spacesFor(contentHash)) {
+      advertised = true
       if (await isApprovedMember(spaceId, from)) return true
     }
-    return deny(DENY.NOT_A_MEMBER)
+    return deny(advertised ? DENY.NOT_A_MEMBER : DENY.NOT_HELD)
   }
 }

--- a/src/shared/transfer/backends/overlay/overlay-instance.js
+++ b/src/shared/transfer/backends/overlay/overlay-instance.js
@@ -102,8 +102,10 @@ export async function initOverlay() {
   // line an audit trail exists for. Do not "simplify" this away.
   //
   // Only a SECURITY denial is recorded. A rate-limited request is flow control and fires
-  // routinely mid-transfer; a missing socket is a teardown race. Recording those produced a wall
-  // of identical "A file request was refused" rows during an ordinary folder mirror.
+  // routinely mid-transfer; a missing socket is a teardown race; a request for a hash we
+  // advertise nowhere is a peer's multi-source fetch asking every connected peer, holder or not.
+  // Recording those produced a wall of identical "A file request was refused" rows during an
+  // ordinary folder mirror.
   const serveAuthorizer = makeServeAuthorizer({
     peerSocket, socketAuthorized, isApprovedMember, serveLimiter, serveIndex,
     onDeny: (reason, ctx) => {

--- a/test/unit/audit-row.test.js
+++ b/test/unit/audit-row.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
 import {
-  actorInitials, actorLabel, avatarKind, dayKey, formatBytes, formatCount,
+  actorInitials, actorLabel, avatarKind, dayKey, denialReasonKey, formatBytes, formatCount,
   groupByDay, isSystemRow, metaParts, rowBadge, sentenceKey, sentenceValues,
   splitSentence, sentinelValues, FIELD_SENTINEL, SENTENCE_FIELDS,
 } from '../../src/renderer/auditRow.js'
@@ -43,6 +43,22 @@ test('a refused request names the requester even with no display name', (t) => {
   t.is(sentenceValues(denied).actor, 'ab3f9c2d1e5a', 'the short key stands in for the missing name')
   t.is(sentenceValues(denied).target, 'budget.xlsx', 'and the file is named when we hold the hash')
   t.is(rowBadge(denied).labelKey, 'activityLog.badgeDenied')
+})
+
+// Two very different events render the same sentence: a peer that may not have the content, and a
+// peer that asked before its identity was verified. The reason is recorded but was never shown,
+// so a reader could not tell an intrusion from a stranger asking for a hash we don't hold.
+test('REGRESSION (FIX-364: a refusal shows WHY it was refused)', (t) => {
+  const denied = (reason) => row({ kind: 'security.serve_denied', outcome: 'denied', subject: { reason, requester: 'ab3f9c2d1e5a' } })
+  t.is(denialReasonKey(denied('not-a-member')), 'activityLog.denialReason.not-a-member')
+  t.is(denialReasonKey(denied('unauthenticated')), 'activityLog.denialReason.unauthenticated')
+
+  // Only the reasons the copy covers. A row from another version — or any kind that carries an
+  // unrelated `reason` — must not render a raw key or an i18n miss.
+  t.is(denialReasonKey(denied('not-held')), null, 'a reason with no copy renders nothing')
+  t.is(denialReasonKey(denied(null)), null)
+  t.is(denialReasonKey(row()), null, 'an ordinary row has no reason to show')
+  t.is(denialReasonKey(row({ subject: { reason: 'quota' } })), null)
 })
 
 test('REGRESSION (FIX-2): an own action renders as "You", never a bare "?" avatar', (t) => {

--- a/test/unit/i18n-key-parity.test.js
+++ b/test/unit/i18n-key-parity.test.js
@@ -2,6 +2,8 @@ import test from 'brittle'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
+import { denialReasonKey } from '../../src/renderer/auditRow.js'
+import { DENY, SECURITY_DENIALS } from '../../src/shared/transfer/backends/overlay/overlay-authorize.js'
 
 // Every locale must carry the SAME translation keys as the reference (en) for
 // every namespace — a missing key silently falls back to the key string in the
@@ -45,3 +47,19 @@ for (const ns of namespaces) {
     })
   }
 }
+
+// Parity above only proves the locales agree with each other. This pins the other end: every
+// denial reason the gate can RECORD must have copy in the reference locale, so adding a reason to
+// the serve gate can never ship a row that renders a raw i18n key at the reader.
+test('i18n: every recorded denial reason has copy in ' + REF, (t) => {
+  const ref = loadKeys(REF, 'common')
+  for (const reason of Object.values(DENY)) {
+    const key = denialReasonKey({ outcome: 'denied', subject: { reason } })
+    if (!SECURITY_DENIALS.has(reason)) {
+      t.is(key, null, reason + ' is not recorded, so it needs no copy')
+      continue
+    }
+    t.ok(key, reason + ' is recorded, so the row must be able to name it')
+    t.ok(ref.has(key), key + ' exists in ' + REF)
+  }
+})

--- a/test/unit/overlay-authorize.test.js
+++ b/test/unit/overlay-authorize.test.js
@@ -45,6 +45,33 @@ test('(c2) authenticated member but hash advertised by no space → deny', async
   t.is(await auth(peer, 'fromKey', 'hash'), false)
 })
 
+// A multi-source fetch broadcasts its content-request to EVERY connected peer, not just the
+// holders, so being asked for content we don't advertise is the routine case, not an intrusion.
+// Reporting it as NOT_A_MEMBER made every ordinary mirror of a peer's folder write one red
+// "Refused a file request" row per file into the other members' activity logs.
+test('REGRESSION (FIX-364: a hash we advertise nowhere is NOT_HELD, not a membership refusal)', async (t) => {
+  const nonHolder = build({ serveIndex: { spacesFor: () => [] } })
+  t.is(await nonHolder.auth(nonHolder.peer, 'fromKey', 'hash'), false, 'still refused — we have nothing to serve')
+  t.is(nonHolder.denials[0].reason, DENY.NOT_HELD)
+  t.absent(SECURITY_DENIALS.has(DENY.NOT_HELD), 'not holding the content is not an access refusal')
+
+  // The genuine refusal must keep its reason: the hash IS advertised, the asker just isn't in
+  // any space advertising it.
+  const outsider = build({ isApprovedMember: async () => false })
+  t.is(await outsider.auth(outsider.peer, 'fromKey', 'hash'), false)
+  t.is(outsider.denials[0].reason, DENY.NOT_A_MEMBER, 'a real membership refusal is unchanged')
+})
+
+test('membership is not consulted for a hash we advertise nowhere', async (t) => {
+  let memberChecked = false
+  const { peer, auth } = build({
+    serveIndex: { spacesFor: () => [] },
+    isApprovedMember: async () => { memberChecked = true; return true },
+  })
+  t.is(await auth(peer, 'fromKey', 'hash'), false)
+  t.absent(memberChecked, 'nothing to be a member OF — the space read is skipped')
+})
+
 test('(d) approved member of an advertising space → allow', async (t) => {
   const { peer, auth } = build()
   t.is(await auth(peer, 'fromKey', 'hash'), true)
@@ -111,6 +138,10 @@ test('each gate reports a distinct denial reason', async (t) => {
   const outsider = build({ isApprovedMember: async () => false })
   await outsider.auth(outsider.peer, 'k', 'h')
   t.is(outsider.denials[0].reason, DENY.NOT_A_MEMBER)
+
+  const nonHolder = build({ serveIndex: { spacesFor: () => [] } })
+  await nonHolder.auth(nonHolder.peer, 'k', 'h')
+  t.is(nonHolder.denials[0].reason, DENY.NOT_HELD)
 })
 
 test('only genuine refusals count as security denials', (t) => {
@@ -118,6 +149,7 @@ test('only genuine refusals count as security denials', (t) => {
   t.ok(SECURITY_DENIALS.has(DENY.NOT_A_MEMBER))
   t.absent(SECURITY_DENIALS.has(DENY.RATE_LIMITED), 'flow control is not an access refusal')
   t.absent(SECURITY_DENIALS.has(DENY.NO_SOCKET), 'a teardown race is not an access refusal')
+  t.absent(SECURITY_DENIALS.has(DENY.NOT_HELD), 'being asked for content we do not have is not an access refusal')
 })
 
 test('the denial carries the requester and hash so a row can name them', async (t) => {


### PR DESCRIPTION
The serve gate reported "not a member" whenever no space advertised the requested hash, and a multi-source fetch asks every connected peer rather than the holders first — so an ordinary folder mirror wrote one red refusal row per file into the other members' activity logs. That case is now its own NOT_HELD reason and records nothing, and the Activity Log names the reason behind the refusals it does keep, which separates an unauthorized request from one that merely arrived before the content-hello verified the sender.
