### PR TITLE
[feat] Detect connectivity problems and explain them

### DIFF
--- a/.claude/mockups/connectivity-verdict.html
+++ b/.claude/mockups/connectivity-verdict.html
@@ -1,0 +1,1356 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Connectivity verdict — mockup</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Plus+Jakarta+Sans:wght@700;800&display=swap" rel="stylesheet" />
+
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    darkMode: 'class',
+    theme: {
+      extend: {
+        colors: {
+          accent: 'var(--color-accent)',
+          primary: 'var(--color-primary)',
+          'primary-container': 'var(--color-primary-container)',
+          'on-primary': 'var(--color-on-primary)',
+          'on-primary-container': 'var(--color-on-primary-container)',
+          secondary: 'var(--color-secondary)',
+          'secondary-container': 'var(--color-secondary-container)',
+          'on-secondary': 'var(--color-on-secondary)',
+          'on-secondary-container': 'var(--color-on-secondary-container)',
+          tertiary: 'var(--color-tertiary)',
+          'tertiary-container': 'var(--color-tertiary-container)',
+          'on-tertiary': 'var(--color-on-tertiary)',
+          'on-tertiary-container': 'var(--color-on-tertiary-container)',
+          surface: 'var(--color-surface)',
+          'surface-container': 'var(--color-surface-container)',
+          'surface-container-low': 'var(--color-surface-container-low)',
+          'surface-container-high': 'var(--color-surface-container-high)',
+          'surface-container-highest': 'var(--color-surface-container-highest)',
+          'surface-container-lowest': 'var(--color-surface-container-lowest)',
+          'on-surface': 'var(--color-on-surface)',
+          'on-surface-variant': 'var(--color-on-surface-variant)',
+          background: 'var(--color-background)',
+          outline: 'var(--color-outline)',
+          'outline-variant': 'var(--color-outline-variant)',
+          success: 'var(--color-success)',
+          'on-success': 'var(--color-on-success)',
+          info: 'var(--color-info)',
+          'on-info': 'var(--color-on-info)',
+          online: 'var(--color-online)',
+          error: 'var(--color-error)',
+          'on-error': 'var(--color-on-error)',
+          'error-container': 'var(--color-error-container)',
+          'on-error-container': 'var(--color-on-error-container)',
+          warning: 'var(--color-warning)',
+          'on-warning': 'var(--color-on-warning)',
+        },
+        fontFamily: {
+          headline: ['Plus Jakarta Sans', 'sans-serif'],
+          body: ['Manrope', 'sans-serif'],
+        },
+      },
+    },
+  }
+</script>
+
+<style>
+  :root {
+    --color-accent: #33253b;
+    --color-primary: #33253b;
+    --color-primary-container: #4a3b52;
+    --color-on-primary: #ffffff;
+    --color-on-primary-container: #baa6c1;
+    --color-secondary: #904d00;
+    --color-secondary-container: #fd9c42;
+    --color-on-secondary: #ffffff;
+    --color-on-secondary-container: #6b3800;
+    --color-tertiary: #541116;
+    --color-tertiary-container: #72272a;
+    --color-on-tertiary: #ffffff;
+    --color-on-tertiary-container: #f6908f;
+    --color-surface: #fbf9f5;
+    --color-surface-container: #efeeea;
+    --color-surface-container-low: #f5f3ef;
+    --color-surface-container-high: #eae8e4;
+    --color-surface-container-highest: #e4e2de;
+    --color-surface-container-lowest: #ffffff;
+    --color-on-surface: #1b1c1a;
+    --color-on-surface-variant: #4a454b;
+    --color-background: #fbf9f5;
+    --color-outline: #7c757c;
+    --color-outline-variant: #ccc4cc;
+    --color-success: #ccebe6;
+    --color-on-success: #0d4d49;
+    --color-info: #d6e6f5;
+    --color-on-info: #1f4a78;
+    --color-online: #0d8b80;
+    --color-error: #ba1a1a;
+    --color-on-error: #ffffff;
+    --color-error-container: #ffdad6;
+    --color-on-error-container: #93000a;
+    --color-warning: #fcd34d;
+    --color-on-warning: #1b1c1a;
+  }
+  .dark {
+    --color-accent: #fce8d2;
+    --color-primary: #fd9c42;
+    --color-primary-container: #4a3320;
+    --color-on-primary: #282c34;
+    --color-on-primary-container: #f6c094;
+    --color-secondary: #e4bf7a;
+    --color-secondary-container: #4a3e28;
+    --color-on-secondary: #282c34;
+    --color-on-secondary-container: #ecd09a;
+    --color-tertiary: #c578dd;
+    --color-tertiary-container: #3e2848;
+    --color-on-tertiary: #282c34;
+    --color-on-tertiary-container: #d49ee6;
+    --color-surface: #282c34;
+    --color-surface-container: #2e323a;
+    --color-surface-container-low: #2e3239;
+    --color-surface-container-high: #5c6068;
+    --color-surface-container-highest: #393f4a;
+    --color-surface-container-lowest: #21252b;
+    --color-on-surface: #fefaf3;
+    --color-on-surface-variant: #ebe2d2;
+    --color-background: #282c34;
+    --color-outline: #5b6270;
+    --color-outline-variant: #393f4a;
+    --color-success: #1f4544;
+    --color-on-success: #7dd3cf;
+    --color-info: #1f3a52;
+    --color-on-info: #9bc6e8;
+    --color-online: #5cc4b8;
+    --color-error: #df6b75;
+    --color-on-error: #282c34;
+    --color-error-container: #6f3338;
+    --color-on-error-container: #ffd2cf;
+    --color-warning: #fbbf24;
+  }
+
+  body {
+    font-family: 'Manrope', sans-serif;
+    background: #d8d4cc;
+    color: var(--color-on-background);
+  }
+  .dark body, body.dark { background: #15171c; }
+  .font-headline { font-family: 'Plus Jakarta Sans', sans-serif; }
+
+  /* Mirall "window" frame */
+  .device-frame {
+    background: var(--color-background);
+    border-radius: 16px;
+    box-shadow: 0 30px 80px rgba(15, 12, 20, 0.18), 0 8px 24px rgba(15, 12, 20, 0.12);
+    overflow: hidden;
+  }
+  .traffic-lights { display: inline-flex; gap: 8px; padding: 14px 16px; }
+  .traffic-lights span {
+    width: 12px; height: 12px; border-radius: 9999px; display: inline-block;
+  }
+  .traffic-lights .r { background: #ff5f57; }
+  .traffic-lights .y { background: #febc2e; }
+  .traffic-lights .g { background: #28c840; }
+
+  /* Section note plate — mockup chrome only, never shipped UI */
+  .note-plate { background: rgba(255,255,255,.72); }
+  .dark .note-plate { background: rgba(0,0,0,.30); }
+</style>
+</head>
+<body class="min-h-screen">
+
+<!-- =========== Page header / theme toggle ============================ -->
+<div class="max-w-[1100px] mx-auto px-6 pt-10 pb-2 flex items-center justify-between">
+  <div>
+    <h1 class="font-headline font-extrabold text-2xl tracking-tight" style="color:#33253b">
+      Connectivity verdict — mockup
+    </h1>
+    <p class="text-sm" style="color:#4a454b">
+      UI delta for <code class="bg-black/5 px-1 rounded text-xs">~/Projects/Mirall/plans/plan-connectivity-verdict.md</code>.
+      Click the toggle to flip light/dark.
+    </p>
+  </div>
+  <button id="theme-toggle"
+    class="rounded-xl border border-black/10 px-3 py-2 text-sm font-bold bg-white shadow-sm hover:shadow"
+    style="color:#33253b">
+    Toggle dark
+  </button>
+</div>
+
+<!-- =========== Annotation banner ============================ -->
+<div class="max-w-[1100px] mx-auto px-6 pt-4">
+  <div class="rounded-2xl p-5 border-2" style="background:#d6e6f5; border-color:#9bc6e8">
+    <div class="flex items-start gap-3">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" style="color:#1f4a78" class="shrink-0 mt-0.5" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+      <div>
+        <p class="font-headline font-extrabold text-base" style="color:#33253b">What's proposed vs. recreated</p>
+        <p class="text-sm mt-1" style="color:#4a454b">
+          <strong>Proposed (the delta):</strong> a dedicated
+          <code class="bg-white/60 px-1 rounded text-xs">ConnectionProblem</code> screen — its own title, its own
+          purpose, and none of the space-management actions (§2, §3), shown in place of the spaces screen when the
+          verdict is degraded and the user has no spaces; connectivity <strong>toasts</strong> for everything that
+          arrives mid-session (§1, §5); a new <strong>onboarding check step</strong> (§6); and a reworked
+          <strong>Network status</strong> screen — a plain-language Connection summary plus a savable diagnostics
+          bundle, with the raw protocol fields demoted to an optional disclosure (§7, §7b). §1b is the timing
+          evidence that picks screen over modal.
+          <br/>
+          <strong>Recreated from code (baseline truth):</strong> the spaces screen header, filter chips and empty
+          state from <code class="bg-white/60 px-1 rounded text-xs">src/renderer/screens/SharedSpaces.tsx</code>;
+          the toast from <code class="bg-white/60 px-1 rounded text-xs">components/toast/Toast.tsx</code> (variant
+          styles, countdown ring, action button); the onboarding shell from
+          <code class="bg-white/60 px-1 rounded text-xs">screens/Onboarding.tsx</code>; the verdict panel, field
+          rows and suggestion list from <code class="bg-white/60 px-1 rounded text-xs">screens/NetworkStatus.tsx</code>.
+          Existing strings are the real <code class="bg-white/60 px-1 rounded text-xs">locales/en/common.json</code>
+          values; everything under <code class="bg-white/60 px-1 rounded text-xs">connectivity.*</code> /
+          <code class="bg-white/60 px-1 rounded text-xs">networkCheck.*</code> is marked proposed new copy.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- =========== Decision note ============================ -->
+<div class="max-w-[1100px] mx-auto px-6 pt-4">
+  <div class="rounded-2xl p-5 border-2" style="background:#ffdad6; border-color:#93000a">
+    <div class="flex items-start gap-3">
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" style="color:#93000a" class="shrink-0 mt-0.5" aria-hidden="true"><path d="M18 6 6 18M6 6l12 12"/></svg>
+      <div>
+        <p class="font-headline font-extrabold text-base" style="color:#33253b">Rejected: a persistent top banner, and a blocking modal</p>
+        <p class="text-sm mt-1" style="color:#4a454b">
+          An earlier draft reused the <code class="bg-white/60 px-1 rounded text-xs">UpdateBanner</code> slot for
+          connectivity errors. <strong>Rejected</strong> — the update banner stays for updates only and is not
+          overloaded with error messaging. Errors go to the toast system; the standing explanation lives in the
+          dedicated Connection problem screen. See §8a for the rejected treatment, kept so the decision stays legible.
+          <br/>
+          Side benefit: <code class="bg-white/60 px-1 rounded text-xs">--banner-h</code> keeps its single owner, so
+          the banner-stacking refactor in the plan (§9.2) is no longer needed.
+          <br/><br/>
+          A <strong>blocking modal</strong> was also considered and rejected — see §1b for the timing evidence and
+          §8 for the treatment. Short version: we know the verdict before the user has acted, so there is nothing
+          to interrupt; and blocking would be unjustified anyway, because creating a space works fine offline.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<!-- =========== SECTION 1: connectivity toasts in isolation =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-12">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">1 · Connectivity toasts (the error channel)</h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    Recreated verbatim from <code class="bg-black/5 px-1 rounded text-xs">Toast.tsx</code>: container
+    <code class="bg-black/5 px-1 rounded text-xs">min-w-[280px] max-w-[720px] rounded-lg px-4 py-3 shadow-lg</code>,
+    per-variant fill, 20px leading icon, underlined action button, and the dismiss control whose countdown ring
+    swaps to a close glyph on hover. <strong>Blocked and at-risk toasts are sticky</strong>
+    (<code class="bg-black/5 px-1 rounded text-xs">duration: 0</code>) — the existing offline toast already is.
+    <br/>
+    A11y: <code class="bg-black/5 px-1 rounded text-xs">error</code> renders
+    <code class="bg-black/5 px-1 rounded text-xs">role="alert" aria-live="assertive"</code>; the others
+    <code class="bg-black/5 px-1 rounded text-xs">role="status" aria-live="polite"</code> — unchanged from the
+    shipped component. Meaning lives in the text, never in the fill colour alone.
+  </p>
+
+  <div class="device-frame p-8 flex flex-col items-end gap-3" style="background:var(--color-surface)">
+
+    <!-- BLOCKED — error variant, sticky -->
+    <div role="alert" aria-live="assertive"
+         class="pointer-events-auto flex items-center gap-3 min-w-[280px] max-w-[720px] rounded-lg px-4 py-3 shadow-lg bg-error-container text-on-surface-variant">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-on-error-container" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+      <span class="min-w-0 flex-1 text-sm leading-snug break-words">Your network is blocking connections to other people. Invites and shares won't arrive.</span>
+      <button type="button" class="shrink-0 rounded-lg px-2 py-1 text-sm font-medium underline underline-offset-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-current/40">What can I do?</button>
+      <button type="button" aria-label="Dismiss" class="relative shrink-0 w-7 h-7 rounded-full hover:bg-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-current/40">
+        <span class="absolute inset-0 flex items-center justify-center" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="8" fill="none" stroke="currentColor" stroke-opacity="0.3" stroke-width="2"/></svg>
+        </span>
+      </button>
+    </div>
+
+    <!-- AT-RISK — warning variant, sticky -->
+    <div role="status" aria-live="polite"
+         class="pointer-events-auto flex items-center gap-3 min-w-[280px] max-w-[720px] rounded-lg px-4 py-3 shadow-lg bg-warning text-on-warning">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-on-warning" aria-hidden="true"><path d="M10.3 3.9 1.8 18a2 2 0 0 0 1.7 3h17a2 2 0 0 0 1.7-3L13.7 3.9a2 2 0 0 0-3.4 0Z"/><path d="M12 9v4M12 17h.01"/></svg>
+      <span class="min-w-0 flex-1 text-sm leading-snug break-words">Connections to many people will fail on this network. Mobile routers and tethering are the usual cause.</span>
+      <button type="button" class="shrink-0 rounded-lg px-2 py-1 text-sm font-medium underline underline-offset-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-current/40">What can I do?</button>
+      <button type="button" aria-label="Dismiss" class="relative shrink-0 w-7 h-7 rounded-full hover:bg-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-current/40">
+        <span class="absolute inset-0 flex items-center justify-center" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="8" fill="none" stroke="currentColor" stroke-opacity="0.3" stroke-width="2"/></svg>
+        </span>
+      </button>
+    </div>
+
+    <!-- RECOVERED — success variant, auto-dismisses (real string, unchanged) -->
+    <div role="status" aria-live="polite"
+         class="pointer-events-auto flex items-center gap-3 min-w-[280px] max-w-[720px] rounded-lg px-4 py-3 shadow-lg bg-success text-on-surface-variant">
+      <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-on-success" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="m8.5 12.5 2.5 2.5 4.5-5"/></svg>
+      <span class="min-w-0 flex-1 text-sm leading-snug break-words">Back online</span>
+      <button type="button" aria-label="Dismiss" class="relative shrink-0 w-7 h-7 rounded-full hover:bg-black/10 focus:outline-none focus-visible:ring-2 focus-visible:ring-current/40">
+        <span class="absolute inset-0 flex items-center justify-center" aria-hidden="true">
+          <svg width="18" height="18" viewBox="0 0 18 18">
+            <circle cx="9" cy="9" r="8" fill="none" stroke="currentColor" stroke-opacity="0.3" stroke-width="2"/>
+            <circle cx="9" cy="9" r="8" fill="none" stroke="currentColor" stroke-width="2" stroke-dasharray="50.3" stroke-dashoffset="18" stroke-linecap="round" transform="rotate(-90 9 9)"/>
+          </svg>
+        </span>
+      </button>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>Copy status:</strong> "Back online" is the shipped
+    <code class="text-xs bg-black/5 px-1 rounded">connectivity.restoredToast</code>. The blocked and at-risk
+    messages are <strong>proposed</strong> new keys
+    (<code class="text-xs bg-black/5 px-1 rounded">connectivity.blockedToast</code> /
+    <code class="text-xs bg-black/5 px-1 rounded">connectivity.atRiskToast</code>). The existing
+    <code class="text-xs bg-black/5 px-1 rounded">offlineToast</code> / <code class="text-xs bg-black/5 px-1 rounded">connectingToast</code>
+    stay for the OS-offline and boot cases.
+    <br/><br/>
+    <strong>Toast identity:</strong> all connectivity toasts keep sharing the single
+    <code class="text-xs bg-black/5 px-1 rounded">TOAST_ID = 'connectivity'</code> from
+    <code class="text-xs bg-black/5 px-1 rounded">ConnectivityToastBridge.tsx</code>, so a verdict change
+    <em>replaces</em> the previous toast rather than stacking a second one.
+  </div>
+</section>
+
+
+<!-- =========== SECTION 1b: WHEN do we know? =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">1b · When the verdict is actually available</h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    This table decides the surface. Measured from the library sources, not assumed —
+    <code class="bg-black/5 px-1 rounded text-xs">dht-rpc</code> emits
+    <code class="bg-black/5 px-1 rounded text-xs">'ready'</code> only <em>after</em> its bootstrap
+    <code class="bg-black/5 px-1 rounded text-xs">FIND_NODE</code> walk finishes
+    (<code class="bg-black/5 px-1 rounded text-xs">index.js:395-404</code>), and every response on that walk
+    already fed <code class="bg-black/5 px-1 rounded text-xs">_natAdd()</code>. So NAT consensus exists at the
+    same instant <code class="bg-black/5 px-1 rounded text-xs">dhtReady</code> flips.
+  </p>
+
+  <div class="note-plate rounded-2xl p-6 overflow-x-auto">
+    <table class="w-full text-sm" style="color:#4a454b; min-width:640px">
+      <thead>
+        <tr class="text-left" style="color:#33253b">
+          <th class="font-headline font-extrabold pb-3 pr-4">Signal</th>
+          <th class="font-headline font-extrabold pb-3 pr-4">Gated on</th>
+          <th class="font-headline font-extrabold pb-3">Typical</th>
+        </tr>
+      </thead>
+      <tbody class="align-top">
+        <tr style="border-top:1px solid rgba(0,0,0,.08)">
+          <td class="py-3 pr-4"><strong>Tier 1 — NAT shape</strong></td>
+          <td class="py-3 pr-4">the bootstrap query, which already sampled it</td>
+          <td class="py-3"><strong style="color:#0d8b80">~1–3 s</strong> — same moment as <code class="text-xs bg-black/5 px-1 rounded">dhtReady</code></td>
+        </tr>
+        <tr style="border-top:1px solid rgba(0,0,0,.08)">
+          <td class="py-3 pr-4"><strong>Tier 4 — canary</strong></td>
+          <td class="py-3 pr-4">stage 1 lookup, then a dial (10 s cap each)</td>
+          <td class="py-3"><strong style="color:#0d8b80">~2–20 s</strong></td>
+        </tr>
+        <tr style="border-top:1px solid rgba(0,0,0,.08)">
+          <td class="py-3 pr-4"><strong>Tier 3 — transport health</strong></td>
+          <td class="py-3 pr-4">4 ticks × <code class="text-xs bg-black/5 px-1 rounded">TICK_INTERVAL 5000</code>; <code class="text-xs bg-black/5 px-1 rounded">cold</code> until then</td>
+          <td class="py-3">~20 s</td>
+        </tr>
+        <tr style="border-top:1px solid rgba(0,0,0,.08)">
+          <td class="py-3 pr-4"><strong>Tier 2 — real peers</strong></td>
+          <td class="py-3 pr-4">having spaces, plus dials that actually failed</td>
+          <td class="py-3">30 s – minutes</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <div class="mt-5 pt-5 text-sm leading-relaxed" style="border-top:2px solid rgba(0,0,0,.12); color:#4a454b">
+      <p class="font-headline font-extrabold text-base mb-2" style="color:#33253b">What follows</p>
+      <p>
+        The decisive verdict for a brand-new user — Tier 1, optionally confirmed by the canary — lands
+        <strong>before the user has done anything</strong>. That is the first frame of the app, not an interruption.
+        A dedicated screen is therefore the right home for it, and no modal is needed: there is no context to seize.
+      </p>
+      <p class="mt-2">
+        The cases that arrive <em>late</em> — a network change mid-session, Tier 2 evidence, a VPN toggled after
+        launch — are exactly the cases where seizing context would be wrong. Those get the toast.
+        <strong>Fast ⇒ screen. Slow ⇒ toast.</strong> A modal is the one shape that is wrong for both.
+      </p>
+    </div>
+  </div>
+</section>
+
+
+<!-- =========== SECTION 2: dedicated screen — BLOCKED =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">
+    2 · Connection problem — a screen of its own <span class="text-xs font-bold ml-1 px-2 py-1 rounded-full align-middle" style="background:#ffdad6;color:#93000a">blocked</span>
+    <span class="text-xs font-bold ml-1 px-2 py-1 rounded-full align-middle" style="background:#fce8d2;color:#7a2d30">primary case — the report</span>
+  </h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    Its own title, its own purpose, and <strong>none of the space-management actions</strong> — no "Shared Spaces"
+    heading, no filter chips, no Create / Join. An earlier draft kept those in place while telling the user nothing
+    could connect, which was incoherent. The top nav stays: Settings and Account must remain reachable, and the
+    avatar ring already carries the status.
+  </p>
+
+  <div class="device-frame">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+
+    <!-- TopNav (recreated: TopNav.tsx) — avatar ring statusVariant="offline" -->
+    <div class="bg-surface-container-lowest/70 border-b border-outline-variant">
+      <div class="flex items-center py-4 px-8 w-full max-w-7xl mx-auto relative">
+        <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <span class="text-2xl font-extrabold text-black dark:text-white tracking-tighter font-headline">Mirall<span style="color:#fd9c42">.</span></span>
+        </div>
+        <div class="flex items-center gap-4 ml-auto">
+          <span class="flex items-center gap-2 bg-surface-container-high text-on-surface-variant rounded-xl px-5 py-2.5 font-headline font-bold text-sm">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            Send feedback
+          </span>
+          <span class="w-7 h-7 flex items-center justify-center text-on-surface-variant" aria-hidden="true">
+            <svg width="26" height="26" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="3"/><circle cx="12" cy="12" r="9"/></svg>
+          </span>
+          <span class="w-10 h-10 rounded-full flex items-center justify-center">
+            <span class="relative w-10 h-10 rounded-full flex items-center justify-center font-bold text-on-primary" style="background:#4a3b52; box-shadow:0 0 0 2px var(--color-error)">R</span>
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <div class="px-8 pt-10 pb-10" style="min-height:620px">
+      <div class="max-w-2xl mx-auto">
+
+        <!-- PageHeader pattern (recreated: PageHeader via NetworkStatus.tsx). No back arrow:
+             with no spaces there is nowhere to go back TO. §5 shows the variant that has one. -->
+        <div class="mb-8">
+          <h1 class="text-4xl font-headline font-extrabold text-accent tracking-tight">Connection problem</h1>
+          <p class="text-on-surface-variant mt-1">Mirall can't reach other people from this network.</p>
+        </div>
+
+        <div role="status" aria-live="polite" class="space-y-6">
+          <!-- verdict card (same recipe as NetworkStatus VerdictBanner) -->
+          <div class="bg-surface-container-low rounded-xl p-6 flex items-start gap-5">
+            <span class="w-4 h-4 rounded-full shrink-0 mt-1.5 bg-error" style="box-shadow:0 0 0 4px color-mix(in srgb, var(--color-error) 25%, transparent)" aria-hidden="true"></span>
+            <div class="flex-1 min-w-0">
+              <p class="text-2xl font-headline font-bold text-accent">Your network is blocking Mirall</p>
+              <p class="text-sm text-on-surface-variant mt-2 leading-relaxed">
+                We can find other people on the Mirall network, but we can't connect to them. While this is the
+                case, invites you send won't arrive and spaces you join won't sync.
+              </p>
+            </div>
+          </div>
+
+          <!-- fix list -->
+          <div>
+            <h2 class="text-xl font-headline font-bold text-accent mb-4">What helps, in this order</h2>
+            <ol class="bg-surface-container-low rounded-xl p-6 space-y-5">
+              <li class="flex items-start gap-4">
+                <span class="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center" aria-hidden="true">1</span>
+                <span class="text-sm text-on-surface leading-relaxed pt-0.5"><span class="font-bold">Turn off your VPN</span> and check again.</span>
+              </li>
+              <li class="flex items-start gap-4">
+                <span class="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center" aria-hidden="true">2</span>
+                <span class="text-sm text-on-surface leading-relaxed pt-0.5">
+                  <span class="font-bold">Use a cable or DSL connection</span> instead of a mobile router or phone tethering.
+                  <span class="text-on-surface-variant">On a mobile network there's no router setting that fixes this.</span>
+                </span>
+              </li>
+              <li class="flex items-start gap-4">
+                <span class="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center" aria-hidden="true">3</span>
+                <span class="text-sm text-on-surface leading-relaxed pt-0.5"><span class="font-bold">Try a different Wi-Fi</span> — company and guest networks often filter this traffic.</span>
+              </li>
+            </ol>
+          </div>
+
+          <!-- actions -->
+          <div class="flex items-center gap-3 flex-wrap">
+            <button class="flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-headline font-bold bg-primary text-on-primary px-5 py-2.5 text-sm" style="box-shadow:0 10px 15px -3px rgba(51,37,59,.1)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
+              Check again
+            </button>
+            <button class="flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">Network details</button>
+            <span class="text-xs text-on-surface-variant ml-auto">Checked just now</span>
+          </div>
+
+          <!-- the escape hatch: creating a space locally still works -->
+          <div class="rounded-xl bg-surface-container-lowest p-5 flex items-start gap-3">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-on-surface-variant mt-0.5" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+            <p class="text-sm text-on-surface-variant leading-relaxed">
+              You can still set up spaces — they'll stay on this device and start syncing once the connection works.
+              <button class="font-bold text-accent underline underline-offset-2 ml-1">Continue to Spaces</button>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>Why this is a screen and not a modal:</strong> at launch we know the verdict in ~1–3 s (§1b), so this
+    <em>is</em> the first frame — there is no context to interrupt. And blocking would be unjustified anyway:
+    creating a space works fine offline; only inviting and syncing fail. Hence "Continue to Spaces" rather than a
+    dead end. See §8 for the rejected modal.
+    <br/><br/>
+    <strong>Routing:</strong> substituted for the spaces screen when the verdict is degraded <em>and</em>
+    <code class="text-xs bg-black/5 px-1 rounded">spaces.length === 0</code>. Also reachable any time from the
+    toast's "What can I do?" and from Network status.
+    <br/><br/>
+    <strong>A11y:</strong> the verdict + fix list sit in one <code class="text-xs bg-black/5 px-1 rounded">role="status" aria-live="polite"</code>
+    region so a re-check is announced. The lamp and step numerals are
+    <code class="text-xs bg-black/5 px-1 rounded">aria-hidden</code> — severity is in the heading text. The fix list
+    is a real <code class="text-xs bg-black/5 px-1 rounded">&lt;ol&gt;</code>. Focus moves to the
+    <code class="text-xs bg-black/5 px-1 rounded">&lt;h1&gt;</code> on mount.
+    <br/><br/>
+    <strong>Deliberately absent:</strong> no IP, no port, no NAT flags. Those stay behind "Network details" (§7).
+  </div>
+</section>
+
+
+<!-- =========== SECTION 3: dedicated screen — AT-RISK =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">
+    3 · Same screen, verdict <span class="text-xs font-bold ml-1 px-2 py-1 rounded-full align-middle" style="background:#ffdcc2;color:#6b3800">at-risk</span>
+  </h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    Symmetric NAT / randomised ports — the actual state in the report. Copy says <em>many</em>, not <em>all</em>:
+    this user really can reach peers whose NAT has a stable mapping, so claiming total failure would be wrong.
+    The fix list reorders — mobile first, because that signal is overwhelmingly a carrier NAT.
+  </p>
+
+  <div class="device-frame">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="px-8 pt-10 pb-10" style="min-height:560px">
+      <div class="max-w-2xl mx-auto">
+        <div class="mb-8">
+          <h1 class="text-4xl font-headline font-extrabold text-accent tracking-tight">Connection problem</h1>
+          <p class="text-on-surface-variant mt-1">Mirall can only reach some people from this network.</p>
+        </div>
+
+        <div role="status" aria-live="polite" class="space-y-6">
+          <div class="bg-surface-container-low rounded-xl p-6 flex items-start gap-5">
+            <span class="w-4 h-4 rounded-full shrink-0 mt-1.5" style="background:var(--color-secondary-container); box-shadow:0 0 0 4px color-mix(in srgb, var(--color-secondary-container) 30%, transparent)" aria-hidden="true"></span>
+            <div class="flex-1 min-w-0">
+              <p class="text-2xl font-headline font-bold text-accent">Limited connection</p>
+              <p class="text-sm text-on-surface-variant mt-2 leading-relaxed">
+                Your connection uses a different port every time it reaches out. Connections to some people will
+                work; to many others they'll fail. Mobile routers and phone tethering are the usual cause.
+              </p>
+            </div>
+          </div>
+
+          <div>
+            <h2 class="text-xl font-headline font-bold text-accent mb-4">What helps, in this order</h2>
+            <ol class="bg-surface-container-low rounded-xl p-6 space-y-5">
+              <li class="flex items-start gap-4">
+                <span class="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center" aria-hidden="true">1</span>
+                <span class="text-sm text-on-surface leading-relaxed pt-0.5">
+                  <span class="font-bold">Use a cable or DSL connection</span> instead of a mobile router or phone tethering.
+                  <span class="text-on-surface-variant">On a mobile network there's no router setting that fixes this.</span>
+                </span>
+              </li>
+              <li class="flex items-start gap-4">
+                <span class="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center" aria-hidden="true">2</span>
+                <span class="text-sm text-on-surface leading-relaxed pt-0.5"><span class="font-bold">Turn off your VPN</span> and check again.</span>
+              </li>
+              <li class="flex items-start gap-4">
+                <span class="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center" aria-hidden="true">3</span>
+                <span class="text-sm text-on-surface leading-relaxed pt-0.5"><span class="font-bold">Try a different Wi-Fi</span> — company and guest networks often filter this traffic.</span>
+              </li>
+            </ol>
+          </div>
+
+          <div class="flex items-center gap-3 flex-wrap">
+            <button class="flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-headline font-bold bg-primary text-on-primary px-5 py-2.5 text-sm" style="box-shadow:0 10px 15px -3px rgba(51,37,59,.1)">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
+              Check again
+            </button>
+            <button class="flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">Network details</button>
+            <span class="text-xs text-on-surface-variant ml-auto">Checked 2 min ago</span>
+          </div>
+
+          <div class="rounded-xl bg-surface-container-lowest p-5 flex items-start gap-3">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-on-surface-variant mt-0.5" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8h.01M11 12h1v4h1"/></svg>
+            <p class="text-sm text-on-surface-variant leading-relaxed">
+              Sharing will still work with some people.
+              <button class="font-bold text-accent underline underline-offset-2 ml-1">Continue to Spaces</button>
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>Why not the warning-yellow lamp:</strong> <code class="text-xs bg-black/5 px-1 rounded">--color-warning</code>
+    (<code class="text-xs bg-black/5 px-1 rounded">#fcd34d</code>) reads too faint as a 16px dot on the near-white
+    surface, so the lamp uses <code class="text-xs bg-black/5 px-1 rounded">secondary-container</code> — the same
+    amber the app already uses for the update banner and the brand dot. Toasts keep the real
+    <code class="text-xs bg-black/5 px-1 rounded">bg-warning</code> fill, where the larger area carries it.
+    Same divergence the <code class="text-xs bg-black/5 px-1 rounded">space-connectivity-stall</code> mockup flagged.
+  </div>
+</section>
+
+
+<!-- =========== SECTION 4: baseline for comparison =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">
+    4 · Baseline — what ships today <span class="text-xs font-bold ml-1 px-2 py-1 rounded-full align-middle" style="background:#efeeea;color:#4a454b">recreated, unchanged</span>
+  </h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    The current empty state (<code class="bg-black/5 px-1 rounded text-xs">SharedSpaces.tsx:74-79</code>), shown for
+    contrast. This is exactly what a blocked first-run user sees today: an invitation to create a space that will
+    silently never sync. <strong>Unchanged by this delivery</strong> — it stays exactly as-is whenever the verdict
+    is <code class="bg-black/5 px-1 rounded text-xs">healthy</code> or
+    <code class="bg-black/5 px-1 rounded text-xs">unknown</code>, which is the overwhelming majority of users.
+    When the verdict is degraded the router renders §2 instead of this screen entirely.
+  </p>
+
+  <div class="device-frame">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="px-8 pt-8 pb-8 flex flex-col" style="min-height:420px">
+      <div class="pb-4 shrink-0">
+        <h1 class="text-5xl font-headline font-extrabold text-accent tracking-tight leading-tight mb-4">
+          Shared <span class="text-transparent bg-clip-text" style="background-image:linear-gradient(to right,var(--color-accent),var(--color-secondary));-webkit-background-clip:text">Spaces</span>
+        </h1>
+        <p class="text-on-surface-variant text-lg max-w-2xl leading-relaxed">Create spaces to share files with your colleagues and peers.</p>
+      </div>
+      <div class="flex-1 flex flex-col items-center justify-center py-20 text-center">
+        <h2 class="text-2xl font-headline font-bold text-accent mb-3">No spaces yet</h2>
+        <p class="text-on-surface-variant max-w-md leading-relaxed">Create one or join with an invite code.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+
+<!-- =========== SECTION 5: user WITH spaces =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">
+    5 · User who already has spaces, verdict <span class="text-xs font-bold ml-1 px-2 py-1 rounded-full align-middle" style="background:#ffdad6;color:#93000a">blocked</span>
+  </h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    Substituting the whole screen is only right when there is nothing to substitute <em>for</em>. This user has
+    spaces and may be mid-task, so the signal is the <strong>sticky toast</strong> plus the avatar's status ring;
+    "What can I do?" navigates to the same §2 screen, which then renders with a back arrow because there is
+    somewhere to return to. This is also the path for a verdict that turns degraded <em>during</em> a session.
+  </p>
+
+  <div class="device-frame">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="px-8 pt-8 pb-8 flex flex-col relative" style="min-height:520px">
+      <div class="pb-4 shrink-0">
+        <h1 class="text-5xl font-headline font-extrabold text-accent tracking-tight leading-tight mb-4">
+          Shared <span class="text-transparent bg-clip-text" style="background-image:linear-gradient(to right,var(--color-accent),var(--color-secondary));-webkit-background-clip:text">Spaces</span>
+        </h1>
+        <p class="text-on-surface-variant text-lg max-w-2xl leading-relaxed">Create spaces to share files with your colleagues and peers.</p>
+      </div>
+
+      <!-- two SpaceCards (approximated: SpaceCard.tsx) -->
+      <div role="list" class="flex-1 space-y-4">
+        <div role="listitem" class="bg-surface-container-low rounded-2xl p-6 flex items-center gap-5" style="box-shadow:0 12px 40px rgba(74,59,82,0.04)">
+          <span class="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-headline font-extrabold text-xl shrink-0" style="background:#8a5a2b">P</span>
+          <div class="flex-1 min-w-0">
+            <p class="font-headline font-bold text-lg text-accent truncate">Project Aurora</p>
+            <p class="text-sm text-on-surface-variant">3 members · Created 12 Aug 2026</p>
+          </div>
+          <span class="flex items-center gap-2 text-sm text-on-surface-variant">
+            <span class="w-2 h-2 rounded-full" style="background:var(--color-outline)" aria-hidden="true"></span>
+            Offline
+          </span>
+        </div>
+        <div role="listitem" class="bg-surface-container-low rounded-2xl p-6 flex items-center gap-5" style="box-shadow:0 12px 40px rgba(74,59,82,0.04)">
+          <span class="w-14 h-14 rounded-2xl flex items-center justify-center text-white font-headline font-extrabold text-xl shrink-0" style="background:#3f6f5e">F</span>
+          <div class="flex-1 min-w-0">
+            <p class="font-headline font-bold text-lg text-accent truncate">Family Photos</p>
+            <p class="text-sm text-on-surface-variant">2 members · Created 4 Jul 2026</p>
+          </div>
+          <span class="flex items-center gap-2 text-sm text-on-surface-variant">
+            <span class="w-2 h-2 rounded-full" style="background:var(--color-outline)" aria-hidden="true"></span>
+            Offline
+          </span>
+        </div>
+      </div>
+
+      <!-- sticky toast, bottom-right (ToastContainer position) -->
+      <div class="absolute right-8 bottom-8">
+        <div role="alert" aria-live="assertive"
+             class="pointer-events-auto flex items-center gap-3 min-w-[280px] max-w-[720px] rounded-lg px-4 py-3 shadow-lg bg-error-container text-on-surface-variant">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-on-error-container" aria-hidden="true"><circle cx="12" cy="12" r="9"/><path d="M12 8v5M12 16h.01"/></svg>
+          <span class="min-w-0 flex-1 text-sm leading-snug break-words">Your network is blocking connections to other people. Invites and shares won't arrive.</span>
+          <button type="button" class="shrink-0 rounded-lg px-2 py-1 text-sm font-medium underline underline-offset-2">What can I do?</button>
+          <button type="button" aria-label="Dismiss" class="relative shrink-0 w-7 h-7 rounded-full hover:bg-black/10">
+            <span class="absolute inset-0 flex items-center justify-center" aria-hidden="true">
+              <svg width="18" height="18" viewBox="0 0 18 18"><circle cx="9" cy="9" r="8" fill="none" stroke="currentColor" stroke-opacity="0.3" stroke-width="2"/></svg>
+            </span>
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>Note the honest gap:</strong> both spaces read a plain "Offline", which is exactly the ambiguity called
+    out in <code class="text-xs bg-black/5 px-1 rounded">plan-pairwise-connectivity-diagnostics.md</code> — an
+    unreachable peer looks identical to one who quit. Fixing that is the <em>pairwise</em> plan's job and is
+    <strong>out of scope here</strong>; this delivery only guarantees the toast explains why every space looks dead
+    at once.
+  </div>
+</section>
+
+
+<!-- =========== SECTION 6: onboarding step =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">6 · Onboarding — the connectivity check step</h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    A second step after the profile step, in the same centred
+    <code class="bg-black/5 px-1 rounded text-xs">max-w-md</code> card shell recreated from
+    <code class="bg-black/5 px-1 rounded text-xs">Onboarding.tsx</code> (fixed drag header, card
+    <code class="bg-black/5 px-1 rounded text-xs">bg-surface-container-low rounded-2xl p-8</code>). Four states.
+    <strong>"Continue anyway" is always present</strong> — never trap someone in a check.
+  </p>
+
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+    <!-- CHECKING -->
+    <div>
+      <div class="device-frame">
+        <div class="flex items-center justify-between border-b border-outline-variant">
+          <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+          <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+          <div class="w-20"></div>
+        </div>
+        <div class="px-8 py-10 flex flex-col items-center" style="min-height:430px">
+          <div class="w-full max-w-md">
+            <div class="flex items-center gap-2 mb-8" aria-hidden="true">
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+            </div>
+            <div class="mb-8">
+              <h1 class="text-3xl font-headline font-extrabold text-accent tracking-tight mb-3">Checking your connection</h1>
+              <p class="text-on-surface-variant leading-relaxed">One moment — we're testing whether you can reach the Mirall network.</p>
+            </div>
+            <div class="bg-surface-container-low rounded-2xl p-8" style="box-shadow:0 12px 40px rgba(74,59,82,0.04)">
+              <div role="status" aria-live="polite" class="flex items-center gap-4">
+                <span class="w-4 h-4 rounded-full shrink-0" style="background:var(--color-outline)" aria-hidden="true"></span>
+                <p class="text-on-surface-variant">Testing…</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="text-xs mt-2 text-center" style="color:#4a454b"><strong>Checking</strong> — runs <code class="bg-black/5 px-1 rounded">network:probe-canary</code> with <code class="bg-black/5 px-1 rounded">force: true</code>.</p>
+    </div>
+
+    <!-- HEALTHY -->
+    <div>
+      <div class="device-frame">
+        <div class="flex items-center justify-between border-b border-outline-variant">
+          <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+          <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+          <div class="w-20"></div>
+        </div>
+        <div class="px-8 py-10 flex flex-col items-center" style="min-height:430px">
+          <div class="w-full max-w-md">
+            <div class="flex items-center gap-2 mb-8" aria-hidden="true">
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+            </div>
+            <div class="mb-8">
+              <h1 class="text-3xl font-headline font-extrabold text-accent tracking-tight mb-3">You're connected</h1>
+              <p class="text-on-surface-variant leading-relaxed">We reached the Mirall network and tested a real connection. You're ready to create or join a space.</p>
+            </div>
+            <div class="bg-surface-container-low rounded-2xl p-8" style="box-shadow:0 12px 40px rgba(74,59,82,0.04)">
+              <div role="status" aria-live="polite" class="flex items-center gap-4 mb-6">
+                <span class="w-4 h-4 rounded-full shrink-0" style="background:var(--color-online); box-shadow:0 0 0 4px color-mix(in srgb, var(--color-online) 25%, transparent)" aria-hidden="true"></span>
+                <p class="font-bold text-on-surface">Connection working</p>
+              </div>
+              <button class="flex items-center justify-center gap-2 w-full rounded-xl font-headline font-bold bg-primary text-on-primary h-14 px-5 text-lg" style="box-shadow:0 10px 15px -3px rgba(51,37,59,.1)">
+                Continue
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M5 12h14M12 5l7 7-7 7"/></svg>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="text-xs mt-2 text-center" style="color:#4a454b"><strong>Healthy</strong> — canary <code class="bg-black/5 px-1 rounded">reachable</code>. Also the <code class="bg-black/5 px-1 rounded">unknown</code> / source-build copy.</p>
+    </div>
+
+    <!-- AT-RISK -->
+    <div>
+      <div class="device-frame">
+        <div class="flex items-center justify-between border-b border-outline-variant">
+          <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+          <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+          <div class="w-20"></div>
+        </div>
+        <div class="px-8 py-10 flex flex-col items-center" style="min-height:520px">
+          <div class="w-full max-w-md">
+            <div class="flex items-center gap-2 mb-8" aria-hidden="true">
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+            </div>
+            <div class="mb-8">
+              <h1 class="text-3xl font-headline font-extrabold text-accent tracking-tight mb-3">Limited connection</h1>
+              <p class="text-on-surface-variant leading-relaxed">Connections to some people will work; to many others they'll fail.</p>
+            </div>
+            <div class="bg-surface-container-low rounded-2xl p-8" style="box-shadow:0 12px 40px rgba(74,59,82,0.04)">
+              <div role="status" aria-live="polite" class="flex items-start gap-4">
+                <span class="w-4 h-4 rounded-full shrink-0 mt-1.5" style="background:var(--color-secondary-container); box-shadow:0 0 0 4px color-mix(in srgb, var(--color-secondary-container) 30%, transparent)" aria-hidden="true"></span>
+                <div>
+                  <p class="font-bold text-on-surface">Your connection uses changing ports</p>
+                  <p class="text-sm text-on-surface-variant leading-relaxed mt-1">Mobile routers and phone tethering are the usual cause.</p>
+                </div>
+              </div>
+              <div class="mt-6 flex flex-col gap-3">
+                <button class="flex items-center justify-center gap-2 w-full rounded-xl font-headline font-bold bg-primary text-on-primary h-14 px-5 text-lg" style="box-shadow:0 10px 15px -3px rgba(51,37,59,.1)">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
+                  Check again
+                </button>
+                <button class="flex items-center justify-center gap-2 w-full rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">Continue anyway</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="text-xs mt-2 text-center" style="color:#4a454b"><strong>At-risk</strong> — symmetric NAT. The report's actual state.</p>
+    </div>
+
+    <!-- BLOCKED -->
+    <div>
+      <div class="device-frame">
+        <div class="flex items-center justify-between border-b border-outline-variant">
+          <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+          <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+          <div class="w-20"></div>
+        </div>
+        <div class="px-8 py-10 flex flex-col items-center" style="min-height:520px">
+          <div class="w-full max-w-md">
+            <div class="flex items-center gap-2 mb-8" aria-hidden="true">
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+              <span class="h-1 flex-1 rounded-full bg-primary"></span>
+            </div>
+            <div class="mb-8">
+              <h1 class="text-3xl font-headline font-extrabold text-accent tracking-tight mb-3">Your network is blocking Mirall</h1>
+              <p class="text-on-surface-variant leading-relaxed">We can find other people, but we can't connect to them.</p>
+            </div>
+            <div class="bg-surface-container-low rounded-2xl p-8" style="box-shadow:0 12px 40px rgba(74,59,82,0.04)">
+              <div role="status" aria-live="polite" class="flex items-start gap-4 mb-6">
+                <span class="w-4 h-4 rounded-full shrink-0 mt-1.5 bg-error" style="box-shadow:0 0 0 4px color-mix(in srgb, var(--color-error) 25%, transparent)" aria-hidden="true"></span>
+                <div>
+                  <p class="font-bold text-on-surface">No connection to other people</p>
+                  <p class="text-sm text-on-surface-variant leading-relaxed mt-1">Invites and shares won't arrive while this is the case.</p>
+                </div>
+              </div>
+              <ol class="space-y-3 mb-6">
+                <li class="flex items-start gap-3">
+                  <span class="shrink-0 w-5 h-5 rounded-full bg-primary text-on-primary font-headline font-bold text-[10px] flex items-center justify-center mt-0.5" aria-hidden="true">1</span>
+                  <span class="text-sm text-on-surface leading-relaxed">Turn off your VPN.</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="shrink-0 w-5 h-5 rounded-full bg-primary text-on-primary font-headline font-bold text-[10px] flex items-center justify-center mt-0.5" aria-hidden="true">2</span>
+                  <span class="text-sm text-on-surface leading-relaxed">Use a cable or DSL connection instead of mobile.</span>
+                </li>
+                <li class="flex items-start gap-3">
+                  <span class="shrink-0 w-5 h-5 rounded-full bg-primary text-on-primary font-headline font-bold text-[10px] flex items-center justify-center mt-0.5" aria-hidden="true">3</span>
+                  <span class="text-sm text-on-surface leading-relaxed">Try a different Wi-Fi.</span>
+                </li>
+              </ol>
+              <div class="flex flex-col gap-3">
+                <button class="flex items-center justify-center gap-2 w-full rounded-xl font-headline font-bold bg-primary text-on-primary h-14 px-5 text-lg" style="box-shadow:0 10px 15px -3px rgba(51,37,59,.1)">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 12a9 9 0 1 1-3-6.7"/><path d="M21 3v6h-6"/></svg>
+                  Check again
+                </button>
+                <button class="flex items-center justify-center gap-2 w-full rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">Continue anyway</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <p class="text-xs mt-2 text-center" style="color:#4a454b"><strong>Blocked</strong> — canary <code class="bg-black/5 px-1 rounded">unreachable</code> after stage 1 found the seeder.</p>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-4 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>A11y:</strong> focus moves to the step heading on mount; the result sits in
+    <code class="text-xs bg-black/5 px-1 rounded">role="status" aria-live="polite"</code> so the outcome is
+    announced when the probe settles rather than silently swapping. The progress bar is
+    <code class="text-xs bg-black/5 px-1 rounded">aria-hidden</code> (decorative — step position is already in the
+    heading). Every button has a visible name; nothing relies on the lamp colour.
+    <br/><br/>
+    <strong>Seeder-down / source build:</strong> both resolve to the <em>healthy-toned</em> card with neutral copy
+    and a plain "Continue" — never the red state. A developer on an
+    <code class="text-xs bg-black/5 px-1 rounded">UPGRADE_KEY=none</code> build, or any user during one of our
+    outages, must not be told their network is broken.
+  </div>
+</section>
+
+
+<!-- =========== SECTION 7: network status screen =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">7 · Network status — plain summary, with the detail in a file</h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    Today the only route to any of this is a disclosure labelled "Address, NAT, DHT, counters", which then shows
+    ~15 rows of raw protocol data — public IP, UDP ports, <code class="bg-black/5 px-1 rounded text-xs">firewalled</code>,
+    <code class="bg-black/5 px-1 rounded text-xs">randomized</code>, <code class="bg-black/5 px-1 rounded text-xs">ephemeral</code>,
+    routing-table size. An ordinary user can read none of it, and two of those NAT flags are misleading anyway.
+    <br/>
+    <strong>Three deltas:</strong> a <strong>Connection summary</strong> in plain language that a user could read
+    back over the phone; a <strong>Diagnostics</strong> card that saves the full detail as a file; and the raw
+    fields demoted to a genuinely optional disclosure rather than being the only way in.
+  </p>
+
+  <div class="device-frame">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="px-8 pt-8 pb-10" style="min-height:760px">
+      <div class="max-w-2xl mx-auto">
+        <div class="flex items-start gap-4 mb-8">
+          <button aria-label="Back" class="w-10 h-10 mt-1 shrink-0 rounded-full hover:bg-surface-container-high flex items-center justify-center">
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-accent" aria-hidden="true"><path d="M19 12H5M12 19l-7-7 7-7"/></svg>
+          </button>
+          <div>
+            <h1 class="text-4xl font-headline font-extrabold text-accent tracking-tight">Network status</h1>
+            <p class="text-on-surface-variant mt-1">Connection details and diagnostics.</p>
+          </div>
+        </div>
+
+        <div class="space-y-8">
+          <!-- Verdict -->
+          <section>
+            <div class="bg-surface-container-low rounded-xl p-6 flex items-center gap-5">
+              <span class="w-4 h-4 rounded-full shrink-0" style="background:var(--color-secondary-container); box-shadow:0 0 0 4px color-mix(in srgb, var(--color-secondary-container) 30%, transparent)" aria-hidden="true"></span>
+              <div role="status" aria-live="polite" class="flex-1 min-w-0">
+                <p class="text-2xl font-headline font-bold text-accent">Limited connection</p>
+                <p class="text-sm text-on-surface-variant mt-1">Your connection uses a different port every time. Connections to many people will fail.</p>
+              </div>
+              <button class="px-4 py-2 rounded-xl bg-primary text-on-primary font-semibold text-sm">Reconnect</button>
+            </div>
+          </section>
+
+          <!-- Suggestions, promoted -->
+          <section>
+            <h2 class="text-xl font-headline font-bold text-accent mb-4">Suggestions</h2>
+            <ul class="bg-surface-container-low rounded-xl p-6 space-y-3 text-sm text-on-surface">
+              <li class="flex items-start gap-3">
+                <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="shrink-0 text-secondary mt-0.5" aria-hidden="true"><path d="M9 18h6M10 22h4M12 2a7 7 0 0 0-4 12.7V17h8v-2.3A7 7 0 0 0 12 2Z"/></svg>
+                <span>On a mobile network there's no router setting that fixes this. A cable or DSL connection will work.</span>
+              </li>
+            </ul>
+          </section>
+
+          <!-- NEW: Connection summary, plain language -->
+          <section>
+            <h2 class="text-xl font-headline font-bold text-accent mb-4">Connection summary</h2>
+            <div class="bg-surface-container-low rounded-xl">
+              <div class="px-6 py-4 flex items-center gap-4" style="border-bottom:1px solid color-mix(in srgb, var(--color-surface-container-high) 30%, transparent)">
+                <span class="text-sm text-on-surface-variant w-56 shrink-0">Connection</span>
+                <span class="flex-1 min-w-0 text-sm text-accent">Limited</span>
+              </div>
+              <div class="px-6 py-4 flex items-center gap-4" style="border-bottom:1px solid color-mix(in srgb, var(--color-surface-container-high) 30%, transparent)">
+                <span class="text-sm text-on-surface-variant w-56 shrink-0">Reachable from outside</span>
+                <span class="flex-1 min-w-0 text-sm text-accent">No — your network uses changing ports</span>
+              </div>
+              <div class="px-6 py-4 flex items-center gap-4" style="border-bottom:1px solid color-mix(in srgb, var(--color-surface-container-high) 30%, transparent)">
+                <span class="text-sm text-on-surface-variant w-56 shrink-0">Connection test</span>
+                <span class="flex-1 min-w-0 text-sm text-accent">Failed · 2 min ago</span>
+              </div>
+              <div class="px-6 py-4 flex items-center gap-4" style="border-bottom:1px solid color-mix(in srgb, var(--color-surface-container-high) 30%, transparent)">
+                <span class="text-sm text-on-surface-variant w-56 shrink-0">People</span>
+                <span class="flex-1 min-w-0 text-sm text-accent">4 found · 0 connected</span>
+              </div>
+              <div class="px-6 py-4 flex items-center gap-4">
+                <span class="text-sm text-on-surface-variant w-56 shrink-0">Running for</span>
+                <span class="flex-1 min-w-0 text-sm text-accent">12 minutes</span>
+              </div>
+            </div>
+          </section>
+
+          <!-- NEW: Diagnostics export -->
+          <section>
+            <h2 class="text-xl font-headline font-bold text-accent mb-4">Diagnostics</h2>
+            <div class="bg-surface-container-low rounded-xl p-6 space-y-5">
+              <p class="text-sm text-on-surface-variant leading-relaxed">
+                If we ask you for details, save this file and send it to us. It describes how your network behaves —
+                not what you share or who you share it with.
+              </p>
+
+              <div class="rounded-xl bg-surface-container-lowest p-5 space-y-4">
+                <div class="flex items-start gap-3">
+                  <input id="mock-redact" type="checkbox" checked class="mt-1 w-4 h-4 shrink-0" />
+                  <label for="mock-redact" class="text-sm text-on-surface leading-relaxed">
+                    <span class="font-bold">Remove identifying details</span>
+                    <span class="block text-on-surface-variant mt-0.5">Your IP address, keys and space names are shortened or left out. Recommended — this is enough for us to diagnose connection problems.</span>
+                  </label>
+                </div>
+                <div class="flex items-start gap-3">
+                  <input id="mock-logs" type="checkbox" class="mt-1 w-4 h-4 shrink-0" />
+                  <label for="mock-logs" class="text-sm text-on-surface leading-relaxed">
+                    <span class="font-bold">Include detailed logs</span>
+                    <span class="block text-on-surface-variant mt-0.5">Turns on detailed logging, then asks you to reproduce the problem before saving.</span>
+                  </label>
+                </div>
+              </div>
+
+              <div class="flex items-center gap-3 flex-wrap">
+                <button class="flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-headline font-bold bg-primary text-on-primary px-5 py-2.5 text-sm" style="box-shadow:0 10px 15px -3px rgba(51,37,59,.1)">
+                  <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><path d="M7 10l5 5 5-5M12 15V3"/></svg>
+                  Save diagnostics
+                </button>
+                <button class="flex items-center justify-center gap-2 whitespace-nowrap rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">
+                  Preview what's included
+                </button>
+              </div>
+
+              <div class="flex items-center gap-3 pt-1">
+                <span class="text-xs text-on-surface-variant">Reference code</span>
+                <span class="text-xs font-mono text-accent">4f2a-91c7</span>
+                <button aria-label="Copy reference code" class="w-7 h-7 rounded-lg hover:bg-surface-container-high flex items-center justify-center">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-outline" aria-hidden="true"><rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h10"/></svg>
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <!-- advanced disclosure — now genuinely optional -->
+          <section>
+            <button aria-expanded="false" class="w-full bg-surface-container-low rounded-xl p-4 flex items-center gap-3 text-left">
+              <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" class="text-outline" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
+              <span class="font-medium text-accent">Show advanced details</span>
+              <span class="ml-auto text-xs text-on-surface-variant">Address, NAT, DHT, counters</span>
+            </button>
+          </section>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>What each summary row hides:</strong> "Reachable from outside" collapses
+    <code class="text-xs bg-black/5 px-1 rounded">firewalled</code> + <code class="text-xs bg-black/5 px-1 rounded">randomized</code> +
+    <code class="text-xs bg-black/5 px-1 rounded">publicPort</code> into one sentence — and drops
+    <code class="text-xs bg-black/5 px-1 rounded">ephemeral</code> entirely, which is
+    <code class="text-xs bg-black/5 px-1 rounded">true</code> for every consumer client and means nothing to anyone.
+    "People" is <code class="text-xs bg-black/5 px-1 rounded">peerReach.discovered</code> vs
+    <code class="text-xs bg-black/5 px-1 rounded">.connected</code>: the gap between those two numbers is the single
+    most diagnostic thing on the screen, and today neither is shown.
+    <br/><br/>
+    <strong>Delivery reuses an existing pattern.</strong> <code class="text-xs bg-black/5 px-1 rounded">ActivityLogSettings.tsx:52-70</code>
+    already does worker → JSON payload → <code class="text-xs bg-black/5 px-1 rounded">Blob</code> →
+    <code class="text-xs bg-black/5 px-1 rounded">&lt;a download&gt;</code>. No save dialog, no main-process change,
+    no new dependency.
+    <br/><br/>
+    <strong>Reference code</strong> is the first 8 chars of the existing
+    <code class="text-xs bg-black/5 px-1 rounded">installId</code> — already sent as the
+    <code class="text-xs bg-black/5 px-1 rounded">x-mirall-install-id</code> header on every feedback POST, so a
+    saved file and a feedback message correlate with no new infrastructure.
+  </div>
+</section>
+
+
+<!-- =========== SECTION 7b: the preview =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">7b · "Preview what's included"</h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    The trust move. A privacy-focused app that masks your IP behind a reveal-with-30s-auto-hide on the very same
+    screen cannot then ship that IP off in a file without showing you. The preview renders the <em>actual</em>
+    bundle that will be written — redactions already applied — in a scrollable
+    <code class="bg-black/5 px-1 rounded text-xs">Modal</code>.
+  </p>
+
+  <div class="device-frame relative">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="relative" style="min-height:560px">
+      <div class="px-8 pt-8 opacity-40">
+        <h1 class="text-4xl font-headline font-extrabold text-accent tracking-tight">Network status</h1>
+        <div class="mt-6 space-y-3">
+          <div class="h-20 rounded-xl bg-surface-container-low"></div>
+          <div class="h-32 rounded-xl bg-surface-container-low"></div>
+        </div>
+      </div>
+
+      <div class="absolute inset-0 flex items-center justify-center p-6" style="background:rgba(15,12,20,0.5)">
+        <div role="dialog" aria-modal="true" aria-labelledby="preview-title"
+             class="w-full max-w-xl bg-surface-container-lowest rounded-2xl shadow-2xl overflow-hidden flex flex-col" style="max-height:480px">
+          <div class="px-6 py-5 shrink-0" style="border-bottom:1px solid var(--color-outline-variant)">
+            <h2 id="preview-title" class="text-xl font-headline font-bold text-accent">What's in the file</h2>
+            <p class="text-sm text-on-surface-variant mt-1">Identifying details removed. This is exactly what will be saved.</p>
+          </div>
+
+          <div class="px-6 py-5 overflow-y-auto text-xs font-mono leading-relaxed" style="color:var(--color-on-surface-variant)">
+<pre style="white-space:pre-wrap">{
+  "schema": 1,
+  "reference": "4f2a-91c7",
+  "app":     { "version": "1.7.1", "channel": "prod", "build": "packaged" },
+  "system":  { "platform": "darwin", "release": "24.6.0", "arch": "arm64" },
+
+  "verdict": {
+    "current": { "verdict": "at-risk", "cause": "symmetric-nat",
+                 "confidence": "measured", "since": 1756000000000 },
+    "history": [
+      { "at": 1755999100000, "verdict": "unknown"  },
+      { "at": 1755999103400, "verdict": "at-risk", "cause": "symmetric-nat" }
+    ]
+  },
+
+  "network": {
+    "dhtReady": true, "readyAfterMs": 3400,
+    "publicHostKnown": true,          <span style="opacity:.65">// the IP itself is NOT included</span>
+    "publicHostChanged": false,
+    "publicPort": 0,                  <span style="opacity:.65">// 0 = symmetric NAT — the finding</span>
+    "localPortStable": true,
+    "firewalled": true, "randomized": true, "ephemeral": true,
+    "routingTableSize": 50,
+    "health": { "degraded": false, "timeoutsRate": 0.04, "cold": false }
+  },
+
+  "peers": {
+    "discovered": 4, "connected": 0, "exhausted": 4,
+    "dials": { "attempted": 17, "opened": 0, "closed": 17 },
+    "samples": [
+      { "peer": "a91c…", "topic": "t0", "attempts": 5, "proven": false },
+      { "peer": "3f77…", "topic": "t0", "attempts": 4, "proven": false }
+    ]
+  },
+
+  "canary": {
+    "state": "unreachable",
+    "stage1": { "announceRecords": 3, "ms": 820 },
+    "stage2": { "dials": 3, "opened": 0, "ms": 30000 }
+  },
+
+  "spaces": { "count": 1, "topics": ["t0"] },   <span style="opacity:.65">// names and ids omitted</span>
+
+  "logs": <span style="opacity:.65">"(not included — enable detailed logs first)"</span>
+}</pre>
+          </div>
+
+          <div class="px-6 py-4 shrink-0 flex items-center gap-3" style="border-top:1px solid var(--color-outline-variant)">
+            <button class="rounded-xl font-headline font-bold bg-primary text-on-primary px-5 py-2.5 text-sm">Save file</button>
+            <button class="rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">Close</button>
+            <span class="ml-auto text-xs text-on-surface-variant">~14 KB</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>The redaction rule that makes this work:</strong> for connectivity debugging we need
+    <em>shapes</em>, not identities. Whether host consensus formed, whether the port is 0, whether it changed over
+    time, how many dials opened — none of that requires the actual IP, the real keys, or space names. So the default
+    bundle answers every diagnostic question while carrying almost nothing identifying, and "remove identifying
+    details" can stay checked for essentially every real support case.
+    <br/><br/>
+    <strong>The one genuinely new dependency:</strong> <code class="text-xs bg-black/5 px-1 rounded">logs</code>.
+    <code class="text-xs bg-black/5 px-1 rounded">logger.js</code> writes to <code class="text-xs bg-black/5 px-1 rounded">console</code>
+    only — nothing is ever persisted — and at default level it emits <em>warn and error only</em>. Main already taps
+    every stream (worker <code class="text-xs bg-black/5 px-1 rounded">stdout</code>/<code class="text-xs bg-black/5 px-1 rounded">stderr</code>
+    at <code class="text-xs bg-black/5 px-1 rounded">main.js:741-747</code>, its own console at
+    <code class="text-xs bg-black/5 px-1 rounded">installMainLogForwarding</code>, and the renderer echo) but keeps
+    none of it. A bounded ring buffer there is the whole feature — see the plan's Phase 10.
+    <br/><br/>
+    <strong>A11y:</strong> the preview is a real <code class="text-xs bg-black/5 px-1 rounded">Modal</code> — focus
+    trapped, Escape closes, <code class="text-xs bg-black/5 px-1 rounded">aria-modal</code> with a labelled title.
+    The <code class="text-xs bg-black/5 px-1 rounded">&lt;pre&gt;</code> is scrollable and keyboard-focusable so it
+    can be read without a mouse. The two checkboxes are real inputs with real
+    <code class="text-xs bg-black/5 px-1 rounded">&lt;label&gt;</code>s, not styled divs.
+  </div>
+</section>
+
+
+<!-- =========== SECTION 8: rejected alternative =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14">
+  <h2 class="font-headline font-extrabold text-lg mb-1" style="color:#33253b">
+    8 · Rejected alternatives <span class="text-xs font-bold ml-1 px-2 py-1 rounded-full align-middle" style="background:#ffdad6;color:#93000a">not building these</span>
+  </h2>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    Kept so the decisions stay legible. <strong>8a</strong> reused the
+    <code class="bg-black/5 px-1 rounded text-xs">UpdateBanner</code> slot for connectivity errors;
+    <strong>8b</strong> blocked the current screen with a modal.
+  </p>
+  <h3 class="font-headline font-bold text-base mb-2" style="color:#33253b">8a · Persistent top banner</h3>
+
+  <div class="device-frame opacity-60">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="bg-surface-container-lowest/70">
+      <div class="flex items-center py-4 px-8 max-w-7xl mx-auto relative">
+        <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <span class="text-2xl font-extrabold text-black dark:text-white tracking-tighter font-headline">Mirall<span style="color:#fd9c42">.</span></span>
+        </div>
+      </div>
+    </div>
+    <div class="bg-error-container text-on-error-container px-8 py-2 flex items-center justify-between">
+      <span class="text-sm font-semibold">Your network is blocking connections to other people.</span>
+      <span class="text-xs font-bold underline">What can I do?</span>
+    </div>
+    <div class="bg-secondary-container text-on-secondary-container px-8 py-2 flex items-center justify-between">
+      <span class="text-sm font-semibold">Update 1.8.0 downloaded — applied on next start</span>
+      <span class="text-xs font-bold px-3 py-1 rounded bg-secondary text-on-secondary">Dismiss</span>
+    </div>
+    <div class="px-8 py-10 text-center text-on-surface-variant text-sm">…app content pushed down by two stacked banners…</div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>Why rejected:</strong>
+    <br/>· The update banner is for <em>updates</em>. Overloading it with error messaging dilutes what it means and
+    trains people to ignore it.
+    <br/>· Two banners stack, as shown, and both would fight over
+    <code class="text-xs bg-black/5 px-1 rounded">--banner-h</code> — <code class="text-xs bg-black/5 px-1 rounded">UpdateBanner</code>
+    is its sole owner today and resets it to <code class="text-xs bg-black/5 px-1 rounded">0px</code> on unmount, so
+    last-effect-wins would hide content under the fixed nav. Dropping this treatment removes the need for the
+    <code class="text-xs bg-black/5 px-1 rounded">BannerStack</code> refactor entirely.
+    <br/>· A permanent bar is the wrong weight for something a user can act on once: it nags on every screen without
+    ever explaining more.
+    <br/><strong>Superseded by:</strong> §8b's rejection too — see below for why the modal went the same way.
+  </div>
+
+
+  <h3 class="font-headline font-bold text-base mb-2 mt-10" style="color:#33253b">8b · Blocking modal over the current screen</h3>
+  <p class="text-sm mb-4" style="color:#4a454b">
+    The shape suggested for the case where a user has already navigated into a space when the verdict lands.
+  </p>
+
+  <div class="device-frame opacity-60 relative">
+    <div class="flex items-center justify-between border-b border-outline-variant">
+      <div class="traffic-lights"><span class="r"></span><span class="y"></span><span class="g"></span></div>
+      <div class="px-4 text-xs font-bold tracking-wide uppercase text-on-surface-variant">Mirall</div>
+      <div class="w-20"></div>
+    </div>
+    <div class="relative" style="min-height:420px">
+      <!-- the space the user was working in, scrimmed out -->
+      <div class="px-8 pt-8">
+        <h1 class="text-4xl font-headline font-extrabold text-accent tracking-tighter">Project Aurora</h1>
+        <div class="mt-6 space-y-3">
+          <div class="h-16 rounded-2xl bg-surface-container-low"></div>
+          <div class="h-16 rounded-2xl bg-surface-container-low"></div>
+          <div class="h-16 rounded-2xl bg-surface-container-low"></div>
+        </div>
+      </div>
+      <!-- scrim + modal (Modal.tsx pattern) -->
+      <div class="absolute inset-0 flex items-center justify-center" style="background:rgba(15,12,20,0.5)">
+        <div role="dialog" aria-modal="true" aria-labelledby="rej-modal-title"
+             class="w-full max-w-md mx-6 bg-surface-container-lowest rounded-2xl p-8 shadow-2xl">
+          <div class="flex items-start gap-4">
+            <span class="w-4 h-4 rounded-full shrink-0 mt-1.5 bg-error" aria-hidden="true"></span>
+            <div>
+              <h2 id="rej-modal-title" class="text-xl font-headline font-bold text-accent">Your network is blocking Mirall</h2>
+              <p class="text-sm text-on-surface-variant mt-2 leading-relaxed">Invites and shares won't arrive while this is the case.</p>
+            </div>
+          </div>
+          <div class="mt-6 flex gap-3">
+            <button class="flex-1 rounded-xl font-headline font-bold bg-primary text-on-primary px-5 py-2.5 text-sm">Check again</button>
+            <button class="flex-1 rounded-xl font-headline font-bold bg-surface-container-high text-on-surface-variant px-5 py-2.5 text-sm">Dismiss</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="note-plate rounded-xl p-4 mt-3 text-xs leading-relaxed" style="color:#4a454b">
+    <strong>Why rejected:</strong>
+    <br/>· <strong>The premise mostly doesn't hold.</strong> §1b: Tier 1 lands in ~1–3 s, at the same instant
+    <code class="text-xs bg-black/5 px-1 rounded">dhtReady</code> flips, because
+    <code class="text-xs bg-black/5 px-1 rounded">dht-rpc</code> emits
+    <code class="text-xs bg-black/5 px-1 rounded">'ready'</code> only after the bootstrap walk that already sampled
+    the NAT. The user has not navigated anywhere yet — there is no context to seize.
+    <br/>· <strong>Where the premise does hold, seizing is exactly wrong.</strong> A verdict that arrives 30 s+ in
+    (network change, Tier 2 evidence, VPN toggled) finds someone mid-task. Yanking them out of a space to announce
+    something they cannot fix in the next five seconds is the classic interrupting-dialog antipattern.
+    <br/>· <strong>Blocking isn't justified.</strong> Creating a space works fine offline; only inviting and syncing
+    fail. A modal that blocks access asserts a severity the situation doesn't have.
+    <br/>· <strong>No room to explain.</strong> The fix list is the actually useful content, and it doesn't fit a
+    dialog without becoming a scrolling wall.
+    <br/><strong>Chosen instead:</strong> fast ⇒ screen (§2, §3), slow ⇒ toast (§1, §5). The toast's action
+    navigates to the same screen, so there is exactly one place the explanation lives.
+  </div>
+</section>
+
+
+<!-- =========== Faithfulness notes =========== -->
+<section class="max-w-[1100px] mx-auto px-6 pt-14 pb-16">
+  <h2 class="font-headline font-extrabold text-lg mb-3" style="color:#33253b">Notes</h2>
+  <div class="note-plate rounded-2xl p-6">
+    <ul class="space-y-3 text-sm leading-relaxed" style="color:#4a454b">
+      <li>· <strong>Recreated from code:</strong> spaces header / filter chips / empty state
+        (<code class="text-xs bg-black/5 px-1 rounded">SharedSpaces.tsx</code>); toast container, variant fills,
+        action button and countdown-ring dismiss (<code class="text-xs bg-black/5 px-1 rounded">Toast.tsx</code>,
+        <code class="text-xs bg-black/5 px-1 rounded">types.ts</code>); top nav incl. the avatar status ring
+        (<code class="text-xs bg-black/5 px-1 rounded">TopNav.tsx</code>); onboarding card shell
+        (<code class="text-xs bg-black/5 px-1 rounded">Onboarding.tsx</code>); verdict card, Section/Field rows,
+        suggestions list, advanced disclosure (<code class="text-xs bg-black/5 px-1 rounded">NetworkStatus.tsx</code>);
+        button geometry from the <code class="text-xs bg-black/5 px-1 rounded">Button</code> primitive; the
+        Connection problem screen is assembled entirely from existing recipes — the
+        <code class="text-xs bg-black/5 px-1 rounded">PageHeader</code> block, the
+        <code class="text-xs bg-black/5 px-1 rounded">VerdictBanner</code> card, and the
+        <code class="text-xs bg-black/5 px-1 rounded">Section</code> list container, all from
+        <code class="text-xs bg-black/5 px-1 rounded">NetworkStatus.tsx</code>. No new primitive.</li>
+      <li>· <strong>Real strings used verbatim:</strong> "Shared / Spaces", "Create spaces to share files with your
+        colleagues and peers.", "All Spaces", "Favorites", "Create Space", "Join Space", "No spaces yet", "Create one
+        or join with an invite code.", "Back online", "Network status", "Connection details and diagnostics.",
+        "Reconnect", "Suggestions", "Connected peers", "Spaces joined", "Show advanced details",
+        "Address, NAT, DHT, counters", "Continue", "Dismiss".</li>
+      <li>· <strong>Proposed new copy</strong> (to be added to all five locales; German uses the generic masculine,
+        no inclusive forms): the whole Connection problem screen (title, subtitle, verdict copy, fix list,
+        "Check again", "Continue to Spaces"), the blocked/at-risk toasts, the whole onboarding step, "Peers found",
+        "Connection test", the whole Connection summary and Diagnostics sections, and the preview modal.</li>
+      <li>· <strong>Tokens only</strong> — no raw hex except the two SpaceCard icon tiles (the curated space-icon
+        palette) and the traffic lights. The two documented divergences: the at-risk lamp uses
+        <code class="text-xs bg-black/5 px-1 rounded">secondary-container</code> rather than
+        <code class="text-xs bg-black/5 px-1 rounded">warning</code> (legibility at 16px on a near-white surface),
+        and icons are inline stroke SVGs approximating Material Symbols — the one divergence
+        <code class="text-xs bg-black/5 px-1 rounded">mockups.md</code> permits.</li>
+      <li>· <strong>A11y bar:</strong> every state region is <code class="text-xs bg-black/5 px-1 rounded">role="status"</code>
+        (or <code class="text-xs bg-black/5 px-1 rounded">role="alert"</code> for the error toast, matching the
+        shipped component); status is always in text, never colour alone; all lamps and step numerals are
+        <code class="text-xs bg-black/5 px-1 rounded">aria-hidden</code>; every control is a real
+        <code class="text-xs bg-black/5 px-1 rounded">&lt;button&gt;</code> with an accessible name and a
+        focus-visible ring, so <code class="text-xs bg-black/5 px-1 rounded">agent-desktop</code> can target it by
+        name/role in the frontend scenarios.</li>
+      <li>· <strong>Out of scope</strong> (deferred to
+        <code class="text-xs bg-black/5 px-1 rounded">plan-pairwise-connectivity-diagnostics.md</code>): per-member
+        direct / relayed / unreachable badges, the per-space stalled-join notice, per-space toast IDs. §5
+        deliberately shows spaces reading a plain "Offline" to make that gap visible rather than implying this
+        delivery closes it. Relay fallback is a separate later delivery.</li>
+    </ul>
+  </div>
+</section>
+
+<script>
+  const btn = document.getElementById('theme-toggle')
+  btn.addEventListener('click', () => {
+    document.documentElement.classList.toggle('dark')
+    document.body.classList.toggle('dark')
+  })
+</script>
+
+</body>
+</html>

--- a/src/main/log-ring.js
+++ b/src/main/log-ring.js
@@ -1,0 +1,48 @@
+// Bounded in-memory ring of recent log lines from all three processes. NEVER written to
+// disk: it exists only to be attached to a diagnostics bundle the user explicitly saves.
+const MAX_LINES = 2000
+const MAX_BYTES = 512 * 1024
+const MAX_LINE_LENGTH = 2000
+
+class LogRing {
+  constructor() {
+    this._lines = []
+    this._bytes = 0
+  }
+
+  push(source, level, text) {
+    if (typeof text !== 'string') return
+    for (const raw of text.split('\n')) {
+      const trimmed = raw.trimEnd()
+      if (!trimmed) continue
+      const line = trimmed.length > MAX_LINE_LENGTH
+        ? trimmed.slice(0, MAX_LINE_LENGTH) + '…[truncated]'
+        : trimmed
+      this._lines.push({ at: Date.now(), source, level, text: line })
+      this._bytes += line.length
+    }
+    while (this._lines.length > MAX_LINES || this._bytes > MAX_BYTES) {
+      const dropped = this._lines.shift()
+      if (!dropped) break
+      this._bytes -= dropped.text.length
+    }
+  }
+
+  // Non-mutating: a preview followed by a save must not come back empty.
+  snapshot(redactFn) {
+    return this._lines.map((entry) => ({
+      ...entry,
+      text: redactFn ? redactFn(entry.text) : entry.text,
+    }))
+  }
+
+  get size() {
+    return this._lines.length
+  }
+
+  get bytes() {
+    return this._bytes
+  }
+}
+
+module.exports = { LogRing, logRing: new LogRing(), MAX_LINES, MAX_BYTES, MAX_LINE_LENGTH }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -4,10 +4,11 @@
 // IPC frames renderer↔worker in both directions; runs the chokidar folder
 // watchers on the worker's behalf (Bare has no recursive watch). Main holds no
 // application state — durable state lives in the worker's store.
-const { app, BrowserWindow, Menu, Tray, dialog, ipcMain, nativeImage, nativeTheme, protocol: electronProtocol, shell, webContents } = require('electron')
+const { app, BrowserWindow, Menu, Tray, dialog, ipcMain, nativeImage, nativeTheme, net, protocol: electronProtocol, shell, webContents } = require('electron')
 const path = require('path')
 const fs = require('fs')
 const os = require('os')
+const { logRing } = require('./log-ring')
 
 // Custom app:// scheme. Registered as standard+secure so the renderer
 // document gets a stable origin across webContents.reload — file://
@@ -337,6 +338,19 @@ function getPear() {
 
 // === Renderer broadcast + log forwarding ===
 
+let redactLinePromise = null
+function loadRedactLine() {
+  if (!redactLinePromise) {
+    redactLinePromise = import('../shared/core/diagnostics-redact.js')
+      .then((m) => m.redactLine)
+      .catch((err) => {
+        console.error('[main] redaction module unavailable:', err.message)
+        return null
+      })
+  }
+  return redactLinePromise
+}
+
 function sendToAll(channel, payload) {
   for (const wc of webContents.getAllWebContents()) {
     if (wc.isDestroyed()) continue
@@ -366,8 +380,9 @@ function installMainLogForwarding() {
     const orig = console[level].bind(console)
     console[level] = (...args) => {
       orig(...args)
-      if (!debug || forwarding) return
       const text = format(...args)
+      logRing.push('main', level, text)
+      if (!debug || forwarding) return
       if (text.startsWith(RENDERER_ECHO_PREFIX)) return
       forwarding = true
       try { sendToAll('main:log', { level, text }) } catch {} finally { forwarding = false }
@@ -672,6 +687,7 @@ function getWorker(specifier) {
     type: 'bootstrap',
     storage: p.storage,
     appVersion: version,
+    upgradeKey: upgrade || null,
     dev: isDev,
     verbose,
     downloadFolder: readDownloadFolder(),
@@ -739,11 +755,15 @@ function getWorker(specifier) {
     }
   })
   worker.stdout.on('data', (data) => {
-    if (debug) process.stdout.write('[worker stdout] ' + data.toString())
+    const text = data.toString()
+    if (debug) process.stdout.write('[worker stdout] ' + text)
+    logRing.push('worker', 'log', text)
     sendToAll('pear:worker:stdout:' + specifier, data)
   })
   worker.stderr.on('data', (data) => {
-    process.stderr.write('[worker stderr] ' + data.toString())
+    const text = data.toString()
+    process.stderr.write('[worker stderr] ' + text)
+    logRing.push('worker', 'error', text)
     sendToAll('pear:worker:stderr:' + specifier, data)
   })
 
@@ -831,6 +851,36 @@ ipcMain.handle('app:identityProtection', () => identityProtection)
 // respawned worker inherits it). The renderer flips the already-running worker
 // separately over the worker IPC channel. A non-boolean arg leaves state
 // untouched and just reports it; turning off reverts to the build default.
+// net.online is documented as asymmetric: false is a strong indicator the user cannot
+// reach remote sites, true is inconclusive. So it is only ever used to declare offline —
+// never to declare healthy.
+const NET_ONLINE_POLL_MS = 2000
+let lastNetOnline = null
+
+function startNetOnlineWatch() {
+  const tick = () => {
+    let online = true
+    try { online = net.online !== false } catch {}
+    if (online === lastNetOnline) return
+    lastNetOnline = online
+    sendToAll('net:online', online)
+  }
+  tick()
+  const timer = setInterval(tick, NET_ONLINE_POLL_MS)
+  timer.unref?.()
+}
+
+ipcMain.handle('net:online', () => {
+  try { return net.online !== false } catch { return true }
+})
+
+ipcMain.handle('diagnostics:logs', async (_evt, opts) => {
+  const redactLine = opts?.redact !== false ? await loadRedactLine() : null
+  // Fail closed: if the redaction module could not load, ship no logs rather than raw ones.
+  if (opts?.redact !== false && !redactLine) return []
+  return logRing.snapshot(redactLine)
+})
+
 ipcMain.handle('app:setVerbose', (_evt, on) => {
   if (typeof on === 'boolean') { verbose = on; debug = on || baseDebug }
   return debug
@@ -1230,6 +1280,15 @@ async function createWindow() {
     if (!win.isDestroyed()) win.webContents.setZoomFactor(currentZoom)
   })
 
+  win.webContents.on('console-message', (_e, level, message, line, sourceId) => {
+    // Skip our own forwarded main logs (the renderer prints them as [main] …),
+    // otherwise mirroring them back here would feed the forwarding loop.
+    if (typeof message === 'string' && message.startsWith(MAIN_LOG_PREFIX)) return
+    const tag = ['VERBOSE', 'INFO', 'WARNING', 'ERROR'][level] || 'INFO'
+    logRing.push('renderer', tag.toLowerCase(), `${sourceId}:${line} ${message}`)
+    if (debug) console.log(`[renderer ${tag}] ${sourceId}:${line} ${message}`)
+  })
+
   if (debug) {
     win.webContents.on('did-fail-load', (_e, code, desc, url) => {
       console.error('[mirall] renderer did-fail-load', code, desc, url)
@@ -1237,13 +1296,7 @@ async function createWindow() {
     win.webContents.on('render-process-gone', (_e, details) => {
       console.error('[mirall] renderer process gone:', details)
     })
-    win.webContents.on('console-message', (_e, level, message, line, sourceId) => {
-      // Skip our own forwarded main logs (the renderer prints them as [main] …),
-      // otherwise mirroring them back here would feed the forwarding loop.
-      if (typeof message === 'string' && message.startsWith(MAIN_LOG_PREFIX)) return
-      const tag = ['LOG', 'WARN', 'ERR', 'DEBUG'][level] || 'LOG'
-      console.log(`[renderer ${tag}] ${sourceId}:${line} ${message}`)
-    })
+
     win.webContents.on('preload-error', (_e, preloadPath, err) => {
       console.error('[mirall] preload error in', preloadPath, err)
     })
@@ -1460,6 +1513,7 @@ if (!lock) {
     // can race with _update and return ENOTDIR.
     preloadAsarCache()
     registerAppProtocol()
+    startNetOnlineWatch()
     require('./notifications').register({
       revealWindow,
       downloadRoots: () => [readDownloadFolder(), ...workerDownloadRoots],

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -19,6 +19,14 @@ contextBridge.exposeInMainWorld('bridge', {
   getChangelog: () => ipcRenderer.invoke('app:getChangelog'),
   getIdentityProtection: () => ipcRenderer.invoke('app:identityProtection'),
   setVerbose: (on) => ipcRenderer.invoke('app:setVerbose', on),
+  getDiagnosticLogs: (opts) => ipcRenderer.invoke('diagnostics:logs', opts),
+  getNetOnline: () => ipcRenderer.invoke('net:online'),
+  onNetOnlineChange: (listener) => {
+    const wrap = (_evt, online) => listener(online)
+    ipcRenderer.on('net:online', wrap)
+    return () => ipcRenderer.removeListener('net:online', wrap)
+  },
+
   onMainLog: (listener) => {
     const wrap = (_evt, payload) => listener(payload)
     ipcRenderer.on('main:log', wrap)

--- a/src/renderer/app.tsx
+++ b/src/renderer/app.tsx
@@ -23,7 +23,7 @@ import CommandPalette from './keyboard/CommandPalette.js'
 import ShortcutsHint from './keyboard/ShortcutsHint.js'
 import type { Command } from './keyboard/registry.js'
 import { HOME_ACCELERATOR } from './keyboard/known-commands.js'
-import type { Space } from './types.js'
+import type { Profile, Space } from './types.js'
 import type { DeepLinkPayload } from './global.js'
 import { decodeInvite } from './invite-envelope.js'
 import { request, subscribe } from './ipc.js'
@@ -49,6 +49,7 @@ const SCREEN_TITLE_KEYS: Record<string, string> = {
   'general-settings': 'a11y.screens.general',
   'network-settings': 'a11y.screens.networkSettings',
   'network-status': 'a11y.screens.network',
+  'connection-problem': 'a11y.screens.connectionProblem',
   'activity-log': 'a11y.screens.activityLog',
   'activity-log-settings': 'a11y.screens.activityLogSettings',
 }
@@ -141,7 +142,7 @@ export default function App() {
   return (
     <ToastProvider>
     <ConnectionStatusProvider>
-    <ConnectivityToastBridge onShowDetails={() => nav.setCurrentScreen('network-status')} />
+    <ConnectivityToastBridge onShowDetails={() => nav.setCurrentScreen('network-status')} onShowHelp={() => nav.setCurrentScreen('connection-problem')} />
     <DownloadFolderToastBridge onChangeFolder={() => nav.openStorageSettings(nav.currentScreen === 'space-view' ? 'space-view' : 'settings')} />
     <WorkerToastBridge />
     <KeyboardProvider currentScreen={nav.currentScreen} selectedSpaceId={nav.selectedSpaceId}>

--- a/src/renderer/components/layout/PageHeader.tsx
+++ b/src/renderer/components/layout/PageHeader.tsx
@@ -1,25 +1,34 @@
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { useTranslation } from 'react-i18next'
 import IconButton from '../primitives/IconButton.js'
 
 interface PageHeaderProps {
   title: string
   subtitle?: ReactNode
-  onBack: () => void
+  onBack?: () => void
+  headingRef?: RefObject<HTMLHeadingElement | null>
 }
 
-export default function PageHeader({ title, subtitle, onBack }: PageHeaderProps) {
+export default function PageHeader({ title, subtitle, onBack, headingRef }: PageHeaderProps) {
   const { t } = useTranslation()
   return (
     <div className="flex items-start gap-4 mb-8">
-      <IconButton
-        icon="arrow_back"
-        onClick={onBack}
-        ariaLabel={t('actions.back')}
-        className="mt-1 shrink-0"
-      />
+      {onBack && (
+        <IconButton
+          icon="arrow_back"
+          onClick={onBack}
+          ariaLabel={t('actions.back')}
+          className="mt-1 shrink-0"
+        />
+      )}
       <div>
-        <h1 className="text-4xl font-headline font-extrabold text-accent tracking-tight">{title}</h1>
+        <h1
+          ref={headingRef}
+          tabIndex={headingRef ? -1 : undefined}
+          className="text-4xl font-headline font-extrabold text-accent tracking-tight focus:outline-none"
+        >
+          {title}
+        </h1>
         {subtitle && (
           <p className="text-on-surface-variant text-lg leading-relaxed">{subtitle}</p>
         )}

--- a/src/renderer/components/layout/ScreenRouter.tsx
+++ b/src/renderer/components/layout/ScreenRouter.tsx
@@ -13,6 +13,8 @@ import NetworkStatus from '../../screens/NetworkStatus.js'
 import Account from '../../screens/Account.js'
 import ActivityLog from '../../screens/ActivityLog.js'
 import ActivityLogSettings from '../../screens/ActivityLogSettings.js'
+import ConnectionProblem from '../../screens/ConnectionProblem.js'
+import { useConnectionGate } from '../../hooks/useConnectionGate.js'
 
 interface ScreenRouterProps {
   nav: AppNavigation
@@ -25,13 +27,27 @@ interface ScreenRouterProps {
 
 export default function ScreenRouter({ nav, profile, onSaveProfile, onOpenFeedback, onShowCreate, onShowJoin }: ScreenRouterProps) {
   const { currentScreen, selectedSpaceId, selectedShare } = nav
+  const gate = useConnectionGate()
   switch (currentScreen) {
     case 'spaces':
-      return (
+      return gate.showConnectionProblem ? (
+        <ConnectionProblem
+          onContinue={gate.dismiss}
+          onShowDetails={() => nav.setCurrentScreen('network-status')}
+        />
+      ) : (
         <SharedSpaces
           onSelectSpace={nav.navigateToSpace}
           onShowCreate={onShowCreate}
           onShowJoin={onShowJoin}
+        />
+      )
+    case 'connection-problem':
+      return (
+        <ConnectionProblem
+          onBack={() => nav.setCurrentScreen('spaces')}
+          onContinue={() => nav.setCurrentScreen('spaces')}
+          onShowDetails={() => nav.setCurrentScreen('network-status')}
         />
       )
     case 'space-view':

--- a/src/renderer/components/layout/TopNav.tsx
+++ b/src/renderer/components/layout/TopNav.tsx
@@ -22,8 +22,8 @@ interface TopNavProps {
 export default function TopNav({ profile, onLogoClick, onSettingsClick, onAccountClick, onFeedbackClick, update, onDismissUpdate }: TopNavProps) {
   const { t } = useTranslation()
   const { state } = useConnectionStatus()
-  const hasIssue = state === 'offline' || state === 'connecting'
-  const statusVariant = state === 'offline' ? 'offline' : state === 'connecting' ? 'connecting' : 'ok'
+  const hasIssue = state === 'offline' || state === 'connecting' || state === 'limited'
+  const statusVariant = state === 'offline' ? 'offline' : hasIssue ? 'connecting' : 'ok'
 
   return (
     <nav className="fixed top-0 w-full z-50" style={{ WebkitAppRegion: 'drag' }}>

--- a/src/renderer/components/modals/DiagnosticsPreviewModal.tsx
+++ b/src/renderer/components/modals/DiagnosticsPreviewModal.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from 'react-i18next'
+import Modal from '../primitives/Modal.js'
+import Button from '../primitives/Button.js'
+import IconButton from '../primitives/IconButton.js'
+import { formatSize } from '../../formatSize.js'
+
+interface Props {
+  isOpen: boolean
+  text: string
+  byteLength: number
+  redacted: boolean
+  onSave: () => void
+  onClose: () => void
+}
+
+export default function DiagnosticsPreviewModal({ isOpen, text, byteLength, redacted, onSave, onClose }: Props) {
+  const { t } = useTranslation()
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} ariaLabel={t('diagnostics.previewTitle')}>
+      <div className="px-10 pt-10 pb-4">
+        <div className="flex justify-between items-start mb-2">
+          <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
+            {t('diagnostics.previewTitle')}
+          </h1>
+          <IconButton
+            icon="close"
+            onClick={onClose}
+            ariaLabel={t('actions.close')}
+            iconClassName="text-secondary"
+          />
+        </div>
+        <p className="text-on-surface-variant font-medium">
+          {redacted ? t('diagnostics.previewIntro') : t('diagnostics.previewIntroRaw')}
+        </p>
+      </div>
+
+      <div className="px-10 pb-4">
+        <pre
+          tabIndex={0}
+          role="region"
+          aria-label={t('diagnostics.previewRegion')}
+          className="max-h-80 overflow-y-auto scrollbar-thin rounded-xl bg-surface-container-lowest p-5 text-xs font-mono whitespace-pre-wrap break-all text-on-surface-variant focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
+        >
+          {text}
+        </pre>
+      </div>
+
+      <div className="px-10 pb-10 flex items-center gap-3">
+        <Button onClick={onSave}>{t('diagnostics.saveFile')}</Button>
+        <Button variant="secondary" onClick={onClose}>{t('actions.close')}</Button>
+        <span className="ml-auto text-xs text-on-surface-variant">
+          {t('diagnostics.approxSize', { size: formatSize(byteLength) })}
+        </span>
+      </div>
+    </Modal>
+  )
+}

--- a/src/renderer/components/settings/DiagnosticsCard.tsx
+++ b/src/renderer/components/settings/DiagnosticsCard.tsx
@@ -1,0 +1,125 @@
+import { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { buildBundle, serialiseBundle, bundleFilename, previewText } from '../../diagnosticsBundle.js'
+import { request } from '../../ipc.js'
+import DiagnosticsPreviewModal from '../modals/DiagnosticsPreviewModal.js'
+import Toggle from '../primitives/Toggle.js'
+import Button from '../primitives/Button.js'
+
+export default function DiagnosticsCard() {
+  const { t } = useTranslation()
+  const [redact, setRedact] = useState(true)
+  const [includeLogs, setIncludeLogs] = useState(false)
+  const [busy, setBusy] = useState(false)
+  const [status, setStatus] = useState<string | null>(null)
+  const [preview, setPreview] = useState<{ text: string; bytes: number; redacted: boolean; serialised: string; filename: string } | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (includeLogs) {
+        window.bridge.setVerbose(false).catch(() => {})
+        request('setVerbose', { verbose: false }).catch(() => {})
+      }
+    }
+  }, [includeLogs])
+
+  function saveSerialised(serialised: string, filename: string) {
+    const blob = new Blob([serialised], { type: 'application/json' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    link.click()
+    URL.revokeObjectURL(url)
+  }
+
+  async function run(action: 'save' | 'preview') {
+    if (busy) return
+    setBusy(true)
+    setStatus(null)
+    try {
+      const bundle = await buildBundle({ redact, includeLogs })
+      const serialised = serialiseBundle(bundle)
+      if (action === 'preview') {
+        setPreview({
+          text: previewText(serialised, t('diagnostics.previewTruncated')),
+          bytes: serialised.length,
+          redacted: redact,
+          serialised,
+          filename: bundleFilename(bundle),
+        })
+        return
+      }
+      saveSerialised(serialised, bundleFilename(bundle))
+      setPreview(null)
+      setStatus(t('diagnostics.saved'))
+    } catch (err) {
+      setStatus(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  // Detailed logging has to be on while the user reproduces the problem, otherwise the
+  // lines we need are the ones that were never recorded.
+  async function handleIncludeLogs(next: boolean) {
+    setIncludeLogs(next)
+    try {
+      await window.bridge.setVerbose(next)
+    } catch {}
+    try {
+      await request('setVerbose', { verbose: next })
+    } catch {}
+    setStatus(next ? t('diagnostics.verboseOn') : null)
+  }
+
+  return (
+    <section>
+      <h2 className="text-xl font-headline font-bold text-accent mb-4">{t('diagnostics.title')}</h2>
+      <div className="bg-surface-container-low rounded-xl p-6 space-y-5">
+        <p className="text-sm text-on-surface-variant leading-relaxed">{t('diagnostics.intro')}</p>
+
+        <div className="rounded-xl bg-surface-container-lowest overflow-hidden divide-y divide-surface-container-high/30">
+          <Toggle
+            label={t('diagnostics.redactLabel')}
+            description={t('diagnostics.redactDescription')}
+            checked={redact}
+            onChange={setRedact}
+          />
+          <Toggle
+            label={t('diagnostics.logsLabel')}
+            description={t('diagnostics.logsDescription')}
+            checked={includeLogs}
+            onChange={handleIncludeLogs}
+          />
+        </div>
+
+        <div className="flex items-center gap-3 flex-wrap">
+          <Button icon="download" onClick={() => run('save')} disabled={busy}>
+            {t('diagnostics.save')}
+          </Button>
+          <Button variant="secondary" onClick={() => run('preview')} disabled={busy}>
+            {t('diagnostics.preview')}
+          </Button>
+        </div>
+
+        <p role="status" aria-live="polite" className="text-xs text-on-surface-variant min-h-4">
+          {status ?? ''}
+        </p>
+      </div>
+
+      <DiagnosticsPreviewModal
+        isOpen={preview !== null}
+        text={preview?.text ?? ''}
+        byteLength={preview?.bytes ?? 0}
+        redacted={preview?.redacted ?? true}
+        onSave={() => {
+          if (preview) saveSerialised(preview.serialised, preview.filename)
+          setPreview(null)
+          setStatus(t('diagnostics.saved'))
+        }}
+        onClose={() => setPreview(null)}
+      />
+    </section>
+  )
+}

--- a/src/renderer/components/widgets/ConnectivityToastBridge.tsx
+++ b/src/renderer/components/widgets/ConnectivityToastBridge.tsx
@@ -4,25 +4,60 @@ import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '../toast/ToastProvider.js'
 import { useConnectionStatus } from '../../hooks/useConnectionStatus.js'
-import type { ConnectivityState } from '../../types.js'
+import type { ConnectivityState, ReachabilityCause, ReachabilityVerdict } from '../../types.js'
 
 const TOAST_ID = 'connectivity'
 
 interface Props {
   onShowDetails: () => void
+  onShowHelp: () => void
 }
 
-export default function ConnectivityToastBridge({ onShowDetails }: Props) {
-  const { state } = useConnectionStatus()
+export default function ConnectivityToastBridge({ onShowDetails, onShowHelp }: Props) {
+  const { state, reachability } = useConnectionStatus()
   const { t } = useTranslation()
   const toast = useToast()
   const previousStateRef = useRef<ConnectivityState | null>(null)
+  const previousVerdictRef = useRef<ReachabilityVerdict | null>(null)
   const seenOnlineRef = useRef<boolean>(false)
   const onShowDetailsRef = useRef(onShowDetails)
+  const onShowHelpRef = useRef(onShowHelp)
 
   useEffect(() => {
     onShowDetailsRef.current = onShowDetails
-  }, [onShowDetails])
+    onShowHelpRef.current = onShowHelp
+  }, [onShowDetails, onShowHelp])
+
+  const verdict = reachability?.verdict ?? null
+  const cause: ReachabilityCause | null = reachability?.cause ?? null
+
+  useEffect(() => {
+    const previousVerdict = previousVerdictRef.current
+    if (previousVerdict === verdict) return
+    previousVerdictRef.current = verdict
+    if (verdict !== 'blocked' && verdict !== 'at-risk') return
+
+    if (cause === 'os-offline') {
+      toast.error(t('connectivity.offlineToast'), {
+        id: TOAST_ID,
+        duration: 0,
+        action: { label: t('connectivity.showDetails'), onClick: () => onShowDetailsRef.current() },
+      })
+      return
+    }
+
+    const key = cause ?? 'generic'
+    const message = verdict === 'blocked'
+      ? t(`connectivity.blockedToast.${key}`, { defaultValue: t('connectivity.blockedToast.generic') })
+      : t(`connectivity.atRiskToast.${key}`, { defaultValue: t('connectivity.atRiskToast.generic') })
+    const options = {
+      id: TOAST_ID,
+      duration: 0,
+      action: { label: t('connectivity.whatCanIDo'), onClick: () => onShowHelpRef.current() },
+    }
+    if (verdict === 'blocked') toast.error(message, options)
+    else toast.warning(message, options)
+  }, [verdict, cause, t, toast])
 
   useEffect(() => {
     const previous = previousStateRef.current
@@ -32,6 +67,10 @@ export default function ConnectivityToastBridge({ onShowDetails }: Props) {
 
     if (previous === state) return
     if (previous === null && state !== 'offline') return
+
+    // The verdict effect above owns every degraded case, os-offline included; this one
+    // keeps the boot and recovery transitions it does not cover.
+    if (verdict === 'blocked' || verdict === 'at-risk') return
 
     if (state === 'offline') {
       toast.error(t('connectivity.offlineToast'), {
@@ -64,7 +103,7 @@ export default function ConnectivityToastBridge({ onShowDetails }: Props) {
         duration: 4000,
       })
     }
-  }, [state, t, toast])
+  }, [state, verdict, t, toast])
 
   return null
 }

--- a/src/renderer/components/widgets/NetworkStatusIndicator.tsx
+++ b/src/renderer/components/widgets/NetworkStatusIndicator.tsx
@@ -12,6 +12,7 @@ interface Props {
 
 const COLOR: Record<ConnectivityState, string> = {
   online: 'bg-online',
+  limited: 'bg-secondary-container',
   connecting: 'bg-warning',
   offline: 'bg-error',
 }
@@ -24,6 +25,7 @@ const DOT_SIZE: Record<IndicatorSize, string> = {
 
 const RING: Record<ConnectivityState, string> = {
   online: 'ring-2 ring-online/30',
+  limited: 'ring-2 ring-secondary-container/30',
   connecting: 'ring-2 ring-warning/30',
   offline: 'ring-2 ring-error/30',
 }

--- a/src/renderer/connectivity.d.ts
+++ b/src/renderer/connectivity.d.ts
@@ -1,0 +1,8 @@
+import type { NetworkStatus, ReachabilityCause } from './types.js'
+
+export type FixStep = 'vpn' | 'mobile' | 'otherNetwork' | 'turnOnNetwork'
+export type ReachableState = 'unknown' | 'noAddress' | 'changingPorts' | 'yes'
+
+export function fixStepsFor(cause: ReachabilityCause | null): FixStep[]
+export function reachableState(status: NetworkStatus): ReachableState
+export function formatDuration(ms: number): string

--- a/src/renderer/connectivity.js
+++ b/src/renderer/connectivity.js
@@ -1,0 +1,27 @@
+// The ordering is a product decision, not cosmetics: a randomised port mapping is
+// overwhelmingly a carrier NAT, and no router setting fixes that one.
+export function fixStepsFor(cause) {
+  // There is no network at all — VPN and NAT advice is noise here.
+  if (cause === 'os-offline') return ['turnOnNetwork']
+  // The tunnel is the only route we have; disconnecting it is the first thing to try.
+  if (cause === 'vpn-only-route') return ['vpn', 'otherNetwork']
+  if (cause === 'symmetric-nat') return ['mobile', 'vpn', 'otherNetwork']
+  return ['vpn', 'mobile', 'otherNetwork']
+}
+
+export function reachableState(status) {
+  if (!status.dhtReady) return 'unknown'
+  if (status.address.publicHost === null) return 'noAddress'
+  if (status.address.publicPort === 0) return 'changingPorts'
+  return 'yes'
+}
+
+export function formatDuration(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return '—'
+  const minutes = Math.floor(ms / 60000)
+  if (minutes < 1) return `${Math.max(0, Math.floor(ms / 1000))}s`
+  if (minutes < 60) return `${minutes}m`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ${minutes % 60}m`
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`
+}

--- a/src/renderer/diagnosticsBundle.ts
+++ b/src/renderer/diagnosticsBundle.ts
@@ -1,0 +1,41 @@
+import { request } from './ipc.js'
+import type { DiagnosticLogEntry } from './types.js'
+
+export interface BundleOptions {
+  redact: boolean
+  includeLogs: boolean
+}
+
+export interface DiagnosticsBundle {
+  schema: number
+  reference: string | null
+  logs: DiagnosticLogEntry[] | null
+  [key: string]: unknown
+}
+
+// Preview and save call this with the same options, so what the user is shown is what
+// gets written.
+export async function buildBundle({ redact, includeLogs }: BundleOptions): Promise<DiagnosticsBundle> {
+  // timeout 0 — matches audit:export; assembling the bundle walks swarm.peers and can
+  // outlast the default request budget.
+  const core = await request('diagnostics:export', { redact }, 0) as DiagnosticsBundle
+  const logs = includeLogs ? await window.bridge.getDiagnosticLogs({ redact }) : null
+  return { ...core, logs }
+}
+
+export function serialiseBundle(bundle: DiagnosticsBundle): string {
+  return JSON.stringify(bundle, null, 2)
+}
+
+export function bundleFilename(bundle: DiagnosticsBundle): string {
+  const stamp = new Date().toISOString().slice(0, 10)
+  const ref = bundle.reference ? `-${bundle.reference}` : ''
+  return `mirall-diagnostics-${stamp}${ref}.json`
+}
+
+const PREVIEW_MAX_CHARS = 64 * 1024
+
+export function previewText(serialised: string, marker: string): string {
+  if (serialised.length <= PREVIEW_MAX_CHARS) return serialised
+  return serialised.slice(0, PREVIEW_MAX_CHARS) + `\n… ${marker}`
+}

--- a/src/renderer/global.d.ts
+++ b/src/renderer/global.d.ts
@@ -1,4 +1,5 @@
 import type { RendererConfig, RendererConfigPatch } from './config-client.js'
+import type { DiagnosticLogEntry } from './types.js'
 
 export interface PkgInfo {
   name: string
@@ -99,6 +100,9 @@ export interface MirallBridge {
   getChangelog(): Promise<string>
   getIdentityProtection(): Promise<IdentityProtection>
   setVerbose(on?: boolean): Promise<boolean>
+  getDiagnosticLogs(opts?: { redact?: boolean }): Promise<DiagnosticLogEntry[]>
+  getNetOnline(): Promise<boolean>
+  onNetOnlineChange(listener: (online: boolean) => void): () => void
   onMainLog(listener: (entry: { level: 'log' | 'warn' | 'error'; text: string }) => void): () => void
   onPearEvent(name: PearEventName, listener: () => void): () => void
 

--- a/src/renderer/hooks/useAppNavigation.ts
+++ b/src/renderer/hooks/useAppNavigation.ts
@@ -76,6 +76,7 @@ export function useAppNavigation(): AppNavigation {
       case 'network-settings':
       case 'general-settings': setCurrentScreen('settings'); break
       case 'network-status': setCurrentScreen('account'); break
+      case 'connection-problem': setCurrentScreen('spaces'); break
       // The viewer hangs off Account and the config off Settings, so each backs out to its own
       // parent; a cross-link between them is a lateral jump, not a step in a history stack.
       case 'activity-log': setCurrentScreen('account'); break

--- a/src/renderer/hooks/useConnectionGate.ts
+++ b/src/renderer/hooks/useConnectionGate.ts
@@ -1,0 +1,36 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useConnectionStatus } from './useConnectionStatus.js'
+import { useSpaces } from './useSpaces.js'
+
+interface ConnectionGate {
+  showConnectionProblem: boolean
+  dismiss: () => void
+}
+
+// Substituting the whole spaces screen is only right when there is nothing to substitute
+// for. With spaces present the toast carries the signal instead.
+export function useConnectionGate(): ConnectionGate {
+  const { reachability } = useConnectionStatus()
+  const { spaces, loading } = useSpaces()
+  const [dismissed, setDismissed] = useState(false)
+  const sinceRef = useRef<number | null>(null)
+
+  const since = reachability?.since ?? null
+
+  useEffect(() => {
+    if (sinceRef.current === since) return
+    sinceRef.current = since
+    // A new episode re-asserts itself rather than staying silently dismissed.
+    setDismissed(false)
+  }, [since])
+
+  const dismiss = useCallback(() => setDismissed(true), [])
+
+  const verdict = reachability?.verdict
+  const degraded = verdict === 'blocked' || verdict === 'at-risk'
+
+  return {
+    showConnectionProblem: degraded && !loading && spaces.length === 0 && !dismissed,
+    dismiss,
+  }
+}

--- a/src/renderer/hooks/useConnectionStatus.tsx
+++ b/src/renderer/hooks/useConnectionStatus.tsx
@@ -10,12 +10,14 @@ import {
   type ReactNode,
 } from 'react'
 import { request, subscribe } from '../ipc.js'
-import type { ConnectivityState, NetworkStatus } from '../types.js'
+import type { CanaryResult, ConnectivityState, NetworkStatus, Reachability } from '../types.js'
 
 interface ConnectionStatusContextValue {
   state: ConnectivityState
   status: NetworkStatus | null
+  reachability: Reachability | null
   reconnect: () => Promise<void>
+  probeCanary: (opts?: { force?: boolean }) => Promise<CanaryResult | null>
 }
 
 const ConnectionStatusContext = createContext<ConnectionStatusContextValue | null>(null)
@@ -27,6 +29,14 @@ function deriveState(status: NetworkStatus | null, browserOnline: boolean, now: 
   if (!browserOnline) return 'offline'
   if (!status) return 'online'
   if (status.suspended) return 'offline'
+
+  // dhtReady alone is NOT connectivity — it only means a bootstrap node answered us.
+  switch (status.reachability?.verdict) {
+    case 'blocked': return 'offline'
+    case 'at-risk': return 'connecting'
+    case 'healthy': return 'online'
+  }
+
   if (status.dhtReady) return 'online'
   const sinceBoot = status.bootedAt > 0 ? now - status.bootedAt : 0
   if (sinceBoot < BOOT_GRACE_MS) return 'online'
@@ -43,6 +53,10 @@ export function ConnectionStatusProvider({ children }: ProviderProps) {
   const [browserOnline, setBrowserOnline] = useState<boolean>(
     typeof navigator !== 'undefined' ? navigator.onLine : true,
   )
+  // Chromium's net.online, read in main. Only ever used to declare offline: Electron
+  // documents `false` as a strong negative and `true` as inconclusive.
+  const [netOnline, setNetOnline] = useState<boolean>(true)
+  const osOnline = browserOnline && netOnline
   const [stableState, setStableState] = useState<ConnectivityState>('online')
   const recheckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
@@ -76,15 +90,32 @@ export function ConnectionStatusProvider({ children }: ProviderProps) {
   }, [])
 
   useEffect(() => {
+    window.bridge.getNetOnline().then(setNetOnline).catch(() => {})
+    return window.bridge.onNetOnlineChange(setNetOnline)
+  }, [])
+
+  // NetworkInformation fires on transitions Chromium notices that never cross the
+  // online/offline boundary — a good moment to re-probe instead of waiting out the
+  // worker's interval. `type` is not exposed on desktop, so this is a trigger, not a signal.
+  useEffect(() => {
+    const connection = (navigator as Navigator & { connection?: EventTarget }).connection
+    if (!connection) return
+    const onChange = () => { request('network:check-liveness').catch(() => {}) }
+    connection.addEventListener('change', onChange)
+    return () => connection.removeEventListener('change', onChange)
+  }, [])
+
+  useEffect(() => {
     if (recheckTimerRef.current) {
       clearTimeout(recheckTimerRef.current)
       recheckTimerRef.current = null
     }
 
     const now = Date.now()
-    setStableState(deriveState(status, browserOnline, now))
+    setStableState(deriveState(status, osOnline, now))
 
-    if (!status || status.suspended || status.dhtReady || !browserOnline) return
+    if (!status || status.suspended || status.dhtReady || !osOnline) return
+    if (status.reachability && status.reachability.verdict !== 'unknown') return
     if (status.bootedAt <= 0) return
 
     const sinceBoot = now - status.bootedAt
@@ -97,9 +128,9 @@ export function ConnectionStatusProvider({ children }: ProviderProps) {
 
     recheckTimerRef.current = setTimeout(() => {
       recheckTimerRef.current = null
-      setStableState(deriveState(status, browserOnline, Date.now()))
+      setStableState(deriveState(status, osOnline, Date.now()))
     }, nextBoundary + 100)
-  }, [status, browserOnline])
+  }, [status, osOnline])
 
   useEffect(() => {
     return () => {
@@ -110,15 +141,28 @@ export function ConnectionStatusProvider({ children }: ProviderProps) {
     }
   }, [])
 
+  useEffect(() => {
+    request('network:online-hint', { online: osOnline }).catch(() => {})
+    request('network:check-liveness').catch(() => {})
+  }, [osOnline])
+
   const reconnect = useCallback(async () => {
     try {
       await request('network:reconnect')
     } catch {}
   }, [])
 
+  const probeCanary = useCallback(async (opts?: { force?: boolean }) => {
+    try {
+      return await request('network:probe-canary', { force: !!opts?.force }) as CanaryResult
+    } catch {
+      return null
+    }
+  }, [])
+
   const value = useMemo<ConnectionStatusContextValue>(
-    () => ({ state: stableState, status, reconnect }),
-    [stableState, status, reconnect],
+    () => ({ state: stableState, status, reachability: status?.reachability ?? null, reconnect, probeCanary }),
+    [stableState, status, reconnect, probeCanary],
   )
 
   return (

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -623,7 +623,25 @@
     "offlineToast": "Netzwerkverbindung verloren. Mirall ist pausiert.",
     "connectingToast": "Neuer Verbindungsversuch…",
     "restoredToast": "Wieder online",
-    "showDetails": "Details anzeigen"
+    "showDetails": "Details anzeigen",
+    "whatCanIDo": "Was tun?",
+    "blockedToast": {
+      "generic": "Dein Netzwerk blockiert Verbindungen zu anderen Teilnehmern. Einladungen und Freigaben kommen nicht an.",
+      "peers-unreachable": "Wir finden andere Teilnehmer, können sie aber nicht erreichen. Einladungen und Freigaben kommen nicht an.",
+      "os-offline": "Dieses Gerät ist mit keinem Netzwerk verbunden.",
+      "vpn-only-route": "Mirall erreicht das Netzwerk nicht. Dein VPN scheint der einzige Weg nach außen zu sein."
+    },
+    "atRiskToast": {
+      "generic": "Verbindungen zu vielen Teilnehmern werden in diesem Netzwerk fehlschlagen.",
+      "symmetric-nat": "Verbindungen zu vielen Teilnehmern werden fehlschlagen. Mobilfunk-Router und Tethering sind die übliche Ursache."
+    },
+    "fix": {
+      "vpn": "VPN ausschalten und erneut prüfen.",
+      "mobile": "Statt Mobilfunk-Router oder Handy-Tethering einen DSL- oder Kabelanschluss nutzen. Im Mobilfunknetz lässt sich das nicht am Router einstellen.",
+      "otherNetwork": "In einem anderen WLAN testen — Firmen- und Gastnetze filtern diesen Verkehr häufig.",
+      "turnOnNetwork": "Schalte dein WLAN wieder ein oder schließe ein Netzwerkkabel an."
+    },
+    "limited": "Eingeschränkt"
   },
   "networkSettings": {
     "title": "Netzwerk",
@@ -688,7 +706,14 @@
       "connectingTitle": "Verbinde mit dem Mirall-Netzwerk…",
       "connectingBody": "Das dauert länger als üblich. Firewall, VPN oder Internetanbieter prüfen.",
       "offlineTitle": "Du bist offline",
-      "offlineBody": "Mirall ist pausiert, bis deine Verbindung zurückkehrt."
+      "offlineBody": "Mirall ist pausiert, bis deine Verbindung zurückkehrt.",
+      "unknownTitle": "Verbindung wird geprüft…",
+      "unknownBody": "Wir ermitteln, wie sich dieses Netzwerk verhält.",
+      "at-riskTitle": "Eingeschränkte Verbindung",
+      "at-riskBody": "Verbindungen zu vielen Teilnehmern werden in diesem Netzwerk fehlschlagen.",
+      "blockedTitle": "Mirall erreicht keine anderen Teilnehmer",
+      "blockedBody": "Solange das so bleibt, kommen Einladungen und Freigaben nicht an.",
+      "body": {}
     },
     "advancedToggle": "Erweiterte Details anzeigen",
     "advancedHint": "Adresse, NAT, DHT, Zähler",
@@ -732,15 +757,50 @@
       "osOffline": "Dein Betriebssystem meldet keine Internetverbindung. WLAN oder Ethernet prüfen.",
       "firewalled": "Dein Router scheint eingehende UDP-Pakete zu blockieren. Peers erreichen dich nur über Holepunching.",
       "randomizedNat": "Dein Netzwerk vergibt zufällige ausgehende Ports. Direkte Verbindungen können fehlschlagen.",
-      "symmetricNat": "Symmetrisches NAT erkannt — Verbindungen laufen über Holepunched-Pfade.",
+      "symmetricNat": "Deine Verbindung nutzt wechselnde Ports. Verbindungen zu vielen Teilnehmern werden fehlschlagen — Mobilfunk-Router und Tethering sind die übliche Ursache.",
       "noPublicAddr": "Öffentliche IP konnte nicht ermittelt werden. Prüfe deine Internetverbindung.",
       "smallRoutingTable": "Bisher wenige DHT-Peers bekannt. Bootstrap läuft möglicherweise noch.",
-      "stillBootstrapping": "Tritt noch dem DHT bei — bitte einen Moment Geduld."
+      "stillBootstrapping": "Tritt noch dem DHT bei — bitte einen Moment Geduld.",
+      "symmetricNatFix": "Im Mobilfunknetz lässt sich das nicht am Router einstellen. Ein DSL- oder Kabelanschluss funktioniert.",
+      "udpDegraded": "Dein Netzwerk verwirft laufend Datenverkehr zum Mirall-Netzwerk. Übertragungen können stocken.",
+      "stillSettling": "Wir ermitteln noch, wie sich dieses Netzwerk verhält — einen Moment bitte."
     },
     "relaying": "Weiterleitung",
     "relayedActive": "Weitergeleitete Verbindungen",
     "relayedAttempts": "Weiterleitungsversuche",
-    "relayedAborts": "Fehlgeschlagene Weiterleitungen"
+    "relayedAborts": "Fehlgeschlagene Weiterleitungen",
+    "summary": {
+      "title": "Verbindungsübersicht",
+      "connection": "Verbindung",
+      "connectionValue": {
+        "healthy": "Funktioniert",
+        "at-risk": "Eingeschränkt",
+        "blocked": "Blockiert",
+        "unknown": "Wird geprüft…"
+      },
+      "reachable": "Von außen erreichbar",
+      "reachableValue": {
+        "yes": "Ja",
+        "changingPorts": "Nein — dein Netzwerk nutzt wechselnde Ports",
+        "noAddress": "Nein — deine Erreichbarkeit lässt sich nicht ermitteln",
+        "unknown": "Wird geprüft…"
+      },
+      "connectionTest": "Verbindungstest",
+      "testValue": {
+        "reachable": "Bestanden",
+        "unreachable": "Fehlgeschlagen",
+        "seeder-down": "Testserver nicht verfügbar",
+        "unavailable": "Nicht ausgeführt",
+        "pending": "Läuft…"
+      },
+      "people": "Teilnehmer",
+      "peopleValue": "{{found}} gefunden · {{connected}} verbunden",
+      "runningFor": "Läuft seit"
+    },
+    "canary": "Verbindungstest",
+    "canaryState": "Ergebnis",
+    "canaryRecords": "Gefundene Testserver",
+    "canaryChecked": "Zuletzt geprüft"
   },
   "a11y": {
     "skipToContent": "Zum Inhalt springen",
@@ -759,7 +819,8 @@
       "network": "Netzwerkstatus",
       "activityLog": "Aktivitätsprotokoll",
       "activityLogSettings": "Einstellungen für das Aktivitätsprotokoll",
-      "networkSettings": "Netzwerkeinstellungen"
+      "networkSettings": "Netzwerkeinstellungen",
+      "connectionProblem": "Verbindungsproblem"
     }
   },
   "avatar": {
@@ -907,5 +968,74 @@
     "deleteConfirmBody": "Alle aufgezeichneten Ereignisse werden von diesem Gerät entfernt. Kann nicht rückgängig gemacht werden.",
     "deleteDone_one": "{{count}} Ereignis gelöscht.",
     "deleteDone_other": "{{count}} Ereignisse gelöscht."
+  },
+  "connectionProblem": {
+    "title": "Verbindungsproblem",
+    "subtitle": {
+      "blocked": "Mirall erreicht aus diesem Netzwerk keine anderen Teilnehmer.",
+      "atRisk": "Mirall erreicht aus diesem Netzwerk nur einen Teil der anderen Teilnehmer.",
+      "offline": "Dieses Gerät ist mit keinem Netzwerk verbunden.",
+      "vpnOnly": "Dein VPN scheint der einzige Weg nach außen zu sein."
+    },
+    "verdict": {
+      "blocked": "Dein Netzwerk blockiert Mirall",
+      "atRisk": "Eingeschränkte Verbindung",
+      "offline": "Du bist offline",
+      "vpnOnly": "Netzwerk nicht erreichbar"
+    },
+    "body": {
+      "generic": "Wir finden andere Teilnehmer im Mirall-Netzwerk, können aber keine Verbindung zu ihnen aufbauen.",
+      "symmetric-nat": "Deine Verbindung nutzt bei jedem Zugriff einen anderen Port. Zu manchen Teilnehmern klappt die Verbindung, zu vielen anderen nicht. Mobilfunk-Router und Handy-Tethering sind die übliche Ursache.",
+      "no-public-address": "Wir konnten nicht ermitteln, wie du für den Rest des Netzwerks erreichbar bist. Andere Teilnehmer haben damit keinen Weg zu dir.",
+      "peers-unreachable": "Wir finden andere Teilnehmer im Mirall-Netzwerk, können aber keine Verbindung zu ihnen aufbauen. Solange das so bleibt, kommen deine Einladungen nicht an und beigetretene Räume gleichen sich nicht ab.",
+      "dht-unreachable": "Mirall erreicht das Netzwerk von hier aus überhaupt nicht.",
+      "udp-degraded": "Dein Netzwerk verwirft laufend Datenverkehr, deshalb können Übertragungen stocken.",
+      "os-offline": "Dieses Gerät ist mit keinem Netzwerk verbunden.",
+      "vpn-only-route": "Jede Route auf diesem Gerät läuft über ein VPN, und darüber antwortet nichts. Wenn das VPN selbst keine Verbindung mehr hat, kommt auch Mirall nicht hinaus."
+    },
+    "fixHeading": "Das hilft — in dieser Reihenfolge",
+    "checkAgain": "Erneut prüfen",
+    "checking": "Wird geprüft…",
+    "networkDetails": "Netzwerkdetails",
+    "checkedJustNow": "Gerade geprüft",
+    "checkedMinutes_one": "Vor {{count}} Minute geprüft",
+    "checkedMinutes_other": "Vor {{count}} Minuten geprüft",
+    "checkedNever": "Noch nicht geprüft",
+    "stillWorks": {
+      "blocked": "Du kannst trotzdem Räume anlegen — sie bleiben auf diesem Gerät und gleichen sich ab, sobald die Verbindung steht.",
+      "atRisk": "Mit einem Teil der Teilnehmer funktioniert das Teilen weiterhin.",
+      "offline": "Räume, die du jetzt anlegst, gleichen sich ab, sobald du wieder verbunden bist.",
+      "vpnOnly": "Räume, die du jetzt anlegst, gleichen sich ab, sobald die Verbindung steht."
+    },
+    "continueToSpaces": "Weiter zu den Räumen",
+    "recoveredTitle": "Verbindung wiederhergestellt",
+    "recoveredSubtitle": "Mirall erreicht wieder andere Teilnehmer.",
+    "recoveredVerdict": "Deine Verbindung funktioniert",
+    "recoveredBody": "Was Mirall blockiert hat, ist behoben. Du kannst einen Raum erstellen oder einem beitreten.",
+    "heading": {
+      "blocked": "Verbindungsproblem",
+      "atRisk": "Verbindungsproblem",
+      "offline": "Keine Netzwerkverbindung",
+      "vpnOnly": "Mirall erreicht das Netzwerk nicht"
+    }
+  },
+  "diagnostics": {
+    "title": "Diagnose",
+    "intro": "Wenn wir dich nach Details fragen, speichere diese Datei und schicke sie uns. Sie beschreibt das Verhalten deines Netzwerks — nicht, was du teilst oder mit wem.",
+    "redactLabel": "Identifizierende Angaben entfernen",
+    "redactDescription": "IP-Adresse, Schlüssel und Raumnamen werden gekürzt oder weggelassen. Empfohlen — das reicht uns, um Verbindungsprobleme zu erkennen.",
+    "logsLabel": "Ausführliche Protokolle einschließen",
+    "logsDescription": "Schaltet die ausführliche Protokollierung ein und bittet dich, das Problem vor dem Speichern zu wiederholen.",
+    "save": "Diagnose speichern",
+    "preview": "Inhalt ansehen",
+    "previewTitle": "Das steht in der Datei",
+    "previewIntro": "Identifizierende Angaben entfernt. Genau das wird gespeichert.",
+    "previewRegion": "Inhalt der Diagnosedatei",
+    "previewTruncated": "(gekürzt — die gespeicherte Datei enthält alles)",
+    "saveFile": "Datei speichern",
+    "approxSize": "ca. {{size}}",
+    "saved": "Diagnosedatei gespeichert.",
+    "verboseOn": "Ausführliche Protokollierung ist aktiv. Wiederhole das Problem und speichere dann die Datei.",
+    "previewIntroRaw": "Identifizierende Angaben sind ENTHALTEN. Genau das wird gespeichert."
   }
 }

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -34,7 +34,8 @@
       "network": "Network status",
       "activityLog": "Activity log",
       "activityLogSettings": "Activity log settings",
-      "networkSettings": "Network settings"
+      "networkSettings": "Network settings",
+      "connectionProblem": "Connection problem"
     }
   },
   "avatar": {
@@ -646,7 +647,25 @@
     "offlineToast": "Network connection lost. Mirall is paused.",
     "connectingToast": "Reconnecting…",
     "restoredToast": "Back online",
-    "showDetails": "Show details"
+    "showDetails": "Show details",
+    "whatCanIDo": "What can I do?",
+    "blockedToast": {
+      "generic": "Your network is blocking connections to other people. Invites and shares won't arrive.",
+      "peers-unreachable": "We can find other people but can't connect to them. Invites and shares won't arrive.",
+      "os-offline": "This device isn't connected to any network.",
+      "vpn-only-route": "Mirall can't reach the network. Your VPN appears to be the only route out."
+    },
+    "atRiskToast": {
+      "generic": "Connections to many people will fail on this network.",
+      "symmetric-nat": "Connections to many people will fail on this network. Mobile routers and tethering are the usual cause."
+    },
+    "fix": {
+      "vpn": "Turn off your VPN and check again.",
+      "mobile": "Use a cable or DSL connection instead of a mobile router or phone tethering. On a mobile network there's no router setting that fixes this.",
+      "otherNetwork": "Try a different Wi-Fi — company and guest networks often filter this traffic.",
+      "turnOnNetwork": "Turn your Wi-Fi back on, or plug in a network cable."
+    },
+    "limited": "Limited"
   },
   "networkSettings": {
     "title": "Network",
@@ -711,7 +730,14 @@
       "connectingTitle": "Connecting to the Mirall network…",
       "connectingBody": "This is taking longer than expected. Check your firewall, VPN, or ISP.",
       "offlineTitle": "You're offline",
-      "offlineBody": "Mirall is paused until your network returns."
+      "offlineBody": "Mirall is paused until your network returns.",
+      "unknownTitle": "Checking your connection…",
+      "unknownBody": "Working out how this network behaves.",
+      "at-riskTitle": "Limited connection",
+      "at-riskBody": "Connections to many people will fail on this network.",
+      "blockedTitle": "Mirall can't reach other people",
+      "blockedBody": "Invites and shares won't arrive while this is the case.",
+      "body": {}
     },
     "advancedToggle": "Show advanced details",
     "advancedHint": "Address, NAT, DHT, counters",
@@ -755,15 +781,50 @@
       "osOffline": "Your operating system reports no internet connection. Check your Wi-Fi or Ethernet.",
       "firewalled": "Your router appears to be blocking inbound UDP. Peers will reach you only via holepunching.",
       "randomizedNat": "Your network randomises outbound ports. Direct connections may fail.",
-      "symmetricNat": "Symmetric NAT detected — connectivity will rely on holepunched paths.",
+      "symmetricNat": "Your connection uses changing ports. Connections to many people will fail — mobile routers and tethering are the usual cause.",
       "noPublicAddr": "Couldn't determine your public IP. Check your internet connection.",
       "smallRoutingTable": "Few DHT peers known so far. Bootstrap may still be in progress.",
-      "stillBootstrapping": "Still joining the DHT — give it a moment."
+      "stillBootstrapping": "Still joining the DHT — give it a moment.",
+      "symmetricNatFix": "On a mobile network there's no router setting that fixes this. A cable or DSL connection will work.",
+      "udpDegraded": "Your network keeps dropping traffic to the Mirall network. Transfers may stall.",
+      "stillSettling": "Still working out how this network behaves — give it a moment."
     },
     "relaying": "Relaying",
     "relayedActive": "Relayed connections",
     "relayedAttempts": "Relay attempts",
-    "relayedAborts": "Relay failures"
+    "relayedAborts": "Relay failures",
+    "summary": {
+      "title": "Connection summary",
+      "connection": "Connection",
+      "connectionValue": {
+        "healthy": "Working",
+        "at-risk": "Limited",
+        "blocked": "Blocked",
+        "unknown": "Checking…"
+      },
+      "reachable": "Reachable from outside",
+      "reachableValue": {
+        "yes": "Yes",
+        "changingPorts": "No — your network uses changing ports",
+        "noAddress": "No — we can't tell how you appear to others",
+        "unknown": "Checking…"
+      },
+      "connectionTest": "Connection test",
+      "testValue": {
+        "reachable": "Passed",
+        "unreachable": "Failed",
+        "seeder-down": "Test server unavailable",
+        "unavailable": "Not run",
+        "pending": "Running…"
+      },
+      "people": "People",
+      "peopleValue": "{{found}} found · {{connected}} connected",
+      "runningFor": "Running for"
+    },
+    "canary": "Connection test",
+    "canaryState": "Result",
+    "canaryRecords": "Test servers found",
+    "canaryChecked": "Last checked"
   },
   "activityLog": {
     "title": "Activity Log",
@@ -907,5 +968,74 @@
     "deleteConfirmBody": "Every recorded event is removed from this device. This can't be undone.",
     "deleteDone_one": "Deleted {{count}} event.",
     "deleteDone_other": "Deleted {{count}} events."
+  },
+  "connectionProblem": {
+    "title": "Connection problem",
+    "subtitle": {
+      "blocked": "Mirall can't reach other people from this network.",
+      "atRisk": "Mirall can only reach some people from this network.",
+      "offline": "This device isn't connected to any network.",
+      "vpnOnly": "Your VPN appears to be the only route out."
+    },
+    "verdict": {
+      "blocked": "Your network is blocking Mirall",
+      "atRisk": "Limited connection",
+      "offline": "You're offline",
+      "vpnOnly": "Can't reach the network"
+    },
+    "body": {
+      "generic": "We can find other people on the Mirall network, but we can't connect to them.",
+      "symmetric-nat": "Your connection uses a different port every time it reaches out. Connections to some people will work; to many others they will fail. Mobile routers and phone tethering are the usual cause.",
+      "no-public-address": "We couldn't work out how you appear to the rest of the network, so other people have no way to reach you.",
+      "peers-unreachable": "We can find other people on the Mirall network, but we can't connect to them. While this is the case, invites you send won't arrive and spaces you join won't sync.",
+      "dht-unreachable": "Mirall can't reach the network from here at all.",
+      "udp-degraded": "Your connection to the network keeps dropping traffic, so transfers may stall.",
+      "os-offline": "This device isn't connected to any network.",
+      "vpn-only-route": "Every route on this device goes through a VPN, and nothing is answering through it. If the VPN lost its own connection, Mirall cannot get out either."
+    },
+    "fixHeading": "What helps, in this order",
+    "checkAgain": "Check again",
+    "checking": "Checking…",
+    "networkDetails": "Network details",
+    "checkedJustNow": "Checked just now",
+    "checkedMinutes_one": "Checked {{count}} minute ago",
+    "checkedMinutes_other": "Checked {{count}} minutes ago",
+    "checkedNever": "Not checked yet",
+    "stillWorks": {
+      "blocked": "You can still set up spaces — they'll stay on this device and start syncing once the connection works.",
+      "atRisk": "Sharing will still work with some people.",
+      "offline": "Spaces you set up now will start syncing as soon as you reconnect.",
+      "vpnOnly": "Spaces you set up now will start syncing once the connection works."
+    },
+    "continueToSpaces": "Continue to Spaces",
+    "recoveredTitle": "Connection restored",
+    "recoveredSubtitle": "Mirall can reach other people again.",
+    "recoveredVerdict": "Your connection is working",
+    "recoveredBody": "Whatever was blocking Mirall has cleared. You can create or join a space.",
+    "heading": {
+      "blocked": "Connection problem",
+      "atRisk": "Connection problem",
+      "offline": "No network connection",
+      "vpnOnly": "Mirall can't reach the network"
+    }
+  },
+  "diagnostics": {
+    "title": "Diagnostics",
+    "intro": "If we ask you for details, save this file and send it to us. It describes how your network behaves — not what you share or who you share it with.",
+    "redactLabel": "Remove identifying details",
+    "redactDescription": "Your IP address, keys and space names are shortened or left out. Recommended — this is enough for us to diagnose connection problems.",
+    "logsLabel": "Include detailed logs",
+    "logsDescription": "Turns on detailed logging, then asks you to reproduce the problem before saving.",
+    "save": "Save diagnostics",
+    "preview": "Preview what's included",
+    "previewTitle": "What's in the file",
+    "previewIntro": "Identifying details removed. This is exactly what will be saved.",
+    "previewRegion": "Diagnostics file contents",
+    "previewTruncated": "(truncated — the saved file contains everything)",
+    "saveFile": "Save file",
+    "approxSize": "about {{size}}",
+    "saved": "Diagnostics file saved.",
+    "verboseOn": "Detailed logging is on. Reproduce the problem, then save the file.",
+    "previewIntroRaw": "Identifying details are INCLUDED. This is exactly what will be saved."
   }
 }

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -623,7 +623,25 @@
     "offlineToast": "Conexión de red perdida. Mirall está en pausa.",
     "connectingToast": "Reconectando…",
     "restoredToast": "De nuevo en línea",
-    "showDetails": "Ver detalles"
+    "showDetails": "Ver detalles",
+    "whatCanIDo": "¿Qué puedo hacer?",
+    "blockedToast": {
+      "generic": "Tu red está bloqueando las conexiones con otras personas. Las invitaciones y los archivos compartidos no llegarán.",
+      "peers-unreachable": "Encontramos a otras personas pero no podemos conectar con ellas. Las invitaciones y los archivos compartidos no llegarán.",
+      "os-offline": "Este dispositivo no está conectado a ninguna red.",
+      "vpn-only-route": "Mirall no puede alcanzar la red. Tu VPN parece ser la única salida."
+    },
+    "atRiskToast": {
+      "generic": "Las conexiones con muchas personas fallarán en esta red.",
+      "symmetric-nat": "Las conexiones con muchas personas fallarán. Los routers móviles y el uso del móvil como módem son la causa habitual."
+    },
+    "fix": {
+      "vpn": "Desactiva la VPN y vuelve a comprobarlo.",
+      "mobile": "Usa una conexión por cable o DSL en lugar de un router móvil o el móvil como módem. En una red móvil no hay ningún ajuste del router que lo solucione.",
+      "otherNetwork": "Prueba con otra red Wi-Fi: las redes de empresa y de invitados suelen filtrar este tráfico.",
+      "turnOnNetwork": "Vuelve a activar el Wi-Fi o conecta un cable de red."
+    },
+    "limited": "Limitada"
   },
   "networkSettings": {
     "title": "Red",
@@ -688,7 +706,14 @@
       "connectingTitle": "Conectando a la red Mirall…",
       "connectingBody": "Está tardando más de lo habitual. Comprueba tu cortafuegos, VPN o ISP.",
       "offlineTitle": "Estás sin conexión",
-      "offlineBody": "Mirall está en pausa hasta que vuelva la conexión."
+      "offlineBody": "Mirall está en pausa hasta que vuelva la conexión.",
+      "unknownTitle": "Comprobando tu conexión…",
+      "unknownBody": "Estamos determinando cómo se comporta esta red.",
+      "at-riskTitle": "Conexión limitada",
+      "at-riskBody": "Las conexiones con muchas personas fallarán en esta red.",
+      "blockedTitle": "Mirall no alcanza a otras personas",
+      "blockedBody": "Mientras esto siga así, las invitaciones y los archivos compartidos no llegarán.",
+      "body": {}
     },
     "advancedToggle": "Mostrar detalles avanzados",
     "advancedHint": "Dirección, NAT, DHT, contadores",
@@ -732,15 +757,50 @@
       "osOffline": "Tu sistema operativo indica que no hay conexión a Internet. Comprueba tu Wi-Fi o Ethernet.",
       "firewalled": "Tu router parece estar bloqueando el UDP entrante. Los pares solo te alcanzarán mediante holepunching.",
       "randomizedNat": "Tu red asigna puertos salientes aleatorios. Las conexiones directas pueden fallar.",
-      "symmetricNat": "NAT simétrico detectado — la conectividad dependerá de rutas con holepunching.",
+      "symmetricNat": "Tu conexión usa puertos cambiantes. Las conexiones con muchas personas fallarán: los routers móviles y el móvil como módem son la causa habitual.",
       "noPublicAddr": "No se pudo determinar tu IP pública. Comprueba tu conexión a Internet.",
       "smallRoutingTable": "Pocos pares DHT conocidos por ahora. El bootstrap puede estar en curso.",
-      "stillBootstrapping": "Aún uniéndose al DHT — espera un momento."
+      "stillBootstrapping": "Aún uniéndose al DHT — espera un momento.",
+      "symmetricNatFix": "En una red móvil no hay ningún ajuste del router que lo solucione. Una conexión por cable o DSL sí funcionará.",
+      "udpDegraded": "Tu red descarta continuamente tráfico hacia la red de Mirall. Las transferencias pueden detenerse.",
+      "stillSettling": "Aún estamos determinando cómo se comporta esta red: dale un momento."
     },
     "relaying": "Retransmisión",
     "relayedActive": "Conexiones retransmitidas",
     "relayedAttempts": "Intentos de retransmisión",
-    "relayedAborts": "Fallos de retransmisión"
+    "relayedAborts": "Fallos de retransmisión",
+    "summary": {
+      "title": "Resumen de la conexión",
+      "connection": "Conexión",
+      "connectionValue": {
+        "healthy": "Funciona",
+        "at-risk": "Limitada",
+        "blocked": "Bloqueada",
+        "unknown": "Comprobando…"
+      },
+      "reachable": "Alcanzable desde fuera",
+      "reachableValue": {
+        "yes": "Sí",
+        "changingPorts": "No: tu red usa puertos cambiantes",
+        "noAddress": "No: no podemos saber cómo te ven los demás",
+        "unknown": "Comprobando…"
+      },
+      "connectionTest": "Prueba de conexión",
+      "testValue": {
+        "reachable": "Superada",
+        "unreachable": "Fallida",
+        "seeder-down": "Servidor de prueba no disponible",
+        "unavailable": "No ejecutada",
+        "pending": "En curso…"
+      },
+      "people": "Personas",
+      "peopleValue": "{{found}} encontradas · {{connected}} conectadas",
+      "runningFor": "En marcha desde hace"
+    },
+    "canary": "Prueba de conexión",
+    "canaryState": "Resultado",
+    "canaryRecords": "Servidores de prueba encontrados",
+    "canaryChecked": "Última comprobación"
   },
   "a11y": {
     "skipToContent": "Saltar al contenido",
@@ -759,7 +819,8 @@
       "network": "Estado de la red",
       "activityLog": "Registro de actividad",
       "activityLogSettings": "Ajustes del registro de actividad",
-      "networkSettings": "Ajustes de red"
+      "networkSettings": "Ajustes de red",
+      "connectionProblem": "Problema de conexión"
     }
   },
   "avatar": {
@@ -907,5 +968,74 @@
     "deleteConfirmBody": "Todos los eventos registrados se eliminarán de este dispositivo. No se puede deshacer.",
     "deleteDone_one": "{{count}} evento eliminado.",
     "deleteDone_other": "{{count}} eventos eliminados."
+  },
+  "connectionProblem": {
+    "title": "Problema de conexión",
+    "subtitle": {
+      "blocked": "Mirall no puede alcanzar a otras personas desde esta red.",
+      "atRisk": "Mirall solo puede alcanzar a algunas personas desde esta red.",
+      "offline": "Este dispositivo no está conectado a ninguna red.",
+      "vpnOnly": "Tu VPN parece ser la única salida."
+    },
+    "verdict": {
+      "blocked": "Tu red está bloqueando Mirall",
+      "atRisk": "Conexión limitada",
+      "offline": "Estás sin conexión",
+      "vpnOnly": "Red inalcanzable"
+    },
+    "body": {
+      "generic": "Encontramos a otras personas en la red de Mirall, pero no podemos conectar con ellas.",
+      "symmetric-nat": "Tu conexión usa un puerto distinto cada vez. Con algunas personas funcionará; con muchas otras fallará. Los routers móviles y el uso del móvil como módem son la causa habitual.",
+      "no-public-address": "No hemos podido determinar cómo te ve el resto de la red, así que nadie tiene forma de alcanzarte.",
+      "peers-unreachable": "Encontramos a otras personas en la red de Mirall, pero no podemos conectar con ellas. Mientras esto siga así, tus invitaciones no llegarán y los espacios a los que te unas no se sincronizarán.",
+      "dht-unreachable": "Mirall no puede alcanzar la red desde aquí en absoluto.",
+      "udp-degraded": "Tu red descarta tráfico continuamente, por lo que las transferencias pueden detenerse.",
+      "os-offline": "Este dispositivo no está conectado a ninguna red.",
+      "vpn-only-route": "Todas las rutas de este dispositivo pasan por una VPN y nada responde a través de ella. Si la VPN ha perdido su propia conexión, Mirall tampoco puede salir."
+    },
+    "fixHeading": "Qué ayuda, en este orden",
+    "checkAgain": "Comprobar de nuevo",
+    "checking": "Comprobando…",
+    "networkDetails": "Detalles de red",
+    "checkedJustNow": "Comprobado ahora mismo",
+    "checkedMinutes_one": "Comprobado hace {{count}} minuto",
+    "checkedMinutes_other": "Comprobado hace {{count}} minutos",
+    "checkedNever": "Aún sin comprobar",
+    "stillWorks": {
+      "blocked": "Aún puedes crear espacios: se quedarán en este dispositivo y empezarán a sincronizarse cuando la conexión funcione.",
+      "atRisk": "Compartir seguirá funcionando con algunas personas.",
+      "offline": "Los espacios que crees ahora se sincronizarán en cuanto vuelvas a conectarte.",
+      "vpnOnly": "Los espacios que crees ahora se sincronizarán cuando la conexión funcione."
+    },
+    "continueToSpaces": "Continuar a Espacios",
+    "recoveredTitle": "Conexión restablecida",
+    "recoveredSubtitle": "Mirall vuelve a alcanzar a otras personas.",
+    "recoveredVerdict": "Tu conexión funciona",
+    "recoveredBody": "Lo que bloqueaba Mirall se ha resuelto. Puedes crear un espacio o unirte a uno.",
+    "heading": {
+      "blocked": "Problema de conexión",
+      "atRisk": "Problema de conexión",
+      "offline": "Sin conexión de red",
+      "vpnOnly": "Mirall no puede alcanzar la red"
+    }
+  },
+  "diagnostics": {
+    "title": "Diagnóstico",
+    "intro": "Si te pedimos detalles, guarda este archivo y envíanoslo. Describe cómo se comporta tu red, no qué compartes ni con quién.",
+    "redactLabel": "Eliminar datos identificativos",
+    "redactDescription": "Tu dirección IP, las claves y los nombres de los espacios se acortan o se omiten. Recomendado: nos basta para diagnosticar problemas de conexión.",
+    "logsLabel": "Incluir registros detallados",
+    "logsDescription": "Activa el registro detallado y te pide que reproduzcas el problema antes de guardar.",
+    "save": "Guardar diagnóstico",
+    "preview": "Ver qué se incluye",
+    "previewTitle": "Qué contiene el archivo",
+    "previewIntro": "Datos identificativos eliminados. Esto es exactamente lo que se guardará.",
+    "previewRegion": "Contenido del archivo de diagnóstico",
+    "previewTruncated": "(recortado: el archivo guardado lo contiene todo)",
+    "saveFile": "Guardar archivo",
+    "approxSize": "aprox. {{size}}",
+    "saved": "Archivo de diagnóstico guardado.",
+    "verboseOn": "El registro detallado está activo. Reproduce el problema y luego guarda el archivo.",
+    "previewIntroRaw": "Los datos identificativos SÍ se incluyen. Esto es exactamente lo que se guardará."
   }
 }

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -623,7 +623,25 @@
     "offlineToast": "Connexion réseau perdue. Mirall est en pause.",
     "connectingToast": "Reconnexion…",
     "restoredToast": "De nouveau en ligne",
-    "showDetails": "Voir les détails"
+    "showDetails": "Voir les détails",
+    "whatCanIDo": "Que faire ?",
+    "blockedToast": {
+      "generic": "Votre réseau bloque les connexions vers les autres personnes. Les invitations et les partages n'arriveront pas.",
+      "peers-unreachable": "Nous trouvons d'autres personnes mais ne pouvons pas nous y connecter. Les invitations et les partages n'arriveront pas.",
+      "os-offline": "Cet appareil n'est connecté à aucun réseau.",
+      "vpn-only-route": "Mirall n'atteint pas le réseau. Votre VPN semble être la seule route disponible."
+    },
+    "atRiskToast": {
+      "generic": "Les connexions vers de nombreuses personnes échoueront sur ce réseau.",
+      "symmetric-nat": "Les connexions vers de nombreuses personnes échoueront. Les routeurs mobiles et le partage de connexion en sont la cause habituelle."
+    },
+    "fix": {
+      "vpn": "Désactivez votre VPN et relancez la vérification.",
+      "mobile": "Utilisez une connexion câble ou DSL plutôt qu'un routeur mobile ou le partage de connexion. Sur un réseau mobile, aucun réglage du routeur ne corrige cela.",
+      "otherNetwork": "Essayez un autre Wi-Fi — les réseaux d'entreprise et invités filtrent souvent ce trafic.",
+      "turnOnNetwork": "Réactivez le Wi-Fi ou branchez un câble réseau."
+    },
+    "limited": "Limitée"
   },
   "networkSettings": {
     "title": "Réseau",
@@ -688,7 +706,14 @@
       "connectingTitle": "Connexion au réseau Mirall…",
       "connectingBody": "Cela prend plus de temps que d'habitude. Vérifiez votre pare-feu, VPN ou FAI.",
       "offlineTitle": "Vous êtes hors ligne",
-      "offlineBody": "Mirall est en pause en attendant le retour de la connexion."
+      "offlineBody": "Mirall est en pause en attendant le retour de la connexion.",
+      "unknownTitle": "Vérification de votre connexion…",
+      "unknownBody": "Nous déterminons le comportement de ce réseau.",
+      "at-riskTitle": "Connexion limitée",
+      "at-riskBody": "Les connexions vers de nombreuses personnes échoueront sur ce réseau.",
+      "blockedTitle": "Mirall n'atteint pas les autres personnes",
+      "blockedBody": "Tant que cela dure, les invitations et les partages n'arriveront pas.",
+      "body": {}
     },
     "advancedToggle": "Afficher les détails avancés",
     "advancedHint": "Adresse, NAT, DHT, compteurs",
@@ -732,15 +757,50 @@
       "osOffline": "Votre système d'exploitation signale qu'il n'y a pas de connexion Internet. Vérifiez votre Wi-Fi ou Ethernet.",
       "firewalled": "Votre routeur semble bloquer l'UDP entrant. Les pairs ne pourront vous atteindre que via holepunching.",
       "randomizedNat": "Votre réseau attribue des ports sortants aléatoires. Les connexions directes peuvent échouer.",
-      "symmetricNat": "NAT symétrique détecté — la connectivité repose sur des chemins holepunched.",
+      "symmetricNat": "Votre connexion utilise des ports changeants. Les connexions vers de nombreuses personnes échoueront — les routeurs mobiles et le partage de connexion en sont la cause habituelle.",
       "noPublicAddr": "Impossible de déterminer votre IP publique. Vérifiez votre connexion Internet.",
       "smallRoutingTable": "Peu de pairs DHT connus pour l'instant. Le bootstrap est peut-être en cours.",
-      "stillBootstrapping": "Connexion au DHT en cours — patientez un instant."
+      "stillBootstrapping": "Connexion au DHT en cours — patientez un instant.",
+      "symmetricNatFix": "Sur un réseau mobile, aucun réglage du routeur ne corrige cela. Une connexion câble ou DSL fonctionnera.",
+      "udpDegraded": "Votre réseau perd en continu du trafic vers le réseau Mirall. Les transferts peuvent se bloquer.",
+      "stillSettling": "Nous déterminons encore le comportement de ce réseau — patientez un instant."
     },
     "relaying": "Relayage",
     "relayedActive": "Connexions relayées",
     "relayedAttempts": "Tentatives de relais",
-    "relayedAborts": "Échecs de relais"
+    "relayedAborts": "Échecs de relais",
+    "summary": {
+      "title": "Résumé de la connexion",
+      "connection": "Connexion",
+      "connectionValue": {
+        "healthy": "Fonctionne",
+        "at-risk": "Limitée",
+        "blocked": "Bloquée",
+        "unknown": "Vérification…"
+      },
+      "reachable": "Joignable depuis l'extérieur",
+      "reachableValue": {
+        "yes": "Oui",
+        "changingPorts": "Non — votre réseau utilise des ports changeants",
+        "noAddress": "Non — impossible de savoir comment les autres vous voient",
+        "unknown": "Vérification…"
+      },
+      "connectionTest": "Test de connexion",
+      "testValue": {
+        "reachable": "Réussi",
+        "unreachable": "Échoué",
+        "seeder-down": "Serveur de test indisponible",
+        "unavailable": "Non exécuté",
+        "pending": "En cours…"
+      },
+      "people": "Personnes",
+      "peopleValue": "{{found}} trouvées · {{connected}} connectées",
+      "runningFor": "En marche depuis"
+    },
+    "canary": "Test de connexion",
+    "canaryState": "Résultat",
+    "canaryRecords": "Serveurs de test trouvés",
+    "canaryChecked": "Dernière vérification"
   },
   "a11y": {
     "skipToContent": "Aller au contenu",
@@ -759,7 +819,8 @@
       "network": "État du réseau",
       "activityLog": "Journal d'activité",
       "activityLogSettings": "Réglages du journal d'activité",
-      "networkSettings": "Paramètres réseau"
+      "networkSettings": "Paramètres réseau",
+      "connectionProblem": "Problème de connexion"
     }
   },
   "avatar": {
@@ -907,5 +968,74 @@
     "deleteConfirmBody": "Tous les événements enregistrés seront retirés de cet appareil. Action irréversible.",
     "deleteDone_one": "{{count}} événement supprimé.",
     "deleteDone_other": "{{count}} événements supprimés."
+  },
+  "connectionProblem": {
+    "title": "Problème de connexion",
+    "subtitle": {
+      "blocked": "Mirall n'atteint aucune autre personne depuis ce réseau.",
+      "atRisk": "Mirall n'atteint qu'une partie des autres personnes depuis ce réseau.",
+      "offline": "Cet appareil n'est connecté à aucun réseau.",
+      "vpnOnly": "Votre VPN semble être la seule route disponible."
+    },
+    "verdict": {
+      "blocked": "Votre réseau bloque Mirall",
+      "atRisk": "Connexion limitée",
+      "offline": "Vous êtes hors ligne",
+      "vpnOnly": "Réseau injoignable"
+    },
+    "body": {
+      "generic": "Nous trouvons d'autres personnes sur le réseau Mirall, mais nous ne pouvons pas nous y connecter.",
+      "symmetric-nat": "Votre connexion utilise un port différent à chaque fois. Avec certaines personnes cela fonctionnera, avec beaucoup d'autres non. Les routeurs mobiles et le partage de connexion en sont la cause habituelle.",
+      "no-public-address": "Nous n'avons pas pu déterminer comment le reste du réseau vous voit : personne ne peut donc vous joindre.",
+      "peers-unreachable": "Nous trouvons d'autres personnes sur le réseau Mirall, mais nous ne pouvons pas nous y connecter. Tant que cela dure, vos invitations n'arriveront pas et les espaces rejoints ne se synchroniseront pas.",
+      "dht-unreachable": "Mirall n'atteint pas du tout le réseau depuis ici.",
+      "udp-degraded": "Votre réseau perd du trafic en continu, les transferts peuvent donc se bloquer.",
+      "os-offline": "Cet appareil n'est connecté à aucun réseau.",
+      "vpn-only-route": "Toutes les routes de cet appareil passent par un VPN, et rien ne répond au travers. Si le VPN a lui-même perdu sa connexion, Mirall ne peut pas sortir non plus."
+    },
+    "fixHeading": "Ce qui aide, dans cet ordre",
+    "checkAgain": "Vérifier à nouveau",
+    "checking": "Vérification…",
+    "networkDetails": "Détails réseau",
+    "checkedJustNow": "Vérifié à l'instant",
+    "checkedMinutes_one": "Vérifié il y a {{count}} minute",
+    "checkedMinutes_other": "Vérifié il y a {{count}} minutes",
+    "checkedNever": "Pas encore vérifié",
+    "stillWorks": {
+      "blocked": "Vous pouvez tout de même créer des espaces : ils resteront sur cet appareil et se synchroniseront dès que la connexion fonctionnera.",
+      "atRisk": "Le partage fonctionnera encore avec certaines personnes.",
+      "offline": "Les espaces créés maintenant se synchroniseront dès votre reconnexion.",
+      "vpnOnly": "Les espaces créés maintenant se synchroniseront dès que la connexion fonctionnera."
+    },
+    "continueToSpaces": "Continuer vers les espaces",
+    "recoveredTitle": "Connexion rétablie",
+    "recoveredSubtitle": "Mirall atteint de nouveau les autres personnes.",
+    "recoveredVerdict": "Votre connexion fonctionne",
+    "recoveredBody": "Ce qui bloquait Mirall est résolu. Vous pouvez créer un espace ou en rejoindre un.",
+    "heading": {
+      "blocked": "Problème de connexion",
+      "atRisk": "Problème de connexion",
+      "offline": "Aucune connexion réseau",
+      "vpnOnly": "Mirall n'atteint pas le réseau"
+    }
+  },
+  "diagnostics": {
+    "title": "Diagnostic",
+    "intro": "Si nous vous demandons des détails, enregistrez ce fichier et envoyez-le-nous. Il décrit le comportement de votre réseau — pas ce que vous partagez ni avec qui.",
+    "redactLabel": "Supprimer les données identifiantes",
+    "redactDescription": "Votre adresse IP, les clés et les noms d'espaces sont raccourcis ou omis. Recommandé — cela nous suffit pour diagnostiquer les problèmes de connexion.",
+    "logsLabel": "Inclure les journaux détaillés",
+    "logsDescription": "Active la journalisation détaillée, puis vous demande de reproduire le problème avant l'enregistrement.",
+    "save": "Enregistrer le diagnostic",
+    "preview": "Voir ce qui est inclus",
+    "previewTitle": "Contenu du fichier",
+    "previewIntro": "Données identifiantes supprimées. C'est exactement ce qui sera enregistré.",
+    "previewRegion": "Contenu du fichier de diagnostic",
+    "previewTruncated": "(tronqué — le fichier enregistré contient tout)",
+    "saveFile": "Enregistrer le fichier",
+    "approxSize": "environ {{size}}",
+    "saved": "Fichier de diagnostic enregistré.",
+    "verboseOn": "La journalisation détaillée est active. Reproduisez le problème, puis enregistrez le fichier.",
+    "previewIntroRaw": "Les données identifiantes SONT incluses. C’est exactement ce qui sera enregistré."
   }
 }

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -623,7 +623,25 @@
     "offlineToast": "Connessione di rete persa. Mirall è in pausa.",
     "connectingToast": "Riconnessione…",
     "restoredToast": "Di nuovo online",
-    "showDetails": "Mostra dettagli"
+    "showDetails": "Mostra dettagli",
+    "whatCanIDo": "Cosa posso fare?",
+    "blockedToast": {
+      "generic": "La tua rete blocca le connessioni verso altre persone. Inviti e condivisioni non arriveranno.",
+      "peers-unreachable": "Troviamo altre persone ma non riusciamo a connetterci. Inviti e condivisioni non arriveranno.",
+      "os-offline": "Questo dispositivo non è connesso ad alcuna rete.",
+      "vpn-only-route": "Mirall non raggiunge la rete. La tua VPN sembra essere l'unica via d'uscita."
+    },
+    "atRiskToast": {
+      "generic": "Le connessioni verso molte persone falliranno su questa rete.",
+      "symmetric-nat": "Le connessioni verso molte persone falliranno. Router mobili e tethering sono la causa più comune."
+    },
+    "fix": {
+      "vpn": "Disattiva la VPN e riprova la verifica.",
+      "mobile": "Usa una connessione via cavo o DSL invece di un router mobile o del tethering. Su una rete mobile non esiste un’impostazione del router che risolva il problema.",
+      "otherNetwork": "Prova un altro Wi-Fi: le reti aziendali e per ospiti filtrano spesso questo traffico.",
+      "turnOnNetwork": "Riattiva il Wi-Fi o collega un cavo di rete."
+    },
+    "limited": "Limitata"
   },
   "networkSettings": {
     "title": "Rete",
@@ -688,7 +706,14 @@
       "connectingTitle": "Connessione alla rete Mirall…",
       "connectingBody": "Sta richiedendo più tempo del solito. Controlla firewall, VPN o ISP.",
       "offlineTitle": "Sei offline",
-      "offlineBody": "Mirall è in pausa in attesa del ritorno della connessione."
+      "offlineBody": "Mirall è in pausa in attesa del ritorno della connessione.",
+      "unknownTitle": "Verifica della connessione…",
+      "unknownBody": "Stiamo capendo come si comporta questa rete.",
+      "at-riskTitle": "Connessione limitata",
+      "at-riskBody": "Le connessioni verso molte persone falliranno su questa rete.",
+      "blockedTitle": "Mirall non raggiunge altre persone",
+      "blockedBody": "Finché è così, inviti e condivisioni non arriveranno.",
+      "body": {}
     },
     "advancedToggle": "Mostra dettagli avanzati",
     "advancedHint": "Indirizzo, NAT, DHT, contatori",
@@ -732,15 +757,50 @@
       "osOffline": "Il sistema operativo segnala l'assenza di connessione a Internet. Controlla Wi-Fi o Ethernet.",
       "firewalled": "Il router sembra bloccare l'UDP in entrata. I peer ti raggiungeranno solo tramite holepunching.",
       "randomizedNat": "La rete assegna porte in uscita casuali. Le connessioni dirette possono fallire.",
-      "symmetricNat": "NAT simmetrico rilevato — la connettività si baserà su percorsi holepunched.",
+      "symmetricNat": "La tua connessione usa porte variabili. Le connessioni verso molte persone falliranno: router mobili e tethering sono la causa più comune.",
       "noPublicAddr": "Impossibile determinare l'IP pubblico. Controlla la connessione a Internet.",
       "smallRoutingTable": "Pochi peer DHT noti finora. Il bootstrap potrebbe essere ancora in corso.",
-      "stillBootstrapping": "Ancora in fase di ingresso nel DHT — attendi un momento."
+      "stillBootstrapping": "Ancora in fase di ingresso nel DHT — attendi un momento.",
+      "symmetricNatFix": "Su una rete mobile non esiste un’impostazione del router che risolva il problema. Una connessione via cavo o DSL funzionerà.",
+      "udpDegraded": "La tua rete perde di continuo traffico verso la rete Mirall. I trasferimenti possono bloccarsi.",
+      "stillSettling": "Stiamo ancora capendo come si comporta questa rete: attendi un momento."
     },
     "relaying": "Inoltro",
     "relayedActive": "Connessioni inoltrate",
     "relayedAttempts": "Tentativi di inoltro",
-    "relayedAborts": "Inoltri non riusciti"
+    "relayedAborts": "Inoltri non riusciti",
+    "summary": {
+      "title": "Riepilogo della connessione",
+      "connection": "Connessione",
+      "connectionValue": {
+        "healthy": "Funziona",
+        "at-risk": "Limitata",
+        "blocked": "Bloccata",
+        "unknown": "Verifica…"
+      },
+      "reachable": "Raggiungibile dall’esterno",
+      "reachableValue": {
+        "yes": "Sì",
+        "changingPorts": "No: la tua rete usa porte variabili",
+        "noAddress": "No: non possiamo sapere come ti vedono gli altri",
+        "unknown": "Verifica…"
+      },
+      "connectionTest": "Test di connessione",
+      "testValue": {
+        "reachable": "Superato",
+        "unreachable": "Fallito",
+        "seeder-down": "Server di test non disponibile",
+        "unavailable": "Non eseguito",
+        "pending": "In corso…"
+      },
+      "people": "Persone",
+      "peopleValue": "{{found}} trovate · {{connected}} connesse",
+      "runningFor": "In funzione da"
+    },
+    "canary": "Test di connessione",
+    "canaryState": "Risultato",
+    "canaryRecords": "Server di test trovati",
+    "canaryChecked": "Ultima verifica"
   },
   "a11y": {
     "skipToContent": "Vai al contenuto",
@@ -759,7 +819,8 @@
       "network": "Stato della rete",
       "activityLog": "Registro attività",
       "activityLogSettings": "Impostazioni del registro attività",
-      "networkSettings": "Impostazioni di rete"
+      "networkSettings": "Impostazioni di rete",
+      "connectionProblem": "Problema di connessione"
     }
   },
   "avatar": {
@@ -907,5 +968,74 @@
     "deleteConfirmBody": "Tutti gli eventi registrati verranno rimossi da questo dispositivo. Non può essere annullato.",
     "deleteDone_one": "{{count}} evento eliminato.",
     "deleteDone_other": "{{count}} eventi eliminati."
+  },
+  "connectionProblem": {
+    "title": "Problema di connessione",
+    "subtitle": {
+      "blocked": "Mirall non raggiunge altre persone da questa rete.",
+      "atRisk": "Mirall raggiunge solo una parte delle altre persone da questa rete.",
+      "offline": "Questo dispositivo non è connesso ad alcuna rete.",
+      "vpnOnly": "La tua VPN sembra essere l'unica via d'uscita."
+    },
+    "verdict": {
+      "blocked": "La tua rete sta bloccando Mirall",
+      "atRisk": "Connessione limitata",
+      "offline": "Sei offline",
+      "vpnOnly": "Rete irraggiungibile"
+    },
+    "body": {
+      "generic": "Troviamo altre persone sulla rete Mirall, ma non riusciamo a connetterci a loro.",
+      "symmetric-nat": "La tua connessione usa ogni volta una porta diversa. Con alcune persone funzionerà, con molte altre no. Router mobili e tethering sono la causa più comune.",
+      "no-public-address": "Non siamo riusciti a capire come ti vede il resto della rete, quindi nessuno può raggiungerti.",
+      "peers-unreachable": "Troviamo altre persone sulla rete Mirall, ma non riusciamo a connetterci a loro. Finché è così, i tuoi inviti non arriveranno e gli spazi a cui aderisci non si sincronizzeranno.",
+      "dht-unreachable": "Mirall non raggiunge affatto la rete da qui.",
+      "udp-degraded": "La tua rete perde traffico di continuo, quindi i trasferimenti possono bloccarsi.",
+      "os-offline": "Questo dispositivo non è connesso ad alcuna rete.",
+      "vpn-only-route": "Tutte le rotte di questo dispositivo passano da una VPN e nulla risponde attraverso di essa. Se la VPN ha perso la propria connessione, nemmeno Mirall può uscire."
+    },
+    "fixHeading": "Cosa aiuta, in questo ordine",
+    "checkAgain": "Verifica di nuovo",
+    "checking": "Verifica in corso…",
+    "networkDetails": "Dettagli di rete",
+    "checkedJustNow": "Verificato proprio ora",
+    "checkedMinutes_one": "Verificato {{count}} minuto fa",
+    "checkedMinutes_other": "Verificato {{count}} minuti fa",
+    "checkedNever": "Non ancora verificato",
+    "stillWorks": {
+      "blocked": "Puoi comunque creare spazi: resteranno su questo dispositivo e inizieranno a sincronizzarsi appena la connessione funziona.",
+      "atRisk": "La condivisione continuerà a funzionare con alcune persone.",
+      "offline": "Gli spazi che crei ora si sincronizzeranno appena ti riconnetti.",
+      "vpnOnly": "Gli spazi che crei ora si sincronizzeranno appena la connessione funziona."
+    },
+    "continueToSpaces": "Continua agli spazi",
+    "recoveredTitle": "Connessione ripristinata",
+    "recoveredSubtitle": "Mirall raggiunge di nuovo altre persone.",
+    "recoveredVerdict": "La tua connessione funziona",
+    "recoveredBody": "Ciò che bloccava Mirall è stato risolto. Puoi creare uno spazio o unirti a uno esistente.",
+    "heading": {
+      "blocked": "Problema di connessione",
+      "atRisk": "Problema di connessione",
+      "offline": "Nessuna connessione di rete",
+      "vpnOnly": "Mirall non raggiunge la rete"
+    }
+  },
+  "diagnostics": {
+    "title": "Diagnostica",
+    "intro": "Se ti chiediamo dei dettagli, salva questo file e inviacelo. Descrive come si comporta la tua rete, non cosa condividi né con chi.",
+    "redactLabel": "Rimuovi i dati identificativi",
+    "redactDescription": "Indirizzo IP, chiavi e nomi degli spazi vengono accorciati o omessi. Consigliato: ci basta per diagnosticare i problemi di connessione.",
+    "logsLabel": "Includi i log dettagliati",
+    "logsDescription": "Attiva la registrazione dettagliata e ti chiede di riprodurre il problema prima di salvare.",
+    "save": "Salva diagnostica",
+    "preview": "Vedi cosa è incluso",
+    "previewTitle": "Cosa contiene il file",
+    "previewIntro": "Dati identificativi rimossi. È esattamente ciò che verrà salvato.",
+    "previewRegion": "Contenuto del file di diagnostica",
+    "previewTruncated": "(troncato: il file salvato contiene tutto)",
+    "saveFile": "Salva file",
+    "approxSize": "circa {{size}}",
+    "saved": "File di diagnostica salvato.",
+    "verboseOn": "La registrazione dettagliata è attiva. Riproduci il problema, poi salva il file.",
+    "previewIntroRaw": "I dati identificativi SONO inclusi. È esattamente ciò che verrà salvato."
   }
 }

--- a/src/renderer/screens/ConnectionProblem.tsx
+++ b/src/renderer/screens/ConnectionProblem.tsx
@@ -1,0 +1,158 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useConnectionStatus } from '../hooks/useConnectionStatus.js'
+import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import { fixStepsFor } from '../connectivity.js'
+import Button from '../components/primitives/Button.js'
+import Icon from '../components/primitives/Icon.js'
+import PageHeader from '../components/layout/PageHeader.js'
+
+interface Props {
+  onBack?: () => void
+  onContinue: () => void
+  onShowDetails: () => void
+}
+
+function relativeCheck(at: number, now: number, t: (key: string, opts?: Record<string, unknown>) => string): string {
+  if (!at) return t('connectionProblem.checkedNever')
+  const minutes = Math.floor(Math.max(0, now - at) / 60000)
+  if (minutes < 1) return t('connectionProblem.checkedJustNow')
+  return t('connectionProblem.checkedMinutes', { count: minutes })
+}
+
+export default function ConnectionProblem({ onBack, onContinue, onShowDetails }: Props) {
+  const { t } = useTranslation()
+  const { status, reachability, probeCanary } = useConnectionStatus()
+  const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
+  const headingRef = useRef<HTMLHeadingElement>(null)
+  const [checking, setChecking] = useState(false)
+
+  useEffect(() => {
+    headingRef.current?.focus()
+  }, [])
+
+  const handleCheckAgain = useCallback(async () => {
+    if (checking) return
+    setChecking(true)
+    try {
+      await probeCanary({ force: true })
+    } finally {
+      setChecking(false)
+    }
+  }, [checking, probeCanary])
+
+  const verdict = reachability?.verdict
+  const degraded = verdict === 'blocked' || verdict === 'at-risk'
+  const blocked = verdict === 'blocked'
+  const cause = reachability?.cause ?? 'generic'
+  // Being offline is not the same as being blocked, and must not read like it.
+  const offline = cause === 'os-offline'
+  // We cannot prove the VPN is at fault, so the wording stays "can't reach" rather than
+  // "your network is blocking" — but the advice leads with the likeliest culprit.
+  const vpnOnly = cause === 'vpn-only-route'
+  const tone = offline ? 'offline' : vpnOnly ? 'vpnOnly' : blocked ? 'blocked' : 'atRisk'
+  const steps = fixStepsFor(reachability?.cause ?? null)
+
+  return (
+    <div
+      ref={ref}
+      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+    >
+      <div className="pt-10 px-8 max-w-2xl mx-auto">
+        <PageHeader
+          title={degraded ? t(`connectionProblem.heading.${tone}`) : t('connectionProblem.recoveredTitle')}
+          subtitle={degraded
+            ? t(`connectionProblem.subtitle.${tone}`)
+            : t('connectionProblem.recoveredSubtitle')}
+          onBack={onBack}
+          headingRef={headingRef}
+        />
+
+        {!degraded && (
+          <div className="bg-surface-container-low rounded-xl p-6 flex items-start gap-5">
+            <span aria-hidden="true" className="w-4 h-4 rounded-full shrink-0 mt-1.5 bg-online ring-4 ring-online/25" />
+            <div className="flex-1 min-w-0">
+              <p role="status" aria-live="polite" className="text-2xl font-headline font-bold text-accent">
+                {t('connectionProblem.recoveredVerdict')}
+              </p>
+              <p className="text-sm text-on-surface-variant mt-2 leading-relaxed">
+                {t('connectionProblem.recoveredBody')}
+              </p>
+              <div className="mt-5">
+                <Button onClick={onContinue}>{t('connectionProblem.continueToSpaces')}</Button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {degraded && (
+        <div className="space-y-6">
+          <div className="bg-surface-container-low rounded-xl p-6 flex items-start gap-5">
+            <span
+              aria-hidden="true"
+              className={`w-4 h-4 rounded-full shrink-0 mt-1.5 ring-4 ${
+                blocked ? 'bg-error ring-error/25' : 'bg-secondary-container ring-secondary-container/30'
+              }`}
+            />
+            <div className="flex-1 min-w-0">
+              <p role="status" aria-live="polite" className="text-2xl font-headline font-bold text-accent">
+                {t(`connectionProblem.verdict.${tone}`)}
+              </p>
+              <p className="text-sm text-on-surface-variant mt-2 leading-relaxed">
+                {t(`connectionProblem.body.${cause}`, { defaultValue: t('connectionProblem.body.generic') })}
+              </p>
+            </div>
+          </div>
+
+          <section>
+            <h2 className="text-xl font-headline font-bold text-accent mb-4">
+              {t('connectionProblem.fixHeading')}
+            </h2>
+            <ol className="bg-surface-container-low rounded-xl p-6 space-y-5">
+              {steps.map((step, index) => (
+                <li key={step} className="flex items-start gap-4">
+                  <span
+                    aria-hidden="true"
+                    className="shrink-0 w-7 h-7 rounded-full bg-primary text-on-primary font-headline font-bold text-sm flex items-center justify-center"
+                  >
+                    {index + 1}
+                  </span>
+                  <span className="text-sm text-on-surface leading-relaxed pt-0.5">
+                    {t(`connectivity.fix.${step}`)}
+                  </span>
+                </li>
+              ))}
+            </ol>
+          </section>
+
+          <div className="flex items-center gap-3 flex-wrap">
+            <Button icon="refresh" onClick={handleCheckAgain} disabled={checking}>
+              {checking ? t('connectionProblem.checking') : t('connectionProblem.checkAgain')}
+            </Button>
+            <Button variant="secondary" onClick={onShowDetails}>
+              {t('connectionProblem.networkDetails')}
+            </Button>
+            <span className="text-xs text-on-surface-variant ml-auto">
+              {relativeCheck(status?.canary?.at ?? 0, Date.now(), t)}
+            </span>
+          </div>
+
+          <div className="rounded-xl bg-surface-container-lowest p-5 flex items-start gap-3">
+            <Icon name="info" size={20} className="shrink-0 text-on-surface-variant mt-0.5" />
+            <p className="text-sm text-on-surface-variant leading-relaxed">
+              {t(`connectionProblem.stillWorks.${tone}`)}
+              <button
+                type="button"
+                onClick={onContinue}
+                className="font-bold text-accent underline underline-offset-2 ml-1 rounded-sm focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
+              >
+                {t('connectionProblem.continueToSpaces')}
+              </button>
+            </p>
+          </div>
+        </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/screens/NetworkStatus.tsx
+++ b/src/renderer/screens/NetworkStatus.tsx
@@ -2,13 +2,14 @@
 import { useEffect, useState, type ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import { isRelayFeatureEnabled } from '../config-client.js'
+import { reachableState, formatDuration } from '../connectivity.js'
+import DiagnosticsCard from '../components/settings/DiagnosticsCard.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { useConnectionStatus } from '../hooks/useConnectionStatus.js'
-import NetworkStatusIndicator from '../components/widgets/NetworkStatusIndicator.js'
 import CopyButton from '../components/primitives/CopyButton.js'
 import Icon from '../components/primitives/Icon.js'
 import PageHeader from '../components/layout/PageHeader.js'
-import type { NetworkStatus, ConnectivityState } from '../types.js'
+import type { NetworkStatus, Reachability } from '../types.js'
 
 interface Props {
   onBack: () => void
@@ -157,38 +158,44 @@ function BootstrapList({ items, emptyLabel, countLabel }: BootstrapListProps) {
 }
 
 interface VerdictBannerProps {
-  state: ConnectivityState
+  reachability: Reachability | null
   status: NetworkStatus | null
   reconnecting: boolean
   reconnectThrottled: boolean
   onReconnect: () => void
 }
 
-function VerdictBanner({ state, status, reconnecting, reconnectThrottled, onReconnect }: VerdictBannerProps) {
+function verdictLamp(verdict: string | undefined): string {
+  if (verdict === 'blocked') return 'bg-error ring-error/25'
+  if (verdict === 'at-risk') return 'bg-secondary-container ring-secondary-container/30'
+  if (verdict === 'healthy') return 'bg-online ring-online/25'
+  return 'bg-outline ring-outline/20'
+}
+
+function VerdictBanner({ reachability, status, reconnecting, reconnectThrottled, onReconnect }: VerdictBannerProps) {
   const { t } = useTranslation()
+  const verdict = reachability?.verdict ?? 'unknown'
   const peerCount = status?.peerCount ?? 0
-  const headline = state === 'online'
-    ? t('networkStatus.verdict.healthyTitle')
-    : state === 'connecting'
-      ? t('networkStatus.verdict.connectingTitle')
-      : t('networkStatus.verdict.offlineTitle')
-  const subline = state === 'online'
+  const cause = reachability?.cause ?? 'generic'
+
+  const headline = t(`networkStatus.verdict.${verdict}Title`)
+  // "Nobody else is online right now" attributes the missing peers to the other side, so
+  // it may only ever appear when we can actually reach the network.
+  const subline = verdict === 'healthy'
     ? peerCount > 0
       ? t('networkStatus.verdict.healthyBodyPeers', { count: peerCount })
       : t('networkStatus.verdict.healthyBodyIdle')
-    : state === 'connecting'
-      ? t('networkStatus.verdict.connectingBody')
-      : t('networkStatus.verdict.offlineBody')
+    : t(`connectionProblem.body.${cause}`, { defaultValue: t(`networkStatus.verdict.${verdict}Body`) })
 
   return (
     <section>
       <div className="bg-surface-container-low rounded-xl p-6 flex items-center gap-5">
-        <NetworkStatusIndicator state={state} size="lg" />
+        <span aria-hidden="true" className={`w-4 h-4 rounded-full shrink-0 ring-4 ${verdictLamp(verdict)}`} />
         <div role="status" aria-live="polite" className="flex-1 min-w-0">
           <p className="text-2xl font-headline font-bold text-accent">{headline}</p>
           <p className="text-sm text-on-surface-variant mt-1">{subline}</p>
         </div>
-        {state !== 'online' && (
+        {verdict !== 'healthy' && (
           <button
             type="button"
             onClick={onReconnect}
@@ -204,28 +211,62 @@ function VerdictBanner({ state, status, reconnecting, reconnectThrottled, onReco
   )
 }
 
-function buildEssentialSuggestions(status: NetworkStatus | null, state: ConnectivityState, browserOnline: boolean, t: (key: string) => string): string[] {
+// nat.firewalled initialises to true and reads true for nearly every home user, and
+// nat.randomized is the same predicate as publicPort === 0 — so neither earns a line of
+// its own. What is left is one statement per real finding.
+function buildSuggestions(status: NetworkStatus | null, browserOnline: boolean, t: (key: string) => string): string[] {
   const lines: string[] = []
-  if (state === 'offline' && !browserOnline) lines.push(t('networkStatus.advice.osOffline'))
-  if (status && state !== 'offline' && status.dhtReady && status.address.publicHost === null) {
-    lines.push(t('networkStatus.advice.noPublicAddr'))
+  if (!status) return lines
+  if (!browserOnline) {
+    lines.push(t('networkStatus.advice.osOffline'))
+    return lines
   }
-  if (status && status.nat.ephemeral === true && status.peerCount === 0 && state === 'connecting') {
-    lines.push(t('networkStatus.advice.stillBootstrapping'))
+  const reachable = reachableState(status)
+  if (reachable === 'noAddress') lines.push(t('networkStatus.advice.noPublicAddr'))
+  if (reachable === 'changingPorts') {
+    lines.push(t('networkStatus.advice.symmetricNat'))
+    lines.push(t('networkStatus.advice.symmetricNatFix'))
   }
-  if (status && state !== 'offline' && status.routing.tableSize > 0 && status.routing.tableSize < 5 && status.peerCount === 0) {
-    lines.push(t('networkStatus.advice.smallRoutingTable'))
+  if (status.dhtHealth?.degraded) lines.push(t('networkStatus.advice.udpDegraded'))
+  if (status.reachability?.verdict === 'unknown' && status.dhtReady) {
+    lines.push(t('networkStatus.advice.stillSettling'))
   }
   return lines
 }
 
-function buildAdvancedSuggestions(status: NetworkStatus | null, t: (key: string) => string): string[] {
-  const lines: string[] = []
-  if (!status) return lines
-  if (status.nat.firewalled === true) lines.push(t('networkStatus.advice.firewalled'))
-  if (status.nat.randomized === true) lines.push(t('networkStatus.advice.randomizedNat'))
-  if (status.dhtReady && status.address.publicPort === 0) lines.push(t('networkStatus.advice.symmetricNat'))
-  return lines
+interface SummaryProps {
+  status: NetworkStatus | null
+  now: number
+}
+
+function ConnectionSummary({ status, now }: SummaryProps) {
+  const { t } = useTranslation()
+  if (!status) return null
+  const verdict = status.reachability?.verdict ?? 'unknown'
+  const canary = status.canary?.state ?? 'unavailable'
+  const canaryWhen = status.canary?.at ? formatRelativeTime(status.canary.at, now) : ''
+
+  return (
+    <Section title={t('networkStatus.summary.title')}>
+      <Field label={t('networkStatus.summary.connection')} value={t(`networkStatus.summary.connectionValue.${verdict}`)} />
+      <Field label={t('networkStatus.summary.reachable')} value={t(`networkStatus.summary.reachableValue.${reachableState(status)}`)} />
+      <Field
+        label={t('networkStatus.summary.connectionTest')}
+        value={`${t(`networkStatus.summary.testValue.${canary}`)}${canaryWhen ? ` · ${canaryWhen}` : ''}`}
+      />
+      <Field
+        label={t('networkStatus.summary.people')}
+        value={t('networkStatus.summary.peopleValue', {
+          found: status.peerReach?.discovered ?? 0,
+          connected: status.peerReach?.connected ?? 0,
+        })}
+      />
+      <Field
+        label={t('networkStatus.summary.runningFor')}
+        value={status.bootedAt > 0 ? formatDuration(now - status.bootedAt) : DASH}
+      />
+    </Section>
+  )
 }
 
 function SuggestionsList({ lines }: { lines: string[] }) {
@@ -246,9 +287,77 @@ function SuggestionsList({ lines }: { lines: string[] }) {
   )
 }
 
+interface AdvancedDetailsProps {
+  status: NetworkStatus | null
+  relayVisible: boolean
+  now: number
+}
+
+function AdvancedDetails({ status, relayVisible, now }: AdvancedDetailsProps) {
+  const { t } = useTranslation()
+  if (!status) return null
+  const portPreserved = status.address.publicPort > 0
+    && status.address.publicPort === status.address.localPort
+  const portPreservationLabel = portPreserved
+    ? t('networkStatus.portPreservedYes')
+    : status.dhtReady ? t('networkStatus.portPreservedNo') : DASH
+
+  return (
+    <>
+              <Section title={t('networkStatus.connection')}>
+                <Field label={t('networkStatus.peerCount')}     value={formatNumber(status.peerCount)} />
+                <Field label={t('networkStatus.topicsJoined')}  value={formatNumber(status.topics)} />
+                <Field label={t('networkStatus.lastConnected')} value={formatRelativeTime(status.lastConnectionAt, now)} />
+              </Section>
+
+              <Section title={t('networkStatus.address')}>
+                <MaskedField label={t('networkStatus.publicHost')} value={status.address.publicHost} />
+                <Field label={t('networkStatus.publicPort')} value={status.address.publicPort ? String(status.address.publicPort) : DASH} mono />
+                <Field label={t('networkStatus.localPort')}  value={status.address.localPort ? String(status.address.localPort) : DASH} mono />
+                <Field
+                  label={t('networkStatus.portPreserved')}
+                  value={portPreservationLabel}
+                  positive={portPreserved}
+                />
+                <MaskedField label={t('networkStatus.publicKey')} value={status.identity.publicKey} visibleSuffix={6} />
+              </Section>
+
+              <Section title={t('networkStatus.nat')}>
+                <Field label={t('networkStatus.firewalled')} value={formatBool(status.nat.firewalled, t)} />
+                <Field label={t('networkStatus.randomized')} value={formatBool(status.nat.randomized, t)} />
+                <Field label={t('networkStatus.ephemeral')}  value={formatBool(status.nat.ephemeral, t)} />
+              </Section>
+
+              {relayVisible && (
+                <Section title={t('networkStatus.relaying')}>
+                  <Field label={t('networkStatus.relayedActive')}   value={formatNumber(status.stats.relaying.successes)} />
+                  <Field label={t('networkStatus.relayedAttempts')} value={formatNumber(status.stats.relaying.attempts)} />
+                  <Field label={t('networkStatus.relayedAborts')}   value={formatNumber(status.stats.relaying.aborts)} />
+                </Section>
+              )}
+
+              <Section title={t('networkStatus.dht')}>
+                <Field label={t('networkStatus.routingTableSize')} value={formatNumber(status.routing.tableSize)} />
+                <Field label={t('networkStatus.dhtVersion')}        value={status.versions.dht} mono />
+                <BootstrapList
+                  items={status.routing.bootstrap}
+                  emptyLabel={DASH}
+                  countLabel={(n) => t('networkStatus.bootstrapEntries', { count: n })}
+                />
+              </Section>
+
+              <Section title={t('networkStatus.canary')}>
+                <Field label={t('networkStatus.canaryState')} value={t(`networkStatus.summary.testValue.${status.canary.state}`)} />
+                <Field label={t('networkStatus.canaryRecords')} value={formatNumber(status.canary.stage1?.announceRecords)} />
+                <Field label={t('networkStatus.canaryChecked')} value={formatRelativeTime(status.canary.at || null, now)} />
+              </Section>
+    </>
+  )
+}
+
 export default function NetworkStatusScreen({ onBack }: Props) {
   const { t } = useTranslation()
-  const { state, status, reconnect } = useConnectionStatus()
+  const { status, reachability, reconnect } = useConnectionStatus()
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
   const [reconnecting, setReconnecting] = useState(false)
   const [reconnectThrottled, setReconnectThrottled] = useState(false)
@@ -269,13 +378,7 @@ export default function NetworkStatusScreen({ onBack }: Props) {
     }
   }
 
-  const essentialSuggestions = buildEssentialSuggestions(status, state, browserOnline, t)
-  const advancedSuggestions = buildAdvancedSuggestions(status, t)
-  const portPreserved = !!status && status.address.publicPort > 0
-    && status.address.publicPort === status.address.localPort
-  const portPreservationLabel = portPreserved
-    ? t('networkStatus.portPreservedYes')
-    : status && status.dhtReady ? t('networkStatus.portPreservedNo') : DASH
+  const suggestions = buildSuggestions(status, browserOnline, t)
 
   return (
     <div
@@ -291,14 +394,18 @@ export default function NetworkStatusScreen({ onBack }: Props) {
 
         <div className="space-y-8">
           <VerdictBanner
-            state={state}
+            reachability={reachability}
             status={status}
             reconnecting={reconnecting}
             reconnectThrottled={reconnectThrottled}
             onReconnect={handleReconnect}
           />
 
-          <SuggestionsList lines={essentialSuggestions} />
+          <SuggestionsList lines={suggestions} />
+
+          <ConnectionSummary status={status} now={now} />
+
+          <DiagnosticsCard />
 
           <section>
             <button
@@ -313,55 +420,10 @@ export default function NetworkStatusScreen({ onBack }: Props) {
             </button>
           </section>
 
-          {advancedOpen && (
-            <>
-              <Section title={t('networkStatus.connection')}>
-                <Field label={t('networkStatus.peerCount')}     value={formatNumber(status?.peerCount)} />
-                <Field label={t('networkStatus.topicsJoined')}  value={formatNumber(status?.topics)} />
-                <Field label={t('networkStatus.lastConnected')} value={formatRelativeTime(status?.lastConnectionAt ?? null, now)} />
-              </Section>
-
-              <Section title={t('networkStatus.address')}>
-                <MaskedField label={t('networkStatus.publicHost')} value={status?.address.publicHost ?? null} />
-                <Field label={t('networkStatus.publicPort')} value={status?.address.publicPort ? String(status.address.publicPort) : DASH} mono />
-                <Field label={t('networkStatus.localPort')}  value={status?.address.localPort ? String(status.address.localPort) : DASH} mono />
-                <Field
-                  label={t('networkStatus.portPreserved')}
-                  value={portPreservationLabel}
-                  positive={portPreserved}
-                />
-                <MaskedField label={t('networkStatus.publicKey')} value={status?.identity.publicKey ?? null} visibleSuffix={6} />
-              </Section>
-
-              <Section title={t('networkStatus.nat')}>
-                <Field label={t('networkStatus.firewalled')} value={formatBool(status?.nat.firewalled ?? null, t)} />
-                <Field label={t('networkStatus.randomized')} value={formatBool(status?.nat.randomized ?? null, t)} />
-                <Field label={t('networkStatus.ephemeral')}  value={formatBool(status?.nat.ephemeral ?? null, t)} />
-              </Section>
-
-              {relayVisible && (
-                <Section title={t('networkStatus.relaying')}>
-                  <Field label={t('networkStatus.relayedActive')}   value={formatNumber(status?.stats.relaying.successes)} />
-                  <Field label={t('networkStatus.relayedAttempts')} value={formatNumber(status?.stats.relaying.attempts)} />
-                  <Field label={t('networkStatus.relayedAborts')}   value={formatNumber(status?.stats.relaying.aborts)} />
-                </Section>
-              )}
-
-              <Section title={t('networkStatus.dht')}>
-                <Field label={t('networkStatus.routingTableSize')} value={formatNumber(status?.routing.tableSize)} />
-                <Field label={t('networkStatus.dhtVersion')}        value={status?.versions.dht ?? DASH} mono />
-                <BootstrapList
-                  items={status?.routing.bootstrap ?? []}
-                  emptyLabel={DASH}
-                  countLabel={(n) => t('networkStatus.bootstrapEntries', { count: n })}
-                />
-              </Section>
-
-              <SuggestionsList lines={advancedSuggestions} />
-            </>
-          )}
+          {advancedOpen && <AdvancedDetails status={status} relayVisible={relayVisible} now={now} />}
         </div>
       </div>
+
     </div>
   )
 }

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -273,7 +273,7 @@ export interface UpdateInfo {
   version: { fork: number; length: number; semver: string | null }
 }
 
-export type ConnectivityState = 'online' | 'connecting' | 'offline'
+export type ConnectivityState = 'online' | 'limited' | 'connecting' | 'offline'
 
 export interface NetworkStatusStats {
   updates: number
@@ -282,7 +282,72 @@ export interface NetworkStatusStats {
     server: { opened: number; closed: number; attempted: number }
   }
   bannedPeers: number
-  relaying: { attempts: number; successes: number; aborts: number }
+  relaying: { selected: number; attempts: number; successes: number; aborts: number }
+}
+
+export type ReachabilityVerdict = 'healthy' | 'at-risk' | 'blocked' | 'unknown'
+
+export type ReachabilityCause =
+  | 'os-offline'
+  | 'dht-unreachable'
+  | 'no-public-address'
+  | 'symmetric-nat'
+  | 'udp-degraded'
+  | 'peers-unreachable'
+  | 'vpn-only-route'
+
+export type CanaryState = 'unavailable' | 'pending' | 'seeder-down' | 'reachable' | 'unreachable'
+
+export interface ReachabilityEvidence {
+  peersDiscovered: number
+  peersConnected: number
+  peersExhausted: number
+  dialsAttempted: number
+  dialsOpened: number
+  publicPort: number
+  canary: CanaryState
+}
+
+export interface Reachability {
+  verdict: ReachabilityVerdict
+  cause: ReachabilityCause | null
+  confidence: 'measured' | 'predicted'
+  evidence: ReachabilityEvidence | null
+  since: number
+}
+
+export interface PeerReach {
+  discovered: number
+  connected: number
+  exhausted: number
+}
+
+export interface DhtHealth {
+  online: boolean
+  degraded: boolean
+  cold: boolean
+  idle: boolean
+  timeoutsRate: number
+}
+
+export interface CanaryResult {
+  state: CanaryState
+  at: number
+  stage1?: { announceRecords: number; ms: number }
+  stage2?: { dials: number; opened: number; ms: number }
+}
+
+export interface Liveness {
+  failures: number
+  checkedAt: number
+  interfaceKind: 'none' | 'tunnel-only' | 'physical'
+}
+
+export interface DiagnosticLogEntry {
+  at: number
+  source: string
+  level: string
+  text: string
 }
 
 export interface NetworkStatus {
@@ -314,6 +379,11 @@ export interface NetworkStatus {
   }
   topics: number
   stats: NetworkStatusStats
+  peerReach: PeerReach
+  dhtHealth: DhtHealth
+  canary: CanaryResult
+  liveness: Liveness
+  reachability: Reachability
   versions: {
     dht: string
   }

--- a/src/shared/core/diagnostics-redact.js
+++ b/src/shared/core/diagnostics-redact.js
@@ -1,0 +1,36 @@
+// Redaction for the diagnostics bundle. Pure and dependency-free so it loads under bare
+// (worker), node (main + unit tests) and the renderer alike — the contract has to be
+// enforced identically on both halves of the bundle.
+//
+// Deliberately aggressive and lossy: a log line that becomes unreadable is a far cheaper
+// failure than one that ships a user's home directory to a support inbox.
+
+const KEY_RE = /\b[0-9a-f]{32,}\b|\b[a-z2-7]{50,}\b/gi
+const IPV4_RE = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g
+const IPV6_RE = /\b[0-9a-f:]*::[0-9a-f:]*[0-9a-f]\b|\b(?:[0-9a-f]{1,4}:){7}[0-9a-f]{1,4}\b/gi
+const PATH_RE = /(?:\/[^\s/\\:]+){2,}|[A-Za-z]:\\(?:[^\s/\\]+\\?){1,}/gu
+
+export function shortId(value, keep = 4) {
+  if (typeof value !== 'string' || !value) return null
+  return value.length <= keep ? '…' : value.slice(0, keep) + '…'
+}
+
+// Order matters: paths first, because a Windows path can contain runs that match nothing
+// else; keys before IPv6, because a long hex run reads as a v6 group.
+export function redactLine(line) {
+  if (typeof line !== 'string') return ''
+  return line
+    .replace(PATH_RE, '‹path›')
+    .replace(KEY_RE, (match) => match.slice(0, 4) + '…')
+    .replace(IPV4_RE, '‹ip›')
+    .replace(IPV6_RE, '‹ip6›')
+}
+
+export function makeAliaser(prefix) {
+  const seen = new Map()
+  return (value) => {
+    if (!value) return null
+    if (!seen.has(value)) seen.set(value, `${prefix}${seen.size}`)
+    return seen.get(value)
+  }
+}

--- a/src/shared/core/reachability.js
+++ b/src/shared/core/reachability.js
@@ -1,0 +1,212 @@
+// Reachability verdict: the one place the app decides whether the user can actually
+// reach peers. Deliberately dependency-free so it loads under node — swarm.js pulls
+// bare-* modules and cannot.
+//
+// GOVERNING RULE: the canary may CONFIRM a verdict, never CREATE one. A canary failure
+// is indistinguishable from our own seeder being down, so it can raise confidence and
+// promote to healthy, but is never the sole basis for telling a user their network is
+// broken.
+
+export const VERDICT = {
+  HEALTHY: 'healthy',
+  AT_RISK: 'at-risk',
+  BLOCKED: 'blocked',
+  UNKNOWN: 'unknown',
+}
+
+export const CAUSE = {
+  OS_OFFLINE: 'os-offline',
+  DHT_UNREACHABLE: 'dht-unreachable',
+  NO_PUBLIC_ADDRESS: 'no-public-address',
+  SYMMETRIC_NAT: 'symmetric-nat',
+  UDP_DEGRADED: 'udp-degraded',
+  PEERS_UNREACHABLE: 'peers-unreachable',
+  VPN_ONLY_ROUTE: 'vpn-only-route',
+}
+
+export const CONFIDENCE = { MEASURED: 'measured', PREDICTED: 'predicted' }
+
+export const CANARY = {
+  UNAVAILABLE: 'unavailable',
+  PENDING: 'pending',
+  SEEDER_DOWN: 'seeder-down',
+  REACHABLE: 'reachable',
+  UNREACHABLE: 'unreachable',
+}
+
+// Measured from dhtReady, NOT from boot. dht-rpc emits 'ready' only after the bootstrap
+// FIND_NODE walk completes, and that walk is what fed the NAT sampler — so the NAT
+// verdict is ready when dhtReady is. This short window only covers a consensus still
+// forming and gives the canary room to confirm.
+export const NAT_SETTLE_MS = 5000
+export const DHT_FAILURE_MS = 45000
+export const MIN_ROUTING_TABLE = 8
+export const MIN_EXHAUSTED_PEERS = 1
+export const BLOCKED_DWELL_MS = 20000
+// Consecutive liveness-probe failures before the network counts as gone.
+export const LIVENESS_FAILURES_FOR_OFFLINE = 2
+
+// Losing the network is a hard, directly-measured event, not an inference from NAT shape.
+// Holding it back for the anti-flap dwell would keep showing "connected" while the user
+// stares at a laptop with the Wi-Fi off.
+const IMMEDIATE_CAUSES = new Set([CAUSE.OS_OFFLINE, CAUSE.DHT_UNREACHABLE])
+
+// Virtual point-to-point interfaces. A VPN keeps one of these UP with an address and the
+// default route even when its underlying transport is dead, so "there is a route" stops
+// meaning "there is connectivity".
+const TUNNEL_PREFIXES = ['utun', 'tun', 'tap', 'wg', 'ppp', 'ipsec', 'gpd', 'nordlynx']
+
+function isTunnelName(name) {
+  const lower = String(name || '').toLowerCase()
+  return TUNNEL_PREFIXES.some((prefix) => lower.startsWith(prefix))
+}
+
+// A link-local address (169.254.x / fe80::) means the interface has no configured route —
+// macOS keeps utun*, awdl0 and llw0 up with only those whether or not Wi-Fi is on, so
+// counting any non-internal address as "connected" never reports being offline.
+function isRoutable(addr) {
+  if (!addr || addr.internal) return false
+  const ip = String(addr.address || '')
+  if (!ip) return false
+  if (ip.startsWith('169.254.')) return false
+  if (ip.toLowerCase().startsWith('fe80')) return false
+  return true
+}
+
+// 'none'        — nothing routable anywhere; the machine is definitively offline.
+// 'tunnel-only' — every routable address is on a VPN/tunnel. Not proof of anything on its
+//                 own, but if we also cannot reach the network it is by far the most
+//                 likely culprit, and the most useful thing to tell the user first.
+// 'physical'    — at least one ordinary interface has a routable address.
+export function routableAddressKind(interfaces) {
+  let sawTunnel = false
+  for (const [name, addresses] of Object.entries(interfaces || {})) {
+    for (const addr of addresses || []) {
+      if (!isRoutable(addr)) continue
+      if (!isTunnelName(name)) return 'physical'
+      sawTunnel = true
+    }
+  }
+  return sawTunnel ? 'tunnel-only' : 'none'
+}
+
+export function hasRoutableAddress(interfaces) {
+  return routableAddressKind(interfaces) !== 'none'
+}
+
+function verdictRank(verdict) {
+  if (verdict === VERDICT.BLOCKED) return 3
+  if (verdict === VERDICT.AT_RISK) return 2
+  return 1
+}
+
+function isEscalation(next, previous) {
+  if (next === VERDICT.UNKNOWN || previous === VERDICT.UNKNOWN) return false
+  return verdictRank(next) > verdictRank(previous)
+}
+
+// The short-circuits: each is decisive on its own and outranks everything below it.
+// Returns null when nothing conclusive applies and the NAT shape should decide.
+function decisiveVerdict(input) {
+  const { now, bootedAt, readyAt, dhtReady, suspended, browserOnline, routing, peerReach, liveness } = input
+
+  // No non-internal address on the machine is definitive and instant — no probe needed,
+  // and it means "you are offline", not "your network is blocking us".
+  if (input.hasInterface === false) return [VERDICT.BLOCKED, CAUSE.OS_OFFLINE, CONFIDENCE.MEASURED]
+  if (!browserOnline) return [VERDICT.BLOCKED, CAUSE.OS_OFFLINE, CONFIDENCE.MEASURED]
+  if (suspended) return [VERDICT.UNKNOWN, null, CONFIDENCE.PREDICTED]
+
+  if (!dhtReady) {
+    const sinceBoot = bootedAt > 0 ? now - bootedAt : 0
+    return sinceBoot < DHT_FAILURE_MS
+      ? [VERDICT.UNKNOWN, null, CONFIDENCE.PREDICTED]
+      : [VERDICT.BLOCKED, CAUSE.DHT_UNREACHABLE, CONFIDENCE.MEASURED]
+  }
+
+  // A live connection settles it, whatever the NAT shape says.
+  if (peerReach.connected > 0) return [VERDICT.HEALTHY, null, CONFIDENCE.MEASURED]
+
+  // Nothing else can notice an idle app losing the network: dhtReady is one-shot, the DHT's
+  // own health window is gated on traffic that is not happening, and with no topics joined
+  // there are no swarm events at all.
+  if ((liveness?.failures ?? 0) >= LIVENESS_FAILURES_FOR_OFFLINE) {
+    // A VPN that keeps the only route while its transport is dead looks identical to a
+    // network that blocks us. We cannot tell them apart — but we can say which is likelier.
+    const cause = input.interfaceKind === 'tunnel-only' ? CAUSE.VPN_ONLY_ROUTE : CAUSE.DHT_UNREACHABLE
+    return [VERDICT.BLOCKED, cause, CONFIDENCE.MEASURED]
+  }
+
+  // Found them, reached none — an outcome rather than a prediction. Keyed on `exhausted`
+  // rather than the dial counters, which are cumulative for the process lifetime.
+  if (peerReach.discovered > 0 && peerReach.exhausted >= MIN_EXHAUSTED_PEERS) {
+    return [VERDICT.BLOCKED, CAUSE.PEERS_UNREACHABLE, CONFIDENCE.MEASURED]
+  }
+
+  const sinceReady = readyAt > 0 ? now - readyAt : 0
+  if (sinceReady < NAT_SETTLE_MS || routing.tableSize < MIN_ROUTING_TABLE) {
+    return [VERDICT.UNKNOWN, null, CONFIDENCE.PREDICTED]
+  }
+
+  if (input.canary.state === CANARY.REACHABLE) return [VERDICT.HEALTHY, null, CONFIDENCE.MEASURED]
+
+  return null
+}
+
+function natVerdict(address, dhtHealth) {
+  if (address.publicHost === null) return [VERDICT.BLOCKED, CAUSE.NO_PUBLIC_ADDRESS]
+  // Symmetric NAT. NOT certain failure — this user can still reach peers with a stable
+  // mapping, throttled by hyperdht's _randomPunchLimit of 1 per 20s.
+  if (address.publicPort === 0) return [VERDICT.AT_RISK, CAUSE.SYMMETRIC_NAT]
+  if (dhtHealth.degraded) return [VERDICT.AT_RISK, CAUSE.UDP_DEGRADED]
+  return [VERDICT.HEALTHY, null]
+}
+
+export function classify(input) {
+  const { address, dhtHealth, peerReach, dials, canary, liveness } = input
+
+  const evidence = {
+    peersDiscovered: peerReach.discovered,
+    peersConnected: peerReach.connected,
+    peersExhausted: peerReach.exhausted,
+    dialsAttempted: dials.attempted,
+    dialsOpened: dials.opened,
+    publicPort: address.publicPort,
+    canary: canary.state,
+    livenessFailures: liveness?.failures ?? 0,
+  }
+  const out = (verdict, cause, confidence) => ({ verdict, cause, confidence, evidence })
+
+  const decisive = decisiveVerdict(input)
+  if (decisive) return out(decisive[0], decisive[1], decisive[2])
+
+  const [verdict, cause] = natVerdict(address, dhtHealth)
+
+  if (canary.state === CANARY.UNREACHABLE) {
+    // Stage 1 found the seeder, stage 2 could not reach it, and the NAT looks fine.
+    // Unexplainable, so we do not accuse.
+    if (verdict === VERDICT.HEALTHY) return out(VERDICT.UNKNOWN, null, CONFIDENCE.PREDICTED)
+    return out(verdict, cause, CONFIDENCE.MEASURED)
+  }
+
+  // UNAVAILABLE / SEEDER_DOWN / PENDING fall through untouched: our outage must never
+  // change the user's verdict.
+  return out(verdict, cause, CONFIDENCE.PREDICTED)
+}
+
+// Escalating to a worse verdict requires BLOCKED_DWELL_MS of agreement; recovery is
+// immediate.
+export function stabilise(raw, previous, now) {
+  if (!previous || previous.verdict === raw.verdict) {
+    return { ...raw, since: previous?.since || now, pending: null }
+  }
+
+  if (!isEscalation(raw.verdict, previous.verdict) || IMMEDIATE_CAUSES.has(raw.cause)) {
+    return { ...raw, since: now, pending: null }
+  }
+
+  const pendingSince = previous.pending?.verdict === raw.verdict ? previous.pending.since : now
+  if (now - pendingSince < BLOCKED_DWELL_MS) {
+    return { ...previous, pending: { verdict: raw.verdict, since: pendingSince } }
+  }
+  return { ...raw, since: now, pending: null }
+}

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -16,7 +16,7 @@ const DEFAULT_MAX_FILES_PER_SHARE = 5000
 
 // Paths / opaque strings; a falsy override means "unset". dhtBootstrap is test-only — a local
 // hyperdht/testnet bootstrap so integration tests stay off the public DHT; null → default.
-const NULLABLE = ['storage', 'appVersion', 'downloadFolder', 'dhtBootstrap']
+const NULLABLE = ['storage', 'appVersion', 'downloadFolder', 'dhtBootstrap', 'upgradeKey']
 
 // Dev toggles + feature flags, all default-off.
 const BOOLEAN = [
@@ -205,6 +205,10 @@ export function isSharePrepareProgressEnabled() {
 
 export function isSeparateContentPlaneEnabled() {
   return config.separateContentPlane
+}
+
+export function getUpgradeKey() {
+  return config.upgradeKey
 }
 
 export function isRelayEnabled() {

--- a/src/shared/transfer/diagnostics.js
+++ b/src/shared/transfer/diagnostics.js
@@ -1,0 +1,72 @@
+import { shortId, makeAliaser } from '../core/diagnostics-redact.js'
+
+export const DIAGNOSTICS_SCHEMA = 1
+
+// Shapes, not identities. Everything a connectivity diagnosis needs — did host consensus
+// form, is the port 0, did it change, how many dials opened — is answerable without the
+// actual IP, the real keys, or space names.
+export function buildDiagnostics(ctx, redact = true) {
+  const { status, history, env, counters, peerSamples } = ctx
+  const topicAlias = makeAliaser('t')
+  const samples = peerSamples.map((peer) => ({
+    peer: redact ? shortId(peer.publicKey) : peer.publicKey,
+    topic: redact ? topicAlias(peer.topic) : peer.topic,
+    attempts: peer.attempts,
+    proven: peer.proven,
+  }))
+
+  return {
+    schema: DIAGNOSTICS_SCHEMA,
+    generatedAt: Date.now(),
+    redacted: redact,
+    reference: env.installId ? env.installId.slice(0, 8) : null,
+
+    app: { version: env.appVersion, channel: env.channel, build: env.packaged ? 'packaged' : 'source' },
+    system: { platform: env.platform, release: env.release, arch: env.arch },
+
+    verdict: { current: status.reachability, history },
+
+    network: {
+      dhtReady: status.dhtReady,
+      announced: status.announced,
+      readyAfterMs: counters.readyAt > 0 && counters.bootedAt > 0 ? counters.readyAt - counters.bootedAt : null,
+      publicHostKnown: status.address.publicHost !== null,
+      publicHostChanged: counters.hostChangeCount > 0,
+      // publicPort === 0 IS the symmetric-NAT finding and identifies nobody, so it is
+      // never redacted.
+      publicPort: status.address.publicPort,
+      localPortStable: counters.localPortStable,
+      firewalled: status.nat.firewalled,
+      randomized: status.nat.randomized,
+      ephemeral: status.nat.ephemeral,
+      routingTableSize: status.routing.tableSize,
+      bootstrapCount: status.routing.bootstrap.length,
+      health: status.dhtHealth,
+      ...(redact ? {} : {
+        publicHost: status.address.publicHost,
+        publicKey: status.identity.publicKey,
+        nodeId: status.identity.nodeId,
+        bootstrap: status.routing.bootstrap,
+      }),
+    },
+
+    peers: {
+      discovered: status.peerReach.discovered,
+      connected: status.peerReach.connected,
+      exhausted: status.peerReach.exhausted,
+      dials: status.stats.connects.client,
+      inbound: status.stats.connects.server,
+      bannedPeers: status.stats.bannedPeers,
+      samples,
+    },
+
+    canary: status.canary,
+    liveness: status.liveness,
+    relaying: status.stats.relaying,
+
+    spaces: {
+      count: status.topics,
+      topics: samples.map((sample) => sample.topic).filter((topic) => topic !== null),
+    },
+  }
+}

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -15,6 +15,7 @@ import Protomux from 'protomux'
 import c from 'compact-encoding'
 import b4a from 'b4a'
 import fs from 'bare-fs'
+import os from 'bare-os'
 import { getStore, diagnoseStoreCores, isStorageInconsistency } from '../core/store.js'
 import {
   getProfileKey, getProfile, getLocalPublicKeyHex, openProfileBee, readPeerApproval, hasOwnApproval,
@@ -25,9 +26,11 @@ import {
   recordJoinRequest, listJoinRequests, getJoinRequestDriveKey, clearJoinRequest,
   pinCreatorKey, markCreatorDivergence, clearCreatorDivergence, ownLooseCatalogPublish, persistLeftTombstone,
 } from '../spaces/space.js'
-import { getRuntimeConfig, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow, isRelayEnabled } from '../core/runtime-config.js'
+import { getRuntimeConfig, getUpgradeKey, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow, isRelayEnabled } from '../core/runtime-config.js'
 import { enabledRelayKeys, relayFunctionFor, decodeRelayKey } from './relay.js'
 import BlindRelay from 'blind-relay'
+import crypto from 'hypercore-crypto'
+import idEncoding from 'hypercore-id-encoding'
 import { catalogKeyField } from '../shares/share-catalog.js'
 import { HEX64 } from '../invite-envelope.js'
 import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, leaveFrameBound } from './handshake-guard.js'
@@ -47,6 +50,7 @@ import { markLeft, isLeft, openMemberView, closeMemberView, rosterDeficits, reco
 import { createPresence, presenceFrameKind } from '../state/presence.js'
 import { makeKeyedCoalescer } from '../state/coalesce.js'
 import { createLogger } from '../core/logger.js'
+import { classify, stabilise, routableAddressKind, CANARY, BLOCKED_DWELL_MS, NAT_SETTLE_MS, LIVENESS_FAILURES_FOR_OFFLINE } from '../core/reachability.js'
 
 const log = createLogger('swarm')
 
@@ -113,7 +117,14 @@ const escalationsSpent = new Map()      // spaceId → discovery.refreshes spent
 let testDrop = null                     // test-only inbound identity-frame drop window
 
 let dhtReady = false
+let readyAt = 0
 let announced = false
+let hostChangeCount = 0
+let lastKnownHost = null
+let currentReachability = { verdict: 'unknown', cause: null, confidence: 'predicted', evidence: null, since: 0, pending: null }
+let verdictHistory = []
+let lastCanaryResult = { state: CANARY.UNAVAILABLE, at: 0 }
+let browserOnlineHint = true
 let lastConnectionAt = null
 let lastEmittedStatus = null
 let statusEmitTimer = null
@@ -180,16 +191,25 @@ export function initSwarm(_ipc) {
   const onDhtReady = () => {
     if (dhtReady) return
     dhtReady = true
+    readyAt = Date.now()
     scheduleStatusEmit()
+    scheduleFirstCanaryProbe()
+    startLivenessLoop()
+    startInterfaceWatch()
   }
   swarm.dht.on('ready', onDhtReady)
   swarm.dht.fullyBootstrapped().then(onDhtReady, () => {})
   swarm.dht.on('persistent', scheduleStatusEmit)
   swarm.dht.on('network-change', scheduleStatusEmit)
   swarm.dht.on('wake-up', scheduleStatusEmit)
-  swarm.dht.on('nat-update', scheduleStatusEmit)
+  swarm.dht.on('nat-update', (host) => {
+    if (typeof host === 'string' && lastKnownHost !== null && host !== lastKnownHost) hostChangeCount++
+    if (typeof host === 'string') lastKnownHost = host
+    scheduleStatusEmit()
+  })
 
   swarm.on('connection', (socket, peerInfo) => {
+    livenessFailures = 0
     applyNetImpairment(socket) // TEST-ONLY: no-op unless runtime-config.netImpair is set
     lastConnectionAt = Date.now()
     scheduleStatusEmit()
@@ -1801,6 +1821,11 @@ export function sendMembershipDeny(profileKeyHex, topicHex) {
 export async function destroySwarm() {
   if (!swarm) return
   log.info('destroying swarm...')
+  if (dwellTimer) { clearTimeout(dwellTimer); dwellTimer = null }
+  if (firstProbeTimer) { clearTimeout(firstProbeTimer); firstProbeTimer = null }
+  if (livenessTimer) { clearInterval(livenessTimer); livenessTimer = null }
+  if (interfaceTimer) { clearInterval(interfaceTimer); interfaceTimer = null }
+  if (livenessRetryTimer) { clearTimeout(livenessRetryTimer); livenessRetryTimer = null }
   if (statusEmitTimer) {
     clearTimeout(statusEmitTimer)
     statusEmitTimer = null
@@ -1822,9 +1847,21 @@ export async function destroySwarm() {
   testDrop = null
   presence.clearAll()
   dhtReady = false
+  readyAt = 0
   announced = false
   lastConnectionAt = null
   lastEmittedStatus = null
+  hostChangeCount = 0
+  lastKnownHost = null
+  currentReachability = { verdict: 'unknown', cause: null, confidence: 'predicted', evidence: null, since: 0, pending: null }
+  verdictHistory = []
+  lastCanaryResult = { state: CANARY.UNAVAILABLE, at: 0 }
+  lastCanaryAt = 0
+  livenessFailures = 0
+  livenessCheckedAt = 0
+  interfaceKind = 'physical'
+  canaryInFlight = null
+  browserOnlineHint = true
   localBindings.clear()
   boundSignerKeys.clear()
   spaceTopics.clear()
@@ -1868,6 +1905,59 @@ function safeRoutingTableSize() {
     const arr = swarm?.dht?.toArray?.({ limit: 50 })
     return Array.isArray(arr) ? arr.length : 0
   } catch { return 0 }
+}
+
+// The gap between peers we DISCOVERED on our topics and peers we actually connected to
+// is the strongest connectivity signal available: the DHT told us where they are and we
+// could not open a socket to any of them.
+function snapshotPeerReach() {
+  const peers = swarm?.peers
+  if (!peers) return { discovered: 0, connected: 0, exhausted: 0 }
+  let exhausted = 0
+  for (const info of peers.values()) {
+    // attempts > 3 is where hyperswarm's _shouldRequeue gives up and the peer leaves the
+    // retry queue until a fresh lookup rediscovers it.
+    if (!info.proven && info.attempts > 3) exhausted++
+  }
+  return { discovered: peers.size, connected: swarm.connections?.size || 0, exhausted }
+}
+
+const PEER_SAMPLE_CAP = 32
+
+// PeerInfo.topics carries an upstream "remove on next major" marker, so never assume it.
+function topicHexOf(info) {
+  const topic = Array.isArray(info?.topics) ? info.topics[0] : null
+  if (!topic) return null
+  try { return b4a.toString(topic, 'hex') } catch { return null }
+}
+
+function snapshotPeerSamples() {
+  const peers = swarm?.peers
+  if (!peers) return []
+  const out = []
+  for (const [key, info] of peers) {
+    if (out.length >= PEER_SAMPLE_CAP) break
+    out.push({
+      publicKey: key,
+      topic: topicHexOf(info),
+      attempts: info.attempts || 0,
+      proven: !!info.proven,
+    })
+  }
+  return out
+}
+
+function snapshotDhtHealth() {
+  const health = swarm?.dht?.health
+  if (!health) return { online: true, degraded: false, cold: true, idle: true, timeoutsRate: 0 }
+  const s = health.stats || {}
+  return {
+    online: s.online !== false,
+    degraded: !!s.degraded,
+    cold: !!s.cold,
+    idle: !!s.idle,
+    timeoutsRate: typeof s.timeoutsRate === 'number' ? s.timeoutsRate : 0,
+  }
 }
 
 function snapshotStats() {
@@ -1917,6 +2007,11 @@ function offlineStatusSnapshot() {
       bannedPeers: 0,
       relaying: { selected: 0, attempts: 0, successes: 0, aborts: 0 },
     },
+    peerReach: { discovered: 0, connected: 0, exhausted: 0 },
+    dhtHealth: { online: false, degraded: false, cold: true, idle: true, timeoutsRate: 0 },
+    canary: { state: CANARY.UNAVAILABLE, at: 0 },
+    liveness: { failures: 0, checkedAt: 0, interfaceKind: 'physical' },
+    reachability: { verdict: 'unknown', cause: null, confidence: 'predicted', evidence: null, since: 0, pending: null },
     versions: { dht: DHT_VERSION },
   }
 }
@@ -1985,8 +2080,307 @@ export async function testRelayReachable(publicKey) {
   return result
 }
 
+const VERDICT_HISTORY_CAP = 200
+
+function recordVerdictTransition(next) {
+  const prev = verdictHistory[verdictHistory.length - 1]
+  if (prev && prev.verdict === next.verdict && prev.cause === next.cause) return
+  verdictHistory.push({ at: Date.now(), verdict: next.verdict, cause: next.cause, confidence: next.confidence })
+  if (verdictHistory.length > VERDICT_HISTORY_CAP) verdictHistory.shift()
+}
+
+function recomputeReachability() {
+  const dht = swarm?.dht || {}
+  const stats = snapshotStats()
+  const now = Date.now()
+  const raw = classify({
+    now,
+    bootedAt,
+    readyAt,
+    dhtReady,
+    suspended: !!swarm?.suspended || !!swarm?.destroyed,
+    browserOnline: browserOnlineHint,
+    hasInterface: interfaceKind !== 'none',
+    interfaceKind,
+    address: {
+      publicHost: typeof dht.host === 'string' ? dht.host : null,
+      publicPort: typeof dht.port === 'number' ? dht.port : 0,
+    },
+    routing: { tableSize: safeRoutingTableSize() },
+    dhtHealth: snapshotDhtHealth(),
+    peerReach: snapshotPeerReach(),
+    dials: { attempted: stats.connects.client.attempted, opened: stats.connects.client.opened },
+    canary: lastCanaryResult,
+    liveness: { failures: livenessFailures, checkedAt: livenessCheckedAt },
+  })
+  currentReachability = stabilise(raw, currentReachability, now)
+  recordVerdictTransition(currentReachability)
+  return currentReachability
+}
+
+export function setBrowserOnlineHint(online) {
+  const next = online !== false
+  if (next === browserOnlineHint) return
+  browserOnlineHint = next
+  scheduleStatusEmit()
+}
+
+export function getVerdictHistory() {
+  return verdictHistory.slice()
+}
+
+export function getDiagnosticCounters() {
+  return {
+    readyAt,
+    bootedAt,
+    hostChangeCount,
+    localPortStable: safeAddress().port > 0,
+  }
+}
+
+export function getPeerSamples() {
+  return snapshotPeerSamples()
+}
+
+const CANARY_TIMEOUT_MS = 10000
+const CANARY_MIN_INTERVAL_MS = 15 * 60 * 1000
+const CANARY_MAX_DIALS = 3
+
+let canaryInFlight = null
+let lastCanaryAt = 0
+
+function parseUpgradeKey(raw) {
+  if (typeof raw !== 'string' || raw.length === 0) return null
+  const bare = raw.replace(/^pear:\/\//, '').split('/')[0].trim()
+  if (!bare) return null
+  try {
+    const key = idEncoding.decode(bare)
+    return key.byteLength === 32 ? key : null
+  } catch { return null }
+}
+
+function dialOnce(dht, peer) {
+  return new Promise((resolve) => {
+    let socket = null
+    let settled = false
+    const finish = (ok) => {
+      if (settled) return
+      settled = true
+      clearTimeout(timer)
+      if (socket) { try { socket.destroy() } catch {} }
+      resolve(ok)
+    }
+    const timer = setTimeout(() => finish(false), CANARY_TIMEOUT_MS)
+    timer.unref?.()
+    try {
+      socket = dht.connect(peer.publicKey, { relayAddresses: peer.relayAddresses })
+      socket.on('open', () => finish(true))
+      socket.on('error', () => finish(false))
+      socket.on('close', () => finish(false))
+    } catch (err) {
+      log.debug('canary dial threw:', err.message)
+      finish(false)
+    }
+  })
+}
+
+// Two stages, because a single probe cannot distinguish "your network is broken" from
+// "our seeder is down". Stage 1 asks the DHT whether the seeder is announcing at all; if
+// it is not, we report seeder-down and the reducer leaves the user's verdict untouched.
+async function runCanaryProbe(upgradeKey) {
+  const driveKey = parseUpgradeKey(upgradeKey)
+  if (!driveKey) return { state: CANARY.UNAVAILABLE, reason: 'no-key' }
+  const dht = swarm?.dht
+  if (!dht || !dhtReady) return { state: CANARY.UNAVAILABLE, reason: 'no-dht' }
+
+  const topic = crypto.discoveryKey(driveKey)
+  const found = []
+  const stream = dht.lookup(topic)
+  const stage1Started = Date.now()
+  const stage1Timer = setTimeout(() => { try { stream.destroy() } catch {} }, CANARY_TIMEOUT_MS)
+  stage1Timer.unref?.()
+  try {
+    for await (const reply of stream) {
+      for (const peer of reply.peers || []) {
+        if (found.length >= CANARY_MAX_DIALS) break
+        found.push(peer)
+      }
+      if (found.length >= CANARY_MAX_DIALS) break
+    }
+  } catch (err) {
+    log.debug('canary lookup failed:', err.message)
+  } finally {
+    clearTimeout(stage1Timer)
+    try { stream.destroy() } catch {}
+  }
+  const stage1 = { announceRecords: found.length, ms: Date.now() - stage1Started }
+
+  if (found.length === 0) return { state: CANARY.SEEDER_DOWN, stage1 }
+
+  const stage2Started = Date.now()
+  let dials = 0
+  for (const peer of found) {
+    dials++
+    if (await dialOnce(dht, peer)) {
+      return { state: CANARY.REACHABLE, stage1, stage2: { dials, opened: 1, ms: Date.now() - stage2Started } }
+    }
+  }
+  return { state: CANARY.UNREACHABLE, stage1, stage2: { dials, opened: 0, ms: Date.now() - stage2Started } }
+}
+
+// Tier 2 needs joined topics to produce evidence, so a user with no spaces has only the
+// NAT shape — a prediction. One automatic probe turns it into a measurement. Deliberately
+// not on a timer: this fires once per swarm, and every other probe is user-initiated.
+let firstProbeTimer = null
+
+// Only runs while nothing else can produce evidence — with peers connected, their presence
+// IS the liveness signal, and a periodic ping from every idle client would be pointless
+// DHT traffic. Targets our own routing table (public infrastructure built for exactly
+// this), never the seeder.
+// A local syscall, not a network round-trip: if the machine has no non-internal address
+// there is definitively no network, and we can say so instantly instead of waiting for
+// probes to time out — and say the *right* thing, rather than blaming a VPN or a router.
+const INTERFACE_POLL_MS = 3000
+
+let interfaceKind = 'physical'
+let interfaceTimer = null
+
+function readInterfaceKind() {
+  try {
+    return routableAddressKind(os.networkInterfaces())
+  } catch {
+    // Never invent an outage from a failed read.
+    return 'physical'
+  }
+}
+
+function startInterfaceWatch() {
+  if (interfaceTimer) return
+  interfaceKind = readInterfaceKind()
+  interfaceTimer = setInterval(() => {
+    const next = readInterfaceKind()
+    if (next === interfaceKind) return
+    // A route reappearing is a fresh start for the probe, not a continuation.
+    if (interfaceKind === 'none' && next !== 'none') livenessFailures = 0
+    interfaceKind = next
+    scheduleStatusEmit()
+  }, INTERFACE_POLL_MS)
+  interfaceTimer.unref?.()
+}
+
+const LIVENESS_INTERVAL_MS = 15000
+const LIVENESS_RETRY_MS = 2000
+const LIVENESS_TIMEOUT_MS = 5000
+
+let livenessTimer = null
+let livenessFailures = 0
+let livenessCheckedAt = 0
+
+// Routing-table entries only: they are real IPs seen over the wire. The bootstrap list is
+// hostnames, and dht.ping() rejects those instantly as "not a valid IP address" — which
+// would be counted as a failure and declare a healthy network dead.
+function livenessTarget() {
+  const dht = swarm?.dht
+  if (!dht) return null
+  try {
+    const nodes = dht.toArray({ limit: 8 })
+    if (nodes && nodes.length) return nodes[Math.floor(nodes.length / 2)]
+  } catch {}
+  return null
+}
+
+async function checkLiveness() {
+  const dht = swarm?.dht
+  if (!dht || !dhtReady || swarm.suspended || swarm.destroyed) return
+  if (swarm.connections?.size > 0) { livenessFailures = 0; return }
+
+  const target = livenessTarget()
+  if (!target) return
+
+  let timer = null
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(() => resolve(false), LIVENESS_TIMEOUT_MS)
+    timer.unref?.()
+  })
+  let alive = false
+  try {
+    alive = await Promise.race([dht.ping(target).then(() => true, () => false), timeout])
+  } catch { alive = false }
+  clearTimeout(timer)
+
+  const before = livenessFailures
+  livenessFailures = alive ? 0 : Math.min(livenessFailures + 1, LIVENESS_FAILURES_FOR_OFFLINE)
+  livenessCheckedAt = Date.now()
+  if (before !== livenessFailures) scheduleStatusEmit()
+
+  // Confirm a first failure promptly rather than after another full interval.
+  if (!alive && livenessFailures < LIVENESS_FAILURES_FOR_OFFLINE) scheduleLivenessRetry()
+}
+
+let livenessRetryTimer = null
+
+function scheduleLivenessRetry() {
+  if (livenessRetryTimer) return
+  livenessRetryTimer = setTimeout(() => {
+    livenessRetryTimer = null
+    checkLiveness().catch((err) => log.debug('liveness retry failed:', err.message))
+  }, LIVENESS_RETRY_MS)
+  livenessRetryTimer.unref?.()
+}
+
+// Lets a network transition the OS *did* notice trigger an immediate re-check instead of
+// waiting out the interval.
+export async function checkLivenessNow() {
+  await checkLiveness()
+  return { failures: livenessFailures, checkedAt: livenessCheckedAt }
+}
+
+function startLivenessLoop() {
+  if (livenessTimer) return
+  livenessTimer = setInterval(() => {
+    checkLiveness().catch((err) => log.debug('liveness check failed:', err.message))
+  }, LIVENESS_INTERVAL_MS)
+  livenessTimer.unref?.()
+}
+
+function scheduleFirstCanaryProbe() {
+  if (firstProbeTimer || spaceTopics.size > 0) return
+  firstProbeTimer = setTimeout(() => {
+    firstProbeTimer = null
+    if (spaceTopics.size > 0) return
+    probeCanary(getUpgradeKey()).catch((err) => log.debug('first canary probe failed:', err.message))
+  }, NAT_SETTLE_MS)
+  firstProbeTimer.unref?.()
+}
+
+export async function probeCanary(upgradeKey, { force = false } = {}) {
+  const now = Date.now()
+  if (!force) {
+    if (now - lastCanaryAt < CANARY_MIN_INTERVAL_MS) return lastCanaryResult
+    if (canaryInFlight) return canaryInFlight
+  }
+
+  canaryInFlight = runCanaryProbe(upgradeKey)
+    .then((result) => {
+      lastCanaryResult = { ...result, at: Date.now() }
+      lastCanaryAt = Date.now()
+      scheduleStatusEmit()
+      return lastCanaryResult
+    })
+    .catch((err) => {
+      log.debug('canary probe failed:', err.message)
+      lastCanaryResult = { state: CANARY.UNAVAILABLE, at: Date.now() }
+      return lastCanaryResult
+    })
+    .finally(() => { canaryInFlight = null })
+
+  return canaryInFlight
+}
+
 export function getSwarmStatus() {
   if (!swarm) return offlineStatusSnapshot()
+
+  const reachability = recomputeReachability()
 
   const peerCount = swarm.connections?.size || 0
   const connecting = swarm.connecting || 0
@@ -2030,6 +2424,11 @@ export function getSwarmStatus() {
     topics: spaceTopics.size,
     contentPlane: getContentPlaneStatus(),
     stats: snapshotStats(),
+    peerReach: snapshotPeerReach(),
+    dhtHealth: snapshotDhtHealth(),
+    canary: lastCanaryResult,
+    liveness: { failures: livenessFailures, checkedAt: livenessCheckedAt, interfaceKind },
+    reachability,
     versions: { dht: DHT_VERSION },
   }
 }
@@ -2069,6 +2468,19 @@ const STATUS_FIELDS = [
   (s) => s.stats.relaying.attempts,
   (s) => s.stats.relaying.successes,
   (s) => s.stats.relaying.aborts,
+  (s) => s.peerReach.discovered,
+  (s) => s.peerReach.connected,
+  (s) => s.peerReach.exhausted,
+  (s) => s.dhtHealth.online,
+  (s) => s.dhtHealth.degraded,
+  (s) => s.dhtHealth.timeoutsRate,
+  (s) => s.canary.state,
+  (s) => s.canary.at,
+  (s) => s.liveness.failures,
+  (s) => s.liveness.interfaceKind,
+  (s) => s.reachability.verdict,
+  (s) => s.reachability.cause,
+  (s) => s.reachability.confidence,
 ]
 
 export function statusEqual(a, b) {
@@ -2077,12 +2489,26 @@ export function statusEqual(a, b) {
   return STATUS_FIELDS.every((field) => field(a) === field(b))
 }
 
+// A blocked user generates LESS swarm activity, not more, so a pending escalation would
+// otherwise sit unemitted until something unrelated happened. One-shot and armed only
+// from the emit path — never from getSwarmStatus, which is a read and must not start
+// timers that outlive destroySwarm.
+let dwellTimer = null
+
+function armDwellRecheck(pending) {
+  if (dwellTimer) { clearTimeout(dwellTimer); dwellTimer = null }
+  if (!pending) return
+  dwellTimer = setTimeout(() => { dwellTimer = null; scheduleStatusEmit() }, BLOCKED_DWELL_MS / 2)
+  dwellTimer.unref?.()
+}
+
 function scheduleStatusEmit() {
   if (statusEmitTimer) return
   statusEmitTimer = setTimeout(() => {
     statusEmitTimer = null
     if (!ipcRef) return
     const next = getSwarmStatus()
+    armDwellRecheck(next.reachability?.pending)
     if (statusEqual(next, lastEmittedStatus)) return
     lastEmittedStatus = next
     try {

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -11,7 +11,7 @@ import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
 import { createIPC, getBootstrapPromise } from '../shared/core/ipc.js'
-import { setRuntimeConfig, getRuntimeConfig, setDownloadFolder, setBandwidthLimits, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap, isRelayEnabled, getRelayConfig, setRelayConfig } from '../shared/core/runtime-config.js'
+import { setRuntimeConfig, getRuntimeConfig, getUpgradeKey, setDownloadFolder, setBandwidthLimits, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap, isRelayEnabled, getRelayConfig, setRelayConfig } from '../shared/core/runtime-config.js'
 import { hydrateDownloadRoots, setSpaceDownloadRoot, forgetSpaceDownloadRoot, listDownloadRoots } from '../shared/core/paths.js'
 import { createLogger } from '../shared/core/logger.js'
 import { installCrashBackstop } from '../shared/core/crash-backstop.js'
@@ -41,7 +41,7 @@ import {
 import { initSpaceKeys } from '../shared/spaces/space-keys.js'
 import { classifyInvite } from '../shared/spaces/invite-policy.js'
 import { encodeInvite, decodeInvite } from '../shared/invite-envelope.js'
-import { initSwarm, joinSpaceTopic, leaveSpaceTopic, cleanupSpaceDrives, compactStore, destroySwarm, broadcastDeparture, getConnectedPeers, isOwnerOnline, broadcastProfileUpdate, sendLeaveFrameToConnectedPeers, awaitLeaveAcks, getSwarmStatus, setRelayThrough, testRelayReachable, reconnectAll, setMembershipControlHandler, setConnectionAttachHook, getSwarmDht, setOverlayReconnectHook, setRevokeServesForSpaceHook, setStalledOwnersHook, rescueStalledTransfers, sendMembershipGrant, sendMembershipDeny, broadcastMembershipCancel, reconcilePendingRequester, isApprovedMember, resolveInvite, markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving, getBoundSignerKey, broadcastSharePrepareProgress, configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, joinPendingLeaveTopic, leavePendingLeaveTopic, hasPendingLeave, takeLeaveAckedKeys, configurePendingCancels, registerPendingCancel, joinPendingCancelTopic, leavePendingCancelTopic, hasPendingCancel, sendPendingCancelToConnected } from '../shared/transfer/swarm.js'
+import { initSwarm, joinSpaceTopic, leaveSpaceTopic, cleanupSpaceDrives, compactStore, destroySwarm, broadcastDeparture, getConnectedPeers, isOwnerOnline, broadcastProfileUpdate, sendLeaveFrameToConnectedPeers, awaitLeaveAcks, getSwarmStatus, setRelayThrough, testRelayReachable, reconnectAll, probeCanary, setBrowserOnlineHint, checkLivenessNow, getVerdictHistory, getDiagnosticCounters, getPeerSamples, setMembershipControlHandler, setConnectionAttachHook, getSwarmDht, setOverlayReconnectHook, setRevokeServesForSpaceHook, setStalledOwnersHook, rescueStalledTransfers, sendMembershipGrant, sendMembershipDeny, broadcastMembershipCancel, reconcilePendingRequester, isApprovedMember, resolveInvite, markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving, getBoundSignerKey, broadcastSharePrepareProgress, configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, joinPendingLeaveTopic, leavePendingLeaveTopic, hasPendingLeave, takeLeaveAckedKeys, configurePendingCancels, registerPendingCancel, joinPendingCancelTopic, leavePendingCancelTopic, hasPendingCancel, sendPendingCancelToConnected } from '../shared/transfer/swarm.js'
 import { initContentSwarm, destroyContentSwarm, setContentAttachHook, setContentResumeHook } from '../shared/transfer/content-swarm.js'
 import { clampDisplayName, checkGrantAssertion } from '../shared/transfer/handshake-guard.js'
 import { openSealedSck } from '../shared/transfer/sck-seal.js'
@@ -69,6 +69,8 @@ import { reclaimLegacyPeerCaches } from '../shared/storage/legacy-peer-cache.js'
 import { classifyLeftovers, forgetUnreferencedPeerCores } from '../shared/storage/leftover.js'
 import { sendFeedback } from '../shared/telemetry/feedback.js'
 import { getInstallId } from '../shared/telemetry/install-id.js'
+import { deriveChannel } from '../shared/core/channel.js'
+import { buildDiagnostics } from '../shared/transfer/diagnostics.js'
 import {
   initAuditLog, record, setAuditIdentity, queryAudit, auditSpaces, auditActors, auditStats,
   getAuditConfig, setAuditConfig, pruneAudit, purgeAudit, exportAudit,
@@ -2294,6 +2296,37 @@ ipc.handle('network:set-relays', async (msg) => {
 })
 
 ipc.handle('network:test-relay', async (msg) => await testRelayReachable(msg?.publicKey))
+
+ipc.handle('network:probe-canary', async (msg) =>
+  await probeCanary(getUpgradeKey(), { force: !!msg?.force }))
+
+// The renderer owns navigator.onLine; the worker cannot see it. Without this a pulled
+// cable would be classified as a NAT problem.
+ipc.handle('network:online-hint', async (msg) => {
+  setBrowserOnlineHint(msg?.online !== false)
+  return { ok: true }
+})
+
+ipc.handle('network:check-liveness', async () => await checkLivenessNow())
+
+ipc.handle('diagnostics:export', async (msg) => {
+  const cfg = getRuntimeConfig()
+  return buildDiagnostics({
+    status: getSwarmStatus(),
+    history: getVerdictHistory(),
+    env: {
+      appVersion: cfg.appVersion || (cfg.dev ? 'dev' : 'unknown'),
+      channel: deriveChannel(cfg),
+      installId: cfg.storage ? await getInstallId(cfg.storage) : null,
+      packaged: !!getUpgradeKey(),
+      platform: os.platform(),
+      release: os.release(),
+      arch: os.arch(),
+    },
+    counters: getDiagnosticCounters(),
+    peerSamples: getPeerSamples(),
+  }, msg?.redact !== false)
+})
 
 ipc.handle('features:get', async () => ({ overlay: isOverlayEnabled(), inPlaceFiles: isInPlaceFilesEnabled() }))
 

--- a/test/frontend/instance.mjs
+++ b/test/frontend/instance.mjs
@@ -351,6 +351,9 @@ export class Instance {
     await this.waitText('Create Space', 30000)
   }
 
+  // Second onboarding step: the connectivity check. Its primary control is disabled
+  // while the probe runs, and its label depends on the verdict — on the local testnet
+  // there is no canary target, so the neutral "Continue" is the expected path.
   // Same `actionable` lens as nodeValue(): a control's disabled state is meaningless
   // on the label that shares its name, and a statictext never carries `disabled` —
   // so matching the label would quietly report an actually-disabled control as

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -110,6 +110,8 @@ import s100 from './scenarios/s100-reshare-after-unshare.mjs'
 import s101 from './scenarios/s101-cancel-then-redownload.mjs'
 import s102 from './scenarios/s102-remove-readd-no-autoresume.mjs'
 import s103 from './scenarios/s103-folder-tree.mjs'
+import s112 from './scenarios/s112-connection-problem.mjs'
+import s113 from './scenarios/s113-diagnostics-export.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -176,7 +178,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s112-connection-problem.mjs
+++ b/test/frontend/scenarios/s112-connection-problem.mjs
@@ -1,0 +1,39 @@
+import { mkdirSync } from 'node:fs'
+import { Instance } from '../instance.mjs'
+import { makeReport } from '../assert.mjs'
+
+// The Connection problem screen replaces the spaces screen when the verdict is degraded
+// and the user has no spaces. The space-management actions must be absent — leaving
+// "Create Space" beside "your network is blocking Mirall" is the incoherence it exists
+// to fix. Reached here through the Network status screen, which is available regardless
+// of the live verdict.
+export default async function s112 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 1 })
+
+  try {
+    await r.ok('launch + open Network status', async () => {
+      await A.launch()
+      await A.openNetworkStatus()
+    })
+
+    await r.ok('the connection summary is present and readable', async () => {
+      for (const label of ['Connection summary', 'Reachable from outside', 'Connection test', 'People']) {
+        if (!(await A.hasText(label))) throw new Error(`summary row missing: ${label}`)
+      }
+    })
+
+    await r.ok('raw NAT rows stay behind the advanced disclosure', async () => {
+      if (await A.hasText('Randomised port mapping')) {
+        throw new Error('advanced NAT rows are visible before expanding the disclosure')
+      }
+      await A.click({ role: 'button', contains: 'Show advanced details' })
+      if (!(await A.hasText('Randomised port mapping'))) {
+        throw new Error('advanced NAT rows did not appear after expanding')
+      }
+      await A.shot('s112-advanced', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/frontend/scenarios/s113-diagnostics-export.mjs
+++ b/test/frontend/scenarios/s113-diagnostics-export.mjs
@@ -1,0 +1,42 @@
+import { mkdirSync } from 'node:fs'
+import { Instance } from '../instance.mjs'
+import { makeReport } from '../assert.mjs'
+
+// The diagnostics card: both toggles reachable by accessible name, and the preview modal
+// shows the real bundle before anything is written.
+export default async function s113 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 1 })
+
+  try {
+    await r.ok('launch + open Network status', async () => {
+      await A.launch()
+      await A.openNetworkStatus()
+    })
+
+    await r.ok('both diagnostics toggles are reachable by name', async () => {
+      for (const name of ['Remove identifying details', 'Include detailed logs']) {
+        if (!(await A.has({ role: 'switch', name }))) throw new Error(`toggle missing: ${name}`)
+      }
+    })
+
+    await r.ok('preview opens, shows the bundle, and closes', async () => {
+      await A.click({ role: 'button', contains: "Preview what's included" })
+      await A.waitText("What's in the file", 15000)
+      if (!(await A.hasText('"schema"'))) throw new Error('preview does not show the bundle JSON')
+      await A.shot('s113-preview', runDir)
+      await A.click({ role: 'button', name: 'Close' })
+    })
+
+    await r.ok('the redacted preview carries no public key', async () => {
+      await A.click({ role: 'button', contains: "Preview what's included" })
+      await A.waitText("What's in the file", 15000)
+      if (await A.hasText('"publicKey"')) {
+        throw new Error('redacted preview exposed publicKey')
+      }
+      await A.click({ role: 'button', name: 'Close' })
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/integration/swarm-status-equal.test.js
+++ b/test/integration/swarm-status-equal.test.js
@@ -19,6 +19,10 @@ const FIELD_PATHS = [
   'stats.connects.server.opened', 'stats.connects.server.closed',
   'stats.bannedPeers',
   'stats.relaying.selected', 'stats.relaying.attempts', 'stats.relaying.successes', 'stats.relaying.aborts',
+  'peerReach.discovered', 'peerReach.connected', 'peerReach.exhausted',
+  'dhtHealth.online', 'dhtHealth.degraded', 'dhtHealth.timeoutsRate',
+  'canary.state', 'canary.at', 'liveness.failures', 'liveness.interfaceKind',
+  'reachability.verdict', 'reachability.cause', 'reachability.confidence',
 ]
 
 function makeStatus () {
@@ -35,6 +39,11 @@ function makeStatus () {
       bannedPeers: 0,
       relaying: { selected: 0, attempts: 0, successes: 0, aborts: 0 },
     },
+    peerReach: { discovered: 4, connected: 1, exhausted: 2 },
+    dhtHealth: { online: true, degraded: false, cold: false, idle: false, timeoutsRate: 0.1 },
+    canary: { state: 'reachable', at: 900 },
+    liveness: { failures: 0, checkedAt: 880, interfaceKind: 'physical' },
+    reachability: { verdict: 'healthy', cause: null, confidence: 'measured', since: 800 },
   }
 }
 

--- a/test/unit/bundle-axe-stripped.test.js
+++ b/test/unit/bundle-axe-stripped.test.js
@@ -40,6 +40,10 @@ test('REGRESSION (FIX-AXE-1): production bundle (__DEV__=false) strips axe-core'
   const out = await bundle(false)
   t.absent(out.includes('@axe-core'), 'no @axe-core module reference in prod bundle')
   t.absent(out.includes('color-contrast'), 'no axe-core rule ids in prod bundle')
+  // A backstop for the two string checks above, not a size budget: axe-core adds ~616KB,
+  // so any inclusion blows past this by a wide margin. Headroom is thin (~5KB) because the
+  // five statically-bundled locales are ~27% of the bundle, which makes this line the
+  // effective budget for new UI copy — lazy-loading them is the real fix.
   t.ok(out.length < 1_000_000, `prod bundle is small without axe-core (${out.length} bytes)`)
 })
 

--- a/test/unit/connection-summary.test.js
+++ b/test/unit/connection-summary.test.js
@@ -1,0 +1,52 @@
+import test from 'brittle'
+import { fixStepsFor, reachableState, formatDuration } from '../../src/renderer/connectivity.js'
+
+const status = (over = {}) => ({
+  dhtReady: true,
+  address: { publicHost: '203.0.113.7', publicPort: 41234, localPort: 41234 },
+  ...over,
+})
+
+test('port 0 with a known host reads as changing ports', (t) => {
+  t.is(reachableState(status({ address: { publicHost: '203.0.113.7', publicPort: 0 } })), 'changingPorts')
+})
+
+test('null host reads as noAddress, NOT changingPorts', (t) => {
+  t.is(reachableState(status({ address: { publicHost: null, publicPort: 0 } })), 'noAddress')
+})
+
+test('a stable mapping reads as yes', (t) => {
+  t.is(reachableState(status()), 'yes')
+})
+
+test('!dhtReady reads as unknown regardless of the address fields', (t) => {
+  t.is(reachableState(status({ dhtReady: false, address: { publicHost: null, publicPort: 0 } })), 'unknown')
+})
+
+test('symmetric NAT puts the mobile step first', (t) => {
+  // No router setting fixes a carrier NAT, so telling someone to check their router
+  // first would send them somewhere that cannot help.
+  t.alike(fixStepsFor('symmetric-nat'), ['mobile', 'vpn', 'otherNetwork'])
+})
+
+test('every other cause leads with the VPN step', (t) => {
+  t.alike(fixStepsFor('peers-unreachable'), ['vpn', 'mobile', 'otherNetwork'])
+  t.alike(fixStepsFor(null), ['vpn', 'mobile', 'otherNetwork'])
+})
+
+test('being offline gets network advice, not VPN and NAT advice', (t) => {
+  t.alike(fixStepsFor('os-offline'), ['turnOnNetwork'])
+})
+
+test('a VPN-only route leads with the VPN step', (t) => {
+  t.alike(fixStepsFor('vpn-only-route'), ['vpn', 'otherNetwork'])
+})
+
+test('formatDuration covers seconds through days', (t) => {
+  t.is(formatDuration(5000), '5s')
+  t.is(formatDuration(12 * 60000), '12m')
+  t.is(formatDuration(3 * 3600000 + 4 * 60000), '3h 4m')
+  t.is(formatDuration(50 * 3600000), '2d 2h')
+  t.is(formatDuration(-1), '—')
+  t.is(formatDuration(Number.NaN), '—')
+})

--- a/test/unit/diagnostics-bundle.test.js
+++ b/test/unit/diagnostics-bundle.test.js
@@ -1,0 +1,135 @@
+import test from 'brittle'
+import { buildDiagnostics, DIAGNOSTICS_SCHEMA } from '../../src/shared/transfer/diagnostics.js'
+
+const PUBLIC_HOST = '203.0.113.7'
+const PUBLIC_KEY = 'a'.repeat(64)
+const NODE_ID = 'b'.repeat(64)
+const PEER_KEY = 'c'.repeat(64)
+const TOPIC = 'd'.repeat(64)
+const BOOTSTRAP = ['node1.example.test:49737', 'node2.example.test:49737']
+const INSTALL_ID = '4f2a91c7-0000-4000-8000-000000000000'
+
+function makeCtx(over = {}) {
+  return {
+    status: {
+      dhtReady: true,
+      announced: true,
+      address: { publicHost: PUBLIC_HOST, publicPort: 0, localPort: 63418 },
+      identity: { publicKey: PUBLIC_KEY, nodeId: NODE_ID },
+      nat: { firewalled: true, randomized: true, ephemeral: true },
+      routing: { tableSize: 50, bootstrap: BOOTSTRAP },
+      topics: 1,
+      reachability: { verdict: 'at-risk', cause: 'symmetric-nat', confidence: 'measured', since: 10 },
+      peerReach: { discovered: 4, connected: 0, exhausted: 4 },
+      dhtHealth: { online: true, degraded: false, cold: false, idle: false, timeoutsRate: 0.04 },
+      canary: { state: 'unreachable', at: 20 },
+      liveness: { failures: 0, checkedAt: 18, interfaceKind: 'tunnel-only' },
+      stats: {
+        connects: {
+          client: { opened: 0, closed: 17, attempted: 17 },
+          server: { opened: 0, closed: 0, attempted: 0 },
+        },
+        bannedPeers: 0,
+        relaying: { selected: 0, attempts: 0, successes: 0, aborts: 0 },
+      },
+      ...over.status,
+    },
+    history: [{ at: 1, verdict: 'unknown', cause: null, confidence: 'predicted' }],
+    env: {
+      appVersion: '1.8.0',
+      channel: 'prod',
+      installId: INSTALL_ID,
+      packaged: true,
+      platform: 'darwin',
+      release: '24.6.0',
+      arch: 'arm64',
+    },
+    counters: { readyAt: 4400, bootedAt: 1000, hostChangeCount: 0, localPortStable: true },
+    peerSamples: [
+      { publicKey: PEER_KEY, topic: TOPIC, attempts: 5, proven: false },
+      { publicKey: 'e'.repeat(64), topic: TOPIC, attempts: 4, proven: false },
+    ],
+    ...over,
+  }
+}
+
+test('REGRESSION (FIX-3: bundle must not leak identity) — redacted bundle carries no IP, key, node id or bootstrap host', (t) => {
+  const serialised = JSON.stringify(buildDiagnostics(makeCtx(), true))
+  t.absent(serialised.includes(PUBLIC_HOST), 'public IP absent')
+  t.absent(serialised.includes(PUBLIC_KEY), 'public key absent')
+  t.absent(serialised.includes(NODE_ID), 'node id absent')
+  t.absent(serialised.includes(PEER_KEY), 'peer key absent')
+  for (const host of BOOTSTRAP) t.absent(serialised.includes(host), 'bootstrap host absent')
+  t.absent(serialised.includes(TOPIC), 'topic absent')
+  t.absent(serialised.includes(INSTALL_ID), 'full install id absent')
+})
+
+test('the symmetric-NAT finding survives redaction', (t) => {
+  // publicPort === 0 identifies nobody and IS the diagnosis — redacting it would make the
+  // bundle useless for the case it exists to serve.
+  const bundle = buildDiagnostics(makeCtx(), true)
+  t.is(bundle.network.publicPort, 0)
+  t.is(bundle.network.publicHostKnown, true)
+  t.is(bundle.network.randomized, true)
+  t.is(bundle.network.routingTableSize, 50)
+})
+
+test('peer counts and dial outcomes survive redaction', (t) => {
+  const bundle = buildDiagnostics(makeCtx(), true)
+  t.is(bundle.peers.discovered, 4)
+  t.is(bundle.peers.connected, 0)
+  t.is(bundle.peers.exhausted, 4)
+  t.is(bundle.peers.dials.attempted, 17)
+  t.is(bundle.peers.dials.opened, 0)
+  t.is(bundle.peers.samples[0].attempts, 5)
+  t.is(bundle.peers.samples[0].proven, false)
+})
+
+test('unredacted bundle carries the real values', (t) => {
+  const bundle = buildDiagnostics(makeCtx(), false)
+  t.is(bundle.network.publicHost, PUBLIC_HOST)
+  t.is(bundle.network.publicKey, PUBLIC_KEY)
+  t.is(bundle.network.nodeId, NODE_ID)
+  t.alike(bundle.network.bootstrap, BOOTSTRAP)
+  t.is(bundle.peers.samples[0].peer, PEER_KEY)
+  t.is(bundle.redacted, false)
+})
+
+test('topic aliases are consistent between the peers and spaces sections', (t) => {
+  const bundle = buildDiagnostics(makeCtx(), true)
+  const fromPeers = new Set(bundle.peers.samples.map((sample) => sample.topic))
+  t.ok(bundle.spaces.topics.length > 0)
+  for (const topic of bundle.spaces.topics) t.ok(fromPeers.has(topic), 'same alias space')
+})
+
+test('reference is the install-id prefix, not the whole id', (t) => {
+  const bundle = buildDiagnostics(makeCtx(), true)
+  t.is(bundle.reference.length, 8)
+  t.is(bundle.reference, INSTALL_ID.slice(0, 8))
+})
+
+test('a source build with no install id still produces a valid bundle', (t) => {
+  const ctx = makeCtx()
+  ctx.env.installId = null
+  ctx.env.packaged = false
+  const bundle = buildDiagnostics(ctx, true)
+  t.is(bundle.reference, null)
+  t.is(bundle.app.build, 'source')
+  t.is(bundle.schema, DIAGNOSTICS_SCHEMA)
+})
+
+test('readyAfterMs is derived, and null when the DHT never came up', (t) => {
+  t.is(buildDiagnostics(makeCtx(), true).network.readyAfterMs, 3400)
+  const ctx = makeCtx()
+  ctx.counters.readyAt = 0
+  t.is(buildDiagnostics(ctx, true).network.readyAfterMs, null)
+})
+
+test('an empty swarm produces a well-formed bundle', (t) => {
+  const ctx = makeCtx()
+  ctx.peerSamples = []
+  ctx.status.peerReach = { discovered: 0, connected: 0, exhausted: 0 }
+  const bundle = buildDiagnostics(ctx, true)
+  t.alike(bundle.peers.samples, [])
+  t.alike(bundle.spaces.topics, [])
+})

--- a/test/unit/diagnostics-redact.test.js
+++ b/test/unit/diagnostics-redact.test.js
@@ -1,0 +1,71 @@
+import test from 'brittle'
+import { redactLine, shortId, makeAliaser } from '../../src/shared/core/diagnostics-redact.js'
+
+test('redactLine removes IPv4', (t) => {
+  t.is(redactLine('connecting to 192.168.1.44:41234'), 'connecting to ‹ip›:41234')
+})
+
+test('redactLine removes IPv6', (t) => {
+  t.absent(redactLine('peer at 2001:db8:85a3::8a2e:370:7334 failed').includes('2001:db8'))
+})
+
+test('redactLine truncates hex keys', (t) => {
+  const key = 'a'.repeat(64)
+  const out = redactLine(`handshake from ${key}`)
+  t.absent(out.includes(key))
+  t.ok(out.includes('aaaa…'))
+})
+
+test('redactLine removes posix and windows paths', (t) => {
+  t.is(redactLine('watching /Users/rene/Documents'), 'watching ‹path›')
+  t.is(redactLine('watching C:\\Users\\rene\\Docs'), 'watching ‹path›')
+})
+
+test('REGRESSION (FIX-2: a path must not swallow the rest of the line)', (t) => {
+  // An early version allowed spaces inside a path segment, so everything after a path —
+  // including keys that still needed redacting — vanished into the placeholder.
+  const out = redactLine('watching /Users/rene/Docs then dialed ' + 'b'.repeat(64))
+  t.ok(out.includes('then dialed'), 'trailing text survives')
+  t.ok(out.includes('bbbb…'), 'the trailing key is still redacted')
+})
+
+test('REGRESSION (FIX-8: IPv6 pattern ate clock times) — timestamps survive', (t) => {
+  // The old `{0,4}` minimum matched any two-colon run, so redaction destroyed every
+  // timestamp in the exported log.
+  t.is(redactLine('2026-08-24 17:39:16 connecting'), '2026-08-24 17:39:16 connecting')
+  t.is(redactLine('took 01:02:03 total'), 'took 01:02:03 total')
+})
+
+test('IPv6 still redacted in both full and compressed forms', (t) => {
+  t.absent(redactLine('at 2001:0db8:85a3:0000:0000:8a2e:0370:7334 x').includes('2001'))
+  t.absent(redactLine('at 2001:db8:85a3::8a2e:370:7334 x').includes('2001'))
+  t.absent(redactLine('bound fe80::1 ok').includes('fe80'))
+})
+
+test('REGRESSION (FIX-9: non-ASCII paths kept the username)', (t) => {
+  const out = redactLine('watching /Users/rené/Dokumente/Freigabe')
+  t.absent(out.includes('rené'), 'the username must not survive')
+  t.is(out, 'watching ‹path›')
+})
+
+test('redactLine is total — never throws, always a string', (t) => {
+  for (const value of [null, undefined, 42, {}, []]) t.is(redactLine(value), '')
+})
+
+test('shortId truncates and never returns the full value', (t) => {
+  const key = 'deadbeef'.repeat(8)
+  t.is(shortId(key), 'dead…')
+  t.absent(shortId(key).includes(key))
+  t.is(shortId(null), null)
+  t.is(shortId('ab', 4), '…')
+})
+
+test('makeAliaser is stable and non-reversible', (t) => {
+  const alias = makeAliaser('t')
+  const topic = 'f'.repeat(64)
+  t.is(alias(topic), 't0')
+  t.is(alias(topic), 't0', 'same input → same alias')
+  t.is(alias('e'.repeat(64)), 't1')
+  t.absent(String(alias(topic)).includes('ffff'))
+  t.is(alias(null), null)
+})

--- a/test/unit/log-ring.test.js
+++ b/test/unit/log-ring.test.js
@@ -1,0 +1,77 @@
+import test from 'brittle'
+import { createRequire } from 'module'
+import { redactLine } from '../../src/shared/core/diagnostics-redact.js'
+
+const require = createRequire(import.meta.url)
+const { LogRing, MAX_LINES, MAX_LINE_LENGTH } = require('../../src/main/log-ring.js')
+
+test('evicts by line count', (t) => {
+  const ring = new LogRing()
+  for (let i = 0; i < MAX_LINES + 10; i++) ring.push('worker', 'log', `line ${i}`)
+  t.is(ring.size, MAX_LINES)
+  t.ok(ring.snapshot()[0].text.startsWith('line 10'), 'oldest lines dropped first')
+})
+
+test('evicts by byte budget before hitting the line cap', (t) => {
+  const ring = new LogRing()
+  const chunk = 'x'.repeat(MAX_LINE_LENGTH)
+  for (let i = 0; i < 500; i++) ring.push('worker', 'log', chunk)
+  t.ok(ring.size < MAX_LINES, 'byte budget bit first')
+  t.ok(ring.bytes <= 512 * 1024)
+})
+
+test('clamps an oversized single line at push time', (t) => {
+  const ring = new LogRing()
+  ring.push('worker', 'log', 'y'.repeat(MAX_LINE_LENGTH * 5))
+  const [entry] = ring.snapshot()
+  t.ok(entry.text.length <= MAX_LINE_LENGTH + 20)
+  t.ok(entry.text.endsWith('…[truncated]'))
+})
+
+test('REGRESSION (FIX-4: snapshot must not drain) — preview then save keeps the logs', (t) => {
+  const ring = new LogRing()
+  ring.push('main', 'warn', 'something happened')
+  const first = ring.snapshot()
+  const second = ring.snapshot()
+  t.is(first.length, 1)
+  t.is(second.length, 1, 'a second read still returns the lines')
+  t.is(ring.size, 1)
+})
+
+test('snapshot applies the redactor to every line', (t) => {
+  const ring = new LogRing()
+  ring.push('worker', 'log', 'dialing 198.51.100.4 from /Users/rene/Docs')
+  ring.push('worker', 'log', 'key ' + 'a'.repeat(64))
+  const out = ring.snapshot(redactLine)
+  for (const entry of out) {
+    t.absent(entry.text.includes('198.51.100.4'))
+    t.absent(entry.text.includes('/Users/rene'))
+    t.absent(entry.text.includes('a'.repeat(64)))
+  }
+})
+
+test('REGRESSION (FIX-7: stream chunks are many lines) — a multi-line chunk becomes many entries', (t) => {
+  // Worker stdout arrives as arbitrary chunks; charging one chunk as one entry truncated
+  // it at MAX_LINE_LENGTH and threw most of a busy worker's output away.
+  const ring = new LogRing()
+  ring.push('worker', 'log', 'alpha\nbravo\ncharlie\n')
+  t.is(ring.size, 3)
+  t.alike(ring.snapshot().map((e) => e.text), ['alpha', 'bravo', 'charlie'])
+})
+
+test('ignores non-strings and blank lines', (t) => {
+  const ring = new LogRing()
+  ring.push('main', 'log', null)
+  ring.push('main', 'log', '')
+  ring.push('main', 'log', '   \n')
+  t.is(ring.size, 0)
+})
+
+test('records the source and level for each line', (t) => {
+  const ring = new LogRing()
+  ring.push('renderer', 'err', 'boom')
+  const [entry] = ring.snapshot()
+  t.is(entry.source, 'renderer')
+  t.is(entry.level, 'err')
+  t.ok(entry.at > 0)
+})

--- a/test/unit/reachability.test.js
+++ b/test/unit/reachability.test.js
@@ -1,0 +1,370 @@
+import test from 'brittle'
+import {
+  classify, stabilise, hasRoutableAddress, routableAddressKind, VERDICT, CAUSE, CONFIDENCE, CANARY,
+  NAT_SETTLE_MS, BLOCKED_DWELL_MS, LIVENESS_FAILURES_FOR_OFFLINE,
+} from '../../src/shared/core/reachability.js'
+
+const BASE = {
+  now: 100000,
+  bootedAt: 1000,
+  readyAt: 4000,
+  dhtReady: true,
+  suspended: false,
+  browserOnline: true,
+  address: { publicHost: '203.0.113.7', publicPort: 41234 },
+  routing: { tableSize: 50 },
+  dhtHealth: { online: true, degraded: false, cold: false, idle: false },
+  peerReach: { discovered: 0, connected: 0, exhausted: 0 },
+  dials: { attempted: 0, opened: 0 },
+  canary: { state: CANARY.UNAVAILABLE },
+  liveness: { failures: 0, checkedAt: 0 },
+  hasInterface: true,
+  interfaceKind: 'physical',
+}
+
+const on = (over = {}) => ({ ...BASE, ...over })
+
+test('healthy: stable mapping, nothing else wrong', (t) => {
+  const r = classify(on())
+  t.is(r.verdict, VERDICT.HEALTHY)
+  t.is(r.cause, null)
+})
+
+test("REGRESSION (FIX-1: dhtReady is not connectivity) — the reported snapshot is not healthy", (t) => {
+  // The 2026-08-21 report: DHT up, 50 routing entries, public IP known, public port 0
+  // (symmetric NAT), no peers. The shipped UI called this "Netzwerk funktioniert".
+  const r = classify(on({ address: { publicHost: '203.0.113.7', publicPort: 0 } }))
+  t.is(r.verdict, VERDICT.AT_RISK)
+  t.is(r.cause, CAUSE.SYMMETRIC_NAT)
+  t.not(r.verdict, VERDICT.HEALTHY, 'must never report healthy on a symmetric NAT')
+})
+
+test('blocked: no public address consensus', (t) => {
+  const r = classify(on({ address: { publicHost: null, publicPort: 0 } }))
+  t.is(r.verdict, VERDICT.BLOCKED)
+  t.is(r.cause, CAUSE.NO_PUBLIC_ADDRESS)
+})
+
+test('tier 2 negative: found peers, reached none', (t) => {
+  const r = classify(on({
+    peerReach: { discovered: 4, connected: 0, exhausted: 4 },
+    dials: { attempted: 12, opened: 0 },
+  }))
+  t.is(r.verdict, VERDICT.BLOCKED)
+  t.is(r.cause, CAUSE.PEERS_UNREACHABLE)
+  t.is(r.confidence, CONFIDENCE.MEASURED)
+})
+
+test('tier 2 negative needs an exhausted peer — a peer still being retried is not evidence', (t) => {
+  const r = classify(on({
+    peerReach: { discovered: 1, connected: 0, exhausted: 0 },
+    dials: { attempted: 1, opened: 0 },
+  }))
+  t.not(r.verdict, VERDICT.BLOCKED)
+})
+
+test('REGRESSION (FIX-5: dial counters are cumulative) — a past success must not disarm the rule', (t) => {
+  // stats.connects.client.opened counts for the whole process lifetime, so keying the
+  // rule on `opened === 0` silently disabled it after the first ever connection.
+  const r = classify(on({
+    peerReach: { discovered: 4, connected: 0, exhausted: 4 },
+    dials: { attempted: 40, opened: 9 },
+  }))
+  t.is(r.verdict, VERDICT.BLOCKED)
+  t.is(r.cause, CAUSE.PEERS_UNREACHABLE)
+})
+
+test('tier 2 positive outranks a bad NAT — a live connection settles it', (t) => {
+  const r = classify(on({
+    address: { publicHost: '203.0.113.7', publicPort: 0 },
+    peerReach: { discovered: 3, connected: 1, exhausted: 0 },
+  }))
+  t.is(r.verdict, VERDICT.HEALTHY)
+  t.is(r.confidence, CONFIDENCE.MEASURED)
+})
+
+test('settle window: no verdict before NAT consensus can exist', (t) => {
+  const r = classify(on({
+    readyAt: 99000,
+    now: 99000 + NAT_SETTLE_MS - 1,
+    address: { publicHost: '203.0.113.7', publicPort: 0 },
+  }))
+  t.is(r.verdict, VERDICT.UNKNOWN)
+})
+
+test('settle window: a thin routing table is not enough to judge', (t) => {
+  const r = classify(on({
+    routing: { tableSize: 3 },
+    address: { publicHost: '203.0.113.7', publicPort: 0 },
+  }))
+  t.is(r.verdict, VERDICT.UNKNOWN)
+})
+
+test('canary seeder-down does NOT change the verdict', (t) => {
+  const healthy = classify(on({ canary: { state: CANARY.SEEDER_DOWN } }))
+  t.is(healthy.verdict, VERDICT.HEALTHY, 'our outage must not blame the user')
+
+  const risky = classify(on({
+    address: { publicHost: '203.0.113.7', publicPort: 0 },
+    canary: { state: CANARY.SEEDER_DOWN },
+  }))
+  t.is(risky.verdict, VERDICT.AT_RISK)
+  t.is(risky.confidence, CONFIDENCE.PREDICTED, 'stays predicted — no corroboration available')
+})
+
+test('canary unavailable (source build) behaves exactly like seeder-down', (t) => {
+  const a = classify(on({ canary: { state: CANARY.UNAVAILABLE } }))
+  const b = classify(on({ canary: { state: CANARY.SEEDER_DOWN } }))
+  t.is(a.verdict, b.verdict)
+  t.is(a.confidence, b.confidence)
+})
+
+test('canary reachable → measured healthy with no spaces joined', (t) => {
+  const r = classify(on({ canary: { state: CANARY.REACHABLE } }))
+  t.is(r.verdict, VERDICT.HEALTHY)
+  t.is(r.confidence, CONFIDENCE.MEASURED)
+})
+
+test('canary unreachable CONFIRMS a bad NAT — predicted becomes measured', (t) => {
+  const r = classify(on({
+    address: { publicHost: '203.0.113.7', publicPort: 0 },
+    canary: { state: CANARY.UNREACHABLE },
+  }))
+  t.is(r.verdict, VERDICT.AT_RISK)
+  t.is(r.confidence, CONFIDENCE.MEASURED)
+})
+
+test('canary unreachable NEVER creates a verdict on its own', (t) => {
+  // NAT looks fine, the seeder was announcing, yet we could not reach it. Unexplainable,
+  // so we report unknown rather than accusing the user.
+  const r = classify(on({ canary: { state: CANARY.UNREACHABLE } }))
+  t.is(r.verdict, VERDICT.UNKNOWN)
+  t.not(r.verdict, VERDICT.BLOCKED)
+})
+
+test('REGRESSION (FIX-10: an idle app must notice the network vanishing)', (t) => {
+  // With no spaces there are no topics, peers or swarm events, dhtReady is one-shot, and
+  // the DHT's own health window is gated on traffic that is not happening — so before the
+  // liveness probe the verdict stayed frozen at healthy after the Wi-Fi was switched off.
+  const healthy = classify(on())
+  t.is(healthy.verdict, VERDICT.HEALTHY, 'precondition: healthy while the network is up')
+
+  const oneFailure = classify(on({ liveness: { failures: 1, checkedAt: 1 } }))
+  t.is(oneFailure.verdict, VERDICT.HEALTHY, 'a single dropped probe is not enough')
+
+  const gone = classify(on({ liveness: { failures: LIVENESS_FAILURES_FOR_OFFLINE, checkedAt: 1 } }))
+  t.is(gone.verdict, VERDICT.BLOCKED)
+  t.is(gone.cause, CAUSE.DHT_UNREACHABLE)
+  t.is(gone.confidence, CONFIDENCE.MEASURED)
+})
+
+test('REGRESSION (FIX-12: link-local addresses are not a network)', (t) => {
+  // macOS keeps utun0-3, awdl0 and llw0 up with only fe80:: addresses whether or not Wi-Fi
+  // is on. Counting any non-internal address as "connected" meant the offline case never
+  // fired on a real Mac — the app kept blaming the user's router instead.
+  const linkLocalOnly = {
+    lo0:   [{ address: '127.0.0.1', internal: true }],
+    utun0: [{ address: 'fe80::b042:7542:92b9:6c19', internal: false }],
+    utun3: [{ address: 'fe80::ce81:b1c:bd2c:69e', internal: false }],
+    awdl0: [{ address: 'fe80::e482:1eff:fe96:a870', internal: false }],
+    llw0:  [{ address: 'fe80::e482:1eff:fe96:a870', internal: false }],
+    en0:   [{ address: 'fe80::14ea:3c2a:be88:403', internal: false }],
+  }
+  t.absent(hasRoutableAddress(linkLocalOnly), 'link-local only is not a network')
+
+  t.absent(hasRoutableAddress({ en1: [{ address: '169.254.5.5', internal: false }] }), 'IPv4 link-local either')
+  t.absent(hasRoutableAddress({}), 'no interfaces at all')
+  t.absent(hasRoutableAddress(null), 'a missing table is not a network')
+
+  const connected = { ...linkLocalOnly, en0: [
+    { address: 'fe80::14ea:3c2a:be88:403', internal: false },
+    { address: '192.168.178.140', internal: false },
+  ] }
+  t.ok(hasRoutableAddress(connected), 'a real routable address counts')
+})
+
+test('a VPN holding the only route is classified as tunnel-only', (t) => {
+  // Real layout from a Mac with WireGuard up and Wi-Fi off: the tunnel keeps its address
+  // and the default route, so the machine still looks "connected" to any local check.
+  const wifiOff = {
+    lo0:   [{ address: '127.0.0.1', internal: true }],
+    utun0: [{ address: 'fe80::b042:7542:92b9:6c19', internal: false }],
+    llw0:  [{ address: 'fe80::cc9d:7aff:fea0:c472', internal: false }],
+    utun4: [{ address: '192.168.178.201', internal: false }],
+  }
+  t.is(routableAddressKind(wifiOff), 'tunnel-only')
+  t.ok(hasRoutableAddress(wifiOff), 'it genuinely does have a route — we cannot call this offline')
+
+  t.is(routableAddressKind({ ...wifiOff, en0: [{ address: '192.168.178.140', internal: false }] }), 'physical')
+  t.is(routableAddressKind({ lo0: [{ address: '127.0.0.1', internal: true }] }), 'none')
+})
+
+test('REGRESSION (FIX-13: a dead VPN route is not "your network is blocking us")', (t) => {
+  // Indistinguishable from a blocking network by probe alone — so the verdict is the same,
+  // but the cause names the likeliest culprit instead of blaming the user's router.
+  const blocked = classify(on({
+    interfaceKind: 'tunnel-only',
+    liveness: { failures: 2, checkedAt: 1 },
+  }))
+  t.is(blocked.verdict, VERDICT.BLOCKED)
+  t.is(blocked.cause, CAUSE.VPN_ONLY_ROUTE)
+
+  const physical = classify(on({
+    interfaceKind: 'physical',
+    liveness: { failures: 2, checkedAt: 1 },
+  }))
+  t.is(physical.cause, CAUSE.DHT_UNREACHABLE, 'without a tunnel it stays the generic cause')
+})
+
+test('the tunnel hint never creates a verdict on its own', (t) => {
+  // Governing rule: a hint refines a cause, it does not invent an outage. A healthy machine
+  // that happens to route through a VPN must still read healthy.
+  const r = classify(on({ interfaceKind: 'tunnel-only', liveness: { failures: 0, checkedAt: 0 } }))
+  t.is(r.verdict, VERDICT.HEALTHY)
+  t.is(r.cause, null)
+})
+
+test('REGRESSION (FIX-11: switching the network off is instant and says so)', (t) => {
+  // No non-internal address on the machine is definitive and local — no probe, no timeout.
+  // It must also be reported as os-offline, not as a network that is "blocking" us: the
+  // blocked copy tells the user to check a VPN and try another Wi-Fi, which is nonsense
+  // when they simply turned the network off.
+  const r = classify(on({ hasInterface: false }))
+  t.is(r.verdict, VERDICT.BLOCKED)
+  t.is(r.cause, CAUSE.OS_OFFLINE)
+  t.is(r.confidence, CONFIDENCE.MEASURED)
+})
+
+test('a missing interface outranks a healthy-looking NAT and zero liveness failures', (t) => {
+  const r = classify(on({
+    hasInterface: false,
+    liveness: { failures: 0, checkedAt: 0 },
+    address: { publicHost: '203.0.113.7', publicPort: 41234 },
+  }))
+  t.is(r.cause, CAUSE.OS_OFFLINE)
+})
+
+test('a live connection outranks failed liveness probes', (t) => {
+  const r = classify(on({
+    peerReach: { discovered: 2, connected: 1, exhausted: 0 },
+    liveness: { failures: 5, checkedAt: 1 },
+  }))
+  t.is(r.verdict, VERDICT.HEALTHY, 'a connected peer is proof of life')
+})
+
+test('losing the network is applied immediately, not held for the dwell', (t) => {
+  // The dwell exists to stop inferred verdicts flapping. A repeated direct probe failure
+  // is measured, and 20s of "connected" while offline is exactly the lie this fixes.
+  const previous = { verdict: VERDICT.HEALTHY, cause: null, since: 0, pending: null }
+  const gone = classify(on({ liveness: { failures: LIVENESS_FAILURES_FOR_OFFLINE, checkedAt: 1 } }))
+  t.is(stabilise(gone, previous, 1000).verdict, VERDICT.BLOCKED)
+
+  const osOffline = classify(on({ browserOnline: false }))
+  t.is(stabilise(osOffline, previous, 1000).verdict, VERDICT.BLOCKED, 'os-offline too')
+})
+
+test('recovery from a liveness outage is immediate', (t) => {
+  const blocked = { verdict: VERDICT.BLOCKED, cause: CAUSE.DHT_UNREACHABLE, since: 0, pending: null }
+  const back = classify(on({ liveness: { failures: 0, checkedAt: 2 } }))
+  t.is(stabilise(back, blocked, 5000).verdict, VERDICT.HEALTHY)
+})
+
+test('os-offline outranks everything', (t) => {
+  const r = classify(on({
+    browserOnline: false,
+    peerReach: { discovered: 9, connected: 9, exhausted: 0 },
+  }))
+  t.is(r.verdict, VERDICT.BLOCKED)
+  t.is(r.cause, CAUSE.OS_OFFLINE)
+})
+
+test('suspended is not a fault', (t) => {
+  t.is(classify(on({ suspended: true })).verdict, VERDICT.UNKNOWN)
+})
+
+test('dht never ready: unknown inside the grace window, blocked after', (t) => {
+  t.is(classify(on({ dhtReady: false, bootedAt: 1, now: 10000 })).verdict, VERDICT.UNKNOWN)
+  const late = classify(on({ dhtReady: false, bootedAt: 1, now: 60000 }))
+  t.is(late.verdict, VERDICT.BLOCKED)
+  t.is(late.cause, CAUSE.DHT_UNREACHABLE)
+})
+
+test('degraded transport is reported only when nothing structural was found', (t) => {
+  const r = classify(on({ dhtHealth: { online: true, degraded: true, cold: false, idle: false } }))
+  t.is(r.cause, CAUSE.UDP_DEGRADED)
+
+  const natWins = classify(on({
+    address: { publicHost: '203.0.113.7', publicPort: 0 },
+    dhtHealth: { online: true, degraded: true, cold: false, idle: false },
+  }))
+  t.is(natWins.cause, CAUSE.SYMMETRIC_NAT, 'the actionable finding wins')
+})
+
+test('evidence carries the numbers a support case needs', (t) => {
+  const r = classify(on({
+    peerReach: { discovered: 4, connected: 0, exhausted: 3 },
+    dials: { attempted: 9, opened: 0 },
+  }))
+  t.is(r.evidence.peersDiscovered, 4)
+  t.is(r.evidence.peersExhausted, 3)
+  t.is(r.evidence.dialsAttempted, 9)
+})
+
+test('escalation waits for the dwell window; recovery is immediate', (t) => {
+  const healthy = { verdict: VERDICT.HEALTHY, cause: null, since: 0, pending: null }
+  const raw = {
+    verdict: VERDICT.BLOCKED,
+    cause: CAUSE.PEERS_UNREACHABLE,
+    confidence: CONFIDENCE.MEASURED,
+    evidence: {},
+  }
+
+  const first = stabilise(raw, healthy, 1000)
+  t.is(first.verdict, VERDICT.HEALTHY, 'held back')
+  t.is(first.pending.verdict, VERDICT.BLOCKED)
+
+  const early = stabilise(raw, first, 1000 + BLOCKED_DWELL_MS - 1)
+  t.is(early.verdict, VERDICT.HEALTHY, 'still held')
+
+  const late = stabilise(raw, first, 1000 + BLOCKED_DWELL_MS + 1)
+  t.is(late.verdict, VERDICT.BLOCKED, 'escalates once sustained')
+
+  const back = stabilise(
+    { ...raw, verdict: VERDICT.HEALTHY, cause: null },
+    late,
+    99999,
+  )
+  t.is(back.verdict, VERDICT.HEALTHY, 'recovery is not delayed')
+})
+
+test('REGRESSION (FIX-6: unknown is not a severity) — leaving unknown is never held back', (t) => {
+  const unknown = { verdict: VERDICT.UNKNOWN, cause: null, since: 0, pending: null }
+  const healthy = { verdict: VERDICT.HEALTHY, cause: null, confidence: CONFIDENCE.MEASURED, evidence: {} }
+  const out = stabilise(healthy, unknown, 1000)
+  t.is(out.verdict, VERDICT.HEALTHY, 'unknown -> healthy is immediate, not a 20s escalation')
+
+  const atRisk = { verdict: VERDICT.AT_RISK, cause: CAUSE.SYMMETRIC_NAT, confidence: CONFIDENCE.PREDICTED, evidence: {} }
+  t.is(stabilise(atRisk, unknown, 1000).verdict, VERDICT.AT_RISK, 'unknown -> at-risk is immediate too')
+})
+
+test('a flapping signal never escalates', (t) => {
+  let state = { verdict: VERDICT.HEALTHY, cause: null, since: 0, pending: null }
+  const bad = {
+    verdict: VERDICT.BLOCKED,
+    cause: CAUSE.PEERS_UNREACHABLE,
+    confidence: CONFIDENCE.MEASURED,
+    evidence: {},
+  }
+  const good = { verdict: VERDICT.HEALTHY, cause: null, confidence: CONFIDENCE.PREDICTED, evidence: {} }
+  for (let i = 0; i < 20; i++) {
+    state = stabilise(i % 2 ? bad : good, state, i * 5000)
+  }
+  t.is(state.verdict, VERDICT.HEALTHY)
+})
+
+test('since is preserved while the verdict holds', (t) => {
+  const first = stabilise(classify(on()), null, 5000)
+  t.is(first.since, 5000)
+  const second = stabilise(classify(on()), first, 90000)
+  t.is(second.since, 5000, 'unchanged verdict keeps its original timestamp')
+})


### PR DESCRIPTION
Connectivity was derived from `dhtReady` alone — true on any network with outbound UDP — so a symmetric-NAT or offline machine still reported "Network is healthy". Replaces that with a reachability verdict and surfaces it honestly.

**Detection** — four independent signals in the worker, combined by a pure reducer (`src/shared/core/reachability.js`): NAT shape from DHT address consensus, observed peer outcomes, DHT transport health, and a two-stage seeder probe. Plus a liveness probe so an idle app notices the network vanishing. A probe failure can only ever *confirm* a verdict, never create one — a seeder outage must not blame the user.

**Disclosure** — a dedicated `ConnectionProblem` screen (substituted for the spaces screen when the user has none), sticky toasts for mid-session changes, and a reworked Network status with a plain-language summary. `UpdateBanner` is untouched.

**Diagnostics** — a savable bundle with default-on redaction and a preview showing exactly what will be written, plus a bounded in-memory log ring across all three processes. Nothing is sent anywhere automatically.

Relay is explicitly a separate, later delivery: for a symmetric-NAT user the honest advice is still "use a different connection".

## Known limits

- VPN-only routes are detected by interface name, so platform-shaped; it reorders advice, it does not diagnose.
- A tunnel holding a dead route is locally indistinguishable from a blocking network — only a probe can tell, and it cannot say why.

## Testing

typecheck · `lint:ci` · build · unit+raw **1073/1073** · `test:bare` **720/720** · `test:flow` **186/187** · frontend **105/106**.

Both failures are pre-existing on `staging` and reproduce without this branch:
- `s70-folder-card-hit-area` — broken by the Electron 42.9.3 bump (#79), filed as #93
- `content-plane-rescue` link-flap — fails on clean-tree baselines; its failing assertion is its own precondition
