### PR TITLE
[docs] Record the fourth inventory-failure wording

### DIFF
--- a/test/frontend/agent.mjs
+++ b/test/frontend/agent.mjs
@@ -63,9 +63,10 @@ export function agentArgs(args, { session = null, headed = false } = {}) {
 
 // 0.8.x builds a global window inventory (CoreGraphics + AX) before resolving a
 // target, and fails the WHOLE command with TIMEOUT when that inventory will not hold
-// still. Seen in three wordings so far: "CoreGraphics window inventory did not
-// stabilize", "Global application window inventory did not stabilize", and
-// "NSWorkspace app inventory timed out". In this suite they fire while a sibling
+// still. Four wordings observed: "CoreGraphics window inventory did not stabilize",
+// "CoreGraphics window inventory timed out", "Global application window inventory did
+// not stabilize", and "NSWorkspace app inventory timed out" — hence matching on the
+// shared "inventory …" shape rather than any one string. They fire while a sibling
 // Electron instance is mid-launch — precisely when windows are churning — and it
 // says nothing about the app under test. Absorb it here, with a backoff long enough
 // for the launch to settle, instead of letting tool noise fail a scenario.


### PR DESCRIPTION
A fourth wording, `"CoreGraphics window inventory timed out"`, was observed alongside the three already listed in `agent.mjs`. It explains why `INVENTORY_UNSTABLE` matches the shared `inventory …` shape rather than any one string.

Comment-only — the regex already covers all four (verified against each). Salvaged from a local commit that duplicated #71 and was otherwise discarded.

Tests: SKIP (docs-only, per `.claude/testing.md`).