### PR TITLE
[fix] Give progress-bar tracks their own color token

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -60,15 +60,16 @@ each key color (`-container`, `-fixed`, `-fixed-dim`, `-fixed-variant`,
 | `primary` / `accent` | `#33253b` | Twilight plum. Headings, primary buttons, key text. (`accent` == `primary` in light mode.) |
 | `on-primary` | `#ffffff` | Text/icon on primary |
 | `secondary` | `#904d00` | Burnt amber — focus rings, links, secondary emphasis |
-| `secondary-container` | `#fd9c42` | Signature orange (the "Mirall dot", progress fill) |
+| `secondary-container` | `#fd9c42` | Signature orange (the "Mirall dot") |
 | `on-secondary-container` | `#6b3800` | |
 | `tertiary` | `#541116` | Deep rose — sparing high-emotion accents |
 | `surface` | `#fbf9f5` | App background (warm cream) |
 | `surface-container-lowest` | `#ffffff` | **File cards at rest (light)**; space cards; folder cards at rest (dark) — see folder/file note |
 | `surface-container-low` | `#f5f3ef` | Section/setting cards; **folder cards at rest (light)**; file cards at rest (dark) |
 | `surface-container` | `#efeeea` | |
-| `surface-container-high` | `#eae8e4` | Neutral chips, toggle track, progress track, icon tiles |
+| `surface-container-high` | `#eae8e4` | Neutral chips, toggle track, icon tiles |
 | `surface-container-highest` | `#e4e2de` | **Card hover lift** (folder & file rows); avatar fallback, "remote" badge |
+| `progress-track` | `#d0cec9` | Progress-bar tracks and the peer-dropdown divider — see the note below |
 | `on-surface` | `#1b1c1a` | Primary body text (near-black; **never** `#000`) |
 | `on-surface-variant` | `#4a454b` | Muted/secondary text |
 | `outline` | `#7c757c` | Badge border, dropzone idle border |
@@ -96,8 +97,8 @@ cream `#fce8d2`, sitting on a cool slate surface ramp. The dark surface tiers
 (authoritative in `tailwind.css` — easy to get subtly wrong when hand-building a
 mockup): `surface` `#282c34`, `surface-container-lowest` `#21252b`,
 `surface-container-low` `#2e3239`, `surface-container` `#2e323a`,
-`surface-container-high` `#5c6068`, `surface-container-highest` `#393f4a`. **The
-ramp is not monotonic by name in dark** — `surface-container-high` (`#5c6068`) is
+`surface-container-high` `#5c6068`, `surface-container-highest` `#393f4a`,
+`progress-track` `#4a5160`. **The ramp is not monotonic by name in dark** — `surface-container-high` (`#5c6068`) is
 markedly *lighter* than `-highest` (`#393f4a`); this is why secondary buttons use
 `dark:bg-surface-container-highest` deliberately (and `dark:hover:bg-surface-container-high`,
 a step *lighter* on hover). The `icon-tile` pair (`#fec78a` / `#0a4742`) is **not
@@ -115,6 +116,18 @@ that never collides with the `surface-container-high` icon tile. Spaces (`SpaceC
 `surface-container-lowest` (the prominent card on the spaces home, not part of the folder/file
 pair). The folder-tree disclosure chevron uses `text-on-surface-variant` (not `outline`, which
 fails the contrast floor on these surfaces in dark).
+
+**`progress-track` sits outside the ramp on purpose.** A progress bar is painted inside a row
+that lifts to `surface-container-highest` on hover, inside the `PeerDownloadIndicator` toggle
+that lifts to `surface-container-high`, and inside modal panels on `surface-container-lowest`.
+Any ramp token the track borrows therefore matches one of its own hosts in some state and the
+bar's total length vanishes — which is what shipped twice: first as `surface-container-high`
+(lost under the toggle hover), then as `surface-container-highest` (lost under the row hover).
+`progress-track` (`#d0cec9` / `#4a5160`) clears every host surface by at least 1.2:1 while
+keeping the `on-info` fill above 3:1 against the track. The same reasoning applies to the
+`PeerDownloadDropdown` divider, which uses `divide-progress-track` because dark
+`outline-variant` is *also* `#393f4a`. Pinned by `test/unit/progress-bar-contrast.test.js`;
+never re-point a track at a `surface-container-*` token.
 
 Theme is chosen via `theme.ts` (`light` | `dark` | `system`); `theme.ts` only
 **applies** the theme — toggling the `.dark` class and setting
@@ -383,14 +396,16 @@ and `available`/`owner-offline`/`unavailable`). Roles carry meaning by label, no
 The `*-fixed` ramps (`secondary-fixed`, `primary-fixed`) are no longer used by pills.
 
 ### Progress bar — `primitives/ProgressBar.tsx`
-`h-1.5 bg-surface-container-high rounded-full` track, `bg-secondary-container`
-fill, `transition-all motion-reduce:transition-none`, `role="progressbar"`
-(no `aria-live` — frequent updates would spam screen readers).
+`h-1.5 bg-progress-track rounded-full` track, `bg-on-info` fill, `transition-all
+motion-reduce:transition-none`, `role="progressbar"` (no `aria-live` — frequent
+updates would spam screen readers). All five bars — this primitive,
+`DownloadProgressLane`, `PeerDownloadIndicator`, `PeerDownloadRow`, and the
+`LeaveSpaceModal` bar — share that track/fill pair.
 
 The transfer-row variant — `widgets/DownloadProgressLane.tsx` — adds a meta line
 (speed · ETA, ETA alone, or downloaded-so-far) and an **indeterminate** mode used
 while the ETA is still warming up (no stable rate yet). Indeterminate renders a
-40%-wide `bg-secondary-container` segment that sweeps the track
+40%-wide `on-info` segment that sweeps the track
 (`.progress-indeterminate`, keyframe below) and, per the ARIA progressbar contract,
 **drops `aria-valuenow`** while carrying the state in `aria-valuetext` (the
 "Estimating…" string). Determinate mode keeps `aria-valuenow` + the width fill.

--- a/src/renderer/components/cards/PeerDownloadDropdown.tsx
+++ b/src/renderer/components/cards/PeerDownloadDropdown.tsx
@@ -36,7 +36,7 @@ export default function PeerDownloadDropdown({ id, spaceId, path, members }: Pee
       tabIndex={0}
       className="mt-1 ml-16 mr-3 mb-1 max-h-60 overflow-y-auto scrollbar-thin rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
     >
-      <ul className="flex flex-col divide-y divide-outline-variant">
+      <ul className="flex flex-col divide-y divide-progress-track">
         {rows.map((r) => (
           <PeerDownloadRow key={r.peerKey} member={r.member} bytes={r.bytes} total={r.total} avgSpeed={r.avgSpeed} paused={r.paused} />
         ))}

--- a/src/renderer/components/cards/PeerDownloadIndicator.tsx
+++ b/src/renderer/components/cards/PeerDownloadIndicator.tsx
@@ -104,7 +104,7 @@ export default function PeerDownloadIndicator({ summary, members, open, onToggle
             aria-valuemin={0}
             aria-valuemax={100}
             aria-valuetext={valueText}
-            className="flex-grow block h-1.5 bg-surface-container-highest rounded-full overflow-hidden"
+            className="flex-grow block h-1.5 bg-progress-track rounded-full overflow-hidden"
           >
             <span
               className={`block h-full rounded-full transition-all motion-reduce:transition-none ${allPaused ? 'bg-on-info/40' : 'bg-on-info'}`}

--- a/src/renderer/components/cards/PeerDownloadRow.tsx
+++ b/src/renderer/components/cards/PeerDownloadRow.tsx
@@ -49,7 +49,7 @@ export default function PeerDownloadRow({ member, bytes, total, avgSpeed, paused
           aria-valuemin={0}
           aria-valuemax={100}
           aria-valuetext={valueText}
-          className="block h-1.5 bg-surface-container-highest rounded-full overflow-hidden"
+          className="block h-1.5 bg-progress-track rounded-full overflow-hidden"
         >
           <span
             className={`block h-full rounded-full transition-all motion-reduce:transition-none ${active ? 'bg-on-info' : 'bg-on-info/40'}`}

--- a/src/renderer/components/modals/LeaveSpaceModal.tsx
+++ b/src/renderer/components/modals/LeaveSpaceModal.tsx
@@ -124,7 +124,7 @@ export default function LeaveSpaceModal({ isOpen, spaceName, spaceId, onClose, o
                 aria-valuenow={percent}
                 aria-valuemin={0}
                 aria-valuemax={100}
-                className="relative h-2 bg-surface-container-highest rounded-full overflow-hidden"
+                className="relative h-2 bg-progress-track rounded-full overflow-hidden"
               >
                 {showStripe && <div className="absolute inset-0 leave-progress-stripe" />}
                 <div

--- a/src/renderer/components/primitives/ProgressBar.tsx
+++ b/src/renderer/components/primitives/ProgressBar.tsx
@@ -25,7 +25,7 @@ export default function ProgressBar({ value, label, meta }: ProgressBarProps) {
         aria-valuenow={value}
         aria-valuemin={0}
         aria-valuemax={100}
-        className="h-1.5 bg-surface-container-highest rounded-full overflow-hidden"
+        className="h-1.5 bg-progress-track rounded-full overflow-hidden"
       >
         <div
           className="h-full bg-on-info rounded-full transition-all motion-reduce:transition-none"

--- a/src/renderer/components/widgets/DownloadProgressLane.tsx
+++ b/src/renderer/components/widgets/DownloadProgressLane.tsx
@@ -42,7 +42,7 @@ export default function DownloadProgressLane({ value, label, speed, eta, bytes, 
         aria-valuemax={100}
         aria-valuenow={indeterminate ? undefined : pct}
         aria-valuetext={indeterminate ? etaTok : valueText}
-        className="relative h-1.5 w-full bg-surface-container-highest rounded-full overflow-hidden"
+        className="relative h-1.5 w-full bg-progress-track rounded-full overflow-hidden"
       >
         {indeterminate ? (
           <div className="progress-indeterminate" />

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -45,6 +45,12 @@
   --color-surface-container-lowest: #ffffff;
   --color-surface-variant: #e4e2de;
   --color-surface-tint: #695871;
+  /* Neutral groove for progress-bar tracks and the peer-dropdown divider. Deliberately
+     outside the surface-container ramp: a bar sits inside a row that lifts to
+     `surface-container-highest` on hover and inside a toggle that lifts to
+     `surface-container-high`, so any ramp token it borrows goes invisible in one of
+     those states. Pinned by test/unit/progress-bar-contrast.test.js (FIX-6). */
+  --color-progress-track: #d0cec9;
   --color-on-surface: #1b1c1a;
   --color-on-surface-variant: #4a454b;
   --color-on-background: #1b1c1a;
@@ -110,6 +116,7 @@
   --color-surface-container-lowest: #21252b;
   --color-surface-variant: #333842;
   --color-surface-tint: #3a4250;
+  --color-progress-track: #4a5160;
   --color-on-surface: #fefaf3;
   --color-on-surface-variant: #ebe2d2;
   --color-on-background: #fefaf3;

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -47,6 +47,7 @@ module.exports = {
         'surface-container-lowest': 'var(--color-surface-container-lowest)',
         'surface-variant': 'var(--color-surface-variant)',
         'surface-tint': 'var(--color-surface-tint)',
+        'progress-track': 'var(--color-progress-track)',
         'on-surface': 'var(--color-on-surface)',
         'on-surface-variant': 'var(--color-on-surface-variant)',
         'on-background': 'var(--color-on-background)',

--- a/test/unit/progress-bar-contrast.test.js
+++ b/test/unit/progress-bar-contrast.test.js
@@ -38,13 +38,15 @@ const BARS = [
   'src/renderer/components/modals/LeaveSpaceModal.tsx',
 ]
 
-test('REGRESSION (FIX-1): on-info fill clears 3:1 vs track AND hover pill, both themes', (t) => {
+test('REGRESSION (FIX-1): on-info fill clears 3:1 vs track AND both hover lifts, both themes', (t) => {
   for (const theme of [':root', '.dark']) {
     const k = tokensFor(theme)
-    const cTrack = contrast(k['color-on-info'], k['color-surface-container-highest'])
-    const cHover = contrast(k['color-on-info'], k['color-surface-container-high'])
+    const cTrack = contrast(k['color-on-info'], k['color-progress-track'])
+    const cPill = contrast(k['color-on-info'], k['color-surface-container-high'])
+    const cRow = contrast(k['color-on-info'], k['color-surface-container-highest'])
     t.ok(cTrack >= 3.0, `${theme}: on-info vs track = ${cTrack.toFixed(2)}:1`)
-    t.ok(cHover >= 3.0, `${theme}: on-info vs hover pill = ${cHover.toFixed(2)}:1`)
+    t.ok(cPill >= 3.0, `${theme}: on-info vs hover pill = ${cPill.toFixed(2)}:1`)
+    t.ok(cRow >= 3.0, `${theme}: on-info vs row hover lift = ${cRow.toFixed(2)}:1`)
   }
 })
 
@@ -80,4 +82,46 @@ test('FIX-5: indeterminate sweep and leave stripe use --color-on-info', (t) => {
   const stripe = classBlock('leave-progress-stripe')
   t.ok(stripe.includes('var(--color-on-info)'), 'leave stripe is on-info')
   t.absent(stripe.includes('--color-primary'), 'leave stripe no longer primary')
+})
+
+// Every surface a progress bar can rest on. Bars live inside file/folder rows that lift to
+// `surface-container-highest` on hover, inside the peer-download toggle that lifts to
+// `surface-container-high`, and inside modal panels (`surface-container-lowest`). A track
+// painted in any of those tokens goes invisible the moment its host adopts the same one.
+const HOST_SURFACES = [
+  'color-surface-container-lowest',
+  'color-surface-container-low',
+  'color-surface-container',
+  'color-surface-container-high',
+  'color-surface-container-highest',
+]
+
+// 1.2:1 is the floor the resting file card already sits at, so it is the weakest
+// separation the design is known to accept — not a WCAG number.
+const TRACK_MIN = 1.2
+
+test('REGRESSION (FIX-6): track token clears every host surface, both themes', (t) => {
+  for (const theme of [':root', '.dark']) {
+    const k = tokensFor(theme)
+    t.ok(k['color-progress-track'], `${theme}: --color-progress-track is defined`)
+    if (!k['color-progress-track']) continue
+    for (const s of HOST_SURFACES) {
+      const c = contrast(k['color-progress-track'], k[s])
+      t.ok(c >= TRACK_MIN, `${theme}: track vs ${s} = ${c.toFixed(2)}:1`)
+    }
+  }
+})
+
+test('REGRESSION (FIX-6): every bar paints its track with the dedicated token', (t) => {
+  for (const f of BARS) {
+    const src = read(f)
+    t.ok(src.includes('bg-progress-track'), `${f}: track uses bg-progress-track`)
+    t.absent(/bg-surface-container-\w+ rounded-full overflow-hidden/.test(src), `${f}: no surface token left on a track`)
+  }
+})
+
+test('REGRESSION (FIX-7): peer-dropdown divider survives the card hover lift', (t) => {
+  const src = read('src/renderer/components/cards/PeerDownloadDropdown.tsx')
+  t.absent(src.includes('divide-outline-variant'), 'divider is not outline-variant (== the dark hover lift)')
+  t.ok(src.includes('divide-progress-track'), 'divider uses the hover-proof neutral token')
 })


### PR DESCRIPTION
The track shared `surface-container-highest` with the file/folder row hover lift, so hovering a row hid the bar's total length in both themes. Its previous value collided with the peer-download toggle's hover the same way, so tracks now use a dedicated `progress-track` token that clears every host surface by at least 1.2:1 while keeping the `on-info` fill above 3:1. The peer-dropdown divider moves too — dark `outline-variant` is the same hex as the hover lift.
