### PR TITLE
[chore] Drop SpaceCard's never-rendered action buttons

### DIFF
--- a/src/renderer/components/cards/SpaceCard.tsx
+++ b/src/renderer/components/cards/SpaceCard.tsx
@@ -8,11 +8,9 @@ import Avatar from '../primitives/Avatar.js'
 interface SpaceCardProps {
   space: Space
   onClick: () => void
-  onToggleFavorite: (spaceId: string) => void
-  onEdit: (space: Space) => void
 }
 
-export default function SpaceCard({ space, onClick, onToggleFavorite, onEdit }: SpaceCardProps) {
+export default function SpaceCard({ space, onClick }: SpaceCardProps) {
   const { t } = useTranslation()
   const gradient = gradientForSpaceId(space.spaceId)
   // spaces:list rosters are slim (no avatars); the facepile reads the cached full roster and
@@ -31,7 +29,7 @@ export default function SpaceCard({ space, onClick, onToggleFavorite, onEdit }: 
       aria-label={space.status === 'pending'
         ? t('spaceCard.openSpacePending', { name: space.name })
         : t('spaceCard.openSpace', { name: space.name })}
-      className="group bg-surface-container-lowest hover:bg-surface-container-highest p-5 rounded-2xl flex items-center gap-6 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
+      className="bg-surface-container-lowest hover:bg-surface-container-highest p-5 rounded-2xl flex items-center gap-6 transition-colors cursor-pointer focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
     >
       <div className={`w-16 h-16 rounded-xl ${gradient} flex items-center justify-center shrink-0`}>
         <Icon name={(space.icon as IconName) || 'hub'} size={32} className="text-on-primary" />
@@ -70,40 +68,6 @@ export default function SpaceCard({ space, onClick, onToggleFavorite, onEdit }: 
           )}
         </div>
       )}
-      <div className="hidden flex items-center gap-1 shrink-0">
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); onEdit(space) }}
-          aria-label={t('space.edit')}
-          className="w-10 h-10 flex items-center justify-center rounded-full hover:bg-surface-container-high/50 active:scale-95 transition-all opacity-0 group-hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
-        >
-          <Icon name="edit" className="text-outline/40" />
-        </button>
-        <button
-          type="button"
-          onClick={(e) => { e.stopPropagation(); onToggleFavorite(space.spaceId) }}
-          aria-label={t(space.favorite ? 'space.removeFavorite' : 'space.addFavorite')}
-          aria-pressed={space.favorite}
-          className="w-10 h-10 flex items-center justify-center rounded-full hover:bg-surface-container-high/50 active:scale-95 transition-all opacity-0 group-hover:opacity-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
-        >
-          <svg
-            width="24"
-            height="24"
-            viewBox="0 0 256 256"
-            className="text-outline/40"
-            fill="currentColor"
-            aria-hidden="true"
-          >
-            <g transform="translate(1.4065934065934016 1.4065934065934016) scale(2.81 2.81)">
-              {space.favorite ? (
-                <path d="M 47.755 3.765 l 11.525 23.353 c 0.448 0.907 1.313 1.535 2.314 1.681 l 25.772 3.745 c 2.52 0.366 3.527 3.463 1.703 5.241 L 70.42 55.962 c -0.724 0.706 -1.055 1.723 -0.884 2.72 l 4.402 25.667 c 0.431 2.51 -2.204 4.424 -4.458 3.239 L 46.43 75.47 c -0.895 -0.471 -1.965 -0.471 -2.86 0 L 20.519 87.588 c -2.254 1.185 -4.889 -0.729 -4.458 -3.239 l 4.402 -25.667 c 0.171 -0.997 -0.16 -2.014 -0.884 -2.72 L 0.931 37.784 c -1.824 -1.778 -0.817 -4.875 1.703 -5.241 l 25.772 -3.745 c 1.001 -0.145 1.866 -0.774 2.314 -1.681 L 42.245 3.765 C 43.372 1.481 46.628 1.481 47.755 3.765 z" />
-              ) : (
-                <path stroke="currentColor" strokeWidth={3.5} strokeLinejoin="round" d="M 69.671 88.046 c -0.808 0 -1.62 -0.195 -2.37 -0.59 L 45 75.732 L 22.7 87.456 c -1.727 0.907 -3.779 0.757 -5.356 -0.388 c -1.577 -1.146 -2.352 -3.052 -2.023 -4.972 l 4.259 -24.832 L 1.539 39.678 c -1.396 -1.361 -1.889 -3.358 -1.287 -5.213 c 0.603 -1.854 2.176 -3.181 4.105 -3.461 l 24.932 -3.622 L 40.44 4.79 C 41.303 3.041 43.05 1.955 45 1.955 c 0 0 0 0 0.001 0 c 1.949 0 3.696 1.086 4.559 2.834 l 11.15 22.592 l 24.932 3.623 c 1.93 0.28 3.503 1.606 4.105 3.461 c 0.603 1.854 0.109 3.851 -1.287 5.213 L 70.419 57.264 l 4.26 24.832 c 0.329 1.921 -0.446 3.827 -2.023 4.972 C 71.764 87.717 70.721 88.046 69.671 88.046 z M 7.055 36.676 l 17.058 16.628 c 1.198 1.167 1.746 2.85 1.462 4.502 l -4.027 23.479 l 21.086 -11.086 c 1.481 -0.779 3.25 -0.779 4.732 0 l 21.085 11.086 l -4.027 -23.48 c -0.283 -1.649 0.264 -3.333 1.463 -4.501 l 17.058 -16.628 L 59.372 33.25 c -1.658 -0.242 -3.089 -1.282 -3.829 -2.783 L 45 9.106 L 34.457 30.468 c -0.74 1.5 -2.171 2.54 -3.827 2.782 L 7.055 36.676 z M 84.779 36.942 h 0.011 H 84.779 z M 44.18 7.444 c 0 0 0 0.001 0.001 0.002 L 44.18 7.444 C 44.18 7.445 44.18 7.445 44.18 7.444 z" />
-              )}
-            </g>
-          </svg>
-        </button>
-      </div>
     </div>
   )
 }

--- a/src/renderer/screens/SharedSpaces.tsx
+++ b/src/renderer/screens/SharedSpaces.tsx
@@ -1,11 +1,10 @@
-// Home screen: the user's spaces as cards, with create/join entry points and space editing.
+// Home screen: the user's spaces as cards, with create/join entry points. Per-space
+// actions (edit, favorite) live in the space's own header menu, not on the cards.
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useSpaces } from '../hooks/useSpaces.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
-import type { Space } from '../types.js'
 import SpaceCard from '../components/cards/SpaceCard.js'
-import EditSpaceModal from '../components/modals/EditSpaceModal.js'
 import Icon from '../components/primitives/Icon.js'
 import Button from '../components/primitives/Button.js'
 
@@ -17,8 +16,7 @@ interface YourSpacesProps {
 
 export default function YourSpaces({ onSelectSpace, onShowCreate, onShowJoin }: YourSpacesProps) {
   const { t } = useTranslation()
-  const { spaces, updateSpace, toggleFavorite } = useSpaces()
-  const [editingSpace, setEditingSpace] = useState<Space | null>(null)
+  const { spaces } = useSpaces()
   const [filter, setFilter] = useState<'all' | 'favorites'>('all')
   const { ref: listRef, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
 
@@ -90,20 +88,10 @@ export default function YourSpaces({ onSelectSpace, onShowCreate, onShowJoin }: 
             <SpaceCard
               space={space}
               onClick={() => onSelectSpace(space.spaceId)}
-              onToggleFavorite={toggleFavorite}
-              onEdit={setEditingSpace}
             />
           </div>
         ))}
       </div>
-
-      {editingSpace && (
-        <EditSpaceModal
-          space={editingSpace}
-          onSave={updateSpace}
-          onClose={() => setEditingSpace(null)}
-        />
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## What & why

The SpaceCard action cluster carried Tailwind `hidden` alongside `flex`. Both are
plain display utilities, and `.hidden` is emitted after `.flex`, so `display:none`
always won — neither the edit pencil nor the favorite star has rendered since the
initial commit. Rather than reviving them, they're removed: per-space edit and
favorite stay in the space's header **More** menu, where they already effectively
lived.

Unwiring the two props cascaded — `toggleFavorite`, `updateSpace`, the
`editingSpace` state and an entire `EditSpaceModal` instance in `SharedSpaces`
were reachable only through the card pencil, so all of it was dead. `SpaceView`
keeps its own modal for the menu path.

No user-visible behavior changes; the Favorites tab is unaffected. The only
visual difference is that the facepile now sits flush against the card's right
padding instead of leaving the gap the invisible buttons reserved.

## Coverage

Renderer-only deletion with no new user-facing behavior, so no new scenario —
existing frontend coverage exercises every affected surface. No data-layer,
IPC or P2P surface touched.

## Ran locally

`test:fe` — s13, s21, s80, s81, s107 all green (spaces list, card navigation,
header-menu edit/favorite, empty states). a11y: removing the buttons also
removes two interactive descendants from inside the card's `role="button"`,
which ARIA disallows; the card keeps its name, role and keyboard handler.