### PR TITLE
[test] Widen the axe-core bundle backstop

### DIFF
--- a/test/unit/bundle-axe-stripped.test.js
+++ b/test/unit/bundle-axe-stripped.test.js
@@ -41,10 +41,12 @@ test('REGRESSION (FIX-AXE-1): production bundle (__DEV__=false) strips axe-core'
   t.absent(out.includes('@axe-core'), 'no @axe-core module reference in prod bundle')
   t.absent(out.includes('color-contrast'), 'no axe-core rule ids in prod bundle')
   // A backstop for the two string checks above, not a size budget: axe-core adds ~616KB,
-  // so any inclusion blows past this by a wide margin. Headroom is thin (~5KB) because the
-  // five statically-bundled locales are ~27% of the bundle, which makes this line the
-  // effective budget for new UI copy — lazy-loading them is the real fix.
-  t.ok(out.length < 1_000_000, `prod bundle is small without axe-core (${out.length} bytes)`)
+  // so any inclusion blows past this by a wide margin. Sized to sit between the two real
+  // outcomes — prod ~1.00MB, dev ~1.62MB — because at 1_000_000 it sat ~200 bytes above the
+  // prod bundle and became a hard gate on UI copy: a patch bump to marked (+782 bytes) was
+  // enough to fail it. The five statically-bundled locales are still ~24% of the bundle;
+  // lazy-loading them is the real fix.
+  t.ok(out.length < 1_250_000, `prod bundle is small without axe-core (${out.length} bytes)`)
 })
 
 test('FIX-AXE-1 control: dev bundle (__DEV__=true) still ships axe-core', async (t) => {


### PR DESCRIPTION
The `< 1_000_000` assertion in `bundle-axe-stripped.test.js` sat ~200 bytes above the real prod bundle after #94, so #87's patch bump to `marked` (18.0.10 → 18.0.11, +782 bytes) tipped it and left staging red — #95 then inherited the failure.

The assertion's real contract is the two string checks above it (both pass); the size line is a backstop against axe-core leaking back in. Retargeted at 1.25MB, between the prod (~1.00MB) and dev (~1.62MB) outcomes, so a leak still fails it by ~366KB while ordinary UI copy doesn't.

Locale lazy-loading (~24% of the bundle) remains the real fix and is not in scope here.