### PR TITLE
[fix] Charge uncontended takes to the bandwidth ledger

### DIFF
--- a/src/shared/transfer/bandwidth-limiter.js
+++ b/src/shared/transfer/bandwidth-limiter.js
@@ -20,7 +20,10 @@
 //     already has chunks in flight — and therefore re-enters its assign loop on every
 //     arrival — cannot barge past a transfer that is waiting its turn;
 //   - a grant hands the stream CREDIT, so the retry it was woken for cannot lose the bytes
-//     to someone else in between.
+//     to someone else in between;
+//   - every byte leaves through the ledger, whichever path served it. An uncontended
+//     `tryTake` debits `deficit` exactly as a grant does — bytes taken while the queue
+//     happened to be empty are still bytes this stream owes the next one to arrive.
 //
 // Without all three, the caller with the highest polling rate takes everything: the bucket
 // refills continuously in wall-clock time, so whoever calls most often consumes each
@@ -289,6 +292,20 @@ function createStream(ctx) {
       advance(ctx)
       if (!bucketAllows(ctx, bytes, bps)) return false
       ctx.tokens -= bytes
+      // FIX-BW10 — charge the LEDGER too, not just the bucket. serve() debits `deficit` on
+      // every grant it makes; this path used to debit nothing, so bytes taken while the
+      // queue happened to be empty were invisible to the round-robin. That is not a rare
+      // corner: streams attach long after the limiter is built, so an uncontended take is
+      // the normal way a transfer starts, and an oversized chunk may borrow a whole second
+      // of the cap here. Measured on a 1 MB/s cap with 2 MB chunks against 16 KB ones, the
+      // unrecorded borrow halved the large stream's repayment time and starved the small
+      // one to exactly 0% for the whole run.
+      //
+      // Floored at one chunk or one second, whichever is larger — the symmetric partner of
+      // the ceiling in distribute(). Without a floor a long solo transfer would accrue debt
+      // for as long as it ran alone and then sit frozen while it repaid, the moment a
+      // second transfer arrived.
+      s.deficit = Math.max(s.deficit - bytes, -Math.max(bytes, bps))
       return true
     },
 

--- a/test/unit/bandwidth-limiter.test.js
+++ b/test/unit/bandwidth-limiter.test.js
@@ -306,8 +306,16 @@ test('REGRESSION (FIX-BW1): three competing streams all make progress', async (t
 // The window must span several grants of the LARGE chunk, or the measurement says nothing:
 // one 1 MB chunk at a 4 MB/s cap is a quarter-second of the whole cap, and whichever stream
 // happens to hold the borrow when the clock stops looks like it took everything.
+// The wait before the first take is LOAD-BEARING, not padding (FIX-BW10). With none, the
+// bucket is still empty when the first stream asks — `last` is stamped at construction — so
+// that ask is refused and every byte in the window is arbitrated by serve(). Production
+// never looks like that: the limiters are built at worker start and streams attach when a
+// transfer begins, so the first ask lands on a full bucket and goes through tryTake's
+// uncontended path. This test only saw the CI runner's scheduling latency stand in for that
+// wait, which is why the bug below reproduced on a 2-vCPU runner and passed on a dev box.
 async function splitBetween (cap, sizes, ms) {
   const l = createBandwidthLimiter(() => cap)
+  await wait(scaled(5))
   const got = sizes.map(() => 0)
   let stopped = false
   sizes.forEach((bytes, i) => {
@@ -344,6 +352,32 @@ test('REGRESSION (FIX-BW3): a chunk bigger than the whole bucket still gets its 
   t.ok(got[0] > 0, `the oversized-chunk stream was served (${Math.round(got[0] / KB)} KB)`)
   t.ok(Math.min(...got) >= total * 0.2,
     `neither side was starved — big=${Math.round(got[0] / KB)}KB small=${Math.round(got[1] / KB)}KB`)
+})
+
+// REGRESSION (FIX-BW10): tryTake's uncontended path charged the shared bucket but not the
+// taker's deficit, so bytes taken while the queue happened to be empty never reached the
+// round-robin. The two tests above only catch it through wall-clock ratios; this one pins
+// the ledger itself on a manual clock, so the ordering is decided by arithmetic rather than
+// by how promptly a runner fires a timer.
+test('REGRESSION (FIX-BW10): an uncontended take is charged to the taker, not just the bucket', async (t) => {
+  const c = clock()
+  const l = createBandwidthLimiter(() => 100 * KB, { now: c.now })
+  const a = l.stream()
+  const b = l.stream()
+  c.advance(1000)
+  t.ok(a.tryTake(100 * KB), 'A takes a full second of budget with nobody queued')
+
+  // Both now queue for the same 100 KB, and one second of budget arrives for the two of
+  // them. A already spent this second, so the refill owes B — reaching A first would mean
+  // A's take never happened as far as fairness is concerned.
+  const served = []
+  a.whenAvailable(100 * KB, () => served.push('a'))
+  b.whenAvailable(100 * KB, () => served.push('b'))
+  c.advance(1000)
+  await wait(scaled(600))   // MAX_ARM_MS is 250; this leaves room for a loaded runner
+  const order = served.slice()   // snapshot: destroy() settles whatever is still parked
+  l.destroy()
+  t.alike(order, ['b'], 'the refill went to B — A owes the second it already took')
 })
 
 test('the aggregate cap still binds once sharing is fair', async (t) => {


### PR DESCRIPTION
`tryTake`'s uncontended path debited the shared bucket but not the stream's `deficit`, so bytes taken while the queue happened to be empty never entered the round-robin. Streams attach long after the limiter is built, so that path is how a transfer normally starts.

Measured on a 1 MB/s cap: a 2 MB-chunk stream against a 16 KB-chunk one took 100% and starved the small one to exactly 0%. The debit is floored at one chunk or one second so a long solo transfer cannot bank debt and freeze when a second one arrives.

This is what has been failing `Tests (unit + raw)` on unrelated PRs (#81, both attempts) — the existing FIX-BW3 test only reached the fast path when runner latency delayed the first take, so it failed on a 2-vCPU runner and passed locally. It now waits explicitly, and a new deterministic FIX-BW10 case pins the ledger on the manual clock.

**Verification** — red-first: with only the source fix reverted, FIX-BW3 and FIX-BW10 fail and nothing else does. Green: limiter suite 39/39 across three runs, `test:node:core` 1004/1004, `content-plane-hol` flow 2/2, `overlay-vendor-backpressure` (Bare) 13/13, typecheck and lint clean.
