### PR TITLE
[feat] Point the empty states at the documentation

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -32,6 +32,10 @@ Testing/a11y **discipline** — the layers, the change-type→coverage matrix, t
 
 **Never blanket-replace `console.log/warn/error` in a brittle test** — the runner emits its own TAP through them, so a blanket stub both miscounts (inflated by exactly the number of prior asserts) and swallows the failure diagnostic. Capture by discriminating on the code-under-test's own prefix/tag; forward everything else to the saved real console.
 
+## UI copy
+
+**An empty state answers the user's live question, not the product's best feature.** A differentiator nobody expected to be otherwise ("sharing never makes a second copy") reads as a boast and spends the one paragraph people actually read; the tell is copy that leads with what the product *doesn't* do. Lead instead with the constraint that contradicts what users bring from elsewhere — files are served from your device, so you must be online — and keep the differentiator only in its consequential form ("move or delete the original and it's gone"). Re-point the deep link at the doc that matches the reframed body, and drop the now-unlinked anchor from the union so the twin test stays honest.
+
 ## Renderer ↔ worker wiring
 
 **A new worker→renderer field must be added to the hook's EXPLICIT field-map.** Renderer hooks project field-by-field (not `{...e}`), so an optional field added only to the shared type + JSX type-checks and is silently dropped before the component. Trace the full path and patch every re-map: worker row object → IPC → hook's `ServerEntry` interface → hook's `.map()` projection → shared type → component. Grep the hook for the field after wiring (and confirm event-rebuild paths use `{...f}` spread). Invisible to typecheck/lint/backend tests; only test:fe catches it.
@@ -169,6 +173,8 @@ retained bytes.
 **Piping a test run into `tail` throws away its exit code, and its failures.** `npm test 2>&1 | tail -8` reports the exit status of `tail` (always 0), and an 8-line window shows a crash's stack trace while hiding the summary — so a suite that aborted reads as "exit code 0" with nothing obviously wrong. It also truncates the TAP `not ok` lines that say WHAT failed. Redirect to a file and check `$?` (`npm test > /tmp/run.log 2>&1; echo $?`), then grep the file for `^not ok`. A green claim built on a piped tail is not evidence.
 
 ## Release / build
+
+**A backstop assertion sized against the current value becomes a gate on unrelated work.** `bundle-axe-stripped.test.js` guards a ~616KB axe-core regression but sat ~200 bytes above the real prod bundle, so a `marked` patch bump (+782 bytes) and one card's worth of new copy (16 keys × 5 locales) each tripped it independently. Size a backstop between the two outcomes it must distinguish — prod ~1.00MB vs dev ~1.62MB, so 1.25MB — not just above today's number. Five statically bundled locales are ~24% of `main.js`, so this line keeps drifting toward a copy budget; lazy-loading them is the real fix.
 
 **Prerelease channels (beta/dev/staging) use single-drive `pear stage` + `pear release`** (`upgrade-keys.json` entry is a STRING). `pear provision` rejects prerelease SemVers, but the OTA updater compares by SemVer precedence, so prerelease builds must carry monotonically increasing `-beta.<run>` versions. Only prod (clean `X.Y.Z`, bumped per release) uses the `{stage, provision}` object. `pear touch` the seed drive ON the seed VM or `pear stage` fails `SESSION_NOT_WRITABLE`.
 

--- a/src/renderer/components/widgets/DocsCard.tsx
+++ b/src/renderer/components/widgets/DocsCard.tsx
@@ -1,0 +1,54 @@
+// "Learn more" card for the empty states. The documentation is English-only while the app
+// ships five languages, so a non-English UI gets one note at the foot of the card rather
+// than a language suffix on every link.
+import { useId } from 'react'
+import { useTranslation } from 'react-i18next'
+import { docsUrl, type DocsTarget } from '../../docs-links.js'
+import Icon, { type IconName } from '../primitives/Icon.js'
+import DocsLink from './DocsLink.js'
+
+interface DocsCardEntry {
+  target: DocsTarget
+  label: string
+}
+
+interface DocsCardProps {
+  icon: IconName
+  title: string
+  body: string
+  links: DocsCardEntry[]
+  className?: string
+}
+
+export default function DocsCard({ icon, title, body, links, className }: DocsCardProps) {
+  const { t, i18n } = useTranslation()
+  const headingId = useId()
+  const showEnglishNote = !(i18n.language ?? 'en').startsWith('en')
+
+  return (
+    <section
+      aria-labelledby={headingId}
+      className={`bg-surface-container-low rounded-xl p-6 text-left${className ? ` ${className}` : ''}`}
+    >
+      <div className="flex items-start gap-4">
+        <div className="w-10 h-10 rounded-full bg-icon-tile flex items-center justify-center text-on-icon-tile shrink-0">
+          <Icon name={icon} size={20} />
+        </div>
+        <div className="min-w-0">
+          <h3 id={headingId} className="font-headline font-bold text-accent mb-1">{title}</h3>
+          <p className="text-sm text-on-surface-variant leading-relaxed mb-4">{body}</p>
+          <ul className="space-y-1">
+            {links.map((link) => (
+              <li key={docsUrl(link.target)}>
+                <DocsLink target={link.target} label={link.label} />
+              </li>
+            ))}
+          </ul>
+          {showEnglishNote && (
+            <p className="text-xs text-on-surface-variant mt-4">{t('docs.englishNote')}</p>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/renderer/components/widgets/DocsLink.tsx
+++ b/src/renderer/components/widgets/DocsLink.tsx
@@ -1,0 +1,29 @@
+// A real anchor, not a button: the main process turns an http(s) navigation into
+// shell.openExternal, so no bridge call is needed, and the destination belongs in the
+// accessible name because the only other signal is a decorative glyph. The anchor is
+// `relative` so the sr-only span — which is position:absolute — resolves against it
+// rather than the initial containing block, where its static position inside a scrolled
+// container would extend the document's own scroll area.
+import { useTranslation } from 'react-i18next'
+import { docsUrl, type DocsTarget } from '../../docs-links.js'
+import Icon from '../primitives/Icon.js'
+
+interface DocsLinkProps {
+  target: DocsTarget
+  label: string
+}
+
+export default function DocsLink({ target, label }: DocsLinkProps) {
+  const { t } = useTranslation()
+  return (
+    <a
+      href={docsUrl(target)}
+      className="relative flex items-center gap-2 rounded-lg -mx-1 px-1 py-1.5 text-sm font-headline font-bold text-secondary hover:underline focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
+    >
+      <Icon name="arrow_forward" size={16} className="shrink-0" />
+      <span>{label}</span>
+      <Icon name="open_in_new" size={14} className="shrink-0 opacity-60" />
+      <span className="sr-only">{t('docs.opensInBrowser')}</span>
+    </a>
+  )
+}

--- a/src/renderer/docs-links.d.ts
+++ b/src/renderer/docs-links.d.ts
@@ -1,0 +1,20 @@
+type TutorialAnchor = 'send-your-first-files'
+
+type GuideAnchor =
+  | 'create-a-space'
+  | 'join-a-space'
+  | 'fix-a-stuck-join'
+  | 'share-files'
+  | 'share-a-folder'
+
+type ExplanationAnchor =
+  | 'membership-approval'
+  | 'spaces-members-availability'
+
+export type DocsTarget =
+  | { page: 'hub' }
+  | { page: 'tutorials'; anchor: TutorialAnchor }
+  | { page: 'guides'; anchor: GuideAnchor }
+  | { page: 'explanation'; anchor: ExplanationAnchor }
+
+export function docsUrl(target: DocsTarget): string

--- a/src/renderer/docs-links.js
+++ b/src/renderer/docs-links.js
@@ -1,0 +1,9 @@
+// Deep links into the public documentation. The anchors mirror the section ids on
+// mirall.app; the site answers 200 for every path, so a stale anchor lands on the page
+// with no scroll rather than failing visibly. The unions in docs-links.d.ts are the guard.
+const DOCS_BASE = 'https://mirall.app/docs'
+
+export function docsUrl (target) {
+  if (target.page === 'hub') return DOCS_BASE
+  return `${DOCS_BASE}/${target.page}#${target.anchor}`
+}

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -52,6 +52,8 @@
     "join": "Raum beitreten",
     "emptyNoSpaces": "Noch keine Räume",
     "emptyNoSpacesHint": "Erstelle einen oder tritt mit Code bei.",
+    "emptyDocsTitle": "Neu bei Mirall?",
+    "emptyDocsBody": "Ein Raum ist eine private Gruppe. Deine Dateien bleiben auf deinem Gerät und gehen direkt an die Leute, die du einlädst — ohne Server dazwischen.",
     "emptyNoFavorites": "Noch keine Favoriten",
     "emptyNoFavoritesHint": "Öffne einen Raum und wähle „Zu Favoriten hinzufügen“ im Menü, um ihn hier festzuhalten.",
     "memberCount_one": "{{count}} Mitglied",
@@ -85,6 +87,8 @@
     "emptyFiles": "Noch keine Dateien geteilt. Lege Dateien in der Seitenleiste ab.",
     "emptyShareTitle": "Noch nichts geteilt",
     "emptyShareSubtitle": "Zieh Dateien oder Ordner in den Bereich rechts, um sie in diesem Raum zu teilen.",
+    "emptyShareDocsTitle": "Was beim Teilen passiert",
+    "emptyShareDocsBody": "Mitglieder laden Dateien direkt von deinem Gerät — dafür musst du online sein und Mirall laufen haben. Geteilte Dateien bleiben da liegen, wo sie sind: Verschiebst oder löschst du eine, ist sie nicht mehr verfügbar.",
     "members": "Mitglieder",
     "emptyMembers": "Noch keine Mitglieder verbunden. Teile den Einladungscode.",
     "membersAndMore": "+{{count}} weitere",
@@ -106,6 +110,8 @@
     "selectNamed": "{{name}} auswählen",
     "waitingApproval": "Warten auf Freigabe für {{name}} …",
     "waitingApprovalHint": "Ein Mitglied dieses Space muss dich freigeben. Du kannst dieses Fenster offen lassen — sobald jemand online ist, wirst du automatisch hinzugefügt.",
+    "waitingDocsTitle": "Warum warte ich?",
+    "waitingDocsBody": "Eine Einladung enthält die Adresse des Raums, nie den Schlüssel dazu. Den übergibt jemand, der schon drin ist — deshalb muss ein Mitglied online und erreichbar sein, bevor du hineinkommst. Automatische Freigabe nimmt die Entscheidung ab, nicht die Übergabe.",
     "encryptedBadge": "Verschlüsselt",
     "unencryptedBadge": "Unverschlüsselt"
   },
@@ -426,6 +432,18 @@
     "releaseFolder": "Loslassen, um „{{name}}“ zu teilen",
     "releaseFolderUnnamed": "Loslassen, um diesen Ordner zu teilen",
     "button": "Dateien wählen"
+  },
+  "docs": {
+    "opensInBrowser": "Öffnet mirall.app in deinem Browser",
+    "englishNote": "Die Dokumentation ist auf Englisch.",
+    "sendFirstFiles": "Die ersten Dateien senden",
+    "createSpace": "Einen Raum erstellen",
+    "joinSpace": "Mit einer Einladung beitreten",
+    "membershipApproval": "Wie Mitgliedschaft und Freigabe funktionieren",
+    "stuckJoin": "Wenn ein Beitritt hängen bleibt",
+    "availability": "Wann Mitglieder von dir herunterladen können",
+    "shareFiles": "Einzelne Dateien teilen",
+    "shareFolder": "Einen ganzen Ordner teilen"
   },
   "updateBanner": {
     "available": "Update verfügbar (v{{version}})",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -76,6 +76,8 @@
     "join": "Join Space",
     "emptyNoSpaces": "No spaces yet",
     "emptyNoSpacesHint": "Create one or join with an invite code.",
+    "emptyDocsTitle": "New to Mirall?",
+    "emptyDocsBody": "A space is a private group. Files stay on your device and move straight to the people you invite — there's no server in between.",
     "emptyNoFavorites": "No favorites yet",
     "emptyNoFavoritesHint": "Open a space and choose Add to Favorites from the menu to pin it here.",
     "memberCount_one": "{{count}} member",
@@ -109,6 +111,8 @@
     "emptyFiles": "No files shared yet. Drop files in the sidebar to get started.",
     "emptyShareTitle": "Nothing shared yet",
     "emptyShareSubtitle": "Drag files or folders into the share area on the right to start sharing with this space.",
+    "emptyShareDocsTitle": "What happens when you share",
+    "emptyShareDocsBody": "Members download files straight from your device, so you'll need to be online and running Mirall while they do. Shared files stay where they are on disk — move or delete one and it's no longer available.",
     "members": "Members",
     "emptyMembers": "No members connected yet. Share the invite code to get started.",
     "membersAndMore": "+{{count}} more",
@@ -130,6 +134,8 @@
     "selectNamed": "Select {{name}}",
     "waitingApproval": "Waiting to be let into {{name}}…",
     "waitingApprovalHint": "A member of this space needs to approve you. You can leave this open — you'll be let in automatically as soon as someone's online.",
+    "waitingDocsTitle": "Why am I waiting?",
+    "waitingDocsBody": "An invite carries the address of the space, never the key to it. Someone already inside hands that over — so a member has to be online and reachable before you can be let in. Auto-approve removes the decision, not the hand-over.",
     "encryptedBadge": "Encrypted",
     "unencryptedBadge": "Unencrypted"
   },
@@ -450,6 +456,18 @@
     "releaseFolder": "Release to share “{{name}}”",
     "releaseFolderUnnamed": "Release to share this folder",
     "button": "Select Files"
+  },
+  "docs": {
+    "opensInBrowser": "Opens mirall.app in your browser",
+    "englishNote": "The documentation is in English.",
+    "sendFirstFiles": "Send your first files",
+    "createSpace": "Create a space",
+    "joinSpace": "Join a space with an invite",
+    "membershipApproval": "How membership and approval work",
+    "stuckJoin": "Fix a join that gets stuck",
+    "availability": "When members can download from you",
+    "shareFiles": "Share individual files",
+    "shareFolder": "Share a whole folder"
   },
   "updateBanner": {
     "available": "App update available (v{{version}})",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -52,6 +52,8 @@
     "join": "Unirse a un espacio",
     "emptyNoSpaces": "Aún no hay espacios",
     "emptyNoSpacesHint": "Crea uno o únete con un código de invitación.",
+    "emptyDocsTitle": "¿Nuevo en Mirall?",
+    "emptyDocsBody": "Un espacio es un grupo privado. Los archivos permanecen en tu dispositivo y van directamente a las personas que invitas: no hay ningún servidor de por medio.",
     "emptyNoFavorites": "Aún no hay favoritos",
     "emptyNoFavoritesHint": "Abre un espacio y elige «Añadir a favoritos» en el menú para fijarlo aquí.",
     "memberCount_one": "{{count}} miembro",
@@ -85,6 +87,8 @@
     "emptyFiles": "Aún no hay archivos compartidos. Suelta archivos en la barra lateral para empezar.",
     "emptyShareTitle": "Aún no hay nada compartido",
     "emptyShareSubtitle": "Arrastra archivos o carpetas al área de la derecha para empezar a compartir en este espacio.",
+    "emptyShareDocsTitle": "Qué ocurre cuando compartes",
+    "emptyShareDocsBody": "Los miembros descargan los archivos directamente de tu dispositivo, así que necesitas estar en línea y con Mirall abierto mientras lo hacen. Los archivos compartidos se quedan donde están en el disco: si mueves o eliminas uno, deja de estar disponible.",
     "members": "Miembros",
     "emptyMembers": "Aún no hay miembros conectados. Comparte el código de invitación para empezar.",
     "membersAndMore": "+{{count}} más",
@@ -106,6 +110,8 @@
     "selectNamed": "Seleccionar a {{name}}",
     "waitingApproval": "Esperando acceso a {{name}}…",
     "waitingApprovalHint": "Un miembro de este espacio debe aprobarte. Puedes dejar esto abierto: entrarás automáticamente en cuanto alguien esté en línea.",
+    "waitingDocsTitle": "¿Por qué estoy esperando?",
+    "waitingDocsBody": "Una invitación lleva la dirección del espacio, nunca su clave. Esa la entrega alguien que ya está dentro, así que un miembro tiene que estar en línea y accesible antes de que puedan dejarte entrar. La aprobación automática elimina la decisión, no la entrega.",
     "encryptedBadge": "Cifrado",
     "unencryptedBadge": "Sin cifrar"
   },
@@ -426,6 +432,18 @@
     "releaseFolder": "Suelta para compartir «{{name}}»",
     "releaseFolderUnnamed": "Suelta para compartir esta carpeta",
     "button": "Seleccionar archivos"
+  },
+  "docs": {
+    "opensInBrowser": "Abre mirall.app en tu navegador",
+    "englishNote": "La documentación está en inglés.",
+    "sendFirstFiles": "Enviar tus primeros archivos",
+    "createSpace": "Crear un espacio",
+    "joinSpace": "Unirse a un espacio con una invitación",
+    "membershipApproval": "Cómo funcionan la membresía y la aprobación",
+    "stuckJoin": "Arreglar una unión que se queda bloqueada",
+    "availability": "Cuándo pueden descargar los miembros",
+    "shareFiles": "Compartir archivos individuales",
+    "shareFolder": "Compartir una carpeta entera"
   },
   "updateBanner": {
     "available": "Actualización disponible (v{{version}})",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -52,6 +52,8 @@
     "join": "Rejoindre un espace",
     "emptyNoSpaces": "Aucun espace pour le moment",
     "emptyNoSpacesHint": "Créez-en un ou rejoignez-en un avec un code d'invitation.",
+    "emptyDocsTitle": "Nouveau sur Mirall ?",
+    "emptyDocsBody": "Un espace est un groupe privé. Vos fichiers restent sur votre appareil et vont directement aux personnes que vous invitez — sans serveur intermédiaire.",
     "emptyNoFavorites": "Aucun favori pour le moment",
     "emptyNoFavoritesHint": "Ouvrez un espace et choisissez « Ajouter aux favoris » dans le menu pour l'épingler ici.",
     "memberCount_one": "{{count}} membre",
@@ -85,6 +87,8 @@
     "emptyFiles": "Aucun fichier partagé pour le moment. Déposez des fichiers dans la barre latérale pour commencer.",
     "emptyShareTitle": "Rien n'est encore partagé",
     "emptyShareSubtitle": "Glissez des fichiers ou des dossiers dans la zone à droite pour commencer à partager dans cet espace.",
+    "emptyShareDocsTitle": "Ce qui se passe quand vous partagez",
+    "emptyShareDocsBody": "Les membres téléchargent les fichiers directement depuis votre appareil : vous devez donc être en ligne, Mirall ouvert, pendant qu'ils le font. Les fichiers partagés restent là où ils sont sur le disque — si vous en déplacez ou supprimez un, il n'est plus disponible.",
     "members": "Membres",
     "emptyMembers": "Aucun membre connecté pour le moment. Partagez le code d'invitation pour commencer.",
     "membersAndMore": "+{{count}} de plus",
@@ -106,6 +110,8 @@
     "selectNamed": "Sélectionner {{name}}",
     "waitingApproval": "En attente d'accès à {{name}}…",
     "waitingApprovalHint": "Un membre de cet espace doit vous approuver. Vous pouvez laisser cette fenêtre ouverte : vous serez admis automatiquement dès que quelqu'un sera en ligne.",
+    "waitingDocsTitle": "Pourquoi cette attente ?",
+    "waitingDocsBody": "Une invitation contient l'adresse de l'espace, jamais sa clé. C'est un appareil déjà membre qui la transmet : un membre doit donc être en ligne et joignable avant que vous puissiez entrer. L'approbation automatique supprime la décision, pas la transmission.",
     "encryptedBadge": "Chiffré",
     "unencryptedBadge": "Non chiffré"
   },
@@ -426,6 +432,18 @@
     "releaseFolder": "Relâchez pour partager « {{name}} »",
     "releaseFolderUnnamed": "Relâchez pour partager ce dossier",
     "button": "Sélectionner des fichiers"
+  },
+  "docs": {
+    "opensInBrowser": "Ouvre mirall.app dans votre navigateur",
+    "englishNote": "La documentation est en anglais.",
+    "sendFirstFiles": "Envoyer vos premiers fichiers",
+    "createSpace": "Créer un espace",
+    "joinSpace": "Rejoindre un espace avec une invitation",
+    "membershipApproval": "Comment fonctionnent l'adhésion et l'approbation",
+    "stuckJoin": "Débloquer une adhésion qui reste en attente",
+    "availability": "Quand les membres peuvent télécharger",
+    "shareFiles": "Partager des fichiers individuels",
+    "shareFolder": "Partager un dossier entier"
   },
   "updateBanner": {
     "available": "Mise à jour disponible (v{{version}})",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -52,6 +52,8 @@
     "join": "Entra in uno spazio",
     "emptyNoSpaces": "Nessuno spazio per ora",
     "emptyNoSpacesHint": "Creane uno o entra con un codice di invito.",
+    "emptyDocsTitle": "Nuovo su Mirall?",
+    "emptyDocsBody": "Uno spazio è un gruppo privato. I file restano sul tuo dispositivo e vanno direttamente alle persone che inviti, senza alcun server di mezzo.",
     "emptyNoFavorites": "Nessun preferito per ora",
     "emptyNoFavoritesHint": "Apri uno spazio e scegli «Aggiungi ai preferiti» dal menu per fissarlo qui.",
     "memberCount_one": "{{count}} membro",
@@ -85,6 +87,8 @@
     "emptyFiles": "Nessun file condiviso per ora. Trascina i file nella barra laterale per iniziare.",
     "emptyShareTitle": "Niente di condiviso ancora",
     "emptyShareSubtitle": "Trascina file o cartelle nell'area a destra per iniziare a condividerli in questo spazio.",
+    "emptyShareDocsTitle": "Cosa succede quando condividi",
+    "emptyShareDocsBody": "I membri scaricano i file direttamente dal tuo dispositivo, quindi devi essere online con Mirall aperto mentre lo fanno. I file condivisi restano dove sono sul disco: se ne sposti o elimini uno, non è più disponibile.",
     "members": "Membri",
     "emptyMembers": "Nessun membro connesso per ora. Condividi il codice di invito per iniziare.",
     "membersAndMore": "+{{count}} altri",
@@ -106,6 +110,8 @@
     "selectNamed": "Seleziona {{name}}",
     "waitingApproval": "In attesa di accesso a {{name}}…",
     "waitingApprovalHint": "Un membro di questo spazio deve approvarti. Puoi lasciare questa finestra aperta: verrai ammesso automaticamente non appena qualcuno sarà online.",
+    "waitingDocsTitle": "Perché sto aspettando?",
+    "waitingDocsBody": "Un invito contiene l'indirizzo dello spazio, mai la sua chiave. A consegnarla è un dispositivo già membro: perciò un membro deve essere online e raggiungibile prima che tu possa entrare. L'approvazione automatica elimina la decisione, non la consegna.",
     "encryptedBadge": "Crittografato",
     "unencryptedBadge": "Non crittografato"
   },
@@ -426,6 +432,18 @@
     "releaseFolder": "Rilascia per condividere «{{name}}»",
     "releaseFolderUnnamed": "Rilascia per condividere questa cartella",
     "button": "Seleziona file"
+  },
+  "docs": {
+    "opensInBrowser": "Apre mirall.app nel tuo browser",
+    "englishNote": "La documentazione è in inglese.",
+    "sendFirstFiles": "Inviare i primi file",
+    "createSpace": "Creare uno spazio",
+    "joinSpace": "Entrare in uno spazio con un invito",
+    "membershipApproval": "Come funzionano appartenenza e approvazione",
+    "stuckJoin": "Risolvere un ingresso bloccato",
+    "availability": "Quando i membri possono scaricare",
+    "shareFiles": "Condividere singoli file",
+    "shareFolder": "Condividere un'intera cartella"
   },
   "updateBanner": {
     "available": "Aggiornamento disponibile (v{{version}})",

--- a/src/renderer/screens/SharedSpaces.tsx
+++ b/src/renderer/screens/SharedSpaces.tsx
@@ -7,6 +7,7 @@ import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import SpaceCard from '../components/cards/SpaceCard.js'
 import Icon from '../components/primitives/Icon.js'
 import Button from '../components/primitives/Button.js'
+import DocsCard from '../components/widgets/DocsCard.js'
 
 interface YourSpacesProps {
   onSelectSpace: (spaceId: string) => void
@@ -72,9 +73,20 @@ export default function YourSpaces({ onSelectSpace, onShowCreate, onShowJoin }: 
         className={`flex-1 overflow-y-auto space-y-4 pb-4 scrollbar-thin${hasOverflow ? ' pr-4' : ''}`}
       >
         {filteredSpaces.length === 0 && filter === 'all' && (
-          <div className="flex flex-col items-center justify-center py-20 text-center">
+          <div className="flex flex-col items-center justify-center py-12 text-center">
             <h2 className="text-2xl font-headline font-bold text-accent mb-3">{t('spaces.emptyNoSpaces')}</h2>
             <p className="text-on-surface-variant max-w-md leading-relaxed">{t('spaces.emptyNoSpacesHint')}</p>
+            <DocsCard
+              icon="school"
+              title={t('spaces.emptyDocsTitle')}
+              body={t('spaces.emptyDocsBody')}
+              className="w-full max-w-md mt-8"
+              links={[
+                { target: { page: 'tutorials', anchor: 'send-your-first-files' }, label: t('docs.sendFirstFiles') },
+                { target: { page: 'guides', anchor: 'create-a-space' }, label: t('docs.createSpace') },
+                { target: { page: 'guides', anchor: 'join-a-space' }, label: t('docs.joinSpace') },
+              ]}
+            />
           </div>
         )}
         {filteredSpaces.length === 0 && filter === 'favorites' && (

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -36,6 +36,7 @@ import Icon from '../components/primitives/Icon.js'
 import IconButton from '../components/primitives/IconButton.js'
 import Button from '../components/primitives/Button.js'
 import Avatar from '../components/primitives/Avatar.js'
+import DocsCard from '../components/widgets/DocsCard.js'
 import { useRegisterCommand } from '../keyboard/KeyboardProvider.js'
 
 interface SpaceViewProps {
@@ -334,7 +335,7 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
       )}
 
       {space?.status === 'pending' ? (
-        <div className="flex-1 flex flex-col items-center justify-center text-center pb-8" role="status" aria-live="polite">
+        <div className="flex-1 flex flex-col items-center justify-center text-center pb-8">
           {(() => {
             const inviters = members.filter((m) => m.publicKey !== profile?.publicKey)
             return inviters.length > 0 ? (
@@ -345,10 +346,24 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
               </div>
             ) : null
           })()}
-          <h2 className="text-2xl font-headline font-bold text-accent mb-3">
-            {t('space.waitingApproval', { name: space?.name || t('space.fallbackName') })}
-          </h2>
-          <p className="text-on-surface-variant max-w-md leading-relaxed">{t('space.waitingApprovalHint')}</p>
+          {/* The live region covers only the two strings that change; the card below is
+              static and would be re-announced on every render from inside it. */}
+          <div role="status" aria-live="polite" className="flex flex-col items-center">
+            <h2 className="text-2xl font-headline font-bold text-accent mb-3">
+              {t('space.waitingApproval', { name: space?.name || t('space.fallbackName') })}
+            </h2>
+            <p className="text-on-surface-variant max-w-md leading-relaxed">{t('space.waitingApprovalHint')}</p>
+          </div>
+          <DocsCard
+            icon="lock"
+            title={t('space.waitingDocsTitle')}
+            body={t('space.waitingDocsBody')}
+            className="w-full max-w-lg mt-8"
+            links={[
+              { target: { page: 'explanation', anchor: 'membership-approval' }, label: t('docs.membershipApproval') },
+              { target: { page: 'guides', anchor: 'fix-a-stuck-join' }, label: t('docs.stuckJoin') },
+            ]}
+          />
         </div>
       ) : (
       <div
@@ -386,6 +401,17 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
                 <p className="text-on-surface-variant max-w-md leading-relaxed">
                   {t('space.emptyShareSubtitle')}
                 </p>
+                <DocsCard
+                  icon="menu_book"
+                  title={t('space.emptyShareDocsTitle')}
+                  body={t('space.emptyShareDocsBody')}
+                  className="w-full max-w-md mt-8"
+                  links={[
+                    { target: { page: 'explanation', anchor: 'spaces-members-availability' }, label: t('docs.availability') },
+                    { target: { page: 'guides', anchor: 'share-files' }, label: t('docs.shareFiles') },
+                    { target: { page: 'guides', anchor: 'share-a-folder' }, label: t('docs.shareFolder') },
+                  ]}
+                />
               </div>
             </div>
           ) : (

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -112,6 +112,7 @@ import s102 from './scenarios/s102-remove-readd-no-autoresume.mjs'
 import s103 from './scenarios/s103-folder-tree.mjs'
 import s112 from './scenarios/s112-connection-problem.mjs'
 import s113 from './scenarios/s113-diagnostics-export.mjs'
+import s114 from './scenarios/s114-waiting-docs-card.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -178,7 +179,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s114-waiting-docs-card.mjs
+++ b/test/frontend/scenarios/s114-waiting-docs-card.mjs
@@ -1,0 +1,37 @@
+import { mkdirSync } from 'node:fs'
+import { Instance } from '../instance.mjs'
+import { createSpaceWithInvite, joinPending } from '../helpers.mjs'
+import { makeReport, assert } from '../assert.mjs'
+
+// A joiner waiting for approval gets the "Why am I waiting?" card explaining that the
+// invite carries the address of the space and not the key to it, with deep links into the
+// documentation. The withdraw path must keep working alongside it.
+// Local-only (real Electron + AX).
+export default async function s114 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  try {
+    await r.ok('a pending joiner sees the waiting docs card', async () => {
+      await A.launch(); await B.launch()
+      const code = await createSpaceWithInvite(A, { name: 'Approval' })
+      await joinPending(B, code)
+
+      await B.focus()
+      await B.waitText('Why am I waiting?', 15000)
+      assert(await B.hasText('never the key to it'), 'the card states the invite/key distinction')
+      assert(await B.has({ role: 'link', contains: 'How membership and approval work' }), 'explanation link present')
+      assert(await B.has({ role: 'link', contains: 'Fix a join that gets stuck' }), 'stuck-join link present')
+      await B.shot('s114-waiting-docs', runDir)
+    })
+
+    await r.ok('the withdraw action still works alongside the card', async () => {
+      await B.click({ role: 'button', name: 'Cancel request' })
+      await B.waitText('No spaces yet', 15000)
+    })
+  } catch {}
+
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/frontend/scenarios/s21-empty-states.mjs
+++ b/test/frontend/scenarios/s21-empty-states.mjs
@@ -1,9 +1,12 @@
 import { mkdirSync } from 'node:fs'
 import { Instance } from '../instance.mjs'
-import { makeReport } from '../assert.mjs'
+import { makeReport, assert } from '../assert.mjs'
 
-// Empty states: a fresh profile shows the no-spaces and no-favorites copy, and a
-// freshly created space shows the empty-share copy.
+// Empty states: a fresh profile shows the no-spaces and no-favorites copy, a freshly
+// created space shows the empty-share copy, and both carry a docs card linking out to
+// mirall.app. Selectors match on `contains`, not `name`: the sr-only "Opens mirall.app in
+// your browser" span is part of each link's accessible name on purpose. The role assertion
+// is the a11y guarantee — these must stay anchors, not buttons wired to an onClick.
 export default async function s21 ({ runDir, bootstrap }) {
   mkdirSync(runDir, { recursive: true })
   const r = makeReport()
@@ -15,15 +18,31 @@ export default async function s21 ({ runDir, bootstrap }) {
       await A.waitText('No spaces yet', 8000)
       await A.shot('s21-no-spaces', runDir)
     })
-    await r.ok('the Favorites tab is empty', async () => {
+    await r.ok('the no-spaces state offers the docs card', async () => {
+      await A.waitText('New to Mirall?', 8000)
+      assert(await A.has({ role: 'link', contains: 'Send your first files' }), 'tutorial link present')
+      assert(await A.has({ role: 'link', contains: 'Create a space' }), 'create-a-space link present')
+      assert(await A.has({ role: 'link', contains: 'Join a space with an invite' }), 'join-a-space link present')
+      assert(await A.hasText('Opens mirall.app in your browser'), 'the destination is in the accessible name')
+      await A.shot('s21-no-spaces-docs', runDir)
+    })
+    await r.ok('the Favorites tab is empty and carries no docs card', async () => {
       await A.click({ name: 'Favorites' })
       await A.waitText('No favorites yet', 8000)
+      assert(!(await A.hasText('New to Mirall?')), 'the favorites empty state stays bare')
       await A.click({ name: 'All Spaces' })
     })
     await r.ok('a new space shows the empty-share copy', async () => {
       await A.createSpaceOnly('Aurora')
       await A.waitText('Nothing shared yet', 8000)
       await A.shot('s21-empty-space', runDir)
+    })
+    await r.ok('the empty space offers the sharing docs card', async () => {
+      await A.waitText('What happens when you share', 8000)
+      assert(await A.has({ role: 'link', contains: 'When members can download from you' }), 'availability link present')
+      assert(await A.has({ role: 'link', contains: 'Share individual files' }), 'share-files link present')
+      assert(await A.has({ role: 'link', contains: 'Share a whole folder' }), 'share-folder link present')
+      await A.shot('s21-empty-space-docs', runDir)
     })
   } catch {}
   return { pass: r.summary(), instances: [A] }

--- a/test/unit/docs-links.test.js
+++ b/test/unit/docs-links.test.js
@@ -1,0 +1,66 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { docsUrl } from '../../src/renderer/docs-links.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const DTS = path.resolve(here, '../../src/renderer/docs-links.d.ts')
+
+// Every link the UI renders, pinned to the exact URL a user lands on.
+const SHIPPING_LINKS = [
+  [{ page: 'tutorials', anchor: 'send-your-first-files' }, 'https://mirall.app/docs/tutorials#send-your-first-files'],
+  [{ page: 'guides', anchor: 'create-a-space' }, 'https://mirall.app/docs/guides#create-a-space'],
+  [{ page: 'guides', anchor: 'join-a-space' }, 'https://mirall.app/docs/guides#join-a-space'],
+  [{ page: 'guides', anchor: 'fix-a-stuck-join' }, 'https://mirall.app/docs/guides#fix-a-stuck-join'],
+  [{ page: 'guides', anchor: 'share-files' }, 'https://mirall.app/docs/guides#share-files'],
+  [{ page: 'guides', anchor: 'share-a-folder' }, 'https://mirall.app/docs/guides#share-a-folder'],
+  [{ page: 'explanation', anchor: 'membership-approval' }, 'https://mirall.app/docs/explanation#membership-approval'],
+  [{ page: 'explanation', anchor: 'spaces-members-availability' }, 'https://mirall.app/docs/explanation#spaces-members-availability'],
+]
+
+test('docs-links: every shipping link resolves to its exact URL', (t) => {
+  for (const [target, expected] of SHIPPING_LINKS) {
+    t.is(docsUrl(target), expected, `${target.page}#${target.anchor}`)
+  }
+})
+
+test('docs-links: the hub target has no anchor and no trailing slash', (t) => {
+  t.is(docsUrl({ page: 'hub' }), 'https://mirall.app/docs')
+})
+
+test('docs-links: every URL is https, on mirall.app, under /docs, with one fragment', (t) => {
+  for (const [target] of SHIPPING_LINKS) {
+    const href = docsUrl(target)
+    const url = new URL(href)
+    t.is(url.protocol, 'https:', `${href} is https`)
+    t.is(url.host, 'mirall.app', `${href} is on the apex`)
+    t.ok(url.pathname.startsWith('/docs/'), `${href} is under /docs`)
+    t.absent(url.pathname.endsWith('/'), `${href} has no trailing slash before the fragment`)
+    t.is((href.match(/#/g) ?? []).length, 1, `${href} has exactly one fragment separator`)
+  }
+})
+
+// TypeScript never runs over the .js, so the sidecar's unions are only a compile-time
+// contract. Read the anchors back out of it and prove the declared set is exactly the set
+// the UI ships: a declared-but-unwired anchor and a wired-but-undeclared one both fail.
+test('docs-links: the .d.ts declares exactly the anchors the UI ships', (t) => {
+  const src = fs.readFileSync(DTS, 'utf8')
+  const pages = {
+    TutorialAnchor: 'tutorials',
+    GuideAnchor: 'guides',
+    ExplanationAnchor: 'explanation',
+  }
+  const declared = []
+  for (const [typeName, page] of Object.entries(pages)) {
+    const block = src.split(`type ${typeName}`)[1]?.split('\n\n')[0] ?? ''
+    const anchors = [...block.matchAll(/'([a-z0-9-]+)'/g)].map((m) => m[1])
+    t.ok(anchors.length > 0, `${typeName} declares at least one anchor`)
+    for (const anchor of anchors) {
+      t.is(docsUrl({ page, anchor }), `https://mirall.app/docs/${page}#${anchor}`, `${page}#${anchor}`)
+      declared.push(`${page}#${anchor}`)
+    }
+  }
+  const shipped = SHIPPING_LINKS.map(([target]) => `${target.page}#${target.anchor}`)
+  t.alike(declared.sort(), shipped.sort(), 'no declared-but-unused and no used-but-undeclared anchors')
+})


### PR DESCRIPTION
The spaces list, the waiting-for-approval screen and the empty space each get a card that states the model in a sentence or two and links into `mirall.app/docs`. Until now the only route to the documentation was the native Help menu, which is hidden entirely on Windows/Linux when the menu bar is set to auto-hide.

Links are plain anchors — the main process already turns an `http(s)` navigation into `shell.openExternal`, so there is no new IPC, preload API or CSP change. `docsUrl` takes a typed target so a mistyped anchor is a compile error; the site answers 200 on every path, so a stale one would otherwise land silently with no scroll.

**Two a11y notes.** The waiting screen's `aria-live` region is narrowed to the heading and hint — it previously wrapped the whole block, which would have re-announced the static card on every render. And `DocsLink`'s anchor is `relative` so its `sr-only` span, which is `position: absolute`, resolves against the link rather than the initial containing block: the same containment #95 applied to the settings scrollers, done at the component so it holds wherever the card is mounted.

**Copy.** The empty-space card leads with the constraint that surprises people — members can only download while you are online — rather than the in-place-sharing differentiator, which nobody arrives expecting otherwise. That fact survives only in its consequential form ("move or delete one and it's no longer available").

Rebased onto staging after #95 and #96. #96 already widened the axe-core backstop this branch had also needed, and at a better value, so that change is dropped here.

Tests: `test:unit` 1064/1064 including the new containment guard from #95. `test:fe` s21 (5/5) and s114 (2/2) ran green locally, and the six `frontend-layout` harnesses pass — including the document-overflow one, which is the guard for the bug class #95 fixed. The link-role assertions are the first in the suite, verified against the Chromium AX tree and then in the real run. The FE suite predates the one-class `relative` addition, which cannot affect the names or roles it asserts.