### PR TITLE
[fix] Contain sr-only live regions in screen scrollers

### DIFF
--- a/src/renderer/screens/Account.tsx
+++ b/src/renderer/screens/Account.tsx
@@ -328,7 +328,7 @@ export default function Account({ profile, onSave, onBack, onOpenNetworkStatus, 
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/ActivityLog.tsx
+++ b/src/renderer/screens/ActivityLog.tsx
@@ -140,7 +140,7 @@ export default function ActivityLog({ onBack, onOpenSettings }: ActivityLogProps
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader title={t('activityLog.title')} subtitle={t('activityLog.intro')} onBack={onBack} />

--- a/src/renderer/screens/ActivityLogSettings.tsx
+++ b/src/renderer/screens/ActivityLogSettings.tsx
@@ -84,7 +84,7 @@ export default function ActivityLogSettings({ onBack, onOpenLog }: ActivityLogSe
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader title={t('activityLogSettings.title')} subtitle={t('activityLogSettings.intro')} onBack={onBack} />

--- a/src/renderer/screens/AppearanceSettings.tsx
+++ b/src/renderer/screens/AppearanceSettings.tsx
@@ -46,7 +46,7 @@ export default function AppearanceSettings({ onBack }: AppearanceSettingsProps) 
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/ConnectionProblem.tsx
+++ b/src/renderer/screens/ConnectionProblem.tsx
@@ -56,7 +56,7 @@ export default function ConnectionProblem({ onBack, onContinue, onShowDetails }:
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-10 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/GeneralSettings.tsx
+++ b/src/renderer/screens/GeneralSettings.tsx
@@ -37,7 +37,7 @@ export default function GeneralSettings({ onBack }: GeneralSettingsProps) {
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/NetworkSettings.tsx
+++ b/src/renderer/screens/NetworkSettings.tsx
@@ -203,7 +203,7 @@ export default function NetworkSettings({ onBack }: NetworkSettingsProps) {
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader title={t('networkSettings.title')} subtitle={t('networkSettings.intro')} onBack={onBack} />

--- a/src/renderer/screens/NetworkStatus.tsx
+++ b/src/renderer/screens/NetworkStatus.tsx
@@ -383,7 +383,7 @@ export default function NetworkStatusScreen({ onBack }: Props) {
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/NotificationSettings.tsx
+++ b/src/renderer/screens/NotificationSettings.tsx
@@ -47,7 +47,7 @@ export default function NotificationSettings({ onBack }: NotificationSettingsPro
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/Settings.tsx
+++ b/src/renderer/screens/Settings.tsx
@@ -27,7 +27,7 @@ export default function Settings({ onBack, onNavigate }: SettingsProps) {
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
         <PageHeader

--- a/src/renderer/screens/StorageSettings.tsx
+++ b/src/renderer/screens/StorageSettings.tsx
@@ -162,7 +162,7 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
   return (
     <div
       ref={ref}
-      className={`h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
+      className={`relative h-[calc(100vh-5.5rem-var(--banner-h,0px))] overflow-y-auto scrollbar-thin pb-8 mr-2 ${hasOverflow ? 'pr-4' : ''}`}
     >
       <div className="pt-8 px-8 max-w-2xl mx-auto">
       <PageHeader title={t('storageSettings.title')} subtitle={t('storageSettings.intro')} onBack={onBack} />

--- a/test/unit/screen-scroller-containment.test.js
+++ b/test/unit/screen-scroller-containment.test.js
@@ -1,0 +1,49 @@
+import test from 'brittle'
+import { readFileSync, readdirSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+const dir = fileURLToPath(new URL('../../src/renderer/screens', import.meta.url))
+const read = (f) => readFileSync(`${dir}/${f}`, 'utf8')
+const screens = readdirSync(dir).filter((f) => f.endsWith('.tsx'))
+
+// Every settings-style screen scrolls its own body in a full-height container
+// (`h-[calc(100vh-…)] overflow-y-auto`) while the window itself never scrolls.
+// That only holds if the container also establishes a containing block.
+//
+// `sr-only` is `position: absolute` (Tailwind's clip-based visually-hidden
+// recipe), and CopyButton renders one as its "Copied" live region. With no
+// positioned ancestor between it and <body>, an absolutely positioned element
+// resolves against the INITIAL containing block, so its static position deep
+// inside the scrolled content extends the DOCUMENT's scrollable area — the
+// window grows a second scrollbar beside the inner one, most visibly on
+// Network status once "Show advanced details" expands. `relative` on the
+// scroller keeps the live region inside the box that already scrolls.
+//
+// The other absolutely positioned descendants of these screens (the search
+// icon in ActivityLog, the toggle knob in ActivityLogSettings, the avatar
+// hover overlay in Account) all sit under their own `relative` parent, and
+// modals position against Modal's `fixed inset-0`, so none of them change
+// containing block here.
+const isScroller = (line) => line.includes('h-[calc(100vh-') && line.includes('overflow-y-auto')
+
+test('REGRESSION (FIX-1): full-height screen scrollers establish a containing block', (t) => {
+  let checked = 0
+  for (const file of screens) {
+    const src = read(file)
+    if (!src.includes('h-[calc(100vh-')) continue
+    const lines = src.split('\n').filter(isScroller)
+    // A screen that has the height but no matching scroller line either uses a
+    // flex-column wrapper (SpaceView, FolderView, SharedSpaces) or wrapped its
+    // className across lines, which this matcher would silently skip.
+    if (lines.length === 0) {
+      t.absent(/overflow-y-auto[\s\S]{0,200}h-\[calc\(100vh-|h-\[calc\(100vh-[\s\S]{0,200}overflow-y-auto/.test(src),
+        `${file}: full-height scroller className stays on one line`)
+      continue
+    }
+    for (const line of lines) {
+      checked++
+      t.ok(/\brelative\b/.test(line), `${file}: full-height scroller is relative`)
+    }
+  }
+  t.ok(checked >= 11, `checked ${checked} full-height screen scrollers`)
+})


### PR DESCRIPTION
CopyButton's sr-only live region is position:absolute, and the full-height screen scrollers established no containing block, so it resolved against the initial containing block and its static position deep in scrolled content grew the document's own scroll area — a second window-level scrollbar, most visible once Network status expands its advanced details. Marking the scrollers relative contains it.
