### PR TITLE
[fix] Report a missing download folder specifically

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -334,6 +334,22 @@ not a status tint; the status hue lives only on the **icon** (`iconColor`). Exce
 `warning` keeps dark `on-warning` text because its container stays bright yellow in
 dark mode. A11y: error = `role="alert" aria-live="assertive"`, others = `status` / `polite`.
 
+**Toast vs. banner — when to use which.** A **persistent, app-wide fault that blocks one
+subsystem** (network down, download folder unreachable) is a **sticky toast**, not a banner:
+`duration: 0`, a stable `id` so re-detection replaces rather than stacks, an `action` pointing at
+the screen that fixes it, and a `success` toast on recovery. Drive it from a renderless *bridge*
+component that watches the state and emits transitions —
+`widgets/ConnectivityToastBridge.tsx` and `widgets/DownloadFolderToastBridge.tsx` are the two
+worked examples; copy their shape rather than inventing a surface. Toasting only on a
+**transition** is what lets a dismissed toast stay dismissed while the fault persists.
+
+The **top-nav banner slot is reserved for `UpdateBanner`** — an informational notice that cannot
+resolve itself (the update is staged until the app restarts) and so needs manual dismissal. It is
+the only banner, and it owns `--banner-h`; adding a second one means reworking that variable's
+ownership and every screen's scroll-height math, so reach for a toast first. Per-*screen*
+affordances that are neither (a pending join request inside a space) are ordinary in-screen cards
+— see `widgets/JoinRequestBanner.tsx`, which despite its name is a card, not a banner.
+
 ### Cards — `components/cards/`
 All share `bg-surface-container-lowest hover:bg-surface-container-low dark:hover:bg-surface-container transition-colors`,
 **no border, no shadow**:

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -18,6 +18,7 @@ import { ToastProvider, useToast } from './components/toast/ToastProvider.js'
 import { ConnectionStatusProvider } from './hooks/useConnectionStatus.js'
 import ConnectivityToastBridge from './components/widgets/ConnectivityToastBridge.js'
 import WorkerToastBridge from './components/widgets/WorkerToastBridge.js'
+import DownloadFolderToastBridge from './components/widgets/DownloadFolderToastBridge.js'
 import CommandPalette from './keyboard/CommandPalette.js'
 import ShortcutsHint from './keyboard/ShortcutsHint.js'
 import type { Command } from './keyboard/registry.js'
@@ -141,6 +142,7 @@ export default function App() {
     <ToastProvider>
     <ConnectionStatusProvider>
     <ConnectivityToastBridge onShowDetails={() => nav.setCurrentScreen('network-status')} />
+    <DownloadFolderToastBridge onChangeFolder={() => nav.openStorageSettings(nav.currentScreen === 'space-view' ? 'space-view' : 'settings')} />
     <WorkerToastBridge />
     <KeyboardProvider currentScreen={nav.currentScreen} selectedSpaceId={nav.selectedSpaceId}>
       <AppCommands

--- a/src/renderer/components/widgets/DownloadFolderToastBridge.tsx
+++ b/src/renderer/components/widgets/DownloadFolderToastBridge.tsx
@@ -1,0 +1,65 @@
+// Renderless bridge turning download-folder availability into toasts: a sticky error while a
+// folder is unreachable, and a brief notice when it comes back.
+//
+// Deliberately the same shape as ConnectivityToastBridge — both report a persistent, app-wide
+// fault that blocks one subsystem, offers one way to fix it, and clears itself when the
+// underlying condition does. A single sticky toast (one `id`, so re-probing replaces rather
+// than stacks) is what keeps one missing folder from reading as N failed downloads.
+import { useEffect, useRef } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useToast } from '../toast/ToastProvider.js'
+import { useDownloadRootStatus } from '../../hooks/useDownloadRootStatus.js'
+
+const TOAST_ID = 'download-folder'
+
+interface Props {
+  onChangeFolder: () => void
+}
+
+export default function DownloadFolderToastBridge({ onChangeFolder }: Props) {
+  const { unavailable, faultSeq } = useDownloadRootStatus()
+  const { t } = useTranslation()
+  const toast = useToast()
+  // Only transitions produce a toast, so a re-probe that finds the same folder still missing
+  // doesn't re-raise one the user has dismissed. A fresh FAILED DOWNLOAD counts as a transition
+  // though (faultSeq): the toast stack keeps at most 4 and evicts the oldest, which a sticky
+  // toast always is, so without that the only surface explaining the fault can disappear on its
+  // own and never come back.
+  const previousRef = useRef<string | null>(null)
+  const onChangeFolderRef = useRef(onChangeFolder)
+
+  useEffect(() => {
+    onChangeFolderRef.current = onChangeFolder
+  }, [onChangeFolder])
+
+  useEffect(() => {
+    // Several roots can be unreachable at once (a per-space override alongside the global one),
+    // almost always from one cause — an ejected disk. Name the first and count the rest rather
+    // than stacking a toast per root.
+    const [first, ...rest] = unavailable
+    const key = JSON.stringify([unavailable, faultSeq])
+    const previous = previousRef.current
+    previousRef.current = key
+    if (previous === key) return
+
+    if (first) {
+      toast.error(t('downloadFolder.unavailableToast', {
+        path: rest.length > 0 ? `${first} (+${rest.length})` : first,
+      }), {
+        id: TOAST_ID,
+        duration: 0,
+        action: {
+          label: t('downloadFolder.changeFolder'),
+          onClick: () => onChangeFolderRef.current(),
+        },
+      })
+      return
+    }
+
+    // Recovered. `previous === null` is the first probe of a healthy session, which is not a
+    // recovery and must stay silent.
+    if (previous) toast.success(t('downloadFolder.restoredToast'), { id: TOAST_ID, duration: 4000 })
+  }, [unavailable, faultSeq, t, toast])
+
+  return null
+}

--- a/src/renderer/errorMessages.ts
+++ b/src/renderer/errorMessages.ts
@@ -7,6 +7,12 @@ const ERROR_I18N_KEY_BY_CODE: Record<string, string> = {
   TRANSFER_REMOVED: 'transferRemoved',
   TRANSFER_NETWORK: 'transferNetwork',
   TRANSFER_RENAME_FAILED: 'transferRenameFailed',
+  TRANSFER_DEST_UNAVAILABLE: 'transferDestUnavailable',
+  // The worker's catch-all for a fetch it could not classify. Mapped EXPLICITLY even though it
+  // resolves to the same string as the fallback: leaving it out is what let every unclassified
+  // local-filesystem failure — a deleted, ejected, or file-shadowed download folder among them —
+  // reach the user as a bare "Transfer failed", and it would silently swallow the next new code too.
+  DOWNLOAD_FAILED: 'transferFailed',
   LOOSE_FILE_LIMIT: 'looseFileLimit',
   SHARE_FILE_LIMIT: 'shareFileLimit',
 }

--- a/src/renderer/hooks/useDownloadRootStatus.ts
+++ b/src/renderer/hooks/useDownloadRootStatus.ts
@@ -1,0 +1,53 @@
+// Which download folders are currently unreachable — deleted, ejected, on a disconnected
+// network share, or replaced by a file. Drives the app-level banner and the Storage Settings
+// warning, so the user learns the folder is gone instead of reading "Transfer failed" on every
+// download that tries to land there.
+import { useCallback, useEffect, useState } from 'react'
+import { request, subscribe } from '../ipc.js'
+
+interface RootsStatus {
+  unavailable?: string[]
+}
+
+interface TransferErrorMessage {
+  errorCode?: string
+}
+
+export function useDownloadRootStatus() {
+  const [unavailable, setUnavailable] = useState<string[]>([])
+  // Counts transfers that failed on an unreachable folder. The unavailable SET is unchanged by a
+  // second failure against the same folder, so it alone cannot tell a consumer that the user just
+  // hit the problem again — which is the one moment re-explaining a dismissed (or stack-evicted)
+  // toast is warranted.
+  const [faultSeq, setFaultSeq] = useState(0)
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await request('downloads:roots-status') as RootsStatus
+      setUnavailable(Array.isArray(res?.unavailable) ? res.unavailable : [])
+    } catch {
+      // A worker that isn't up yet is not evidence the folder is gone — leave the last
+      // known state alone rather than clearing a banner that is currently correct.
+    }
+  }, [])
+
+  useEffect(() => {
+    void refresh()
+    const unsubs = [
+      subscribe<RootsStatus>('event:download-roots-status', (msg) => {
+        setUnavailable(Array.isArray(msg?.unavailable) ? msg.unavailable : [])
+      }),
+      // The worker probes on a 60s tick, so a download that just failed on a gone folder would
+      // otherwise sit behind a generic-looking error for up to a minute before the banner
+      // explains it. The failure itself is the signal to re-probe now.
+      subscribe<TransferErrorMessage>('event:transfer-error', (msg) => {
+        if (msg?.errorCode !== 'TRANSFER_DEST_UNAVAILABLE') return
+        setFaultSeq((n) => n + 1)
+        void refresh()
+      }),
+    ]
+    return () => { for (const off of unsubs) off() }
+  }, [refresh])
+
+  return { unavailable, faultSeq, refresh }
+}

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -432,6 +432,11 @@
     "appliedOnNextStart": "wird beim nächsten Beenden und Öffnen von Mirall angewendet",
     "dismiss": "Ausblenden"
   },
+  "downloadFolder": {
+    "unavailableToast": "Download-Ordner nicht verfügbar. Mirall kann {{path}} nicht erreichen – Downloads schlagen fehl, bis der Ordner wieder verfügbar ist oder ein anderer gewählt wird.",
+    "changeFolder": "Ordner ändern",
+    "restoredToast": "Download-Ordner ist wieder verfügbar"
+  },
   "storageIndicator": {
     "title": "Speicher im Raum",
     "sizeOnDevice": "{{size}} auf diesem Gerät"
@@ -548,6 +553,7 @@
     "reclaimDone": "{{size}} freigegeben.",
     "reclaimNone": "Der Speicher ist bereits optimiert.",
     "folderError": "Ordner konnte nicht gesetzt werden: {{error}}",
+    "folderUnavailable": "Dieser Ordner ist derzeit nicht verfügbar. Er wurde möglicherweise verschoben oder gelöscht, oder er liegt auf einem getrennten Laufwerk – Downloads schlagen fehl, bis der Ordner wieder verfügbar ist oder ein anderer gewählt wird.",
     "calculating": "Berechne Speicher…",
     "appStorage": "App-Speicher",
     "showDetails": "Details anzeigen",

--- a/src/renderer/locales/de/errors.json
+++ b/src/renderer/locales/de/errors.json
@@ -5,6 +5,7 @@
   "transferRemoved": "Vom Eigentümer nicht mehr geteilt",
   "transferNetwork": "Netzwerkfehler",
   "transferRenameFailed": "Download konnte nicht abgeschlossen werden",
+  "transferDestUnavailable": "Download-Ordner nicht verfügbar",
   "transferFailed": "Übertragung fehlgeschlagen",
   "joinFailed": "Beitritt zum Raum fehlgeschlagen",
   "feedbackFailed": "Feedback konnte nicht gesendet werden",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -455,6 +455,11 @@
     "appliedOnNextStart": "will be applied next time you quit and reopen Mirall",
     "dismiss": "Dismiss"
   },
+  "downloadFolder": {
+    "unavailableToast": "Download folder unavailable. Mirall can't reach {{path}} — downloads will fail until you reconnect it or choose another folder.",
+    "changeFolder": "Change folder",
+    "restoredToast": "Download folder is available again"
+  },
   "storageIndicator": {
     "title": "Space Storage",
     "sizeOnDevice": "{{size}} on this device"
@@ -562,6 +567,7 @@
     "downloadFolderDesc": "Where Mirall saves files downloaded from your space members.",
     "changeFolder": "Change…",
     "folderError": "Could not set folder: {{error}}",
+    "folderUnavailable": "This folder is currently unavailable. It may have been moved, deleted, or is on a disconnected drive — downloads will fail until you reconnect it or choose another folder.",
     "calculating": "Calculating storage...",
     "appStorage": "App Storage",
     "showDetails": "Show details",

--- a/src/renderer/locales/en/errors.json
+++ b/src/renderer/locales/en/errors.json
@@ -5,6 +5,7 @@
   "transferRemoved": "File no longer shared by owner",
   "transferNetwork": "Network error",
   "transferRenameFailed": "Could not finalize download",
+  "transferDestUnavailable": "Download folder unavailable",
   "transferFailed": "Transfer failed",
   "joinFailed": "Failed to join space",
   "feedbackFailed": "Failed to send feedback",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -432,6 +432,11 @@
     "appliedOnNextStart": "se aplicará la próxima vez que cierres y vuelvas a abrir Mirall",
     "dismiss": "Descartar"
   },
+  "downloadFolder": {
+    "unavailableToast": "Carpeta de descargas no disponible. Mirall no puede acceder a {{path}}: las descargas fallarán hasta que vuelvas a conectarla o elijas otra carpeta.",
+    "changeFolder": "Cambiar carpeta",
+    "restoredToast": "La carpeta de descargas vuelve a estar disponible"
+  },
   "storageIndicator": {
     "title": "Almacenamiento del espacio",
     "sizeOnDevice": "{{size}} en este dispositivo"
@@ -548,6 +553,7 @@
     "reclaimDone": "Se liberaron {{size}}.",
     "reclaimNone": "El almacenamiento ya está optimizado.",
     "folderError": "No se pudo establecer la carpeta: {{error}}",
+    "folderUnavailable": "Esta carpeta no está disponible en este momento. Puede que se haya movido o eliminado, o que esté en una unidad desconectada: las descargas fallarán hasta que vuelvas a conectarla o elijas otra carpeta.",
     "calculating": "Calculando almacenamiento…",
     "appStorage": "Almacenamiento de la app",
     "showDetails": "Mostrar detalles",

--- a/src/renderer/locales/es/errors.json
+++ b/src/renderer/locales/es/errors.json
@@ -5,6 +5,7 @@
   "transferRemoved": "El propietario ya no comparte el archivo",
   "transferNetwork": "Error de red",
   "transferRenameFailed": "No se pudo finalizar la descarga",
+  "transferDestUnavailable": "Carpeta de descargas no disponible",
   "transferFailed": "Error de transferencia",
   "joinFailed": "Error al unirse al espacio",
   "feedbackFailed": "Error al enviar los comentarios",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -432,6 +432,11 @@
     "appliedOnNextStart": "sera appliquée au prochain redémarrage de Mirall",
     "dismiss": "Ignorer"
   },
+  "downloadFolder": {
+    "unavailableToast": "Dossier de téléchargement indisponible. Mirall ne peut pas accéder à {{path}} — les téléchargements échoueront tant qu'il n'est pas reconnecté ou qu'un autre dossier n'est pas choisi.",
+    "changeFolder": "Changer de dossier",
+    "restoredToast": "Le dossier de téléchargement est de nouveau disponible"
+  },
   "storageIndicator": {
     "title": "Stockage de l'espace",
     "sizeOnDevice": "{{size}} sur cet appareil"
@@ -548,6 +553,7 @@
     "reclaimDone": "{{size}} libérés.",
     "reclaimNone": "Le stockage est déjà optimisé.",
     "folderError": "Impossible de définir le dossier : {{error}}",
+    "folderUnavailable": "Ce dossier est actuellement indisponible. Il a peut-être été déplacé ou supprimé, ou il se trouve sur un disque déconnecté — les téléchargements échoueront tant qu'il n'est pas reconnecté ou qu'un autre dossier n'est pas choisi.",
     "calculating": "Calcul du stockage…",
     "appStorage": "Stockage de l'application",
     "showDetails": "Afficher les détails",

--- a/src/renderer/locales/fr/errors.json
+++ b/src/renderer/locales/fr/errors.json
@@ -5,6 +5,7 @@
   "transferRemoved": "Fichier n'est plus partagé par le propriétaire",
   "transferNetwork": "Erreur réseau",
   "transferRenameFailed": "Impossible de finaliser le téléchargement",
+  "transferDestUnavailable": "Dossier de téléchargement indisponible",
   "transferFailed": "Échec du transfert",
   "joinFailed": "Échec de l'adhésion à l'espace",
   "feedbackFailed": "Échec de l'envoi du commentaire",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -432,6 +432,11 @@
     "appliedOnNextStart": "verrà applicato la prossima volta che chiudi e riapri Mirall",
     "dismiss": "Ignora"
   },
+  "downloadFolder": {
+    "unavailableToast": "Cartella di download non disponibile. Mirall non riesce a raggiungere {{path}}: i download falliranno finché non la ricolleghi o non scegli un'altra cartella.",
+    "changeFolder": "Cambia cartella",
+    "restoredToast": "La cartella di download è di nuovo disponibile"
+  },
   "storageIndicator": {
     "title": "Archiviazione dello spazio",
     "sizeOnDevice": "{{size}} su questo dispositivo"
@@ -548,6 +553,7 @@
     "reclaimDone": "Liberati {{size}}.",
     "reclaimNone": "L'archiviazione è già ottimizzata.",
     "folderError": "Impossibile impostare la cartella: {{error}}",
+    "folderUnavailable": "Questa cartella non è al momento disponibile. Potrebbe essere stata spostata o eliminata, oppure si trova su un'unità scollegata: i download falliranno finché non la ricolleghi o non scegli un'altra cartella.",
     "calculating": "Calcolo dell'archiviazione…",
     "appStorage": "Spazio dell'app",
     "showDetails": "Mostra dettagli",

--- a/src/renderer/locales/it/errors.json
+++ b/src/renderer/locales/it/errors.json
@@ -5,6 +5,7 @@
   "transferRemoved": "File non più condiviso dal proprietario",
   "transferNetwork": "Errore di rete",
   "transferRenameFailed": "Impossibile finalizzare il download",
+  "transferDestUnavailable": "Cartella di download non disponibile",
   "transferFailed": "Trasferimento non riuscito",
   "joinFailed": "Impossibile entrare nello spazio",
   "feedbackFailed": "Impossibile inviare il feedback",

--- a/src/renderer/screens/StorageSettings.tsx
+++ b/src/renderer/screens/StorageSettings.tsx
@@ -5,6 +5,7 @@ import { request } from '../ipc.js'
 import { formatSize } from '../utils.js'
 import { mountErrorI18nKey } from '../errorMessages.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import { useDownloadRootStatus } from '../hooks/useDownloadRootStatus.js'
 import CopyButton from '../components/primitives/CopyButton.js'
 import FilePath from '../components/widgets/FilePath.js'
 import Icon from '../components/primitives/Icon.js'
@@ -75,6 +76,13 @@ function StorageBreakdown({ info, freeing, freedBytes, onFreeSpace }: { info: St
   )
 }
 
+// Trailing separators and Unicode composition are the two ways the same folder reaches us
+// spelled differently; neither changes which folder it is.
+function samePath(a: string, b: string) {
+  const strip = (p: string) => p.replace(/[/\\]+$/, '').normalize('NFC')
+  return strip(a) === strip(b)
+}
+
 export default function StorageSettings({ onBack }: StorageSettingsProps) {
   const { t } = useTranslation()
   const { t: tErr } = useTranslation('errors')
@@ -83,6 +91,7 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
   const [downloadFolder, setDownloadFolder] = useState<string>('')
   const [folderError, setFolderError] = useState<string | null>(null)
   const [detailsOpen, setDetailsOpen] = useState(false)
+  const { unavailable: unavailableRoots, refresh: refreshRootStatus } = useDownloadRootStatus()
   const [freeing, setFreeing] = useState(false)
   const [freedBytes, setFreedBytes] = useState<number | null>(null)
   const freeingRef = useRef(false)
@@ -131,11 +140,22 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
       // config, and the next launch would spawn the worker on it with nothing left to check it.
       await request('settings:set-download-folder', { folder: picked })
       setDownloadFolder(await window.bridge.setDownloadFolder(picked))
+      // The picker only accepts a folder that validated, so the warning below is stale the
+      // moment this resolves — re-probe rather than leaving it up until the next 60s tick.
+      await refreshRootStatus()
     } catch (err) {
       const key = mountErrorI18nKey((err as { code?: string } | null)?.code)
       setFolderError(key ? tErr(key) : err instanceof Error ? err.message : String(err))
     }
-  }, [tErr])
+  }, [tErr, refreshRootStatus])
+
+  // This screen shows the GLOBAL root; `unavailableRoots` also carries per-space overrides, so
+  // match rather than test for a non-empty list. The two strings reach us by different routes —
+  // main stores the path the picker returned, the worker stores its own resolved + NFC-normalized
+  // copy — so compare them normalized instead of raw, or a folder with an umlaut in its name
+  // silently fails to match and the warning never shows.
+  const folderUnavailable = downloadFolder.length > 0
+    && unavailableRoots.some((root) => samePath(root, downloadFolder))
 
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
 
@@ -165,8 +185,14 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
                   {t('storageSettings.changeFolder')}
                 </button>
               </div>
+              {/* A rejected pick leaves BOTH true — the old folder is still unavailable and the
+                  new one was refused. Order matters for a screen reader: the rejection is what
+                  just happened and what the user can act on, so it is announced first. */}
               {folderError && (
                 <p className="mt-3 text-sm text-error" role="alert">{t('storageSettings.folderError', { error: folderError })}</p>
+              )}
+              {folderUnavailable && (
+                <p className="mt-3 text-sm text-error" role="alert">{t('storageSettings.folderUnavailable')}</p>
               )}
             </div>
           </section>

--- a/src/shared/core/errors.js
+++ b/src/shared/core/errors.js
@@ -21,6 +21,7 @@ export const ErrorCodes = {
   TRANSFER_CHECKSUM: 'TRANSFER_CHECKSUM',
   TRANSFER_REMOVED: 'TRANSFER_REMOVED',
   TRANSFER_RENAME_FAILED: 'TRANSFER_RENAME_FAILED',
+  TRANSFER_DEST_UNAVAILABLE: 'TRANSFER_DEST_UNAVAILABLE',
   EOWNERSHIP: 'EOWNERSHIP',
   SHARE_NAME_COLLISION: 'SHARE_NAME_COLLISION',
   SHARE_NAME_INVALID: 'SHARE_NAME_INVALID',
@@ -62,6 +63,20 @@ export function classifyTransferError(err) {
     return ErrorCodes.TRANSFER_REMOVED
   }
   return ErrorCodes.TRANSFER_NETWORK
+}
+
+// Local-filesystem failures that a download folder which has been deleted, ejected, replaced by
+// a file, or served off a dropped network mount can produce. The errno ALONE never settles it —
+// the same codes arise from ordinary transient faults — so a caller must confirm by probing the
+// destination folder; this set only says "worth probing". Kept here, next to
+// classifyTransferError, so the two can't drift, and free of any fs import — that is what keeps
+// this module loadable under plain Node, and so unit-testable rather than integration-only.
+const LOCAL_DEST_FAULT_CODES = new Set([
+  'ENOENT', 'ENOTDIR', 'ENODEV', 'ENXIO', 'EIO', 'ESTALE', 'EACCES', 'EPERM', 'EROFS',
+])
+
+export function isLocalDestFault(code) {
+  return LOCAL_DEST_FAULT_CODES.has(code)
 }
 
 export function isRetryableTransferError(errorCode) {

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -915,10 +915,13 @@ const folderEngine = createOverlayDownloadEngine({
   emitProgress: (job, p) => shareDeco(job, { bytes: p.bytes, total: p.total, speed: p.speed, eta: p.eta }),
   emitVerifying: (job, fraction) => shareDeco(job, { phase: 'verifying', verifyFraction: fraction, bytes: job.prevBytes || 0, total: job.size }),
   // Folder rows surface errors via the list refresh (Resume retries); only the terminal
-  // failures cross the wire — disk-full and an integrity mismatch need the user's attention
-  // (toast + notification) and no automatic retry can fix either.
+  // failures cross the wire — disk-full, an integrity mismatch and an unreachable download
+  // folder need the user's attention (toast + notification) and no automatic retry can fix any
+  // of them. The membership of this set and the auto-resume suppression in overlay-download.js
+  // are the same judgement: a fault the user must clear before a retry can ever succeed.
   emitError: (job, errorCode) => {
-    if (errorCode === ErrorCodes.TRANSFER_DISK_FULL || errorCode === ErrorCodes.TRANSFER_CHECKSUM) {
+    if (errorCode === ErrorCodes.TRANSFER_DISK_FULL || errorCode === ErrorCodes.TRANSFER_CHECKSUM
+      || errorCode === ErrorCodes.TRANSFER_DEST_UNAVAILABLE) {
       ipcRef?.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode })
     }
     shareDeco(job, { done: true })

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -18,7 +18,7 @@ import { makeProgressTicker } from '../../progress-ticker.js'
 import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js'
 import { republishDecision } from '../../supersede-decision.js'
 import { makeKeyedCoalescer } from '../../../state/coalesce.js'
-import { ErrorCodes, classifyTransferError } from '../../../core/errors.js'
+import { ErrorCodes, classifyTransferError, isLocalDestFault } from '../../../core/errors.js'
 import { createLogger } from '../../../core/logger.js'
 
 const log = createLogger('overlay-download')
@@ -53,11 +53,28 @@ function defaultFreeBytes (dir) {
   }
 }
 
+// Is `dir` a usable destination folder right now? Anything other than a live directory —
+// missing, or a plain file sitting where the folder belongs — reads as unavailable.
+function defaultDirExists (dir) {
+  try { return fs.statSync(dir).isDirectory() } catch { return false }
+}
+
 // A terminal fetch failure's ErrorCode. Disk-full/permission/removed classify specifically
 // (the renderer has dedicated messages and disk-full is excluded from auto-resume); anything
 // unrecognized stays the generic DOWNLOAD_FAILED rather than masquerading as a network error.
-function terminalCodeFor (r) {
+//
+// The download folder is checked FIRST, because a local-fs errno on its own is ambiguous: the
+// very same ENOENT/ENOTDIR/EACCES arise from a transient fault and from a download folder the
+// user deleted, ejected, or replaced with a file. Only probing the folder separates them, and
+// without that the whole class lands on DOWNLOAD_FAILED — the generic "Transfer failed" that
+// tells the user nothing they can act on. macOS makes the ambiguity concrete: /Volumes is
+// root-owned, so a fetch into an ejected volume fails EACCES and would otherwise report
+// "Permission denied" and send the user to check permissions that are perfectly fine.
+function terminalCodeFor (r, job, dirExists) {
   if (r.code === 'EHASHMISMATCH') return ErrorCodes.TRANSFER_CHECKSUM
+  if (isLocalDestFault(r.cause?.code) && !dirExists(path.dirname(job.finalPath))) {
+    return ErrorCodes.TRANSFER_DEST_UNAVAILABLE
+  }
   const classified = classifyTransferError(r.cause)
   return classified === ErrorCodes.TRANSFER_NETWORK ? ErrorCodes.DOWNLOAD_FAILED : classified
 }
@@ -82,7 +99,7 @@ function discardPartial (finalPath) {
 // }
 // job: { spaceId, pendingKey, path, relPath, transferId, contentHash, size, sourceSeq,
 //        ownerPublicKey, verifyKey, finalPath, prevBytes, ...channel-specific }
-export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContentToFile, hasOverlay = () => !!getOverlay(), freeBytes = defaultFreeBytes, stallRetry = {} } = {}) {
+export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContentToFile, hasOverlay = () => !!getOverlay(), freeBytes = defaultFreeBytes, stallRetry = {}, dirExists = defaultDirExists } = {}) {
   const registry = new Map() // transferId -> { contentHash, finalPath, paused, cancelled, fetching, spaceId, pendingKey, ownerPublicKey, restartJob }
   // transferId -> contentHash for a paused transfer whose single-flight slot was
   // released (the fetch IIFE deletes it on settle). Lets a later discard still tell
@@ -231,9 +248,10 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       return
     }
     diag.finish('failed')
-    const code = terminalCodeFor(r)
+    const code = terminalCodeFor(r, job, dirExists)
     if (code === ErrorCodes.TRANSFER_CHECKSUM) log.warn('overlay integrity failure — holder served bytes that do not match the content hash:', job.relPath)
     else if (code === ErrorCodes.TRANSFER_DISK_FULL) log.warn('overlay fetch failed — disk full:', job.relPath)
+    else if (code === ErrorCodes.TRANSFER_DEST_UNAVAILABLE) log.warn('overlay fetch failed — download folder unavailable:', path.dirname(job.finalPath))
     else log.debug('overlay fetch failed:', job.relPath, '-', r.code)
     await recordPendingError(job.spaceId, job.pendingKey, code).catch(() => {})
     channel.emitError(job, code)
@@ -345,6 +363,22 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       if (!ownerOnline(job.ownerPublicKey)) {
         registry.delete(transferId)
         log.debug('overlay download queued — owner not present on the control plane:', job.relPath)
+        channel.emitUpdated(job.spaceId)
+        return { queued: true }
+      }
+
+      // Preflight: the download folder must still be there. This is not redundant with the
+      // terminal classification below — the receive path mkdir -p's the destination
+      // (vendor/transfer.js), so a folder the user simply DELETED is silently recreated and the
+      // download completes into a resurrected empty folder with no error to classify at all.
+      // Downloads are flat (finalPath is always <root>/<basename>), so dirname IS the root.
+      // Runs BEFORE the free-space gate on purpose: defaultFreeBytes fails open on a statfs
+      // error, so a gone root sails straight past that check.
+      if (!dirExists(path.dirname(job.finalPath))) {
+        registry.delete(transferId)
+        log.warn('overlay download refused — download folder unavailable:', path.dirname(job.finalPath))
+        await recordPendingError(job.spaceId, job.pendingKey, ErrorCodes.TRANSFER_DEST_UNAVAILABLE).catch(() => {})
+        channel.emitError(job, ErrorCodes.TRANSFER_DEST_UNAVAILABLE)
         channel.emitUpdated(job.spaceId)
         return { queued: true }
       }
@@ -545,7 +579,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       if (!channel.ownsPendingRow(row) || row.ownerKey !== ownerKey) continue
       const transferId = channel.transferIdForRow(spaceId, row)
       if (registry.has(transferId)) continue // active → reconcileActive* owns supersede + removal
-      const suppressed = pausedHashes.has(transferId) || row.errorCode === ErrorCodes.TRANSFER_CHECKSUM || row.errorCode === ErrorCodes.TRANSFER_DISK_FULL
+      const suppressed = pausedHashes.has(transferId) || row.errorCode === ErrorCodes.TRANSFER_CHECKSUM || row.errorCode === ErrorCodes.TRANSFER_DISK_FULL || row.errorCode === ErrorCodes.TRANSFER_DEST_UNAVAILABLE
       if (suppressed && !deep) continue
       const { removed, seq, job } = await channel.resolvePendingRow(spaceId, row)
       const decision = republishDecision(row.contentHash, { removed, seq, contentHash: job?.contentHash ?? null }, row.sourceSeq)

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1001,8 +1001,52 @@ async function probeMountPoints() {
   }
 }
 
+// === Download-root availability ===
+//
+// The mount probe above covers owned/mirrored folders; download roots had no equivalent, which
+// is why a deleted or ejected download folder only ever surfaced as a failing transfer. Every
+// root counts, not just the global one — a per-space override can vanish on its own.
+//
+// Level-triggered probe, edge-triggered emit: re-broadcasting an unchanged set every minute
+// would churn the renderer for nothing, so the event fires only when the set actually changes.
+// The renderer gets its INITIAL state from downloads:roots-status instead of waiting up to a
+// full interval for the first transition.
+let unavailableRoots = []
+
+// The download-root twin of owned-folders' mountRootAvailable, deliberately kept separate: a
+// download root is not a mount, and borrowing the mount-named helper would imply it is.
+function rootAvailable(root) {
+  try { return fs.statSync(root).isDirectory() } catch { return false }
+}
+
+function readUnavailableRoots() {
+  return listDownloadRoots().filter((root) => !rootAvailable(root))
+}
+
+function sameRootSet(a, b) {
+  return a.length === b.length && a.every((root, i) => root === b[i])
+}
+
+function probeDownloadRoots() {
+  const next = readUnavailableRoots()
+  if (sameRootSet(next, unavailableRoots)) return
+  unavailableRoots = next
+  if (next.length > 0) log.warn('download folder unavailable:', next.join(', '))
+  else log.info('all download folders are available again')
+  ipc.emit('event:download-roots-status', { unavailable: next })
+}
+
+// The renderer asks on mount and again whenever a transfer reports the folder gone, so the
+// banner can appear at once rather than on the next tick. Re-probing (rather than returning the
+// cached set) is what makes that second call worth making.
+ipc.handle('downloads:roots-status', async () => {
+  probeDownloadRoots()
+  return { unavailable: unavailableRoots }
+})
+
 const mountProbeTimer = setInterval(() => {
   probeMountPoints().catch((err) => log.debug('mount probe failed:', err.message))
+  try { probeDownloadRoots() } catch (err) { log.debug('download-root probe failed:', err.message) }
 }, MOUNT_PROBE_INTERVAL_MS)
 mountProbeTimer.unref?.()
 

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -82,6 +82,7 @@ import s105 from './scenarios/s105-network-limits.mjs'
 import s106 from './scenarios/s106-network-relays.mjs'
 import s107 from './scenarios/s107-space-download-folder.mjs'
 import s108 from './scenarios/s108-profile-groups.mjs'
+import s109 from './scenarios/s109-download-folder-gone.mjs'
 import s79 from './scenarios/s79-folder-source-missing.mjs'
 import s80 from './scenarios/s80-space-switch-roster.mjs'
 import s81 from './scenarios/s81-space-card-facepile.mjs'
@@ -173,7 +174,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s109-download-folder-gone.mjs
+++ b/test/frontend/scenarios/s109-download-folder-gone.mjs
@@ -1,0 +1,118 @@
+import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { workDir } from '../paths.mjs'
+
+// REGRESSION (FIX-DLDIR-2/3): a download folder that disappeared produced no message the user
+// could act on. The failing download said "Transfer failed" — the renderer's catch-all — and
+// nothing anywhere named the folder as the cause.
+//
+// What this scenario pins is the user-visible half of the fix, which no lower layer can see:
+// the specific reason reaches the file row, a sticky toast names the folder and offers the fix,
+// Storage Settings marks it, and all of it clears once a working folder is chosen. The negative
+// assertion (`Transfer failed` absent) is the actual bug, so it is asserted explicitly rather
+// than implied by the positive one.
+export default async function s109 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Archive')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'notes.txt'), 'shared notes')
+  writeFileSync(path.join(ownDir, 'second.txt'), 'more notes')
+
+  const rescueDl = workDir('rescue-dl-')
+  mkdirSync(rescueDl, { recursive: true })
+
+  const pause = (ms) => new Promise((res) => setTimeout(res, ms))
+
+  try {
+    await r.ok('B downloads normally while its download folder exists', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      await A.addOwnedFolder(ownDir)
+      await B.waitText('Archive', 60000)
+      await B.openFolder('Archive')
+      await B.waitText('notes.txt', 20000)
+      await B.click({ role: 'button', name: 'Download' })
+      await waitFor(() => existsSync(path.join(B.downloadFolder, 'notes.txt')), 60000, 'first file downloaded')
+      await B.waitText('On your device', 20000)
+    })
+
+    await r.ok('with the folder deleted, the failure names the folder — not "Transfer failed"', async () => {
+      // The folder goes away behind the app's back: an ejected disk, a dropped network share, or
+      // simply the user deleting it. Nothing tells the app.
+      rmSync(B.downloadFolder, { recursive: true, force: true })
+      assert(!existsSync(B.downloadFolder), 'precondition: the download folder is gone')
+
+      // second.txt has never been downloaded, so its row still offers Download.
+      await B.click({ role: 'button', name: 'Download', last: true })
+      await B.waitText('Download folder unavailable', 30000)
+
+      // That text alone does not say WHICH surface rendered it: the row's error string is a
+      // prefix of the toast's, and waitText scans the whole tree. Only an errored row offers
+      // Retry, so this is what actually pins "the specific reason reached the file row" — without
+      // it the row half could regress silently while the toast kept the scenario green.
+      await waitFor(() => B.has({ role: 'button', name: 'Retry' }), 20000, 'the file row shows the failure')
+
+      // The bug, stated directly.
+      assert(!(await B.hasText('Transfer failed')), 'the generic catch-all is NOT what the user sees')
+      assert(!(await B.hasText('Permission denied')), 'nor the misleading permission message')
+
+      // The preflight refuses before any write, so the deleted folder is not silently recreated.
+      assert(!existsSync(B.downloadFolder), 'the deleted folder was not resurrected by the download')
+      await B.shot('s109-B-download-folder-gone', runDir)
+    })
+
+    await r.ok('a sticky toast names the folder and offers a way out', async () => {
+      // Raised off the worker probe, which the renderer re-queries the moment a transfer reports
+      // the folder gone — so it must be up without waiting out the 60s probe interval.
+      await B.waitText('Change folder', 20000)
+      assert(await B.hasText(B.downloadFolder), 'the toast names the folder that is missing')
+      await B.shot('s109-B-toast', runDir)
+    })
+
+    await r.ok('Storage Settings marks the folder as unavailable', async () => {
+      await B.click({ name: 'Back' })
+      await B.waitText('Archive', 20000)
+      await B.openManageStorage()
+      await B.waitText('This folder is currently unavailable', 20000)
+      await B.shot('s109-B-storage-settings-warning', runDir)
+    })
+
+    await r.ok('choosing a working folder clears the toast and the warning', async () => {
+      // The Browse click is handed to nativeChoosePath as the trigger rather than fired here,
+      // so a swallowed one is re-fired instead of timing out on a panel that never opens.
+      await B.nativeChoosePath(rescueDl, { trigger: () => B.click({ role: 'button', name: 'Change…' }) })
+      await pause(1200)
+      assert(await B.hasText(rescueDl), 'the new folder is shown')
+      await waitFor(async () => !(await B.hasText('This folder is currently unavailable')), 20000,
+        'the settings warning cleared')
+      // The sticky fault toast is replaced by the recovery notice (same toast id), so the fault
+      // text and its action both go away.
+      await waitFor(async () => !(await B.hasText('Change folder')), 20000, 'the fault toast cleared')
+      await B.waitText('Download folder is available again', 20000)
+      await B.shot('s109-B-recovered', runDir)
+    })
+
+    await r.ok('the download that failed now succeeds into the new folder', async () => {
+      await B.click({ name: 'Back' })
+      await B.waitText('Archive', 30000)
+      await B.openFolder('Archive')
+      await B.waitText('second.txt', 20000)
+      // The failed row offers Retry, not Download — which is also what makes it targetable here.
+      // notes.txt has meanwhile reverted to Download (its copy lived in the folder that is gone),
+      // so a name:'Download' match would be ambiguous between the two rows.
+      await B.click({ role: 'button', name: 'Retry' })
+      await waitFor(() => existsSync(path.join(rescueDl, 'second.txt')), 60000, 'downloaded into the new folder')
+      assert(!(await B.hasText('Download folder unavailable')), 'no stale failure text left behind')
+    })
+  } catch {}
+
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/integration/download-root-unavailable.test.js
+++ b/test/integration/download-root-unavailable.test.js
@@ -1,0 +1,238 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import url from 'bare-url'
+import { freshPeer } from '../helpers/store.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { initPendingTransfers, recordPending, getPendingFor } from '../../src/shared/transfer/pending-transfers.js'
+import { initDownloads } from '../../src/shared/transfer/files.js'
+import { ErrorCodes } from '../../src/shared/core/errors.js'
+import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
+
+// REGRESSION (FIX-DLDIR-2: a download folder that had been deleted, ejected, or replaced by a
+// file produced no message the user could act on).
+//
+// Two separate holes, both covered here:
+//
+//  1. NO ERROR AT ALL for the commonest case. The receive path mkdir -p's the destination
+//     (vendor/transfer.js), so a folder the user simply deleted was silently recreated and the
+//     download completed into a resurrected empty folder. Nothing failed, so nothing could be
+//     classified — only a preflight catches it.
+//  2. THE WRONG ERROR when the mkdir did fail. Every local-fs errno fell through
+//     classifyTransferError to TRANSFER_NETWORK, which the engine rewrote to DOWNLOAD_FAILED and
+//     the renderer rendered as the generic "Transfer failed". macOS made it worse: /Volumes is
+//     root-owned, so an ejected volume failed EACCES and reported "Permission denied", sending
+//     the user to check permissions that were fine.
+//
+// The engine now probes the folder in both places, and a row that failed this way no longer
+// auto-resumes — which is what stopped a gone folder from re-failing (and re-notifying, at
+// critical urgency) on every owner reconnect.
+
+const SPACE = 'space1'
+const OWNER = 'ownerpub'
+const HASH = 'b'.repeat(64)
+
+function testChannel (events, over = {}) {
+  return {
+    diagLabel: 'test download',
+    inPlace: false,
+    ownsPendingRow: (row) => row.overlayShare === true,
+    pendingExtra: (job) => ({ overlayShare: true, shareId: job.shareId, relPath: job.relPath }),
+    emitProgress: () => {},
+    emitError: (job, code) => events.push(['error', job, code]),
+    emitComplete: () => {},
+    emitCancelled: () => {},
+    emitSuperseded: () => {},
+    emitPaused: (job, reason) => events.push(['paused', job, reason]),
+    emitUpdated: (spaceId) => events.push(['updated', spaceId]),
+    emitDecorationDone: () => {},
+    transferIdForRow: (spaceId, row) => spaceId + '|folder1|' + row.relPath,
+    isOwnerOnline: () => true,
+    ...over,
+  }
+}
+
+async function setup (t) {
+  const ctx = await freshPeer(t)
+  await initDownloads()
+  await initPendingTransfers()
+  await initOverlay()
+  t.teardown(async () => { await teardownOverlay() })
+  return ctx
+}
+
+function makeJob (dir, over = {}) {
+  return {
+    spaceId: SPACE, pendingKey: '/Photos/doc.bin', path: '/Photos/doc.bin', relPath: 'doc.bin',
+    shareId: 'folder1', transferId: SPACE + '|folder1|doc.bin',
+    contentHash: HASH, size: 4096, ownerPublicKey: OWNER, verifyKey: 'folder1|doc.bin',
+    finalPath: path.join(dir, 'doc.bin'), ...over,
+  }
+}
+
+const errorsIn = (events) => events.filter((e) => e[0] === 'error').map((e) => e[2])
+const tick = () => new Promise((r) => setTimeout(r, 60))
+const settle = () => new Promise((r) => setTimeout(r, 400)) // past the 250ms resume coalescer
+
+// Guards every assertion below. The code travels to the renderer as a bare string and is mapped
+// there by literal (errorMessages.ts), so this pins the wire contract — and, less obviously, keeps
+// the rest of this file honest: if the constant were missing, `ErrorCodes.TRANSFER_DEST_UNAVAILABLE`
+// would be undefined and each `t.is(<no error emitted>, undefined)` would pass vacuously.
+test('the destination-unavailable code is the exact string the renderer maps', (t) => {
+  t.is(ErrorCodes.TRANSFER_DEST_UNAVAILABLE, 'TRANSFER_DEST_UNAVAILABLE')
+})
+
+// === Preflight: the folder is already gone when the download starts ===
+
+test('REGRESSION (FIX-DLDIR-2: a download into a deleted folder reports the folder, not "Transfer failed")', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  const engine = createOverlayDownloadEngine(testChannel(events))
+  let fetches = 0
+  getOverlay().fetchFile = async () => { fetches++; return { ok: true } }
+
+  // The user's custom download folder, then removed behind the app's back.
+  const gone = ctx.tmpDir('dl-gone')
+  fs.rmSync(gone, { recursive: true, force: true })
+  const job = makeJob(gone)
+
+  const res = await engine.start(job)
+  await tick()
+
+  t.is(errorsIn(events)[0], ErrorCodes.TRANSFER_DEST_UNAVAILABLE, 'the specific code reaches the renderer')
+  t.is(fetches, 0, 'no bytes were requested for a folder that cannot receive them')
+  t.ok(res.queued, 'start did not hand back a live transfer')
+  t.absent(engine.has(job.transferId), 'no slot left registered')
+
+  // Optional-chained on purpose: without the fix there is no row at all, and a TypeError here
+  // aborts the whole file before the remaining cases get to report.
+  const row = await getPendingFor(SPACE, job.pendingKey)
+  t.is(row?.errorCode, ErrorCodes.TRANSFER_DEST_UNAVAILABLE, 'the reason is durable, so a restart still explains it')
+})
+
+test('REGRESSION (FIX-DLDIR-2: a download folder replaced by a file is refused, not written through)', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  const engine = createOverlayDownloadEngine(testChannel(events))
+  getOverlay().fetchFile = async () => ({ ok: true })
+
+  const shadowed = path.join(ctx.tmpDir('dl-shadow'), 'Downloads')
+  fs.writeFileSync(shadowed, 'not a folder')
+
+  await engine.start(makeJob(shadowed))
+  await tick()
+
+  t.is(errorsIn(events)[0], ErrorCodes.TRANSFER_DEST_UNAVAILABLE, 'ENOTDIR-shaped case is the same fault to the user')
+})
+
+test('a healthy download folder is untouched by the preflight', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  const engine = createOverlayDownloadEngine(testChannel(events))
+  let fetches = 0
+  getOverlay().fetchFile = async () => { fetches++; return { ok: true } }
+
+  await engine.start(makeJob(ctx.tmpDir('dl-ok')))
+  await tick()
+
+  t.is(fetches, 1, 'the fetch ran')
+  t.is(errorsIn(events).length, 0, 'no error was surfaced for a folder that is present')
+})
+
+// === Terminal classification: the folder disappears mid-transfer ===
+
+// The preflight cannot cover this — the folder was there when the download started. Each errno
+// below is one the old classifier folded into TRANSFER_NETWORK → DOWNLOAD_FAILED.
+for (const code of ['ENOENT', 'ENOTDIR', 'EIO', 'EACCES']) {
+  test(`REGRESSION (FIX-DLDIR-2: a mid-transfer ${code} on a vanished folder is not "Transfer failed")`, async (t) => {
+    const ctx = await setup(t)
+    const events = []
+    const dir = ctx.tmpDir('dl-vanish-' + code)
+    const job = makeJob(dir)
+    const engine = createOverlayDownloadEngine(testChannel(events))
+
+    // The folder survives the preflight, then goes away while the bytes are in flight.
+    getOverlay().fetchFile = async () => {
+      fs.rmSync(dir, { recursive: true, force: true })
+      const err = new Error(`${code}: simulated failure, open '${job.finalPath}'`)
+      err.code = code
+      throw err
+    }
+
+    await engine.start(job)
+    await tick()
+
+    t.is(errorsIn(events)[0], ErrorCodes.TRANSFER_DEST_UNAVAILABLE, `${code} classified by the folder, not the errno`)
+  })
+}
+
+test('a local-fs failure with the folder still present keeps its own classification', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  const dir = ctx.tmpDir('dl-present')
+  const job = makeJob(dir)
+  const engine = createOverlayDownloadEngine(testChannel(events))
+
+  // Same errno, folder intact: this is a genuine permission problem on a folder that IS there,
+  // and must keep saying so. The probe is what separates the two — without it, either this case
+  // or the ejected-volume case above is guaranteed to be wrong.
+  getOverlay().fetchFile = async () => {
+    const err = new Error("EACCES: permission denied, open '" + job.finalPath + "'")
+    err.code = 'EACCES'
+    throw err
+  }
+
+  await engine.start(job)
+  await tick()
+
+  t.is(errorsIn(events)[0], ErrorCodes.TRANSFER_PERMISSION, 'still a permission error, not a folder fault')
+})
+
+// === The folder-share channel must let this code cross the wire ===
+
+// Folder rows normally surface an error only through the list refresh; just three terminal codes
+// are also emitted as event:transfer-error, which is what drives the toast, the OS notification,
+// and the banner's immediate re-probe. A dest-unavailable failure that stayed off the wire would
+// show the right words on the row and nothing anywhere else — the exact half-fix this pins
+// against. Asserted structurally because the gate lives in the channel, not the engine.
+test('REGRESSION (FIX-DLDIR-2: the folder-share channel emits transfer-error for a gone folder)', (t) => {
+  const src = fs.readFileSync(
+    path.join(url.fileURLToPath(new URL('../../src/shared/transfer/backends/overlay/overlay-backend.js', import.meta.url))),
+    'utf8',
+  )
+  const gate = src.slice(src.indexOf('emitError: (job, errorCode)'), src.indexOf('emitComplete:'))
+  t.ok(gate.includes('ErrorCodes.TRANSFER_DEST_UNAVAILABLE'), 'the code is in the cross-the-wire set')
+  t.ok(gate.includes('ErrorCodes.TRANSFER_DISK_FULL'), 'alongside disk-full')
+  t.ok(gate.includes('ErrorCodes.TRANSFER_CHECKSUM'), 'and the integrity failure')
+})
+
+// === Auto-resume suppression ===
+
+test('REGRESSION (FIX-DLDIR-2: a dest-unavailable row does not re-fail on every owner reconnect)', async (t) => {
+  const ctx = await setup(t)
+  const events = []
+  const dir = ctx.tmpDir('dl-suppress')
+  const job = makeJob(dir)
+  let fetches = 0
+
+  const engine = createOverlayDownloadEngine(testChannel(events, {
+    resolvePendingRow: async () => ({ removed: false, seq: undefined, job }),
+  }))
+  getOverlay().fetchFile = async () => { fetches++; return { ok: true } }
+
+  // The row a gone folder leaves behind.
+  await recordPending(SPACE, job.pendingKey, {
+    total: job.size, inPlace: false, ownerKey: OWNER, finalPath: job.finalPath,
+    contentHash: HASH, bytesTransferred: 0, overlayShare: true, shareId: 'folder1', relPath: job.relPath,
+    errorCode: ErrorCodes.TRANSFER_DEST_UNAVAILABLE,
+  })
+
+  await engine.resumeForOwner(OWNER, SPACE)
+  await settle()
+
+  // Without the suppression the reconnect restarts the download, it fails again, and the renderer
+  // fires another critical-urgency notification — once per reconnect, for as long as the folder
+  // stays gone. The row is deliberately kept: it is the user's unfulfilled intent.
+  t.is(fetches, 0, 'the reconnect did not retry a download that cannot land')
+  t.ok(await getPendingFor(SPACE, job.pendingKey), 'the intent survives — this is a pause, not a drop')
+})

--- a/test/unit/error-code-mapping.test.js
+++ b/test/unit/error-code-mapping.test.js
@@ -1,0 +1,61 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// REGRESSION (FIX-DLDIR-3: DOWNLOAD_FAILED was a code the download engine emits and the renderer
+// had no mapping for, so it fell through errorCodeToI18nKey's default to the generic "Transfer
+// failed" — which is how an entire class of local-filesystem failures, a deleted or ejected
+// download folder among them, reached the user as a message they could do nothing with).
+//
+// The failure mode is silent by construction: an unmapped code does not throw, it renders
+// plausible-looking text. Nothing else catches it — the locale parity guard checks that all five
+// locales agree, not that a code the worker can send has anywhere to land — so these two
+// invariants are what keep the next new code from repeating it.
+//
+// i18n-key-parity.test.js covers en↔locale parity; this file covers worker↔renderer.
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const SRC = path.resolve(here, '../../src')
+const read = (p) => fs.readFileSync(path.join(SRC, p), 'utf8')
+
+const errorMessagesSrc = read('renderer/errorMessages.ts')
+const enErrors = JSON.parse(read('renderer/locales/en/errors.json'))
+
+// Both maps are plain object literals of `CODE: 'i18nKey',` — parse them out rather than
+// importing, since this is a Node runner and the source is TypeScript.
+function mapEntries (constName) {
+  const start = errorMessagesSrc.indexOf(`const ${constName}`)
+  if (start === -1) return []
+  const body = errorMessagesSrc.slice(start, errorMessagesSrc.indexOf('\n}', start))
+  return [...body.matchAll(/^\s*([A-Z][A-Z0-9_]*):\s*'([^']+)'/gm)].map((m) => [m[1], m[2]])
+}
+
+const transferMap = mapEntries('ERROR_I18N_KEY_BY_CODE')
+const mountMap = mapEntries('MOUNT_ERROR_I18N_KEY_BY_CODE')
+
+test('the renderer error maps were parsed (guards the parser itself)', (t) => {
+  t.ok(transferMap.length >= 8, `found ${transferMap.length} transfer mappings`)
+  t.ok(mountMap.length >= 8, `found ${mountMap.length} mount mappings`)
+})
+
+// A mapping that points at a key no catalog defines renders the raw key string to the user —
+// the same silent-garbage outcome as no mapping at all.
+test('every mapped i18n key exists in the en errors catalog', (t) => {
+  for (const [code, key] of [...transferMap, ...mountMap]) {
+    t.ok(Object.hasOwn(enErrors, key), `${code} → errors.${key} exists`)
+  }
+})
+
+// REGRESSION (FIX-DLDIR-3). Derived from the engine source rather than hand-listed, so a code
+// added there in future is covered without anyone remembering to update this test.
+test('REGRESSION (FIX-DLDIR-3: every code the download engine emits has a renderer mapping)', (t) => {
+  const engineSrc = read('shared/transfer/backends/overlay/overlay-download.js')
+  const emitted = new Set([...engineSrc.matchAll(/ErrorCodes\.([A-Z][A-Z0-9_]*)/g)].map((m) => m[1]))
+  t.ok(emitted.size > 0, 'the engine references error codes at all')
+
+  const mapped = new Set(transferMap.map(([code]) => code))
+  for (const code of emitted) {
+    t.ok(mapped.has(code), `${code} is mapped in errorMessages.ts (not silently generic)`)
+  }
+})

--- a/test/unit/errors.test.js
+++ b/test/unit/errors.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { ErrorCodes, classifyTransferError, isRetryableTransferError } from '../../src/shared/core/errors.js'
+import { ErrorCodes, classifyTransferError, isRetryableTransferError, isLocalDestFault } from '../../src/shared/core/errors.js'
 
 test('classifyTransferError maps fs codes', (t) => {
   t.is(classifyTransferError({ code: 'ENOSPC' }), ErrorCodes.TRANSFER_DISK_FULL)
@@ -38,4 +38,32 @@ test('isRetryableTransferError only for NETWORK', (t) => {
   t.absent(isRetryableTransferError(ErrorCodes.TRANSFER_CHECKSUM))
   t.absent(isRetryableTransferError(ErrorCodes.TRANSFER_REMOVED))
   t.absent(isRetryableTransferError(undefined))
+})
+
+// REGRESSION (FIX-DLDIR-1: a download folder that had been deleted, ejected, or replaced by a
+// file produced no specific error — every one of these errnos fell through classifyTransferError
+// to TRANSFER_NETWORK, which the engine rewrote to DOWNLOAD_FAILED and the renderer rendered as
+// the generic "Transfer failed"). The predicate below is what lets the caller notice the class is
+// worth a folder probe at all.
+test('REGRESSION (FIX-DLDIR-1: local destination faults are recognised as a class)', (t) => {
+  for (const code of ['ENOENT', 'ENOTDIR', 'ENODEV', 'ENXIO', 'EIO', 'ESTALE', 'EACCES', 'EPERM', 'EROFS']) {
+    t.ok(isLocalDestFault(code), code + ' is a candidate local-destination fault')
+  }
+})
+
+test('isLocalDestFault ignores non-fs and absent codes', (t) => {
+  // ENOSPC is a real disk-full condition on a folder that IS there — probing would only
+  // mislabel it, and it has its own message.
+  t.absent(isLocalDestFault('ENOSPC'), 'disk-full is not a destination fault')
+  t.absent(isLocalDestFault('ECONNRESET'), 'a network errno is not a destination fault')
+  t.absent(isLocalDestFault(undefined), 'no code at all')
+  t.absent(isLocalDestFault(null), 'null code')
+})
+
+// The probe lives at the call site (overlay-download.js), so the classifier itself must be
+// unchanged for every input it already handled — the new code is additive, not a re-bucketing.
+test('classifyTransferError is unchanged by the destination-fault work', (t) => {
+  t.is(classifyTransferError({ code: 'ENOENT' }), ErrorCodes.TRANSFER_NETWORK, 'still network without a probe')
+  t.is(classifyTransferError({ code: 'EACCES' }), ErrorCodes.TRANSFER_PERMISSION, 'permission still wins on its own')
+  t.is(classifyTransferError({ code: 'ENOSPC' }), ErrorCodes.TRANSFER_DISK_FULL, 'disk-full untouched')
 })

--- a/test/unit/event-taxonomy.test.js
+++ b/test/unit/event-taxonomy.test.js
@@ -51,6 +51,9 @@ const TAXONOMY = {
   'event:transfer-removed': 'signal',
   'event:leave-progress': 'signal',
   'event:network-status': 'signal',
+  // App-global, like network-status: there is no space/share axis for the hint bus to fan on, and
+  // it is durably backstopped by the downloads:roots-status request the renderer makes on mount.
+  'event:download-roots-status': 'signal',
   'event:profile-needed': 'signal',
   'event:worker-ready': 'signal',
   'event:owned-folder-preview-progress': 'signal',


### PR DESCRIPTION
## What & why

A download folder that had been deleted, ejected, or replaced by a file produced no message the user could act on. Every local-filesystem errno fell through `classifyTransferError` to `TRANSFER_NETWORK`, which the engine rewrote to `DOWNLOAD_FAILED` — and the renderer had no mapping for that, so it rendered the catch-all "Transfer failed". On macOS an ejected volume failed `EACCES` and read as "Permission denied", sending the user to check permissions that were fine. In the commonest case there was no error at all: the receive path `mkdir -p`s the destination, so a deleted folder was silently recreated and the download landed in it.

Now `TRANSFER_DEST_UNAVAILABLE`, decided by probing the folder — the errno alone is ambiguous. A preflight in the download engine catches the folder-already-gone case before any write, terminal classification catches it mid-transfer, and such a row no longer auto-resumes (it re-failed, and re-notified at critical urgency, on every owner reconnect). Surfaced in the file row, in a sticky toast with a "Change folder" action, and in Storage Settings.

The toast follows `ConnectivityToastBridge` — same shape of fault, same treatment. `design.md` gained the toast-vs-banner rule, whose absence is why this was guessable.

Also mapped `DOWNLOAD_FAILED` explicitly, so the next unmapped code can't silently become "Transfer failed" again; a unit guard now derives the engine's emitted codes from source and fails if one is unmapped.

## Coverage

- **Unit** — the fault-code class; the worker↔renderer mapping guard (red on the original `DOWNLOAD_FAILED` omission).
- **Integration** — preflight, mid-transfer classification per errno, the "folder present → keep the old classification" control, auto-resume suppression, and the folder-share channel's cross-the-wire gate. 7 of 10 fail without the fix.
- **Frontend** — `s109`, the only layer that can see the user-facing half.
- **Flow** — none added; no P2P behaviour changes. Existing download flow tests re-run.

## Ran locally

`test:fe s109` (download → delete folder → row error + toast → Storage Settings warning → pick a new folder → clears → re-download succeeds) and `s8 s17 s48 s49 s52 s66 s82 s107` for regressions; all green. Dev axe: no new violations. VoiceOver: toast announces as an alert with a named action; the Storage Settings warning is `role="alert"`, ordered after the pick-rejection message so the actionable one is read first.