### PR TITLE
[chore] Adapt the frontend harness to agent-desktop 0.8.1

### DIFF
--- a/test/agent-desktop/README.md
+++ b/test/agent-desktop/README.md
@@ -23,14 +23,20 @@ In scope:
 Not in scope:
 
 - P2P transfer flows (would need a second Mirall instance — separate harness).
-- Windows / Linux (`agent-desktop` is macOS-only).
+- Windows / Linux. `agent-desktop` is macOS-only and the non-macOS release assets do not change that: the `agent-desktop-ffi-*` artifacts are the C-ABI library, the CLI ships for Darwin only, and upstream's `crates/windows` / `crates/linux` are empty scaffolds whose adapters return `PlatformNotSupported`. Upstream's own README lists every Windows/Linux capability as *Planned*.
 - Worker / Bare-runtime logic (use the brittle suite under `test/index.test.js`).
 
 ## Preconditions
 
-1. **macOS** with the `agent-desktop` CLI on `PATH`. Install once:
+1. **macOS** with the `agent-desktop` CLI on `PATH` (>= 0.8.0). Install once:
    ```bash
    npm install -g agent-desktop
+   ```
+   Upgrading from a pre-0.5 CLI? Delete the two root state files first — older
+   versions wrote refmap entries without a `process_instance`, and 0.8.x rejects
+   them, so every `status` call fails with `INVALID_ARGS` until they are gone:
+   ```bash
+   rm -f ~/.agent-desktop/last_refmap.json ~/.agent-desktop/latest_snapshot_id
    ```
 2. **Accessibility permission** granted to whichever process runs the CLI (your terminal, or the Claude Code harness). Verify with:
    ```bash
@@ -41,7 +47,7 @@ Not in scope:
 4. **Mirall is running** in one of two modes:
    - Installed app — process name `Mirall`. This is what end users see.
    - Dev build via `npm start` / `electron-forge start` — process name `Electron`.
-5. **Only one Electron window open.** If Chrome DevTools is attached, close it first (Cmd+Opt+I in Mirall, or Cmd+W from inside DevTools). Both windows are owned by the same `Electron` app and the CLI cannot disambiguate them; the focused one wins, which is usually DevTools.
+5. **Only one Electron window open.** If Chrome DevTools is attached, close it first (Cmd+Opt+I in Mirall, or Cmd+W from inside DevTools). Both windows are owned by the same `Electron` app, and this script targets by `--app`. On 0.8.x that is a hard `AMBIGUOUS_TARGET` error listing the candidates — earlier versions silently snapshotted whichever window had focus, which was usually DevTools and produced a confusing "button not found" instead.
 
 ## How to run
 
@@ -62,8 +68,8 @@ PASS: sidebar: All Spaces
 PASS: sidebar: Favorites
 PASS: sidebar: Create Space
 PASS: sidebar: Join Space
-PASS: space card found: Open <space-name> (@e8)
-PASS: clicked @e8
+PASS: space card found: Open <space-name> (@s359l44w95ysun:e8)
+PASS: clicked @s359l44w95ysun:e8
 PASS: left SharedSpaces screen
 PASS: on space screen (Files Shared)
 
@@ -79,6 +85,8 @@ Side effect: the script clicks into the first space card it finds and leaves the
 | `APP_NOT_FOUND: No window found for app 'Mirall'` | Wrong process name. Dev build runs as `Electron`. | Pass the right argument: `smoke-test.sh Electron`. |
 | Snapshot returns DevTools UI (`Send Feedback` not found, ref_count ~8, "Developer Tools" in tree) | Chrome DevTools window is open under the same `Electron` process. | Close DevTools and rerun. |
 | `permissions.granted: false` | Terminal lost Accessibility permission (common after macOS updates or terminal upgrades). | Re-grant in System Settings → Privacy & Security → Accessibility. |
+| `AMBIGUOUS_TARGET: More than one window matches the target` | More than one `Electron` window (usually DevTools, sometimes a second dev instance). The error's `details.candidates` lists them. | Close the extra window, or re-run the failing command with `--window-id <id>` from `list-windows`. |
+| `INVALID_ARGS: RefEntry requires a positive pid and process instance` | Left-over `~/.agent-desktop` state written by a pre-0.5 CLI. | `rm -f ~/.agent-desktop/last_refmap.json ~/.agent-desktop/latest_snapshot_id` |
 | `ACTION_FAILED: All chain steps exhausted` on click | Transient focus state, modal overlay, or the target stopped being interactable since the snapshot. | Rerun. If reproducible, fall back to `agent-desktop mouse-click --xy X,Y` after `agent-desktop get @ref bounds`. |
 | `STALE_REF: Element not found: role=..., name="..."` | A ref from an earlier snapshot no longer matches because the UI changed (e.g. a button's accessible name changed after a fix). | Re-run `snapshot` and use the new ref. |
 
@@ -95,7 +103,7 @@ agent-desktop snapshot --root @e3 --app "Electron" -i --compact   # drill into a
 agent-desktop screenshot --app "Electron"
 ```
 
-Refs (`@e1`, `@e2`, ...) are scoped to a single `snapshot` invocation and assigned in depth-first interactive order. Re-snapshot after any UI change before reusing a ref.
+Refs are scoped to a single `snapshot` invocation and assigned in depth-first interactive order. Re-snapshot after any UI change before reusing a ref. Since 0.8.0 a ref is **snapshot-qualified** — `@s359l44w95ysun:e3`, not `@e3` — so it carries its own scope and resolves in a later CLI process on its own. A bare `@e3` still works, but only with an explicit `--snapshot <id>` (or a `--session` whose latest snapshot is the one you meant).
 
 aria-label on icon-only buttons and on `<div role="button">` lands in the AX `description` field, not `name`. Use both when matching:
 

--- a/test/frontend/agent.mjs
+++ b/test/frontend/agent.mjs
@@ -12,7 +12,18 @@ const BIN = 'agent-desktop'
 // retry re-snapshots, so a just-appearing element is caught on the next pass —
 // which lets the menu/modal helpers settle with a short fixed wait instead of a
 // long conservative one. A genuinely-absent element still fails after the tries.
-const RETRYABLE = new Set(['STALE_REF', 'WINDOW_NOT_FOUND', 'ACTION_FAILED', 'ELEMENT_NOT_FOUND'])
+// ACTION_NOT_SUPPORTED covers "window exists but is not exposed through
+// accessibility": Chromium attaches a renderer's AX tree lazily, so a window can be
+// listed and painted a beat before it answers AX queries. agent-desktop 0.4.x
+// returned an empty tree in that gap and the scenarios' own waits rode it out;
+// 0.8.x makes it an error. Instance.launch() closes the gap explicitly, and this
+// entry covers the mid-scenario case (a repaint or reload re-attaching AX).
+// SNAPSHOT_INCOMPLETE is ours, not agent-desktop's: 0.7.0 stopped returning a
+// TIMEOUT error for a snapshot that exhausts its walk budget and now returns
+// ok:true with data.complete=false. instance.snap() turns that into this code so a
+// partial tree retries (and ultimately fails loudly) instead of being asserted
+// against as if it were the whole window.
+const RETRYABLE = new Set(['STALE_REF', 'WINDOW_NOT_FOUND', 'ACTION_FAILED', 'ELEMENT_NOT_FOUND', 'SNAPSHOT_INCOMPLETE', 'ACTION_NOT_SUPPORTED'])
 
 // agent-desktop's activation chain (the AXPress → AXOpen → physical-fallback
 // ladder a ref action walks) gives up after AGENT_DESKTOP_CHAIN_TIMEOUT_MS,
@@ -24,6 +35,17 @@ const RETRYABLE = new Set(['STALE_REF', 'WINDOW_NOT_FOUND', 'ACTION_FAILED', 'EL
 // an unsettled action fails fast into the retry instead of stalling. Overridable.
 const CHAIN_TIMEOUT_MS = process.env.AGENT_DESKTOP_CHAIN_TIMEOUT_MS ?? '2500'
 
+// agent-desktop 0.5.0+ also auto-waits for ref resolution and transient
+// actionability on every ref action (--timeout-ms, default 5000) — a SEPARATE
+// budget that runs BEFORE the chain above. Left at the default it stacks: a
+// genuinely-absent element burns 5s here, then the chain, then withRetry does it
+// all twice more. This harness re-snapshots and re-resolves the ref on every
+// retry, so waiting long inside one CLI process only delays the re-resolution
+// that would have fixed it. Cap it low and let the retry do the settling.
+// Only these subcommands accept the flag (verified against 0.8.1 --help).
+const AUTO_WAIT_CMDS = new Set(['click', 'type', 'focus', 'set-value', 'scroll', 'hover', 'toggle', 'select'])
+const ACTION_TIMEOUT_MS = process.env.AGENT_DESKTOP_ACTION_TIMEOUT_MS ?? '1500'
+
 // agent-desktop 0.3.0+ takes --session / --headed as GLOBAL options that must
 // precede the subcommand. --session namespaces the persisted "latest snapshot"
 // so a ref resolves the same across the separate snapshot/act CLI processes this
@@ -33,10 +55,47 @@ export function agentArgs(args, { session = null, headed = false } = {}) {
   const globals = []
   if (session) globals.push('--session', session)
   if (headed) globals.push('--headed')
-  return [...globals, ...args]
+  const tuned = AUTO_WAIT_CMDS.has(args[0]) && !args.includes('--timeout-ms')
+    ? [...args, '--timeout-ms', ACTION_TIMEOUT_MS]
+    : args
+  return [...globals, ...tuned]
 }
 
-export function ad(args, { allowError = false, session = null, headed = false } = {}) {
+// 0.8.x builds a global window inventory (CoreGraphics + AX) before resolving a
+// target, and fails the WHOLE command with TIMEOUT when that inventory will not hold
+// still. Seen in three wordings so far: "CoreGraphics window inventory did not
+// stabilize", "Global application window inventory did not stabilize", and
+// "NSWorkspace app inventory timed out". In this suite they fire while a sibling
+// Electron instance is mid-launch — precisely when windows are churning — and it
+// says nothing about the app under test. Absorb it here, with a backoff long enough
+// for the launch to settle, instead of letting tool noise fail a scenario.
+const INVENTORY_UNSTABLE = /inventory (did not stabilize|timed out)/i
+const INVENTORY_TRIES = 4
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+export async function ad(args, opts = {}) {
+  for (let attempt = 0; ; attempt++) {
+    const mayRetry = attempt < INVENTORY_TRIES - 1
+    try {
+      const parsed = await adOnce(args, opts)
+      // With allowError the failure comes back as a value rather than a throw.
+      if (mayRetry && parsed?.ok === false && INVENTORY_UNSTABLE.test(parsed.error?.message ?? '')) {
+        await sleep(300 * (attempt + 1))
+        continue
+      }
+      return parsed
+    } catch (e) {
+      if (mayRetry && INVENTORY_UNSTABLE.test(e.raw?.error?.message ?? '')) {
+        await sleep(300 * (attempt + 1))
+        continue
+      }
+      throw e
+    }
+  }
+}
+
+function adOnce(args, { allowError = false, session = null, headed = false } = {}) {
   const argv = agentArgs(args, { session, headed })
   return new Promise((resolve, reject) => {
     const env = { ...process.env, AGENT_DESKTOP_CHAIN_TIMEOUT_MS: CHAIN_TIMEOUT_MS }

--- a/test/frontend/instance.mjs
+++ b/test/frontend/instance.mjs
@@ -21,6 +21,17 @@ const REPO = path.resolve(import.meta.dirname, '../..')
 // exclude them by title to keep pid-based re-resolution on the main window.
 const NATIVE_PANEL_TITLES = new Set(['Open', 'Save'])
 
+// agent-desktop 0.8.x widened `list-windows`: one dev Electron app now reports the
+// real window plus ~8 helper windows that are titled "Electron", carry the same
+// pid, and are NOT exposed through accessibility (snapshotting one returns
+// ACTION_NOT_SUPPORTED). 0.4.x listed only the real window, so `launch()` could
+// take the last fresh entry and always land on it. Ordering across those entries is
+// not guaranteed, so the last fresh window is now sometimes a phantom — which is
+// why this presented as most-but-not-all scenarios failing at their first snapshot.
+// `visible` separates them cleanly: only the real window reports true. It is also
+// the property we actually depend on, since an off-screen or unpainted window has
+// no usable AX tree either.
+
 // Poll interval for the harness's own wait loops. Each iteration does a ~0.4s
 // snapshot, so the snapshot dominates and a tight sleep just trims dead time
 // between polls without spamming the AX system.
@@ -28,7 +39,7 @@ const POLL_MS = 150
 async function mirallWindows() {
   const { data } = await ad(['list-windows'])
   return data
-    .filter((w) => w.app_name === 'Electron' && !NATIVE_PANEL_TITLES.has(w.title))
+    .filter((w) => w.app_name === 'Electron' && w.visible === true && !NATIVE_PANEL_TITLES.has(w.title))
     .map((w) => ({ id: w.id, pid: w.pid }))
 }
 
@@ -95,8 +106,35 @@ export class Instance {
     // focus()) because focus() no-ops for single instances — the one-time initial
     // raise must still happen so the renderer paints and snapshots aren't empty.
     await ad(['focus-window', '--window-id', this.windowId], { allowError: true })
+    await this._waitForAx()
     if (onboard) await this.onboard()
     return this
+  }
+
+  // A window appears in list-windows as soon as the OS has it, but Chromium builds
+  // web-content accessibility lazily per renderer process, so for a short window it
+  // is listed, painted, and still unable to answer an AX query. agent-desktop 0.4.x
+  // papered over that by returning an empty tree — the scenarios' own waitText loops
+  // absorbed it — while 0.8.x fails the snapshot outright with ACTION_NOT_SUPPORTED
+  // ("exists but is not exposed through accessibility"). It is a race, not a hard
+  // break: on a fast launch the renderer wins and the scenario passes, which is why
+  // it presents as most-but-not-all scenarios failing at their first step. Block
+  // here until the window actually answers, so every scenario starts from a window
+  // that is known to be drivable.
+  async _waitForAx(timeout = 30000) {
+    const deadline = Date.now() + timeout
+    let last = null
+    while (Date.now() < deadline) {
+      try {
+        await this.snap({ interactive: true })
+        return
+      } catch (e) {
+        if (e.code !== 'ACTION_NOT_SUPPORTED' && e.code !== 'WINDOW_NOT_FOUND') throw e
+        last = e
+        await new Promise((r) => setTimeout(r, POLL_MS))
+      }
+    }
+    throw new Error(`${this.name}: window ${this.windowId} never exposed an AX tree in ${timeout}ms (last: ${last?.code})`)
   }
 
   // `interactive` drops static-text / non-actionable nodes (-i) and collapses
@@ -106,9 +144,36 @@ export class Instance {
   // smaller payload to serialize/parse. Text/state assertions keep the full tree.
   async snap({ interactive = false } = {}) {
     const lens = interactive ? ['-i', '--compact'] : []
-    try {
+    // agent-desktop 0.7.0+ returns ok:true with data.complete=false when the AX
+    // walk exhausts its budget (it used to be a TIMEOUT error, which this
+    // harness surfaced as a retryable throw). A truncated tree is indistinguishable
+    // from a missing element once it reaches findNode/allText, so it would show up
+    // as unexplained "no element {...}" flake. Reject it here instead. `complete`
+    // is absent on <0.7.0, and `=== false` leaves that case untouched.
+    const take = async () => {
       const { data } = await this.ad(['snapshot', '--window-id', this.windowId, '--max-depth', '40', ...lens])
+      if (data.complete === false) {
+        throw Object.assign(new Error(`${this.name}: AX snapshot truncated (window ${this.windowId})`), {
+          code: 'SNAPSHOT_INCOMPLETE',
+        })
+      }
       return data.tree
+    }
+    // A truncated tree is almost always load, not size: the AX walk has an internal
+    // time budget (there is no flag to raise it), and with three or four Electron
+    // instances up, one window's walk can miss it while the same window snapshots
+    // fine a moment later. withRetry's flat 150ms is too tight to ride that out, so
+    // back off here first and only surface SNAPSHOT_INCOMPLETE once it persists.
+    for (let attempt = 0; attempt < 3; attempt++) {
+      try {
+        return await take()
+      } catch (e) {
+        if (e.code !== 'SNAPSHOT_INCOMPLETE' || attempt === 2) break
+        await new Promise((r) => setTimeout(r, 400 * (attempt + 1)))
+      }
+    }
+    try {
+      return await take()
     } catch (e) {
       // agent-desktop reassigns a window's AX id when the renderer repaints/
       // reloads, so a cached windowId can go stale mid-scenario (WINDOW_NOT_FOUND)
@@ -118,14 +183,13 @@ export class Instance {
       const match = (await mirallWindows()).find((w) => w.pid === this.pid)
       if (!match) throw e
       this.windowId = match.id
-      const { data } = await this.ad(['snapshot', '--window-id', this.windowId, '--max-depth', '40', ...lens])
-      return data.tree
+      return take()
     }
   }
 
   async _ref(sel) {
     const tree = await this.snap({ interactive: true })
-    const node = findNode(tree, sel)
+    const node = findNode(tree, { ...sel, actionable: true })
     if (!node || !node.ref) {
       throw Object.assign(new Error(`${this.name}: no element ${JSON.stringify(sel)}`), {
         code: 'ELEMENT_NOT_FOUND',
@@ -143,7 +207,21 @@ export class Instance {
   click(sel) {
     return withRetry(async () => {
       await this.focus()
-      return this.ad(['click', await this._ref(sel)])
+      const ref = await this._ref(sel)
+      try {
+        return await this.ad(['click', ref])
+      } catch (e) {
+        // agent-desktop 0.8.x separates semantic delivery (AXPress) from physical
+        // delivery (a real cursor click) and will not cross that line by itself:
+        // an element exposing no usable press action returns POLICY_DENIED instead
+        // of quietly falling back, which is what 0.4.x's activation chain did. A
+        // few of our controls only have the physical path (react-aria composites
+        // whose press handler sits on a wrapper node). Opt into it for exactly
+        // those, rather than running the whole suite --headed — the default stays
+        // cursor-free, and only the elements that need the pointer take it.
+        if (e.code !== 'POLICY_DENIED') throw e
+        return await this.ad(['click', ref], { headed: true })
+      }
     })
   }
 
@@ -214,18 +292,17 @@ export class Instance {
   // Case-insensitive: macOS AX reflects CSS text-transform, so uppercased badges
   // ("MIRRORED", "SHARED BY YOU") come through transformed.
   async waitText(substr, timeout = 30000) {
-    // Single window: agent-desktop's native text wait blocks in ONE process with
-    // efficient internal polling — no per-iteration full snapshot — and is
-    // case-insensitive substring, so it's strictly faster than our JS loop
-    // (~0.13s when the text is already up vs a ~0.4s snapshot). It scopes by
-    // --app, so it's only definitive when this instance is the sole Electron
-    // window; multi-instance keeps the per-window snapshot loop so the text is
-    // proven on THIS window, not a sibling that happens to show the same string.
-    if (this.total === 1) {
-      const res = await ad(['wait', '--text', substr, '--app', 'Electron', '--timeout', String(timeout)], { allowError: true })
-      if (res.ok) return true
-      throw new Error(`${this.name}: text "${substr}" not seen in ${timeout}ms (window ${this.windowId})`)
-    }
+    // NO native `wait --text` fast path. It used to be worth it for the
+    // single-window case (~0.13s vs a ~0.4s snapshot), but agent-desktop 0.8.x
+    // matches --text against an element's accessible NAME only, while the strings
+    // this suite asserts on are mostly static text — and macOS AX puts static-text
+    // content in `value`, not `name` (see tree.mjs). So the fast path silently
+    // stopped seeing headings and body copy: `wait --text "Settings"` still matched
+    // the nav BUTTON, while `wait --text "Manage your experience"` timed out on a
+    // Settings screen that demonstrably contained it. The snapshot loop below reads
+    // name + description + value via allText(), which is the behaviour every
+    // assertion here was written against, and it is what the multi-instance path
+    // already used — which is exactly why only single-instance scenarios broke.
     const needle = substr.toLowerCase()
     const deadline = Date.now() + timeout
     let last = ''
@@ -250,8 +327,14 @@ export class Instance {
   }
 
   // Read a node's AX value (e.g. "0"/"1" for aria-pressed / aria-checked toggles).
+  // Reads a CONTROL's value — a toggle's pressed state ("0"/"1"), a field's text —
+  // so it takes the same `actionable` lens as _ref(): a <label for> surfaces as a
+  // ref'd statictext with the control's accessible name and its own text as `value`,
+  // and being earlier in document order it would otherwise win every name-only match
+  // and return the label string instead of the control's value. Visible-text
+  // assertions go through hasText()/waitText(), which deliberately still see it.
   async nodeValue(sel) {
-    const node = findNode(await this.snap(), sel)
+    const node = findNode(await this.snap(), { ...sel, actionable: true })
     return node ? node.value : null
   }
 
@@ -262,8 +345,12 @@ export class Instance {
     await this.waitText('Create Space', 30000)
   }
 
+  // Same `actionable` lens as nodeValue(): a control's disabled state is meaningless
+  // on the label that shares its name, and a statictext never carries `disabled` —
+  // so matching the label would quietly report an actually-disabled control as
+  // enabled, which is a false PASS rather than a visible failure.
   async isDisabled(sel) {
-    const node = findNode(await this.snap(), sel)
+    const node = findNode(await this.snap(), { ...sel, actionable: true })
     return !!node && (node.states ?? []).includes('disabled')
   }
 

--- a/test/frontend/preflight.mjs
+++ b/test/frontend/preflight.mjs
@@ -10,14 +10,22 @@
 //          refmap — every cross-process ref came back STALE_REF and the suite hung.
 //   0.3.0+ reintroduced persisted, session-scoped snapshots (a per-`snapshot_id`
 //          refmap addressable via --session / --snapshot), so cross-process refs
-//          work again. This is the floor the harness now requires.
-export const MIN_AGENT_DESKTOP = '0.3.0'
+//          work again.
+//   0.7.0  an over-budget snapshot stopped being a TIMEOUT error and became
+//          ok:true + `complete:false`. instance.snap() reads that flag; on an
+//          older CLI the flag is simply absent, so a truncated tree would be
+//          silently asserted against. That makes 0.7.0 a correctness floor.
+//   0.8.0  refs became snapshot-qualified (`@<snapshot_id>:eN`) and ref actions
+//          gained their own --timeout-ms budget, which agent.mjs now sets.
+//          This is the floor the harness requires.
+export const MIN_AGENT_DESKTOP = '0.8.0'
 
-// True if `version` is older than the 0.3.0 floor (or unparseable). Only the
-// major/minor are significant — the pre-0.3 break was a minor-line change.
+// True if `version` is older than the floor (or unparseable). Only the
+// major/minor are significant — every break above was a minor-line change.
+const MIN_MINOR = Number(MIN_AGENT_DESKTOP.split('.')[1])
 export function agentDesktopTooOld(version) {
   const [major, minor] = String(version).split('.').map(Number)
   if (!Number.isFinite(major) || !Number.isFinite(minor)) return true
   if (major > 0) return false
-  return minor < 3
+  return minor < MIN_MINOR
 }

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -157,6 +157,17 @@ function pruneAgentDesktopStore() {
   for (const sub of ['snapshots', 'sessions']) {
     rmSync(path.join(store, sub), { recursive: true, force: true })
   }
+  // The two root-level files are the global "latest snapshot" pointer and its
+  // refmap. agent-desktop <0.5 wrote RefEntry records with a pid but no
+  // process_instance; 0.8.x's deserializer rejects those outright, so a store
+  // carried over from an older CLI makes `agent-desktop status` fail with
+  // INVALID_ARGS ("RefEntry requires a positive pid and process instance") until
+  // they are gone. Nothing here reads them — each Instance uses its own
+  // --session namespace — so clearing them is free and keeps the CLI usable
+  // by hand (and by the agent-desktop skill) after this suite has run.
+  for (const f of ['last_refmap.json', 'latest_snapshot_id']) {
+    rmSync(path.join(store, f), { force: true })
+  }
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 

--- a/test/frontend/tree.mjs
+++ b/test/frontend/tree.mjs
@@ -20,10 +20,19 @@ export function flatten(node, out = []) {
   return out
 }
 
-export function findNode(tree, { role, name, contains, last = false }) {
+// `actionable` drops `statictext` from consideration. agent-desktop 0.4.x removed
+// static text from the interactive lens (-i) entirely; 0.8.x keeps it AND gives it a
+// ref, so a <label for> now appears as a ref'd statictext carrying the very same
+// accessible name as the control it labels. Being earlier in document order it wins
+// any name-only match, so ref resolution for a click/type silently retargeted the
+// label — set-value wrote to it and the read-back returned the label text instead of
+// the field's. Static text is never a valid action target, so ref resolution skips
+// it; assertions deliberately do not, since that is where visible text lives.
+export function findNode(tree, { role, name, contains, last = false, actionable = false }) {
   const matches = flatten(tree).filter(
     (n) =>
       (role == null || n.role === role) &&
+      (!actionable || n.role !== 'statictext') &&
       (name == null || n.name === name || n.description === name) &&
       (contains == null || n.label.includes(contains)),
   )


### PR DESCRIPTION
0.8.x changes several behaviours the AX harness relied on: list-windows reports invisible helper windows, `wait --text` matches accessible names only (not static-text values), the interactive lens keeps ref'd statictext so a <label> wins name-only matches, ref actions carry their own auto-wait budget, window-inventory reads time out under launch churn, an undeliverable click returns POLICY_DENIED instead of falling back to physical, and a truncated snapshot returns ok with complete:false. Ref resolution and control reads now exclude statictext, which also closes a false pass in isDisabled(). Version floor raised to 0.8.0; stale pre-0.5 refmap state is pruned, since 0.8.x rejects it.
