### PR TITLE
[fix] Reclaim disk when the activity log is purged

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -105,6 +105,25 @@ import time, before any test runs). The bare-free rule `path-keys.js` documents 
 real, load-bearing layering constraint — pure string math goes in `path-keys.js`, and lifecycle
 hooks that need a `bare-*` module belong in the worker, which is Bare-only anyway.
 
+**Never `core.clear()` a block range of a Hyperbee to reclaim deleted rows — it corrupts the live
+tree.** Every append writes one block holding `{key, value, index}`, so blocks are simultaneously
+data *and* B-tree index, and old blocks stay referenced by the current root long after their keys
+are deleted. The tell: a fresh reopen (not the warm handle — the node cache masks it) reads back 0
+rows and stalls on a non-local block. `del` is an append too, so pruning a Hyperbee always *costs*
+disk and never frees it. To reset a bee wholesale use `core.truncate(0)` + `compactRange` (a
+`clear()` after the truncate is a no-op — hypercore early-returns once `start >= length`) — **not**
+`clearAndPurgeCore`: deleting a core's storage and reopening it under
+the same (derived, deterministic) key hands back corestore's cached tracker entry, which reports
+the old length over storage that is gone, so every later read hangs. Truncation keeps the handle
+valid and needs no alias surgery. Order matters too — clearing a bee's blocks *before* closing it
+wedges `bee.close()`, since the close path reads blocks that are no longer local.
+
+**Size a store problem only after `compactRange` — raw directory size is mostly write
+amplification.** A bee measuring 25 MB on disk fell to 4.4 MB from RocksDB compaction alone and to
+1.1 MB after a full clear + compaction, so an uncompacted `du` overstated the reclaimable residue
+by ~6x. Compact first, then measure, or you optimize transient SST/WAL churn instead of the real
+retained bytes.
+
 ## Stopping long-running work
 
 **Stopping a periodic loop must cancel the in-flight pass, not just the timer.** Clearing `setInterval`/pending timers leaves a materialize/download pass already iterating thousands of files running to completion — and its trailing persist can RESURRECT the just-torn-down state. Use a per-key generation counter checked between items (bail if it changed), abort the active stream/transfer (track it in a map the stop path can `destroy()`), and guard the trailing persist. Test with enough files/bytes that the pass is genuinely in flight at stop time; assert both "progress halts" AND "state not resurrected."

--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -313,9 +313,24 @@ carrying the totals; the recurring reconcile records nothing), byte-moving activ
 one row per transfer by `audit-sessions.js`, and a per-kind token bucket collapses any overflow
 into a single `audit.suppressed` row.
 
-Retention prunes by age **and** count on boot and daily. A Hyperbee `del` only appends a
-tombstone, so the prune follows up with `core.clear()` over the released block range to actually
-reclaim disk.
+Retention prunes by age **and** count on boot and daily (`maxEntries`, default 200k, binds
+whenever a burst outruns the age window). It bounds the **row count, not the bytes**: a Hyperbee
+`del` only appends a tombstone, so pruned rows stop being readable while their blocks stay on
+disk. Byte reclamation is deliberately not attempted — `core.clear()` over the pruned range is
+unsafe here, because every Hyperbee block carries B-tree index data alongside its key/value, so
+clearing old blocks strands index nodes the live tree still points at (measured: after clearing a
+pruned prefix, a fresh open reads back **0** surviving rows and stalls on a missing block).
+Residue after RocksDB compaction is on the order of ~1&nbsp;KB per pruned row, retained
+indefinitely — see the NOTE above `pruneAudit()` in `audit-log.js`.
+
+**`audit:purge` is the one path that does reclaim.** A purge discards the whole event set, so it
+can reset the core outright where a partial prune cannot: `truncate(0)` empties the tree in place
+and drops its blocks, and a `compactRange` then returns the bytes (measured: 8.3&nbsp;MB
+of log → 0.08&nbsp;MB, against 22&nbsp;MB when the same rows were deleted key-by-key). Truncation
+rather than a core purge-and-recreate is deliberate — recreating the core hands back a stale
+corestore tracker entry whose storage is gone, and every later read hangs. The retention config and
+the `seen/` watermarks are written back across the reset; `pstate/` is not, since observed peer
+state is log content.
 
 **The log survives a space leave** — a deliberate exception to §6's "leave removes everything
 space-scoped" rule, since a space left under dispute is exactly when the trail matters. It never

--- a/src/shared/audit/audit-log.js
+++ b/src/shared/audit/audit-log.js
@@ -14,7 +14,7 @@
 //                                  Working state, not a record: audit:purge deliberately leaves
 //                                  it, because resetting it would replay every peer's whole
 //                                  history as if it had just happened.
-import { createLocalBee } from '../core/store.js'
+import { createLocalBee, getStore } from '../core/store.js'
 import { createLogger } from '../core/logger.js'
 import { buildRecord } from './audit-record.js'
 import { STATE_OFF } from './peer-observer.js'
@@ -29,6 +29,7 @@ import {
 
 const log = createLogger('audit')
 
+const AUDIT_BEE_NAME = 'audit-log'
 const SEQ_WIDTH = 16
 const EVT = 'evt/'
 const BY_SPACE = 'by-space/'
@@ -65,7 +66,7 @@ let writeChain = Promise.resolve()
 const rateBuckets = new Map()
 
 export async function initAuditLog({ installId = null } = {}) {
-  bee = createLocalBee('audit-log')
+  bee = createLocalBee(AUDIT_BEE_NAME)
   await bee.ready()
   device = installId
   const stored = await bee.get(CONFIG_KEY)
@@ -350,10 +351,15 @@ export async function setAuditConfig(patch = {}) {
 // NOTE — byte-level reclamation is deliberately NOT done here. A Hyperbee `del` only appends a
 // tombstone, so pruned rows stop being readable but their blocks stay on disk. Releasing them
 // with core.clear() is unsafe as written: Hyperbee interleaves B-tree index nodes with value
-// blocks, so a range clear can drop a node the live index still points at. Growth is bounded in
-// the meantime by `maxEntries`, which caps the row count regardless of the age window. Reclaiming
-// the bytes needs its own change (measure first; the established pattern elsewhere in the
-// codebase is purge-and-recreate the core, not an in-place clear).
+// blocks, so a range clear can drop a node the live index still points at — measured, clearing a
+// pruned prefix leaves a fresh open reading back zero rows and stalling on a missing block.
+// Growth is bounded in the meantime by `maxEntries`, which caps the row count regardless of the
+// age window; the residue is ~1KB per pruned row after compaction.
+//
+// A TOTAL wipe can reclaim, because it need not preserve any index — see purgeAudit, which
+// truncates the core to zero instead. That does not generalize to a partial prune: keeping the
+// newest N rows would mean copy-forward (read the survivors, truncate, re-append), whose cost
+// scales with `maxEntries` on every prune. Worth building only if the residue is shown to matter.
 
 export async function pruneAudit({ now = Date.now() } = {}) {
   if (!bee) return { removed: 0 }
@@ -411,25 +417,67 @@ export async function pruneAudit({ now = Date.now() } = {}) {
   return { removed }
 }
 
+// The user's explicit wipe — and the ONE place bytes are actually reclaimed. Deleting the rows
+// key-by-key would free nothing (see the NOTE above pruneAudit): a `del` is an append, so a
+// row-wise purge left every original block on disk and added a tombstone per row on top, ending
+// with a bigger store than before. A purge discards the whole event set, so it can do what a
+// partial prune cannot — reset the core itself.
+//
+// `truncate(0)` (not a core purge-and-recreate) is the primitive: it empties the tree in place AND
+// drops the blocks, so the bee handle stays valid and corestore never has to resolve a same-key
+// core it still has cached — recreating the core instead reopens a stale in-memory tracker entry
+// whose storage is gone, and every later read hangs. No `clear()` follows it: hypercore's clear
+// early-returns once `start >= length`, so after a truncate to zero it is a measured no-op.
+//
+// Two keys are written back rather than being lost with the reset:
+//   config  — retention settings are user preferences, not log content.
+//   seen/   — the peer-bee watermarks. Dropping them makes first contact re-read every peer's
+//             whole history and replay it as if it had just happened (see the header), turning
+//             "delete my activity" into "flood it with a decade of theirs".
+// `pstate/` is deliberately NOT written back: it mirrors observed peer state, so it is log
+// content, and keeping it would suppress the next standing-state row for every subject.
 export async function purgeAudit() {
   if (!bee) return { purged: 0 }
   await flushAudit()
+
   let purged = 0
-  for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH })) {
-    await bee.del(entry.key)
-    purged += 1
+  for await (const _entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH })) purged += 1
+  const seen = []
+  for await (const entry of bee.createReadStream({ gte: SEEN, lt: SEEN + HIGH })) {
+    seen.push([entry.key, entry.value])
   }
-  for await (const entry of bee.createReadStream({ gte: BY_SPACE, lt: BY_SPACE + HIGH })) {
-    await bee.del(entry.key)
+  const keptConfig = { ...config }
+
+  // A row recorded during those scans is racing a total wipe, so losing it is the right outcome —
+  // but the append chain must be idle before the core is reset under it.
+  await flushAudit()
+
+  const live = bee
+  const core = bee.core
+  bee = null // record() no-ops for the reset window rather than appending into a truncating core
+  try {
+    await core.truncate(0)
+  } finally {
+    bee = live // same handle, now an empty tree
   }
-  // The per-peer observed-state mirror is part of the log, not of replication state: leaving
-  // it behind both defeats "delete all activity" as a privacy action and suppresses the next
-  // standing-state row for every subject (the mirror would still read 'on').
-  for await (const entry of bee.createReadStream({ gte: PSTATE, lt: PSTATE + HIGH })) {
-    await bee.del(entry.key)
-  }
+
+  nextSeq = 0
+  await bee.put(CONFIG_KEY, keptConfig)
+  for (const [key, value] of seen) await bee.put(key, value)
   rateBuckets.clear()
-  log.info('purged', purged, 'rows')
+
+  // The truncate releases the blocks; compaction is what returns the bytes to the filesystem
+  // (without it the store still reads ~1.5MB of SST churn for a log this size). It is a
+  // whole-store pass, affordable here only because a purge is a deliberate, confirmed, one-off
+  // user action — never do this on the recurring prune path.
+  try {
+    await getStore().storage.db.compactRange(null, null, {
+      blobGarbageCollectionPolicy: 1,
+      blobGarbageCollectionAgeCutoff: 1.0,
+    })
+  } catch (err) { log.warn('compaction after purge failed:', err.message) }
+
+  log.info('purged', purged, 'rows and reclaimed the core')
   return { purged }
 }
 

--- a/test/integration/audit-log.test.js
+++ b/test/integration/audit-log.test.js
@@ -7,7 +7,7 @@ import { initStore, setMasterSecret, LOCAL_BEE_NAMES } from '../../src/shared/co
 import {
   initAuditLog, record, flushAudit, queryAudit, auditSpaces, auditActors,
   auditStats, getAuditConfig, setAuditConfig, pruneAudit, purgeAudit, exportAudit,
-  getPeerSubjectState, setPeerSubjectState,
+  getPeerSubjectState, setPeerSubjectState, getSeenVersion, setSeenVersion,
 } from '../../src/shared/audit/audit-log.js'
 
 let seq = 0
@@ -210,6 +210,120 @@ test('purge empties the log and resets nothing else', async (t) => {
   t.is((await queryAudit({})).entries.length, 0)
   t.alike(await auditSpaces(), [], 'the space filter empties with it')
   t.is(getAuditConfig().enabled, true, 'purge is not a disable')
+})
+
+// Writes across many kinds: the per-kind token bucket admits only 120 rows per kind per minute,
+// so a single-kind loop silently caps at 120 and makes a byte measurement meaningless.
+const BULK_KINDS = ['file.shared', 'file.unshared', 'invite.minted', 'member.joined', 'member.left',
+  'mirror.created', 'mirror.removed', 'serve.completed', 'share.created', 'share.deleted',
+  'space.created', 'space.joined', 'transfer.completed', 'transfer.failed']
+
+function bulkRows (rounds) {
+  let written = 0
+  for (let i = 0; i < rounds; i++) {
+    for (const kind of BULK_KINDS) {
+      const ok = record(kind, {
+        actor: { type: 'peer', key: 'ab12cd34'.repeat(8), name: 'Peer Number ' + i },
+        space: { id: 'sp' + (i % 4), name: 'Space Number ' + (i % 4) },
+        target: { kind: 'member', id: 'ab12cd34'.repeat(8), name: 'Target Number ' + i },
+      })
+      if (ok) written += 1
+    }
+  }
+  return written
+}
+
+function dirSize (dir) {
+  let total = 0
+  for (const name of fs.readdirSync(dir)) {
+    const p = path.join(dir, name)
+    const st = fs.statSync(p)
+    total += st.isDirectory() ? dirSize(p) : st.size
+  }
+  return total
+}
+
+// REGRESSION (FIX-365: purge deleted rows key-by-key, which reclaimed nothing — a Hyperbee `del`
+// is an append, so every original block stayed on disk and gained a tombstone on top. The user's
+// explicit "delete the log" left the store BIGGER than before. Purge now truncates the core to
+// zero and compacts.)
+test('REGRESSION (FIX-365): purge reclaims the log’s bytes, it does not just hide the rows', async (t) => {
+  const storage = await boot(t)
+  const baseline = dirSize(storage)
+
+  const written = bulkRows(110)
+  await flushAudit()
+  t.ok(written > 1000, 'wrote enough rows for a byte measurement (' + written + ')')
+
+  const grown = dirSize(storage)
+  t.ok(grown > baseline * 2, 'the log actually took disk: ' + baseline + ' -> ' + grown)
+
+  const { purged } = await purgeAudit()
+  t.is(purged, written, 'every row is counted as purged')
+
+  const reclaimed = dirSize(storage)
+  t.ok(reclaimed < grown / 2, 'purge freed the bytes: ' + grown + ' -> ' + reclaimed)
+  t.is((await queryAudit({})).entries.length, 0, 'and the rows are gone')
+})
+
+// The core is emptied wholesale, so anything that must outlive a purge has to be written back
+// explicitly. These two keys are the ones that must — and the one that must not.
+test('purge carries config and peer watermarks across the reset, but not observed state', async (t) => {
+  await boot(t)
+  await setAuditConfig({ retentionDays: 30, maxEntries: 4242 })
+  await setSeenVersion('beefbeef', 987)
+  await setPeerSubjectState('beefbeef/some/path', 'on')
+  bulkRows(2)
+  await flushAudit()
+
+  await purgeAudit()
+
+  const cfg = getAuditConfig()
+  t.is(cfg.retentionDays, 30, 'retention is a user setting, not log content')
+  t.is(cfg.maxEntries, 4242, 'and so is the entry cap')
+  t.is(await getSeenVersion('beefbeef'), 987,
+    'dropping the watermark would replay every peer’s whole history as if it just happened')
+  t.is(await getPeerSubjectState('beefbeef/some/path'), null,
+    'observed peer state IS log content — it must not survive a wipe')
+})
+
+// testing.md: a two-mode subsystem must exercise its production-default mode in destructive
+// paths — and the reset must not quietly depend on identity mode. Without M the bee opens by
+// NAME (an aliased core) rather than by derived keyPair, which is exactly where a purge that
+// deleted-and-recreated the core would strand a stale alias.
+test('purge reclaims in insecure mode too, where the bee opens by name', async (t) => {
+  const storage = await boot(t, { identity: false })
+  const baseline = dirSize(storage)
+  const written = bulkRows(110)
+  await flushAudit()
+
+  const grown = dirSize(storage)
+  t.ok(grown > baseline * 2, 'the log took disk without M: ' + baseline + ' -> ' + grown)
+
+  const { purged } = await purgeAudit()
+  t.is(purged, written, 'every row purged')
+  t.ok(dirSize(storage) < grown / 2, 'bytes freed without M too: ' + grown + ' -> ' + dirSize(storage))
+
+  record('space.created', { actor: { type: 'self' }, space: { id: 'sp1', name: 'Still Works' } })
+  await flushAudit()
+  t.is((await queryAudit({})).entries.length, 1, 'and the name-opened core still accepts writes')
+})
+
+test('the log is fully usable after a purge', async (t) => {
+  await boot(t)
+  bulkRows(3)
+  await flushAudit()
+  await purgeAudit()
+
+  record('space.created', { actor: { type: 'self' }, space: { id: 'sp9', name: 'After Purge' } })
+  await flushAudit()
+
+  const { entries } = await queryAudit({})
+  t.is(entries.length, 1, 'the truncated core accepts writes')
+  t.is(entries[0].kind, 'space.created')
+  t.is(entries[0].seq, 0, 'seq restarts from zero on an emptied core')
+  const stats = await auditStats()
+  t.is(stats.count, 1, 'and stats read the emptied tree, not a stale snapshot')
 })
 
 test('stats report the true range', async (t) => {


### PR DESCRIPTION
Deleting the log removed rows key-by-key, which freed nothing — a Hyperbee del is an append, so every block stayed on disk and gained a tombstone, leaving the store bigger than before (8.3MB of log became 22MB). Purge now truncates the core to zero and compacts, carrying the retention config and peer watermarks across the reset. The same reset is unsafe for the recurring prune, which must keep a live index; the architecture doc claimed that prune already reclaimed, and did not.
