### PR TITLE
[feat] Record connectivity events in the activity log

### DIFF
--- a/src/renderer/auditKinds.ts
+++ b/src/renderer/auditKinds.ts
@@ -38,4 +38,10 @@ export const AUDIT_KINDS: string[] = [
   'security.integrity_failure',
   'security.creator_divergence',
   'audit.suppressed',
+  'network.offline',
+  'network.blocked',
+  'network.at_risk',
+  'network.restored',
+  'network.peer_lost',
+  'network.peer_back',
 ]

--- a/src/renderer/auditRow.d.ts
+++ b/src/renderer/auditRow.d.ts
@@ -1,4 +1,4 @@
-import type { AuditEntry } from './types.js'
+import type { AuditEntry, AuditFilters } from './types.js'
 
 export interface ActorLabel {
   key: string | null
@@ -17,6 +17,10 @@ export interface SentenceValues {
   target: string
 }
 
+export type MetaPart =
+  | { text: string; key?: never; values?: never }
+  | { key: string; values?: Record<string, string | number>; text?: never }
+
 export interface DayGroup {
   key: string
   entries: AuditEntry[]
@@ -26,6 +30,7 @@ export function actorLabel(entry: AuditEntry): ActorLabel
 export function avatarKind(entry: AuditEntry): 'self' | 'peer' | 'system'
 export function actorInitials(entry: AuditEntry): string | null
 export function rowBadge(entry: AuditEntry): RowBadge | null
+export function systemIcon(entry: AuditEntry): 'hub' | 'history'
 export function isSystemRow(entry: AuditEntry): boolean
 export function denialReasonKey(entry: AuditEntry): string | null
 export function sentenceKey(entry: AuditEntry): string
@@ -39,6 +44,13 @@ export function sentinelValues(): SentenceValues
 export function splitSentence(rendered: string, values: SentenceValues): SentenceSegment[]
 export function formatBytes(bytes: number): string | null
 export function formatCount(n: number): string | null
-export function metaParts(entry: AuditEntry): string[]
+export function metaParts(entry: AuditEntry): MetaPart[]
 export function dayKey(ts: number, now?: number): string
 export function groupByDay(entries: AuditEntry[], now?: number): DayGroup[]
+
+export interface EmptyState {
+  key: 'empty' | 'emptyFiltered' | 'emptyNetwork'
+  icon: 'history' | 'search' | 'hub'
+}
+
+export function emptyStateFor(filters: AuditFilters, active: boolean): EmptyState

--- a/src/renderer/auditRow.js
+++ b/src/renderer/auditRow.js
@@ -3,6 +3,7 @@
 //
 // Every field it reads is snapshotted in the record itself — nothing here joins against live
 // state, because a row routinely outlives the space, share or peer it describes.
+import { formatDuration } from './connectivity.js'
 
 // Which participant a row is "about". `actorLabelKey` distinguishes the three cases the copy
 // has to handle: you did it, a named peer did it, or the app did it on its own.
@@ -39,10 +40,29 @@ export function actorInitials(entry) {
 // point a badge on most rows is chrome rather than signal — and the sentence already names a peer
 // as the actor, so "REPORTED" restated what the row said. The tier stays on the record for the
 // export and the backend console, it just does not decorate the list.
+//
+// A connectivity row keeps outcome 'ok' — the vocabulary answers "did the described ACT succeed",
+// and a network state is not an act, so 'error' would render FAILED and read as a failed transfer.
+// Severity is keyed on the kind instead, reusing the SHIPPED connectivity strings so the log, the
+// status dot and the toast say the same word. Peer rows get none: a member closing a laptop is
+// routine, and by the rule above a badge on a routine row is chrome.
+const KIND_BADGE = {
+  'network.offline': { labelKey: 'connectivity.offline', tone: 'error' },
+  'network.blocked': { labelKey: 'connectivity.offline', tone: 'error' },
+  'network.at_risk': { labelKey: 'connectivity.limited', tone: 'passive' },
+}
+
 export function rowBadge(entry) {
   if (entry.outcome === 'denied') return { labelKey: 'activityLog.badgeDenied', tone: 'error' }
   if (entry.outcome === 'error') return { labelKey: 'activityLog.badgeFailed', tone: 'error' }
-  return null
+  return KIND_BADGE[entry.kind] || null
+}
+
+// `history` is the log's own mark; a device connectivity row gets the app's Network glyph instead,
+// so the device family reads as one family. Peer rows are not system rows — they keep the person's
+// initials, which is the correct read.
+export function systemIcon(entry) {
+  return entry.category === 'network' ? 'hub' : 'history'
 }
 
 export function isSystemRow(entry) {
@@ -142,23 +162,54 @@ export function formatCount(n) {
   return Number.isFinite(n) ? n.toLocaleString() : null
 }
 
-// The muted second line: space name first (it is the row's strongest context), then whatever
-// detail the kind carries. Returns already-joined display text plus the parts, so a caller can
-// re-order without re-deriving.
+// Closed set, like DENIAL_REASONS: a cause written by a newer version renders nothing rather than a
+// raw key.
+const NETWORK_CAUSES = new Set([
+  'os-offline', 'dht-unreachable', 'no-public-address', 'symmetric-nat',
+  'udp-degraded', 'peers-unreachable', 'vpn-only-route',
+])
+
+// The hold-down means a degraded row lands about a minute after the transition. Below this the gap
+// is not worth a clause; above it, naming the real start keeps the row honest without backdating
+// `ts`, which the prune path's clock hysteresis relies on.
+const START_GAP_MS = 30000
+
+function formatClock(ts) {
+  return new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })
+}
+
+// The muted second line: space name first (it is the row's strongest context), then whatever detail
+// the kind carries. Returns STRUCTURED parts — `{ key, values }` for anything that needs
+// translating, `{ text }` for a value that is already a proper noun or a formatted number. It used
+// to return finished strings, which is how a hard-coded English ' files' shipped to five locales.
 export function metaParts(entry) {
   const parts = []
-  if (entry.space?.name) parts.push(entry.space.name)
+  if (entry.space?.name) parts.push({ text: entry.space.name })
   const subject = entry.subject || {}
   if (Number.isFinite(subject.fileCount)) {
     const files = formatCount(subject.fileCount)
-    if (files !== null) parts.push(files + ' files')
+    if (files !== null) {
+      parts.push({ key: 'activityLog.metaFiles', values: { count: subject.fileCount, formatted: files } })
+    }
   }
   if (Number.isFinite(subject.bytes)) {
     const size = formatBytes(subject.bytes)
-    if (size) parts.push(size)
+    if (size) parts.push({ text: size })
   }
-  if (typeof subject.mountPath === 'string' && subject.mountPath) parts.push(subject.mountPath)
-  if (typeof subject.to === 'string' && subject.to) parts.push(subject.to)
+  if (typeof subject.mountPath === 'string' && subject.mountPath) parts.push({ text: subject.mountPath })
+  if (typeof subject.to === 'string' && subject.to) parts.push({ text: subject.to })
+
+  if (entry.category === 'network') {
+    if (typeof entry.code === 'string' && NETWORK_CAUSES.has(entry.code)) {
+      parts.push({ key: 'activityLog.cause.' + entry.code })
+    }
+    if (Number.isFinite(subject.durationMs)) {
+      parts.push({ key: 'activityLog.wasOfflineFor', values: { duration: formatDuration(subject.durationMs) } })
+    }
+    if (Number.isFinite(subject.sinceTs) && entry.ts - subject.sinceTs >= START_GAP_MS) {
+      parts.push({ key: 'activityLog.startedAt', values: { time: formatClock(subject.sinceTs) } })
+    }
+  }
   return parts
 }
 
@@ -186,4 +237,24 @@ export function groupByDay(entries, now = Date.now()) {
     current.entries.push(entry)
   }
   return groups
+}
+
+// Which empty state the viewer should show, and the glyph for it. Lives here rather than inline in
+// the screen so the branching is unit-testable and does not push an already-over-budget component
+// further past the complexity guardrail.
+//
+// An empty NETWORK log is good news, not a failed search — but only when nothing else narrows the
+// view: with a date range applied, "the whole time it has been running" is false the moment an
+// outage exists outside the window.
+export function emptyStateFor(filters, active) {
+  if (!active) return { key: 'empty', icon: 'history' }
+  const networkOnly = filters.categories.length === 1
+    && filters.categories[0] === 'network'
+    && !filters.search.trim()
+    && !filters.spaceId
+    && !filters.actorKey
+    && filters.sinceDays === null
+  return networkOnly
+    ? { key: 'emptyNetwork', icon: 'hub' }
+    : { key: 'emptyFiltered', icon: 'search' }
 }

--- a/src/renderer/components/layout/ScreenRouter.tsx
+++ b/src/renderer/components/layout/ScreenRouter.tsx
@@ -34,6 +34,7 @@ export default function ScreenRouter({ nav, profile, onSaveProfile, onOpenFeedba
         <ConnectionProblem
           onContinue={gate.dismiss}
           onShowDetails={() => nav.setCurrentScreen('network-status')}
+          onShowHistory={() => nav.openActivityLog({ categories: ['network'] })}
         />
       ) : (
         <SharedSpaces
@@ -48,6 +49,7 @@ export default function ScreenRouter({ nav, profile, onSaveProfile, onOpenFeedba
           onBack={() => nav.setCurrentScreen('spaces')}
           onContinue={() => nav.setCurrentScreen('spaces')}
           onShowDetails={() => nav.setCurrentScreen('network-status')}
+          onShowHistory={() => nav.openActivityLog({ categories: ['network'] })}
         />
       )
     case 'space-view':
@@ -98,7 +100,7 @@ export default function ScreenRouter({ nav, profile, onSaveProfile, onOpenFeedba
           onSave={onSaveProfile}
           onBack={() => nav.setCurrentScreen(nav.preAccountScreen)}
           onOpenNetworkStatus={() => nav.setCurrentScreen('network-status')}
-          onOpenActivityLog={nav.openActivityLog}
+          onOpenActivityLog={() => nav.openActivityLog()}
           onFeedback={onOpenFeedback}
         />
       )
@@ -113,19 +115,25 @@ export default function ScreenRouter({ nav, profile, onSaveProfile, onOpenFeedba
     case 'network-settings':
       return <NetworkSettings onBack={() => nav.setCurrentScreen('settings')} />
     case 'network-status':
-      return <NetworkStatus onBack={() => nav.setCurrentScreen('account')} />
+      return (
+        <NetworkStatus
+          onBack={() => nav.setCurrentScreen('account')}
+          onShowHistory={() => nav.openActivityLog({ categories: ['network'] })}
+        />
+      )
     case 'activity-log':
       return (
         <ActivityLog
-          onBack={() => nav.setCurrentScreen('account')}
+          onBack={nav.goBack}
           onOpenSettings={nav.openActivityLogSettings}
+          initialFilters={nav.activityLogPreset ?? undefined}
         />
       )
     case 'activity-log-settings':
       return (
         <ActivityLogSettings
           onBack={() => nav.setCurrentScreen('settings')}
-          onOpenLog={nav.openActivityLog}
+          onOpenLog={() => nav.openActivityLog()}
         />
       )
     default:

--- a/src/renderer/hooks/useAppNavigation.ts
+++ b/src/renderer/hooks/useAppNavigation.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react'
 import type { Dispatch, SetStateAction } from 'react'
 import type { ShareWithRole } from './useShares.js'
+import type { AuditFilters } from '../types.js'
 
 export interface AppNavigation {
   currentScreen: string
@@ -9,6 +10,8 @@ export interface AppNavigation {
   preSettingsScreen: 'spaces' | 'space-view'
   preAccountScreen: 'spaces' | 'space-view'
   storageBackTarget: 'settings' | 'space-view'
+  activityLogBackTarget: string
+  activityLogPreset: Partial<AuditFilters> | null
   setCurrentScreen: Dispatch<SetStateAction<string>>
   setSelectedSpaceId: Dispatch<SetStateAction<string | null>>
   setSelectedShare: Dispatch<SetStateAction<ShareWithRole | null>>
@@ -16,7 +19,7 @@ export interface AppNavigation {
   openSettings: () => void
   openAccount: () => void
   openStorageSettings: (from: 'settings' | 'space-view') => void
-  openActivityLog: () => void
+  openActivityLog: (preset?: Partial<AuditFilters> | null) => void
   openActivityLogSettings: () => void
   goBack: () => void
   goHome: () => void
@@ -30,6 +33,10 @@ export function useAppNavigation(): AppNavigation {
   const [storageBackTarget, setStorageBackTarget] = useState<'settings' | 'space-view'>('settings')
   const [selectedSpaceId, setSelectedSpaceId] = useState<string | null>(null)
   const [selectedShare, setSelectedShare] = useState<ShareWithRole | null>(null)
+  const [activityLogPreset, setActivityLogPreset] = useState<Partial<AuditFilters> | null>(null)
+  // The viewer hangs off Account, but the connectivity screens now cross-link into it too, so Back
+  // has to return where the user came from rather than always to Account.
+  const [activityLogBackTarget, setActivityLogBackTarget] = useState<string>('account')
 
   const openSettings = useCallback(() => {
     setPreSettingsScreen((prev) => {
@@ -52,7 +59,14 @@ export function useAppNavigation(): AppNavigation {
     setCurrentScreen('storage-settings')
   }, [])
 
-  const openActivityLog = useCallback(() => setCurrentScreen('activity-log'), [])
+  const openActivityLog = useCallback((preset: Partial<AuditFilters> | null = null) => {
+    setActivityLogPreset(preset)
+    // The viewer/config cross-link stays a lateral jump, not a history step: following it and
+    // pressing Back returns to THAT screen's own parent, which is the shipped convention.
+    const lateral = currentScreen === 'activity-log' || currentScreen === 'activity-log-settings'
+    setActivityLogBackTarget(lateral ? 'account' : currentScreen)
+    setCurrentScreen('activity-log')
+  }, [currentScreen])
   const openActivityLogSettings = useCallback(() => setCurrentScreen('activity-log-settings'), [])
 
   const navigateToSpace = useCallback((spaceId: string) => {
@@ -79,11 +93,11 @@ export function useAppNavigation(): AppNavigation {
       case 'connection-problem': setCurrentScreen('spaces'); break
       // The viewer hangs off Account and the config off Settings, so each backs out to its own
       // parent; a cross-link between them is a lateral jump, not a step in a history stack.
-      case 'activity-log': setCurrentScreen('account'); break
+      case 'activity-log': setCurrentScreen(activityLogBackTarget); break
       case 'activity-log-settings': setCurrentScreen('settings'); break
       default: break
     }
-  }, [currentScreen, preSettingsScreen, preAccountScreen, storageBackTarget])
+  }, [currentScreen, preSettingsScreen, preAccountScreen, storageBackTarget, activityLogBackTarget])
 
   const goHome = useCallback(() => {
     setSelectedShare(null)
@@ -104,6 +118,8 @@ export function useAppNavigation(): AppNavigation {
     preSettingsScreen,
     preAccountScreen,
     storageBackTarget,
+    activityLogBackTarget,
+    activityLogPreset,
     setCurrentScreen,
     setSelectedSpaceId,
     setSelectedShare,

--- a/src/renderer/hooks/useAuditLog.ts
+++ b/src/renderer/hooks/useAuditLog.ts
@@ -115,4 +115,4 @@ export function useAuditFacets(refreshKey: number) {
   return { spaces, actors }
 }
 
-export const AUDIT_CATEGORIES: AuditCategory[] = ['members', 'files', 'folders', 'security']
+export const AUDIT_CATEGORIES: AuditCategory[] = ['members', 'files', 'folders', 'security', 'network']

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -800,7 +800,8 @@
     "canary": "Verbindungstest",
     "canaryState": "Ergebnis",
     "canaryRecords": "Gefundene Testserver",
-    "canaryChecked": "Zuletzt geprüft"
+    "canaryChecked": "Zuletzt geprüft",
+    "connectionHistory": "Verbindungsverlauf"
   },
   "a11y": {
     "skipToContent": "Zum Inhalt springen",
@@ -828,7 +829,7 @@
   },
   "activityLog": {
     "title": "Aktivitätsprotokoll",
-    "intro": "Eine Aufzeichnung dessen, was in deinen Räumen passiert ist — auf diesem Gerät gespeichert.",
+    "intro": "Eine Aufzeichnung dessen, was in deinen Räumen und mit der Verbindung dieses Geräts passiert ist — gespeichert auf diesem Gerät.",
     "searchLabel": "Aktivität durchsuchen",
     "searchPlaceholder": "Personen, Dateien und Ordner durchsuchen…",
     "spaceFilterValue": "Raum: {{value}}",
@@ -843,7 +844,8 @@
       "members": "Mitglieder",
       "files": "Dateien",
       "folders": "Ordner",
-      "security": "Sicherheit"
+      "security": "Sicherheit",
+      "network": "Netzwerk"
     },
     "events": "Ereignisse",
     "showingCount_one": "{{count}} Ereignis",
@@ -902,7 +904,13 @@
       "peer.share_created": "{{actor}} hat den Ordner {{target}} geteilt",
       "peer.share_deleted": "{{actor}} hat den Ordner {{target}} gelöscht",
       "mirror.peer_mirrored": "{{actor}} spiegelt deinen Ordner {{target}}",
-      "mirror.peer_unmirrored": "{{actor}} spiegelt deinen Ordner {{target}} nicht mehr"
+      "mirror.peer_unmirrored": "{{actor}} spiegelt deinen Ordner {{target}} nicht mehr",
+      "network.offline": "Dieses Gerät war offline",
+      "network.blocked": "Mirall konnte andere nicht erreichen",
+      "network.at_risk": "Verbindungen zu vielen Personen schlagen in diesem Netzwerk fehl",
+      "network.restored": "Verbindung wiederhergestellt",
+      "network.peer_lost": "{{actor}} ist offline gegangen",
+      "network.peer_back": "{{actor}} ist wieder online"
     },
     "kindLabel": {
       "space.created": "Raum erstellt",
@@ -937,7 +945,28 @@
       "peer.share_created": "Ordner von Mitglied geteilt",
       "peer.share_deleted": "Ordner von Mitglied gelöscht",
       "mirror.peer_mirrored": "dein Ordner gespiegelt",
-      "mirror.peer_unmirrored": "Spiegelung deines Ordners beendet"
+      "mirror.peer_unmirrored": "Spiegelung deines Ordners beendet",
+      "network.offline": "offline gegangen",
+      "network.blocked": "Verbindung blockiert",
+      "network.at_risk": "Verbindung gefährdet",
+      "network.restored": "Verbindung wiederhergestellt",
+      "network.peer_lost": "Mitglied offline gegangen",
+      "network.peer_back": "Mitglied wieder online"
+    },
+    "metaFiles_one": "{{formatted}} Datei",
+    "metaFiles_other": "{{formatted}} Dateien",
+    "startedAt": "seit {{time}}",
+    "wasOfflineFor": "Offline für {{duration}}",
+    "emptyNetworkTitle": "Keine Verbindungsprobleme aufgezeichnet",
+    "emptyNetworkDesc": "Mirall konnte das Netzwerk erreichen, solange die App lief.",
+    "cause": {
+      "os-offline": "Kein Netzwerk auf diesem Gerät",
+      "dht-unreachable": "Netzwerk nicht erreichbar",
+      "no-public-address": "Keine öffentliche Adresse",
+      "symmetric-nat": "Dein Router wechselt die Ports",
+      "udp-degraded": "Unzuverlässige Verbindung",
+      "peers-unreachable": "Personen gefunden, aber keine Verbindung möglich",
+      "vpn-only-route": "Dein VPN ist der einzige Weg nach außen"
     }
   },
   "activityLogSettings": {
@@ -948,7 +977,7 @@
     "openLogSummary_other": "{{count}} Ereignisse aufgezeichnet",
     "recording": "Aufzeichnung",
     "recordActivity": "Aktivität aufzeichnen",
-    "recordActivityDesc": "Führt lokal Buch über die Vorgänge in deinen Räumen. Verlässt dieses Gerät nie.",
+    "recordActivityDesc": "Lokale Aufzeichnung dessen, was in deinen Räumen passiert — auch, wann dieses Gerät die Verbindung verloren hat. Verlässt dieses Gerät nie.",
     "retention": "Ereignisse aufbewahren für",
     "retentionDesc": "Ältere Ereignisse werden automatisch gelöscht.",
     "retentionDays_one": "{{count}} Tag",
@@ -956,7 +985,7 @@
     "survivesLeave": "Ereignisse bleiben auch für verlassene Räume erhalten, bis sie ablaufen.",
     "export": "Export",
     "exportTitle": "Als JSON exportieren",
-    "exportDesc": "Alle aufgezeichneten Ereignisse in eine Datei speichern.",
+    "exportDesc": "Alle aufgezeichneten Ereignisse in eine Datei speichern. Enthält auch, wann dieses Gerät offline war.",
     "exportAction": "Exportieren…",
     "exportDone_one": "{{count}} Ereignis exportiert.",
     "exportDone_other": "{{count}} Ereignisse exportiert.",
@@ -1017,7 +1046,8 @@
       "atRisk": "Verbindungsproblem",
       "offline": "Keine Netzwerkverbindung",
       "vpnOnly": "Mirall erreicht das Netzwerk nicht"
-    }
+    },
+    "connectionHistory": "Verbindungsverlauf"
   },
   "diagnostics": {
     "title": "Diagnose",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -824,11 +824,12 @@
     "canary": "Connection test",
     "canaryState": "Result",
     "canaryRecords": "Test servers found",
-    "canaryChecked": "Last checked"
+    "canaryChecked": "Last checked",
+    "connectionHistory": "Connection history"
   },
   "activityLog": {
     "title": "Activity Log",
-    "intro": "A record of what happened in your spaces, kept on this device.",
+    "intro": "A record of what happened in your spaces and on this device's connection, kept on this device.",
     "searchLabel": "Search activity",
     "searchPlaceholder": "Search people, files and folders…",
     "spaceFilterValue": "Space: {{value}}",
@@ -843,7 +844,8 @@
       "members": "Members",
       "files": "Files",
       "folders": "Folders",
-      "security": "Security"
+      "security": "Security",
+      "network": "Network"
     },
     "events": "Events",
     "showingCount_one": "Showing {{count}} event",
@@ -902,7 +904,13 @@
       "peer.share_created": "{{actor}} shared the folder {{target}}",
       "peer.share_deleted": "{{actor}} deleted the folder {{target}}",
       "mirror.peer_mirrored": "{{actor}} mirrored your folder {{target}}",
-      "mirror.peer_unmirrored": "{{actor}} stopped mirroring your folder {{target}}"
+      "mirror.peer_unmirrored": "{{actor}} stopped mirroring your folder {{target}}",
+      "network.offline": "This device went offline",
+      "network.blocked": "Mirall couldn't reach other people",
+      "network.at_risk": "Connections to many people will fail on this network",
+      "network.restored": "Connection restored",
+      "network.peer_lost": "{{actor}} went offline",
+      "network.peer_back": "{{actor}} is back online"
     },
     "kindLabel": {
       "space.created": "space created",
@@ -937,7 +945,28 @@
       "peer.share_created": "folder shared by member",
       "peer.share_deleted": "folder deleted by member",
       "mirror.peer_mirrored": "your folder mirrored",
-      "mirror.peer_unmirrored": "your folder unmirrored"
+      "mirror.peer_unmirrored": "your folder unmirrored",
+      "network.offline": "went offline",
+      "network.blocked": "connection blocked",
+      "network.at_risk": "connection at risk",
+      "network.restored": "connection restored",
+      "network.peer_lost": "member went offline",
+      "network.peer_back": "member back online"
+    },
+    "metaFiles_one": "{{formatted}} file",
+    "metaFiles_other": "{{formatted}} files",
+    "startedAt": "started {{time}}",
+    "wasOfflineFor": "Offline for {{duration}}",
+    "emptyNetworkTitle": "No connection problems recorded",
+    "emptyNetworkDesc": "Mirall has been able to reach the network the whole time it has been running.",
+    "cause": {
+      "os-offline": "No network on this device",
+      "dht-unreachable": "Couldn't reach the network",
+      "no-public-address": "No public address",
+      "symmetric-nat": "Your router changes ports",
+      "udp-degraded": "Unreliable connection",
+      "peers-unreachable": "Found people, couldn't connect to any",
+      "vpn-only-route": "Your VPN is the only route out"
     }
   },
   "activityLogSettings": {
@@ -948,7 +977,7 @@
     "openLogSummary_other": "{{count}} events recorded",
     "recording": "Recording",
     "recordActivity": "Record activity",
-    "recordActivityDesc": "Keep a local record of what happens in your spaces. Never leaves this device.",
+    "recordActivityDesc": "Keep a local record of what happens in your spaces, including when this device loses its connection. Never leaves this device.",
     "retention": "Keep events for",
     "retentionDesc": "Older events are deleted automatically.",
     "retentionDays_one": "{{count}} day",
@@ -956,7 +985,7 @@
     "survivesLeave": "Events are kept even for spaces you have left, until they age out.",
     "export": "Export",
     "exportTitle": "Export as JSON",
-    "exportDesc": "Save every recorded event to a file.",
+    "exportDesc": "Save every recorded event to a file. It includes when this device was offline.",
     "exportAction": "Export…",
     "exportDone_one": "Exported {{count}} event.",
     "exportDone_other": "Exported {{count}} events.",
@@ -1017,7 +1046,8 @@
       "atRisk": "Connection problem",
       "offline": "No network connection",
       "vpnOnly": "Mirall can't reach the network"
-    }
+    },
+    "connectionHistory": "Connection history"
   },
   "diagnostics": {
     "title": "Diagnostics",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -800,7 +800,8 @@
     "canary": "Prueba de conexión",
     "canaryState": "Resultado",
     "canaryRecords": "Servidores de prueba encontrados",
-    "canaryChecked": "Última comprobación"
+    "canaryChecked": "Última comprobación",
+    "connectionHistory": "Historial de conexión"
   },
   "a11y": {
     "skipToContent": "Saltar al contenido",
@@ -828,7 +829,7 @@
   },
   "activityLog": {
     "title": "Registro de actividad",
-    "intro": "Un registro de lo que ha ocurrido en tus espacios, guardado en este dispositivo.",
+    "intro": "Un registro de lo que ha pasado en tus espacios y en la conexión de este dispositivo, guardado en este dispositivo.",
     "searchLabel": "Buscar en la actividad",
     "searchPlaceholder": "Buscar personas, archivos y carpetas…",
     "spaceFilterValue": "Espacio: {{value}}",
@@ -843,7 +844,8 @@
       "members": "Miembros",
       "files": "Archivos",
       "folders": "Carpetas",
-      "security": "Seguridad"
+      "security": "Seguridad",
+      "network": "Red"
     },
     "events": "Eventos",
     "showingCount_one": "{{count}} evento",
@@ -902,7 +904,13 @@
       "peer.share_created": "{{actor}} compartió la carpeta {{target}}",
       "peer.share_deleted": "{{actor}} eliminó la carpeta {{target}}",
       "mirror.peer_mirrored": "{{actor}} replicó tu carpeta {{target}}",
-      "mirror.peer_unmirrored": "{{actor}} dejó de replicar tu carpeta {{target}}"
+      "mirror.peer_unmirrored": "{{actor}} dejó de replicar tu carpeta {{target}}",
+      "network.offline": "Este dispositivo se quedó sin conexión",
+      "network.blocked": "Mirall no pudo conectar con otras personas",
+      "network.at_risk": "Las conexiones con muchas personas fallarán en esta red",
+      "network.restored": "Conexión restablecida",
+      "network.peer_lost": "{{actor}} se desconectó",
+      "network.peer_back": "{{actor}} está de nuevo en línea"
     },
     "kindLabel": {
       "space.created": "espacio creado",
@@ -937,7 +945,28 @@
       "peer.share_created": "carpeta compartida por un miembro",
       "peer.share_deleted": "carpeta eliminada por un miembro",
       "mirror.peer_mirrored": "tu carpeta replicada",
-      "mirror.peer_unmirrored": "réplica de tu carpeta detenida"
+      "mirror.peer_unmirrored": "réplica de tu carpeta detenida",
+      "network.offline": "sin conexión",
+      "network.blocked": "conexión bloqueada",
+      "network.at_risk": "conexión en riesgo",
+      "network.restored": "conexión restablecida",
+      "network.peer_lost": "miembro desconectado",
+      "network.peer_back": "miembro de nuevo en línea"
+    },
+    "metaFiles_one": "{{formatted}} archivo",
+    "metaFiles_other": "{{formatted}} archivos",
+    "startedAt": "desde las {{time}}",
+    "wasOfflineFor": "Sin conexión durante {{duration}}",
+    "emptyNetworkTitle": "No se han registrado problemas de conexión",
+    "emptyNetworkDesc": "Mirall ha podido conectarse a la red durante todo el tiempo que ha estado en marcha.",
+    "cause": {
+      "os-offline": "Este dispositivo no tiene red",
+      "dht-unreachable": "No se pudo conectar con la red",
+      "no-public-address": "Sin dirección pública",
+      "symmetric-nat": "Tu router cambia de puertos",
+      "udp-degraded": "Conexión poco fiable",
+      "peers-unreachable": "Se encontraron personas, pero no se pudo conectar con ninguna",
+      "vpn-only-route": "Tu VPN es la única salida"
     }
   },
   "activityLogSettings": {
@@ -948,7 +977,7 @@
     "openLogSummary_other": "{{count}} eventos registrados",
     "recording": "Registro",
     "recordActivity": "Registrar actividad",
-    "recordActivityDesc": "Guarda un registro local de lo que ocurre en tus espacios. Nunca sale de este dispositivo.",
+    "recordActivityDesc": "Mantén un registro local de lo que ocurre en tus espacios, incluido cuándo este dispositivo pierde la conexión. Nunca sale de este dispositivo.",
     "retention": "Conservar eventos durante",
     "retentionDesc": "Los eventos más antiguos se eliminan automáticamente.",
     "retentionDays_one": "{{count}} día",
@@ -956,7 +985,7 @@
     "survivesLeave": "Los eventos se conservan incluso para espacios que has abandonado, hasta que caduquen.",
     "export": "Exportar",
     "exportTitle": "Exportar como JSON",
-    "exportDesc": "Guardar todos los eventos registrados en un archivo.",
+    "exportDesc": "Guarda todos los eventos registrados en un archivo. Incluye cuándo este dispositivo estuvo sin conexión.",
     "exportAction": "Exportar…",
     "exportDone_one": "{{count}} evento exportado.",
     "exportDone_other": "{{count}} eventos exportados.",
@@ -1017,7 +1046,8 @@
       "atRisk": "Problema de conexión",
       "offline": "Sin conexión de red",
       "vpnOnly": "Mirall no puede alcanzar la red"
-    }
+    },
+    "connectionHistory": "Historial de conexión"
   },
   "diagnostics": {
     "title": "Diagnóstico",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -800,7 +800,8 @@
     "canary": "Test de connexion",
     "canaryState": "Résultat",
     "canaryRecords": "Serveurs de test trouvés",
-    "canaryChecked": "Dernière vérification"
+    "canaryChecked": "Dernière vérification",
+    "connectionHistory": "Historique de connexion"
   },
   "a11y": {
     "skipToContent": "Aller au contenu",
@@ -828,7 +829,7 @@
   },
   "activityLog": {
     "title": "Journal d'activité",
-    "intro": "Un relevé de ce qui s'est passé dans vos espaces, conservé sur cet appareil.",
+    "intro": "Un enregistrement de ce qui s'est passé dans vos espaces et sur la connexion de cet appareil, conservé sur cet appareil.",
     "searchLabel": "Rechercher dans l'activité",
     "searchPlaceholder": "Rechercher personnes, fichiers et dossiers…",
     "spaceFilterValue": "Espace : {{value}}",
@@ -843,7 +844,8 @@
       "members": "Membres",
       "files": "Fichiers",
       "folders": "Dossiers",
-      "security": "Sécurité"
+      "security": "Sécurité",
+      "network": "Réseau"
     },
     "events": "Événements",
     "showingCount_one": "{{count}} événement",
@@ -902,7 +904,13 @@
       "peer.share_created": "{{actor}} a partagé le dossier {{target}}",
       "peer.share_deleted": "{{actor}} a supprimé le dossier {{target}}",
       "mirror.peer_mirrored": "{{actor}} met votre dossier {{target}} en miroir",
-      "mirror.peer_unmirrored": "{{actor}} ne met plus votre dossier {{target}} en miroir"
+      "mirror.peer_unmirrored": "{{actor}} ne met plus votre dossier {{target}} en miroir",
+      "network.offline": "Cet appareil était hors ligne",
+      "network.blocked": "Mirall n'a pas pu joindre les autres",
+      "network.at_risk": "Les connexions à de nombreuses personnes échoueront sur ce réseau",
+      "network.restored": "Connexion rétablie",
+      "network.peer_lost": "{{actor}} s’est déconnecté",
+      "network.peer_back": "{{actor}} est de nouveau en ligne"
     },
     "kindLabel": {
       "space.created": "espace créé",
@@ -937,7 +945,28 @@
       "peer.share_created": "dossier partagé par un membre",
       "peer.share_deleted": "dossier supprimé par un membre",
       "mirror.peer_mirrored": "votre dossier mis en miroir",
-      "mirror.peer_unmirrored": "miroir de votre dossier arrêté"
+      "mirror.peer_unmirrored": "miroir de votre dossier arrêté",
+      "network.offline": "hors ligne",
+      "network.blocked": "connexion bloquée",
+      "network.at_risk": "connexion à risque",
+      "network.restored": "connexion rétablie",
+      "network.peer_lost": "membre déconnecté",
+      "network.peer_back": "membre de nouveau en ligne"
+    },
+    "metaFiles_one": "{{formatted}} fichier",
+    "metaFiles_other": "{{formatted}} fichiers",
+    "startedAt": "depuis {{time}}",
+    "wasOfflineFor": "Hors ligne pendant {{duration}}",
+    "emptyNetworkTitle": "Aucun problème de connexion enregistré",
+    "emptyNetworkDesc": "Mirall a pu joindre le réseau pendant toute la durée d'exécution.",
+    "cause": {
+      "os-offline": "Aucun réseau sur cet appareil",
+      "dht-unreachable": "Réseau injoignable",
+      "no-public-address": "Aucune adresse publique",
+      "symmetric-nat": "Votre routeur change de ports",
+      "udp-degraded": "Connexion peu fiable",
+      "peers-unreachable": "Personnes trouvées, aucune connexion possible",
+      "vpn-only-route": "Votre VPN est la seule route vers Internet"
     }
   },
   "activityLogSettings": {
@@ -948,7 +977,7 @@
     "openLogSummary_other": "{{count}} événements enregistrés",
     "recording": "Enregistrement",
     "recordActivity": "Enregistrer l'activité",
-    "recordActivityDesc": "Conserve un relevé local de ce qui se passe dans vos espaces. Ne quitte jamais cet appareil.",
+    "recordActivityDesc": "Conserver un enregistrement local de ce qui se passe dans vos espaces, y compris les pertes de connexion de cet appareil. Ne quitte jamais cet appareil.",
     "retention": "Conserver les événements",
     "retentionDesc": "Les événements plus anciens sont supprimés automatiquement.",
     "retentionDays_one": "{{count}} jour",
@@ -956,7 +985,7 @@
     "survivesLeave": "Les événements sont conservés même pour les espaces que vous avez quittés, jusqu’à leur expiration.",
     "export": "Exporter",
     "exportTitle": "Exporter en JSON",
-    "exportDesc": "Enregistrer tous les événements dans un fichier.",
+    "exportDesc": "Enregistrer tous les événements dans un fichier. Il indique aussi quand cet appareil était hors ligne.",
     "exportAction": "Exporter…",
     "exportDone_one": "{{count}} événement exporté.",
     "exportDone_other": "{{count}} événements exportés.",
@@ -1017,7 +1046,8 @@
       "atRisk": "Problème de connexion",
       "offline": "Aucune connexion réseau",
       "vpnOnly": "Mirall n'atteint pas le réseau"
-    }
+    },
+    "connectionHistory": "Historique de connexion"
   },
   "diagnostics": {
     "title": "Diagnostic",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -800,7 +800,8 @@
     "canary": "Test di connessione",
     "canaryState": "Risultato",
     "canaryRecords": "Server di test trovati",
-    "canaryChecked": "Ultima verifica"
+    "canaryChecked": "Ultima verifica",
+    "connectionHistory": "Cronologia connessione"
   },
   "a11y": {
     "skipToContent": "Vai al contenuto",
@@ -828,7 +829,7 @@
   },
   "activityLog": {
     "title": "Registro attività",
-    "intro": "Un resoconto di ciò che è accaduto nei tuoi spazi, conservato su questo dispositivo.",
+    "intro": "Un registro di ciò che è successo nei tuoi spazi e nella connessione di questo dispositivo, conservato su questo dispositivo.",
     "searchLabel": "Cerca nell'attività",
     "searchPlaceholder": "Cerca persone, file e cartelle…",
     "spaceFilterValue": "Spazio: {{value}}",
@@ -843,7 +844,8 @@
       "members": "Membri",
       "files": "File",
       "folders": "Cartelle",
-      "security": "Sicurezza"
+      "security": "Sicurezza",
+      "network": "Rete"
     },
     "events": "Eventi",
     "showingCount_one": "{{count}} evento",
@@ -902,7 +904,13 @@
       "peer.share_created": "{{actor}} ha condiviso la cartella {{target}}",
       "peer.share_deleted": "{{actor}} ha eliminato la cartella {{target}}",
       "mirror.peer_mirrored": "{{actor}} ha replicato la tua cartella {{target}}",
-      "mirror.peer_unmirrored": "{{actor}} ha smesso di replicare la tua cartella {{target}}"
+      "mirror.peer_unmirrored": "{{actor}} ha smesso di replicare la tua cartella {{target}}",
+      "network.offline": "Questo dispositivo è andato offline",
+      "network.blocked": "Mirall non è riuscito a raggiungere altre persone",
+      "network.at_risk": "Le connessioni a molte persone falliranno su questa rete",
+      "network.restored": "Connessione ripristinata",
+      "network.peer_lost": "{{actor}} è andato offline",
+      "network.peer_back": "{{actor}} è di nuovo online"
     },
     "kindLabel": {
       "space.created": "spazio creato",
@@ -937,7 +945,28 @@
       "peer.share_created": "cartella condivisa da un membro",
       "peer.share_deleted": "cartella eliminata da un membro",
       "mirror.peer_mirrored": "la tua cartella replicata",
-      "mirror.peer_unmirrored": "replica della tua cartella interrotta"
+      "mirror.peer_unmirrored": "replica della tua cartella interrotta",
+      "network.offline": "andato offline",
+      "network.blocked": "connessione bloccata",
+      "network.at_risk": "connessione a rischio",
+      "network.restored": "connessione ripristinata",
+      "network.peer_lost": "membro andato offline",
+      "network.peer_back": "membro di nuovo online"
+    },
+    "metaFiles_one": "{{formatted}} file",
+    "metaFiles_other": "{{formatted}} file",
+    "startedAt": "dalle {{time}}",
+    "wasOfflineFor": "Offline per {{duration}}",
+    "emptyNetworkTitle": "Nessun problema di connessione registrato",
+    "emptyNetworkDesc": "Mirall è riuscito a raggiungere la rete per tutto il tempo in cui è stato in esecuzione.",
+    "cause": {
+      "os-offline": "Nessuna rete su questo dispositivo",
+      "dht-unreachable": "Rete non raggiungibile",
+      "no-public-address": "Nessun indirizzo pubblico",
+      "symmetric-nat": "Il tuo router cambia porta",
+      "udp-degraded": "Connessione inaffidabile",
+      "peers-unreachable": "Persone trovate, nessuna connessione riuscita",
+      "vpn-only-route": "La tua VPN è l’unica via di uscita"
     }
   },
   "activityLogSettings": {
@@ -948,7 +977,7 @@
     "openLogSummary_other": "{{count}} eventi registrati",
     "recording": "Registrazione",
     "recordActivity": "Registra attività",
-    "recordActivityDesc": "Tiene un resoconto locale di ciò che accade nei tuoi spazi. Non lascia mai questo dispositivo.",
+    "recordActivityDesc": "Conserva un registro locale di ciò che accade nei tuoi spazi, incluso quando questo dispositivo perde la connessione. Non lascia mai questo dispositivo.",
     "retention": "Conserva gli eventi per",
     "retentionDesc": "Gli eventi più vecchi vengono eliminati automaticamente.",
     "retentionDays_one": "{{count}} giorno",
@@ -956,7 +985,7 @@
     "survivesLeave": "Gli eventi restano anche per gli spazi che hai lasciato, fino alla scadenza.",
     "export": "Esporta",
     "exportTitle": "Esporta come JSON",
-    "exportDesc": "Salva tutti gli eventi registrati in un file.",
+    "exportDesc": "Salva tutti gli eventi registrati in un file. Include quando questo dispositivo era offline.",
     "exportAction": "Esporta…",
     "exportDone_one": "{{count}} evento esportato.",
     "exportDone_other": "{{count}} eventi esportati.",
@@ -1017,7 +1046,8 @@
       "atRisk": "Problema di connessione",
       "offline": "Nessuna connessione di rete",
       "vpnOnly": "Mirall non raggiunge la rete"
-    }
+    },
+    "connectionHistory": "Cronologia connessione"
   },
   "diagnostics": {
     "title": "Diagnostica",

--- a/src/renderer/screens/ActivityLog.tsx
+++ b/src/renderer/screens/ActivityLog.tsx
@@ -2,7 +2,7 @@ import { useCallback, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { useAuditLog, useAuditFacets, hasActiveFilters, EMPTY_FILTERS, AUDIT_CATEGORIES } from '../hooks/useAuditLog.js'
-import { actorInitials, avatarKind, denialReasonKey, groupByDay, metaParts, rowBadge, sentenceKey, sentenceValues, sentinelValues, splitSentence } from '../auditRow.js'
+import { actorInitials, avatarKind, denialReasonKey, groupByDay, metaParts, rowBadge, sentenceKey, sentenceValues, sentinelValues, splitSentence, systemIcon, emptyStateFor } from '../auditRow.js'
 import { AUDIT_KINDS } from '../auditKinds.js'
 import type { AuditCategory, AuditEntry, AuditFilters } from '../types.js'
 import Icon from '../components/primitives/Icon.js'
@@ -12,6 +12,7 @@ import PageHeader from '../components/layout/PageHeader.js'
 interface ActivityLogProps {
   onBack: () => void
   onOpenSettings: () => void
+  initialFilters?: Partial<AuditFilters>
 }
 
 const ACTION_BUTTON = 'shrink-0 bg-surface-container-high dark:bg-surface-container-highest text-accent rounded-xl px-5 py-2.5 font-headline font-bold text-sm hover:bg-surface-container-highest dark:hover:bg-surface-container-high active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30'
@@ -43,7 +44,10 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
   // The reason trails the row's own context (space, totals): "DENIED" says something was refused,
   // this says what a reader should do about it — nothing, if we simply had no verified identity yet.
   const reasonKey = denialReasonKey(entry)
-  const meta = [...metaParts(entry), ...(reasonKey ? [t(reasonKey)] : [])].join(' · ')
+  const meta = [
+    ...metaParts(entry).map((part) => (part.key ? t(part.key, part.values) : part.text)),
+    ...(reasonKey ? [t(reasonKey)] : []),
+  ].join(' · ')
   const avatar = avatarKind(entry)
   const badgeClasses = badge?.tone === 'error'
     ? 'bg-error-container text-on-error-container'
@@ -55,7 +59,7 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
         aria-hidden="true"
         className="w-8 h-8 rounded-full bg-surface-container-highest text-accent flex items-center justify-center text-xs font-headline font-bold shrink-0"
       >
-        {avatar === 'system' ? <Icon name="history" size={16} /> : avatar === 'self' ? t('activityLog.actorSelf') : actorInitials(entry)}
+        {avatar === 'system' ? <Icon name={systemIcon(entry)} size={16} /> : avatar === 'self' ? t('activityLog.actorSelf') : actorInitials(entry)}
       </span>
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2">
@@ -101,10 +105,12 @@ function FilterChip({ label, onRemove }: { label: string; onRemove: () => void }
   )
 }
 
-export default function ActivityLog({ onBack, onOpenSettings }: ActivityLogProps) {
+export default function ActivityLog({ onBack, onOpenSettings, initialFilters }: ActivityLogProps) {
   const { t } = useTranslation()
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
-  const [filters, setFilters] = useState<AuditFilters>(EMPTY_FILTERS)
+  // Lazy initialiser: a preset seeds the FIRST render only, so a re-render never clobbers a filter
+  // the user has since changed. Clear all resets to EMPTY_FILTERS, not to the preset.
+  const [filters, setFilters] = useState<AuditFilters>(() => ({ ...EMPTY_FILTERS, ...initialFilters }))
   const { spaces, actors } = useAuditFacets(0)
 
   // A term typed in the viewer's own language is matched against the TRANSLATED kind labels and
@@ -119,6 +125,7 @@ export default function ActivityLog({ onBack, onOpenSettings }: ActivityLogProps
   const { entries, loading, loadingMore, error, hasMore, loadMore } = useAuditLog(filters, kinds)
   const groups = useMemo(() => groupByDay(entries), [entries])
   const active = hasActiveFilters(filters)
+  const empty = emptyStateFor(filters, active)
 
   const toggleCategory = useCallback((category: AuditCategory) => {
     setFilters((prev) => ({
@@ -195,7 +202,7 @@ export default function ActivityLog({ onBack, onOpenSettings }: ActivityLogProps
                 />
               </div>
 
-              <div className="flex bg-surface-container-high dark:bg-surface-container-highest p-1 rounded-full w-fit">
+              <div className="flex flex-wrap gap-1 bg-surface-container-high dark:bg-surface-container-highest p-1 rounded-3xl w-fit">
                 <button
                   type="button"
                   aria-pressed={filters.categories.length === 0}
@@ -265,10 +272,10 @@ export default function ActivityLog({ onBack, onOpenSettings }: ActivityLogProps
             {!loading && entries.length === 0 ? (
               <div className="bg-surface-container-low rounded-xl p-10 text-center">
                 <div className="w-12 h-12 rounded-full bg-surface-container-high mx-auto flex items-center justify-center text-on-surface-variant mb-4">
-                  <Icon name={active ? 'search' : 'history'} size={22} />
+                  <Icon name={empty.icon} size={22} />
                 </div>
-                <p className="font-semibold text-accent mb-1">{t(active ? 'activityLog.emptyFilteredTitle' : 'activityLog.emptyTitle')}</p>
-                <p className="text-sm text-on-surface-variant mb-5">{t(active ? 'activityLog.emptyFilteredDesc' : 'activityLog.emptyDesc')}</p>
+                <p className="font-semibold text-accent mb-1">{t(`activityLog.${empty.key}Title`)}</p>
+                <p className="text-sm text-on-surface-variant mb-5">{t(`activityLog.${empty.key}Desc`)}</p>
                 {active && (
                   <button type="button" onClick={clearAll} className={ACTION_BUTTON}>
                     {t('activityLog.clearFilters')}

--- a/src/renderer/screens/ConnectionProblem.tsx
+++ b/src/renderer/screens/ConnectionProblem.tsx
@@ -11,6 +11,7 @@ interface Props {
   onBack?: () => void
   onContinue: () => void
   onShowDetails: () => void
+  onShowHistory: () => void
 }
 
 function relativeCheck(at: number, now: number, t: (key: string, opts?: Record<string, unknown>) => string): string {
@@ -20,7 +21,7 @@ function relativeCheck(at: number, now: number, t: (key: string, opts?: Record<s
   return t('connectionProblem.checkedMinutes', { count: minutes })
 }
 
-export default function ConnectionProblem({ onBack, onContinue, onShowDetails }: Props) {
+export default function ConnectionProblem({ onBack, onContinue, onShowDetails, onShowHistory }: Props) {
   const { t } = useTranslation()
   const { status, reachability, probeCanary } = useConnectionStatus()
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
@@ -131,6 +132,9 @@ export default function ConnectionProblem({ onBack, onContinue, onShowDetails }:
             </Button>
             <Button variant="secondary" onClick={onShowDetails}>
               {t('connectionProblem.networkDetails')}
+            </Button>
+            <Button variant="secondary" onClick={onShowHistory}>
+              {t('connectionProblem.connectionHistory')}
             </Button>
             <span className="text-xs text-on-surface-variant ml-auto">
               {relativeCheck(status?.canary?.at ?? 0, Date.now(), t)}

--- a/src/renderer/screens/NetworkStatus.tsx
+++ b/src/renderer/screens/NetworkStatus.tsx
@@ -6,6 +6,7 @@ import { reachableState, formatDuration } from '../connectivity.js'
 import DiagnosticsCard from '../components/settings/DiagnosticsCard.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { useConnectionStatus } from '../hooks/useConnectionStatus.js'
+import Button from '../components/primitives/Button.js'
 import CopyButton from '../components/primitives/CopyButton.js'
 import Icon from '../components/primitives/Icon.js'
 import PageHeader from '../components/layout/PageHeader.js'
@@ -13,6 +14,7 @@ import type { NetworkStatus, Reachability } from '../types.js'
 
 interface Props {
   onBack: () => void
+  onShowHistory: () => void
 }
 
 const DASH = '—'
@@ -237,9 +239,10 @@ function buildSuggestions(status: NetworkStatus | null, browserOnline: boolean, 
 interface SummaryProps {
   status: NetworkStatus | null
   now: number
+  onShowHistory: () => void
 }
 
-function ConnectionSummary({ status, now }: SummaryProps) {
+function ConnectionSummary({ status, now, onShowHistory }: SummaryProps) {
   const { t } = useTranslation()
   if (!status) return null
   const verdict = status.reachability?.verdict ?? 'unknown'
@@ -265,6 +268,9 @@ function ConnectionSummary({ status, now }: SummaryProps) {
         label={t('networkStatus.summary.runningFor')}
         value={status.bootedAt > 0 ? formatDuration(now - status.bootedAt) : DASH}
       />
+      <div className="pt-3">
+        <Button variant="secondary" onClick={onShowHistory}>{t('networkStatus.connectionHistory')}</Button>
+      </div>
     </Section>
   )
 }
@@ -355,7 +361,7 @@ function AdvancedDetails({ status, relayVisible, now }: AdvancedDetailsProps) {
   )
 }
 
-export default function NetworkStatusScreen({ onBack }: Props) {
+export default function NetworkStatusScreen({ onBack, onShowHistory }: Props) {
   const { t } = useTranslation()
   const { status, reachability, reconnect } = useConnectionStatus()
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
@@ -403,7 +409,7 @@ export default function NetworkStatusScreen({ onBack }: Props) {
 
           <SuggestionsList lines={suggestions} />
 
-          <ConnectionSummary status={status} now={now} />
+          <ConnectionSummary status={status} now={now} onShowHistory={onShowHistory} />
 
           <DiagnosticsCard />
 

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -389,7 +389,7 @@ export interface NetworkStatus {
   }
 }
 
-export type AuditCategory = 'members' | 'files' | 'folders' | 'security'
+export type AuditCategory = 'members' | 'files' | 'folders' | 'security' | 'network'
 export type AuditTier = 'A' | 'B' | 'C'
 export type AuditOutcome = 'ok' | 'denied' | 'error'
 

--- a/src/shared/audit/audit-kinds.js
+++ b/src/shared/audit/audit-kinds.js
@@ -9,7 +9,13 @@
 // There is no tier D: what a peer does with bytes after receipt, and transfers between two
 // other members, are unobservable here (overlay transfers are point-to-point — only the holder
 // sees them).
-export const CATEGORY = { MEMBERS: 'members', FILES: 'files', FOLDERS: 'folders', SECURITY: 'security' }
+export const CATEGORY = {
+  MEMBERS: 'members',
+  FILES: 'files',
+  FOLDERS: 'folders',
+  SECURITY: 'security',
+  NETWORK: 'network',
+}
 
 export const KINDS = {
   'space.created': { category: CATEGORY.MEMBERS, tier: 'A' },
@@ -51,6 +57,22 @@ export const KINDS = {
   'security.integrity_failure': { category: CATEGORY.SECURITY, tier: 'A' },
   'security.creator_divergence': { category: CATEGORY.SECURITY, tier: 'B' },
   'audit.suppressed': { category: CATEGORY.SECURITY, tier: 'A' },
+  // The log's negative space. Every kind above records something that HAPPENED, and the questions a
+  // reader brings are usually about what didn't — a file that never arrived, a member who never
+  // appeared. Those produce no rows at all, so silence reads as "the other side did nothing". These
+  // are the one record that turns it into "nothing could happen, and here is the window", which is
+  // why they clear the bar the app-housekeeping kinds below do not.
+  //
+  // Tier A: measured on this device, by this install.
+  'network.offline': { category: CATEGORY.NETWORK, tier: 'A' },
+  'network.blocked': { category: CATEGORY.NETWORK, tier: 'A' },
+  'network.at_risk': { category: CATEGORY.NETWORK, tier: 'A' },
+  'network.restored': { category: CATEGORY.NETWORK, tier: 'A' },
+  // Tier B: the socket is Noise-authenticated and the identity bound through the handshake. NOT a
+  // membership change — member.left covers leaving — and written only while OUR OWN connectivity is
+  // healthy, because a blocked device makes every peer look gone.
+  'network.peer_lost': { category: CATEGORY.NETWORK, tier: 'B' },
+  'network.peer_back': { category: CATEGORY.NETWORK, tier: 'B' },
 }
 
 // Also absent, because nothing can currently produce them: `invite.revoked` (the only revoke
@@ -58,6 +80,12 @@ export const KINDS = {
 // is removed through owned-folder:delete, already covered by share.deleted). A kind that can
 // never fire is worse than a missing one: it still appears in the search labels and the i18n
 // catalogue.
+//
+// Also absent: `network.unknown` — an unknown verdict means boot, suspend, or a consensus still
+// forming, so it would put one contentless row in the log per app launch. And no canary kind:
+// reachability.js's governing rule is that a canary failure is indistinguishable from OUR seeder
+// being down, so it may confirm a verdict but never create one — a row would blame the user for
+// our outage.
 //
 // Deliberately absent: app.updated, app.worker_crashed, storage.cleanup,
 // settings.download_folder, feedback.sent — app housekeeping, not "which user did what in a

--- a/src/shared/audit/audit-log.js
+++ b/src/shared/audit/audit-log.js
@@ -10,6 +10,10 @@
 //                                  order, which makes a reverse range scan both the
 //                                  newest-first listing and the pagination cursor.
 //   by-space/<spaceId>/<seq>    -> seq. Serves the space filter without a full scan.
+//   by-device/<seq>             -> seq. The same index for the rows that have NO space (device
+//                                  connectivity). An outage is why the file never arrived, so it
+//                                  belongs in a space's timeline — but attributing it TO the space
+//                                  would be wrong, hence a second index rather than a fan-out.
 //   seen/<beeKeyHex>            -> the version of a peer's bee we have already turned into rows.
 //                                  Working state, not a record: audit:purge deliberately leaves
 //                                  it, because resetting it would replay every peer's whole
@@ -33,9 +37,11 @@ const AUDIT_BEE_NAME = 'audit-log'
 const SEQ_WIDTH = 16
 const EVT = 'evt/'
 const BY_SPACE = 'by-space/'
+const BY_DEVICE = 'by-device/'
 const CONFIG_KEY = 'config'
 const SEEN = 'seen/'
 const PSTATE = 'pstate/'
+const NSTATE = 'nstate'
 const HIGH = '￿'
 
 // Rows walked per query call before returning a partial page. A filtered listing may have to
@@ -48,6 +54,7 @@ const RATE_MAX_PER_WINDOW = 120
 const pad = (seq) => String(seq).padStart(SEQ_WIDTH, '0')
 const evtKey = (seq) => EVT + pad(seq)
 const spaceKey = (spaceId, seq) => BY_SPACE + spaceId + '/' + pad(seq)
+const deviceKey = (seq) => BY_DEVICE + pad(seq)
 
 let bee = null
 let nextSeq = 0
@@ -163,6 +170,7 @@ async function append(kind, fields) {
   const batch = bee.batch()
   await batch.put(evtKey(seq), rec)
   if (rec.space?.id) await batch.put(spaceKey(rec.space.id, seq), seq)
+  else await batch.put(deviceKey(seq), seq)
   await batch.flush()
 }
 
@@ -184,17 +192,45 @@ function matches(rec, { kindSet, catSet, actorKey, needle, since, until }) {
   return true
 }
 
-// Newest-first walk. The space filter rides the by-space index; everything else walks the
-// primary range. `cursor` is the highest seq to consider (exclusive upper bound is cursor + 1).
+async function* fromIndex(prefix, upper) {
+  const range = { gte: prefix, lt: upper == null ? prefix + HIGH : prefix + upper }
+  for await (const entry of bee.createReadStream(range, { reverse: true })) {
+    const node = await bee.get(EVT + pad(entry.value))
+    if (node?.value) yield node.value
+  }
+}
+
+async function* mergeDesc(a, b) {
+  try {
+    let ta = await a.next()
+    let tb = await b.next()
+    while (!ta.done || !tb.done) {
+      if (tb.done || (!ta.done && ta.value.seq > tb.value.seq)) {
+        yield ta.value
+        ta = await a.next()
+      } else {
+        yield tb.value
+        tb = await b.next()
+      }
+    }
+  } finally {
+    // `yield*` forwards return() to this generator, but a and b are pulled by hand, so they would
+    // stay suspended with their read streams undestroyed. queryAudit breaks out on every full page,
+    // which is the normal path — without this, each one leaks two streams.
+    await a.return?.()
+    await b.return?.()
+  }
+}
+
+// Newest-first walk. The space filter rides the by-space index MERGED with the device index —
+// a connectivity outage is why nothing arrived, so it belongs in the space's story even though it
+// is not attributable to the space. Merging two ordered streams keeps the index property; the
+// alternative under a space filter is a full primary-range scan, which is what the index exists to
+// avoid. `cursor` is the highest seq to consider (exclusive upper bound is cursor + 1).
 async function* walk(spaceId, cursor) {
   const upper = cursor == null ? null : pad(cursor + 1)
   if (spaceId) {
-    const prefix = BY_SPACE + spaceId + '/'
-    const range = { gte: prefix, lt: upper == null ? prefix + HIGH : prefix + upper }
-    for await (const entry of bee.createReadStream(range, { reverse: true })) {
-      const node = await bee.get(EVT + pad(entry.value))
-      if (node?.value) yield node.value
-    }
+    yield* mergeDesc(fromIndex(BY_SPACE + spaceId + '/', upper), fromIndex(BY_DEVICE, upper))
     return
   }
   const range = { gte: EVT, lt: upper == null ? EVT + HIGH : EVT + upper }
@@ -338,6 +374,22 @@ export async function setPeerSubjectState(key, state) {
   else await bee.put(PSTATE + key, state)
 }
 
+// The last DEVICE connectivity state we RECORDED. Durable for the same reason pstate/ is: without
+// it, relaunching on the same bad network writes the same row on every launch, and an in-memory
+// guard cannot survive the restart that causes it.
+export async function getNetworkState() {
+  if (!bee) return null
+  const node = await bee.get(NSTATE)
+  return node?.value && typeof node.value === 'object' ? node.value : null
+}
+
+export async function setNetworkState(state) {
+  if (!bee) return
+  // Healthy is the absence of an episode, so drop the key rather than store a tombstone.
+  if (!state) await bee.del(NSTATE)
+  else await bee.put(NSTATE, state)
+}
+
 export function getAuditConfig() {
   return { ...config }
 }
@@ -410,6 +462,7 @@ export async function pruneAudit({ now = Date.now() } = {}) {
     const batch = bee.batch()
     await batch.del(entry.key)
     if (rec?.space?.id) await batch.del(spaceKey(rec.space.id, rec.seq))
+    else if (rec) await batch.del(deviceKey(rec.seq))
     await batch.flush()
     removed += 1
   }
@@ -434,8 +487,10 @@ export async function pruneAudit({ now = Date.now() } = {}) {
 //   seen/   — the peer-bee watermarks. Dropping them makes first contact re-read every peer's
 //             whole history and replay it as if it had just happened (see the header), turning
 //             "delete my activity" into "flood it with a decade of theirs".
-// `pstate/` is deliberately NOT written back: it mirrors observed peer state, so it is log
-// content, and keeping it would suppress the next standing-state row for every subject.
+// `pstate/` and `nstate` are deliberately NOT written back: both mirror observed state, so they are
+// log content, and keeping them would suppress the next standing-state row. The cost is one row
+// after a purge if the network is still degraded, which is right — the log was emptied, and the
+// standing fact is worth restating.
 export async function purgeAudit() {
   if (!bee) return { purged: 0 }
   await flushAudit()

--- a/src/shared/audit/network-episodes.js
+++ b/src/shared/audit/network-episodes.js
@@ -1,0 +1,142 @@
+// Folds the connectivity verdict into audit rows. Pure and clock-injected — no store, no timers,
+// no Date.now() — so the awkward cases (a flap inside the hold-down, a sleep, an outage spanning a
+// restart) test without a Corestore or a swarm. Same split as peer-observer / peer-watch: the rules
+// live here, the I/O lives in network-watch.js.
+//
+// Three rules:
+//   1. UNKNOWN IS A NO-OP. It means boot, suspend, or a consensus still forming. A closed laptop
+//      must not read as an outage, so it neither opens nor closes an episode.
+//   2. HOLD DOWN BEFORE RECORDING, BOTH DIRECTIONS. stabilise() in reachability.js already dwells
+//      before ESCALATING, but it deliberately exempts os-offline and dht-unreachable (the live UI
+//      must react to a pulled cable instantly) and recovery is always immediate. Without a second
+//      hold-down here, one Wi-Fi roam writes a degraded row and a restored row.
+//   3. STANDING-STATE DEDUPE, DURABLY. The last kind we recorded is persisted by the caller, so
+//      relaunching on the same bad network is silent.
+import { VERDICT, CAUSE } from '../core/reachability.js'
+
+// Every transient we do NOT want in the log settles well inside this: a Wi-Fi roam, a VPN
+// reconnect, a sleep/wake re-association. Everything the log SHOULD carry outlives it.
+export const EPISODE_DWELL_MS = 60000
+
+export const KIND_OFFLINE = 'network.offline'
+export const KIND_BLOCKED = 'network.blocked'
+export const KIND_AT_RISK = 'network.at_risk'
+export const KIND_RESTORED = 'network.restored'
+
+// Two sentinels, deliberately distinct: 'healthy' is a REAL state (no episode is open), while null
+// is "no opinion" and must not be compared against anything.
+export const NO_EPISODE = 'healthy'
+export const NO_OPINION = null
+
+// The kind a (verdict, cause) pair belongs to — NOT one kind per cause. A cause that changes inside
+// the same kind (dht-unreachable -> no-public-address, both blocked) is the same standing fact and
+// must not write a second row. os-offline earns its own kind because "you are not on a network" and
+// "this network blocks us" have different remedies, and the shipped ConnectionProblem copy already
+// splits them.
+export function kindFor(verdict, cause) {
+  if (verdict === VERDICT.UNKNOWN) return NO_OPINION
+  if (verdict === VERDICT.HEALTHY) return NO_EPISODE
+  if (verdict === VERDICT.AT_RISK) return KIND_AT_RISK
+  return cause === CAUSE.OS_OFFLINE ? KIND_OFFLINE : KIND_BLOCKED
+}
+
+// Chosen so a reader can tell the two blocked shapes apart months later: "found nobody" and "found
+// peers, reached none" are the same kind and very different problems. Evidence is as of RECORDING,
+// not as of the transition — the row's job is to be readable, not to be a time series.
+export function evidenceFor(kind, evidence = {}) {
+  if (kind === KIND_OFFLINE) {
+    return { confidence: evidence.confidence ?? null, interfaceKind: evidence.interfaceKind ?? null }
+  }
+  if (kind === KIND_AT_RISK) {
+    return { confidence: evidence.confidence ?? null, publicPort: evidence.publicPort ?? 0 }
+  }
+  if (kind === KIND_BLOCKED) {
+    return {
+      confidence: evidence.confidence ?? null,
+      peersDiscovered: evidence.peersDiscovered ?? 0,
+      peersExhausted: evidence.peersExhausted ?? 0,
+    }
+  }
+  if (kind === KIND_RESTORED) {
+    return { confidence: evidence.confidence ?? null, peersConnected: evidence.peersConnected ?? 0 }
+  }
+  return {}
+}
+
+function degradedRow(candidate) {
+  return { kind: candidate.target, code: candidate.cause, subject: { sinceTs: candidate.since } }
+}
+
+function restoredRow(persisted, candidate, session) {
+  // The duration is only honest when the outage began in THIS process. If it started before a
+  // restart the app was closed for an unknown part of it, and an invented figure is worse than an
+  // absent one — metaParts drops the part when durationMs is null.
+  const sameSession = !!persisted?.session && persisted.session === session
+  const startedAt = Number.isFinite(persisted?.since) ? persisted.since : null
+  return {
+    kind: KIND_RESTORED,
+    code: persisted?.cause ?? null,
+    subject: {
+      // NOT `sinceTs`: this is when the connection came BACK, and the meta line renders sinceTs as
+      // "started …" — which would date the outage to the moment it was fixed.
+      recoveredTs: candidate.since,
+      fromKind: persisted?.kind ?? null,
+      durationMs: sameSession && startedAt !== null ? Math.max(0, candidate.since - startedAt) : null,
+    },
+  }
+}
+
+export function createEpisodeTracker({ dwellMs = EPISODE_DWELL_MS } = {}) {
+  // Purely in-memory, and that is correct: a state not observed for `dwellMs` within ONE session
+  // has not been observed.
+  let candidate = null
+
+  function pendingWait(now) {
+    if (!candidate) return null
+    return Math.max(0, dwellMs - (now - candidate.firstSeenAt))
+  }
+
+  // `persisted` is the last state we recorded: { kind, cause, since, session } | null.
+  // Returns { row, next, waitMs }, where `next` is meaningful ONLY when `row` is non-null (null
+  // then means "delete the key"). Gating it on `row` is what keeps "nothing changed" and "clear
+  // it" from needing a third sentinel.
+  function step({ verdict, cause = null, since = 0, now, session, persisted = null }) {
+    const target = kindFor(verdict, cause)
+
+    // The candidate is NOT cleared here: a blocked verdict that blips through `unknown` on its way
+    // back to blocked keeps its hold-down running, which is the point of the hold-down.
+    if (target === NO_OPINION) return { row: null, next: null, waitMs: pendingWait(now) }
+
+    const recorded = persisted?.kind ?? NO_EPISODE
+
+    if (target === recorded) {
+      candidate = null
+      return { row: null, next: null, waitMs: null }
+    }
+
+    if (!candidate || candidate.target !== target) {
+      candidate = { target, cause, since: since || now, firstSeenAt: now }
+    } else if (cause && candidate.cause !== cause) {
+      candidate.cause = cause
+    }
+
+    const held = now - candidate.firstSeenAt
+    if (held < dwellMs) return { row: null, next: null, waitMs: dwellMs - held }
+
+    const row = target === NO_EPISODE
+      ? restoredRow(persisted, candidate, session)
+      : degradedRow(candidate)
+    const next = target === NO_EPISODE
+      ? null
+      : { kind: target, cause: candidate.cause, since: candidate.since, session }
+
+    candidate = null
+    return { row, next, waitMs: null }
+  }
+
+  return {
+    step,
+    reset: () => { candidate = null },
+    pending: () => (candidate ? { ...candidate } : null),
+  }
+}

--- a/src/shared/audit/network-watch.js
+++ b/src/shared/audit/network-watch.js
@@ -1,0 +1,167 @@
+// Wires both pure trackers into the data layer: owns the timers, writes the rows, advances the
+// durable device state, and enforces the one rule neither tracker can see on its own — a PEER row
+// is only honest while OUR OWN connectivity is healthy. When this device is blocked every peer
+// looks unreachable, and the device row already says why; writing "Anna went offline" for each of
+// twenty members would blame twenty people for one pulled cable.
+//
+// The timers are not optional. Once the verdict is stable-blocked and the app is idle, swarm.js
+// stops emitting status altogether (the liveness probe only emits when its failure COUNT changes),
+// so "re-check on the next emit" would leave a held-down row unwritten forever.
+import { createLogger } from '../core/logger.js'
+import { record, getNetworkState, setNetworkState } from './audit-log.js'
+import { createEpisodeTracker, evidenceFor } from './network-episodes.js'
+import { createPeerPresenceTracker } from './peer-episodes.js'
+
+const log = createLogger('network-watch')
+
+let device = null
+let peers = null
+let deviceTimer = null
+let peerTimer = null
+let emitUpdated = null
+let session = null
+let last = null
+let degraded = false
+let running = false
+let pending = false
+
+export function initNetworkWatch({ emit = null, sessionId = null, dwellMs = 0, peerDwellMs = 0 } = {}) {
+  device = createEpisodeTracker(dwellMs ? { dwellMs } : {})
+  peers = createPeerPresenceTracker(peerDwellMs ? { dwellMs: peerDwellMs } : {})
+  emitUpdated = emit
+  // Distinguishes an outage that began in the run still going from one spanning a restart, which is
+  // what makes the duration on a restored row honest — or, correctly, absent.
+  session = sessionId || Date.now().toString(36)
+  last = null
+  degraded = false
+}
+
+export function resetNetworkWatch() {
+  if (deviceTimer) { clearTimeout(deviceTimer); deviceTimer = null }
+  if (peerTimer) { clearTimeout(peerTimer); peerTimer = null }
+  device?.reset()
+  peers?.reset()
+  last = null
+  running = false
+  pending = false
+  degraded = false
+}
+
+// Called from swarm.js's status EMIT path — never from getSwarmStatus, which is a read and must not
+// start timers that outlive destroySwarm.
+export function observeReachability(observation) {
+  if (!device) return
+  last = observation
+  const nowDegraded = observation.verdict !== 'healthy' && observation.verdict !== 'unknown'
+  if (nowDegraded && !degraded) peers.abandon()
+  if (observation.verdict !== 'unknown') degraded = nowDegraded
+  void pumpDevice()
+}
+
+// The peer hooks sit in the handshake and disconnect hot paths, so they carry audit-log.js's
+// contract: auditing must never fail, slow, or throw into the operation it describes.
+function guarded(fn) {
+  return (...args) => {
+    try {
+      return fn(...args)
+    } catch (err) {
+      log.warn('peer presence step failed:', err.message)
+      return undefined
+    }
+  }
+}
+
+async function pumpDevice() {
+  if (!device || !last) return
+  if (running) { pending = true; return }
+  running = true
+  try {
+    const persisted = await getNetworkState()
+    const { row, next, waitMs } = device.step({ ...last, now: Date.now(), session, persisted })
+
+    if (deviceTimer) { clearTimeout(deviceTimer); deviceTimer = null }
+    if (waitMs != null) {
+      deviceTimer = setTimeout(() => { deviceTimer = null; void pumpDevice() }, waitMs + 50)
+      deviceTimer.unref?.()
+    }
+    if (!row) return
+
+    const written = record(row.kind, {
+      actor: { type: 'system', key: null, name: null },
+      code: row.code,
+      subject: { ...row.subject, ...evidenceFor(row.kind, last.evidence) },
+    })
+    // record() no-ops when the log is disabled or the kind is rate-limited. Advancing the durable
+    // state for a row that was never written would permanently suppress the next one.
+    if (!written) return
+    await setNetworkState(next)
+    emitUpdated?.()
+  } catch (err) {
+    log.warn('device episode step failed:', err.message)
+  } finally {
+    running = false
+    // The drain belongs HERE: several paths above return from inside the try, and a return runs
+    // finally and then exits the function — anything after the try/finally is dead code on those
+    // paths, so an observation that arrived mid-step would sit unprocessed until the next emit.
+    if (pending) { pending = false; void pumpDevice() }
+  }
+}
+
+export const peerLost = guarded((publicKey, spaceId, meta) => {
+  if (!peers || degraded) return
+  peers.lost(publicKey, spaceId, { now: Date.now(), meta })
+  armPeerTimer()
+})
+
+export const peerSeen = guarded((publicKey, spaceId) => {
+  if (!peers) return
+  const row = peers.seen(publicKey, spaceId, { now: Date.now() })
+  if (row) writePeerRow(row)
+  armPeerTimer()
+})
+
+// The space name is resolved asynchronously by the caller, so it lands after the episode is open.
+export const peerLostMeta = guarded((publicKey, spaceId, patch) => {
+  peers?.annotate(publicKey, spaceId, patch)
+})
+
+// A leave is not a disconnect: member.left already tells that story, and joining against live
+// membership at write time would break the log's zero-joins rule in the other direction.
+export const peerLeft = guarded((publicKey, spaceId) => {
+  peers?.abandon(publicKey, spaceId)
+})
+
+// Guarded like the exported hooks: this also runs from a bare setTimeout, where a throw would
+// escape into the event loop as an uncaught exception. Each row is written in its own guard so one
+// failure cannot drop the rest — their episodes are already flagged recorded.
+const armPeerTimer = guarded(() => {
+  if (peerTimer) { clearTimeout(peerTimer); peerTimer = null }
+  const { rows, waitMs } = peers.step(Date.now())
+  for (const row of rows) {
+    try {
+      writePeerRow(row)
+    } catch (err) {
+      log.warn('peer row write failed:', err.message)
+    }
+  }
+  if (waitMs != null) {
+    peerTimer = setTimeout(() => { peerTimer = null; armPeerTimer() }, waitMs + 50)
+    peerTimer.unref?.()
+  }
+})
+
+function writePeerRow(row) {
+  const name = row.meta?.memberName ?? null
+  const space = { id: row.spaceId, name: row.meta?.spaceName ?? null }
+  if (row.suppressed) {
+    record('audit.suppressed', { space, subject: { kind: row.kind, count: row.cap, windowMs: row.windowMs } })
+    return
+  }
+  const written = record(row.kind, {
+    actor: { type: 'peer', key: row.publicKey, name },
+    space,
+    target: { kind: 'member', id: row.publicKey, name },
+    subject: row.subject,
+  })
+  if (written) emitUpdated?.()
+}

--- a/src/shared/audit/peer-episodes.js
+++ b/src/shared/audit/peer-episodes.js
@@ -1,0 +1,157 @@
+// Folds per-peer presence flapping into at most one row per real absence.
+//
+// The floor is much higher than the device hold-down because a peer reconnect is routine: an app
+// restart, a mux re-dial, a lid closing for a meeting. "Anna was gone for six minutes" is worth a
+// row; "Anna's socket blipped" is not. A `peer_back` row is written ONLY when a `peer_lost` row was
+// written for that pair, so a peer flapping below the floor produces nothing at all — never a lone
+// "is back online" closing an absence the reader never saw.
+//
+// Nothing here is persisted, deliberately: after OUR OWN restart every peer is "disconnected", and
+// we cannot distinguish "they left while we were down" from "we were down". An open absence dies
+// with the process.
+
+export const PEER_DWELL_MS = 300000
+const PEER_CAP_WINDOW_MS = 86400000
+const PEER_CAP = 12
+// A recorded absence stays open so the return can close it. A peer that never comes back would
+// otherwise pin one entry forever, so an absence this old is forgotten — the cost is no
+// "is back online" row for a peer returning after a week, which is the right thing to lose.
+const PEER_STALE_MS = 604800000
+
+export const KIND_PEER_LOST = 'network.peer_lost'
+export const KIND_PEER_BACK = 'network.peer_back'
+
+export function peerKeyOf(publicKey, spaceId) {
+  return publicKey + '|' + spaceId
+}
+
+export function createPeerPresenceTracker({
+  dwellMs = PEER_DWELL_MS,
+  cap = PEER_CAP,
+  capWindowMs = PEER_CAP_WINDOW_MS,
+  staleMs = PEER_STALE_MS,
+} = {}) {
+  const open = new Map()
+  const recent = new Map()
+
+  // `meta` is a snapshot taken now, because the row has to render once the roster is gone — the
+  // same zero-joins rule the record itself follows.
+  function lost(publicKey, spaceId, { now, meta = null }) {
+    const key = peerKeyOf(publicKey, spaceId)
+    // A second loss without an intervening `seen` is the same absence (a departure frame followed
+    // by the socket close). Keep the first timestamp.
+    if (open.has(key)) return
+    open.set(key, { publicKey, spaceId, lostAt: now, meta, recorded: false })
+  }
+
+  function seen(publicKey, spaceId, { now }) {
+    const key = peerKeyOf(publicKey, spaceId)
+    const episode = open.get(key)
+    if (!episode) return null
+    open.delete(key)
+    if (!episode.recorded) return null
+    return {
+      kind: KIND_PEER_BACK,
+      publicKey,
+      spaceId,
+      meta: episode.meta,
+      subject: { durationMs: Math.max(0, now - episode.lostAt) },
+    }
+  }
+
+  // The space name is resolved asynchronously by the caller, but the episode must be captured
+  // synchronously or a reconnect can overtake the loss — so the name lands afterwards.
+  function annotate(publicKey, spaceId, patch) {
+    const episode = open.get(peerKeyOf(publicKey, spaceId))
+    if (episode && !episode.recorded) episode.meta = { ...episode.meta, ...patch }
+  }
+
+  // Drop an absence WITHOUT a row: the peer left the space (member.left tells that story), our own
+  // connectivity went bad (every peer looks gone, and the device row says why), or we are shutting
+  // down. Omit both ids to abandon everything.
+  function abandon(publicKey = null, spaceId = null) {
+    if (publicKey === null) { open.clear(); return }
+    if (spaceId !== null) { open.delete(peerKeyOf(publicKey, spaceId)); return }
+    for (const [key, episode] of open) if (episode.publicKey === publicKey) open.delete(key)
+  }
+
+  // Returns 'record' | 'suppress-first' | 'suppress'. The marker fires only on the transition into
+  // the capped state: audit-log.js exempts audit.suppressed from its own rate guard, so emitting one
+  // per over-cap absence would bound nothing at all — the cap has to collapse them here.
+  function admission(key, now) {
+    const entry = recent.get(key) || { stamps: [], marked: false }
+    entry.stamps = entry.stamps.filter((at) => now - at < capWindowMs)
+    if (entry.stamps.length >= cap) {
+      const first = !entry.marked
+      entry.marked = true
+      recent.set(key, entry)
+      return first ? 'suppress-first' : 'suppress'
+    }
+    entry.marked = false
+    entry.stamps.push(now)
+    recent.set(key, entry)
+    return 'record'
+  }
+
+  function forget(now) {
+    for (const [key, episode] of open) {
+      if (episode.recorded && now - episode.lostAt > staleMs) open.delete(key)
+    }
+    for (const [key, entry] of recent) {
+      if (!entry.stamps.some((at) => now - at < capWindowMs) && !entry.marked) recent.delete(key)
+    }
+  }
+
+  // Past the cap the tracker emits a marker rather than dropping silently — a gap the reader cannot
+  // see is worse than a visible one, the same call audit-log.js's rate guard makes.
+  function step(now) {
+    const rows = []
+    let nextDue = null
+    forget(now)
+    for (const [key, episode] of open) {
+      if (episode.recorded) continue
+      const due = episode.lostAt + dwellMs
+      if (now < due) {
+        nextDue = nextDue === null ? due : Math.min(nextDue, due)
+        continue
+      }
+      const verdict = admission(key, now)
+      if (verdict !== 'record') {
+        // Dropped, not flagged recorded: a suppressed absence the reader never saw must not later
+        // emit a lone "is back online" closing it.
+        open.delete(key)
+        if (verdict === 'suppress-first') {
+          rows.push({
+            suppressed: true,
+            kind: KIND_PEER_LOST,
+            publicKey: episode.publicKey,
+            spaceId: episode.spaceId,
+            meta: episode.meta,
+            cap,
+            windowMs: capWindowMs,
+          })
+        }
+        continue
+      }
+      episode.recorded = true
+      rows.push({
+        kind: KIND_PEER_LOST,
+        publicKey: episode.publicKey,
+        spaceId: episode.spaceId,
+        meta: episode.meta,
+        subject: { sinceTs: episode.lostAt },
+      })
+    }
+    return { rows, waitMs: nextDue === null ? null : Math.max(0, nextDue - now) }
+  }
+
+  return {
+    lost,
+    seen,
+    annotate,
+    abandon,
+    step,
+    reset: () => { open.clear(); recent.clear() },
+    size: () => open.size,
+  }
+}

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -129,6 +129,10 @@ const DEFAULTED = {
   // protective bounds above these fail OPEN — see getBandwidthLimits.
   downloadKBps: 0,
   uploadKBps: 0,
+  // TEST-ONLY: how long a peer must be unreachable before the audit log records the absence.
+  // 0 = use peer-episodes.js's own default, which is what production always runs. Flow tests
+  // shrink it because five minutes of wall-clock is not a test.
+  peerPresenceDwellMs: 0,
 }
 
 function buildConfig(next) {
@@ -181,6 +185,10 @@ function coerceKBps(next, fallback) {
 
 export function getRuntimeConfig() {
   return config
+}
+
+export function getPeerPresenceDwellMs() {
+  return config.peerPresenceDwellMs
 }
 
 export function isMembershipApprovalEnabled() {

--- a/src/shared/transfer/diagnostics.js
+++ b/src/shared/transfer/diagnostics.js
@@ -2,6 +2,35 @@ import { shortId, makeAliaser } from '../core/diagnostics-redact.js'
 
 export const DIAGNOSTICS_SCHEMA = 1
 
+const VERDICT_OF = {
+  'network.offline': 'blocked',
+  'network.blocked': 'blocked',
+  'network.at_risk': 'at-risk',
+  'network.restored': 'healthy',
+}
+
+// The kinds verdictHistoryFromAudit understands, exported so the query that feeds it filters on the
+// same list. Querying the whole `network` CATEGORY instead would let peer-presence rows fill the
+// page limit and crowd the device history out of a support bundle entirely.
+export const VERDICT_KINDS = Object.keys(VERDICT_OF)
+
+// PRIVACY: only the device family is mapped, and only its timing and counters. Those rows carry
+// space: null and actor {type:'system'}, so nothing here can leak a space name, a peer name or a
+// path. The peer family DOES carry names and is excluded by the lookup returning undefined.
+export function verdictHistoryFromAudit(entries = []) {
+  return entries
+    .filter((entry) => VERDICT_OF[entry.kind])
+    .map((entry) => ({
+      at: entry.ts,
+      verdict: VERDICT_OF[entry.kind],
+      cause: entry.code || null,
+      confidence: entry.subject?.confidence ?? null,
+      since: entry.subject?.sinceTs ?? null,
+      durationMs: entry.subject?.durationMs ?? null,
+    }))
+    .reverse()
+}
+
 // Shapes, not identities. Everything a connectivity diagnosis needs — did host consensus
 // form, is the port 0, did it change, how many dials opened — is answerable without the
 // actual IP, the real keys, or space names.

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -42,6 +42,7 @@ import { LOOSE_SHARE_ID } from './transfer-id.js'
 import { shareDecoKey } from './decoration-key.js'
 import { record } from '../audit/audit-log.js'
 import { observePeerProfile } from '../audit/peer-watch.js'
+import { observeReachability, peerLost, peerLostMeta, peerSeen, peerLeft, resetNetworkWatch } from '../audit/network-watch.js'
 import { sealSck } from './sck-seal.js'
 import { sanitizeAvatar } from '../identity-limits.js'
 import { reconcileAssertedRoot } from '../spaces/creator-root.js'
@@ -73,10 +74,30 @@ const PRESENCE_HEARTBEAT_MS = 5000
 const presence = createPresence({
   ttl: PRESENCE_TTL_MS,
   onExpire: (peerKey, spaceId) => {
+    auditPeerLost(peerKey, spaceId)
     membersPoke.poke(spaceId)
     ipcRef?.emit('event:files-updated', { spaceId })
   },
 })
+
+// The episode is opened SYNCHRONOUSLY, because peerSeen and peerLeft are synchronous: awaiting the
+// space name first would let a reconnect or a leave overtake the loss and open an episode for a peer
+// that is already back. The name is snapshotted rather than joined at render time (a row outlives
+// the space record), so it lands as a patch once the store read returns — well inside the floor.
+function auditPeerLost(peerKey, spaceId, displayName = null) {
+  const memberName = displayName || connectedPeers.get(peerKey)?.displayName || null
+  peerLost(peerKey, spaceId, { memberName, spaceName: null })
+  getSpace(spaceId).then((space) => {
+    peerLostMeta(peerKey, spaceId, {
+      memberName: memberName || peerName(space, peerKey),
+      spaceName: space?.name ?? null,
+    })
+  }).catch((err) => log.debug('peer presence name lookup skipped:', err.message))
+}
+
+function peerName(space, peerKey) {
+  return (space?.members || []).find((m) => m.publicKey === peerKey)?.displayName || null
+}
 let presenceTimer = null
 
 let swarm
@@ -527,6 +548,7 @@ function trackPeerConnection(socket, spaceId, msg) {
   // heartbeat. Refreshed by presence frames; cleared on disconnect. The flip return value is
   // ignored here: the handshake path emits members-updated unconditionally after the persist.
   presence.mark(peerKey, spaceId)
+  peerSeen(peerKey, spaceId)
   return isNewToSpace
 }
 
@@ -753,6 +775,7 @@ function handleDisconnect(socket) {
 
     for (const [spaceId] of peer.spaces) {
       log.info('peer left:', peer.displayName, 'from space', spaceId)
+      auditPeerLost(peerKey, spaceId, peer.displayName)
       ipcRef.emit('event:member-left', { spaceId, publicKey: peerKey })
       ipcRef.emit('event:files-updated', { spaceId })
     }
@@ -856,6 +879,7 @@ async function handleLeaveFrame(socket, peerInfo, msg) {
   log.info('peer left space (leave frame):', profileKey.slice(0, 12) + '...', '→', spaceId)
 
   presence.clear(profileKey, spaceId)   // the leaver is offline in this space immediately
+  peerLeft(profileKey, spaceId)         // ...but that is a LEAVE; member.left carries it
 
   const peer = connectedPeers.get(profileKey)
   if (peer) {
@@ -1657,6 +1681,7 @@ function handlePresenceFrame(socket, msg) {
   if (presence.mark(profileKey, spaceId)) {
     // Same-socket lease restore: the peer went silent past the TTL and is back without
     // a re-handshake — the arrival mirror of the onExpire departure emit.
+    peerSeen(profileKey, spaceId)
     membersPoke.poke(spaceId)
     ipcRef?.emit('event:files-updated', { spaceId })
   }
@@ -1830,6 +1855,7 @@ export async function destroySwarm() {
     clearTimeout(statusEmitTimer)
     statusEmitTimer = null
   }
+  resetNetworkWatch()
   if (presenceTimer) {
     clearInterval(presenceTimer)
     presenceTimer = null
@@ -2515,6 +2541,28 @@ function scheduleStatusEmit() {
       ipcRef.emit('event:network-status', next)
     } catch (err) {
       log.warn('status emit failed:', err.message)
+    }
+    // AFTER the emit, and in its own guard: auditing must never fail into the operation it
+    // describes, and a throw here would otherwise leave the UI without a status update. It rides
+    // the EMIT path rather than getSwarmStatus because that is a read and must not start timers
+    // (see armDwellRecheck above); the tracker owns its own hold-down timer, so a stable-blocked
+    // idle app still gets its row.
+    try {
+      observeReachability({
+        verdict: next.reachability.verdict,
+        cause: next.reachability.cause,
+        since: next.reachability.since,
+        evidence: {
+          confidence: next.reachability.confidence,
+          peersDiscovered: next.peerReach.discovered,
+          peersExhausted: next.peerReach.exhausted,
+          peersConnected: next.peerReach.connected,
+          publicPort: next.address.publicPort,
+          interfaceKind: next.liveness.interfaceKind,
+        },
+      })
+    } catch (err) {
+      log.warn('connectivity audit skipped:', err.message)
     }
   }, STATUS_EMIT_DEBOUNCE_MS)
 }

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -11,7 +11,7 @@ import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
 import { createIPC, getBootstrapPromise } from '../shared/core/ipc.js'
-import { setRuntimeConfig, getRuntimeConfig, getUpgradeKey, setDownloadFolder, setBandwidthLimits, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap, isRelayEnabled, getRelayConfig, setRelayConfig } from '../shared/core/runtime-config.js'
+import { setRuntimeConfig, getRuntimeConfig, getUpgradeKey, setDownloadFolder, setBandwidthLimits, getDeepReconcileEvery, isHandshakeIdentityBindingEnabled, isOverlayEnabled, isInPlaceFilesEnabled, isSharePrepareProgressEnabled, isSeparateContentPlaneEnabled, getListFilesCap, isRelayEnabled, getRelayConfig, setRelayConfig, getPeerPresenceDwellMs } from '../shared/core/runtime-config.js'
 import { hydrateDownloadRoots, setSpaceDownloadRoot, forgetSpaceDownloadRoot, listDownloadRoots } from '../shared/core/paths.js'
 import { createLogger } from '../shared/core/logger.js'
 import { installCrashBackstop } from '../shared/core/crash-backstop.js'
@@ -70,11 +70,12 @@ import { classifyLeftovers, forgetUnreferencedPeerCores } from '../shared/storag
 import { sendFeedback } from '../shared/telemetry/feedback.js'
 import { getInstallId } from '../shared/telemetry/install-id.js'
 import { deriveChannel } from '../shared/core/channel.js'
-import { buildDiagnostics } from '../shared/transfer/diagnostics.js'
+import { buildDiagnostics, verdictHistoryFromAudit, VERDICT_KINDS } from '../shared/transfer/diagnostics.js'
 import {
   initAuditLog, record, setAuditIdentity, queryAudit, auditSpaces, auditActors, auditStats,
   getAuditConfig, setAuditConfig, pruneAudit, purgeAudit, exportAudit,
 } from '../shared/audit/audit-log.js'
+import { initNetworkWatch } from '../shared/audit/network-watch.js'
 import { publishShare, tombstoneShare, readOwnShares, isValidShareName, generateShareId, ensureSharesCap } from '../shared/shares/shares.js'
 import { migrateLegacyOwnedSharesToOverlay } from '../shared/shares/migrate-content-mode.js'
 import { migrateCatalogsToEncrypted } from '../shared/shares/migrate-catalog-encrypt.js'
@@ -189,6 +190,10 @@ await initPendingTransfers()
 // happen. A failure here must not abort boot — an unavailable audit log degrades to no rows.
 try {
   await initAuditLog({ installId: await getInstallId(bootstrap.storage) })
+  // The emit is what makes an OPEN Activity Log refresh while an outage is happening. Nothing else
+  // in the app hints Scope.audit(), so without it the one class of event a user actually watches
+  // for lands in a list that does not move.
+  initNetworkWatch({ emit: () => ipc.emit('event:audit-updated', {}), peerDwellMs: getPeerPresenceDwellMs() })
 } catch (err) {
   log.warn('audit log unavailable — events will not be recorded:', err.message)
 }
@@ -2309,11 +2314,31 @@ ipc.handle('network:online-hint', async (msg) => {
 
 ipc.handle('network:check-liveness', async () => await checkLivenessNow())
 
+const DIAGNOSTIC_HISTORY_LIMIT = 50
+
+// The in-memory ring dies with the process, so a bundle collected after a restart — precisely the
+// bundle a user sends after "it was broken this morning" — carried no history at all. The two are
+// MERGED rather than one replacing the other: the durable rows are hold-down-deduped, so they drop
+// this session's sub-60s flaps and settling states, which is exactly the detail a bundle collected
+// during a live problem needs.
+async function durableVerdictHistory () {
+  const ring = getVerdictHistory()
+  try {
+    const { entries } = await queryAudit({ kinds: VERDICT_KINDS, limit: DIAGNOSTIC_HISTORY_LIMIT })
+    const durable = verdictHistoryFromAudit(entries)
+    if (!durable.length) return ring
+    const newest = durable[durable.length - 1].at
+    return [...durable, ...ring.filter((entry) => entry.at > newest)]
+  } catch {
+    return ring
+  }
+}
+
 ipc.handle('diagnostics:export', async (msg) => {
   const cfg = getRuntimeConfig()
   return buildDiagnostics({
     status: getSwarmStatus(),
-    history: getVerdictHistory(),
+    history: await durableVerdictHistory(),
     env: {
       appVersion: cfg.appVersion || (cfg.dev ? 'dev' : 'unknown'),
       channel: deriveChannel(cfg),

--- a/test/flow/audit-coverage.test.js
+++ b/test/flow/audit-coverage.test.js
@@ -68,6 +68,12 @@ const UNTRIGGERABLE = {
   'security.integrity_failure': 'needs bytes that fail their hash',
   'security.creator_divergence': 'needs a forked member-set root',
   'audit.suppressed': 'needs a burst past the rate guard — integration-tested',
+  'network.offline': 'needs the machine to lose its network — unit-tested in network-episodes.test.js',
+  'network.blocked': 'needs a network that blocks peer connections',
+  'network.at_risk': 'needs a symmetric NAT',
+  'network.restored': 'closes one of the above',
+  'network.peer_lost': 'driven in audit-network-presence.test.js, which shrinks the presence dwell',
+  'network.peer_back': 'driven in audit-network-presence.test.js',
 }
 
 async function rows (peer) {

--- a/test/flow/audit-network-presence.test.js
+++ b/test/flow/audit-network-presence.test.js
@@ -1,0 +1,79 @@
+import test from 'brittle'
+import crypto from 'crypto'
+import path from 'path'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
+import { mkTmpDir } from '../helpers/fixtures.js'
+
+// Production waits five minutes before calling a peer gone; that is tuning, not a contract, and
+// five minutes of wall-clock is not a test. Everything else here is real: two peers, a real
+// handshake, a real socket teardown.
+const PRESENCE_DWELL_MS = 2000
+
+const kekHex = () => crypto.randomBytes(32).toString('hex')
+const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
+const flags = () => ({
+  identityKEK: kekHex(),
+  membershipApprovalEnabled: true,
+  handshakeIdentityBindingEnabled: true,
+  peerPresenceDwellMs: PRESENCE_DWELL_MS,
+})
+
+const kindsOf = (entries) => entries.map((e) => e.kind)
+const find = (entries, kind) => entries.find((e) => e.kind === kind)
+
+async function rows (peer) {
+  return (await peer.request('audit:list', { limit: 200 })).entries
+}
+
+test('a peer that really goes away is recorded once, and its return closes the row', { timeout: 220000 }, async (t) => {
+  const bootstrap = await localTestnet(t)
+  const storageB = idStore(t)
+  const downloadsB = mkTmpDir(t)
+  const kekB = kekHex()
+  const flagsB = { ...flags(), identityKEK: kekB }
+
+  const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
+  const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: storageB, downloads: downloadsB, flags: flagsB })
+
+  const spaceId = await connectInSpaceWithApproval(t, A, B)
+  const bKey = (await B.request('profile:get')).publicKey
+
+  B.kill()
+
+  await A.until('audit:list', { limit: 200 }, (page) => kindsOf(page.entries).includes('network.peer_lost'), { ms: 60000 })
+  const lost = find(await rows(A), 'network.peer_lost')
+  t.is(lost.tier, 'B', 'the socket was authenticated, so the absence is attributable')
+  t.is(lost.actor.key, bKey, 'the real remote profile key, not a claimed one')
+  t.is(lost.actor.name, 'Bob', 'the name is snapshotted, so the row survives the roster')
+  t.is(lost.space.id, spaceId, 'presence is per space')
+  t.ok(lost.subject.sinceTs > 0, 'and the row names when the absence began')
+
+  const B2 = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: storageB, downloads: downloadsB, flags: flagsB })
+  t.teardown(() => B2.kill())
+
+  await A.until('audit:list', { limit: 200 }, (page) => kindsOf(page.entries).includes('network.peer_back'), { ms: 90000 })
+  const back = find(await rows(A), 'network.peer_back')
+  t.is(back.actor.key, bKey)
+  t.ok(back.subject.durationMs >= PRESENCE_DWELL_MS, 'the return row carries how long the absence lasted')
+
+  const all = await rows(A)
+  t.is(all.filter((e) => e.kind === 'network.peer_lost').length, 1, 'one absence, one row')
+})
+
+// member.left already tells that story; a second row seconds later reads as two separate events.
+test('leaving the space is a leave, not a disconnect', { timeout: 220000 }, async (t) => {
+  const bootstrap = await localTestnet(t)
+  const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
+  const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
+
+  const spaceId = await connectInSpaceWithApproval(t, A, B)
+  await B.request('space:leave', { spaceId })
+
+  await A.until('audit:list', { limit: 200 }, (page) => kindsOf(page.entries).includes('member.left'), { ms: 60000 })
+  await new Promise((resolve) => setTimeout(resolve, PRESENCE_DWELL_MS * 3))
+
+  const all = await rows(A)
+  t.ok(find(all, 'member.left'), 'the leave is recorded')
+  t.absent(find(all, 'network.peer_lost'), 'and not doubled as a connectivity loss')
+})

--- a/test/frontend/instance.mjs
+++ b/test/frontend/instance.mjs
@@ -402,6 +402,12 @@ export class Instance {
     await this.waitText('Network status', 8000)
   }
 
+  async openActivityLog() {
+    await this.openAccount()
+    await this.click({ role: 'button', name: 'Activity Log' })
+    await this.waitText('A record of what happened', 8000)
+  }
+
   async openJoinModal() {
     await this.click({ role: 'button', name: 'Join Space' })
     await this.waitText('Join a Space', 8000)

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -112,6 +112,7 @@ import s102 from './scenarios/s102-remove-readd-no-autoresume.mjs'
 import s103 from './scenarios/s103-folder-tree.mjs'
 import s112 from './scenarios/s112-connection-problem.mjs'
 import s113 from './scenarios/s113-diagnostics-export.mjs'
+import s114 from './scenarios/s114-activity-log-network.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -178,7 +179,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s114-activity-log-network.mjs
+++ b/test/frontend/scenarios/s114-activity-log-network.mjs
@@ -1,0 +1,60 @@
+import { mkdirSync } from 'node:fs'
+import { Instance } from '../instance.mjs'
+import { makeReport } from '../assert.mjs'
+import { flatten } from '../tree.mjs'
+
+// The Network category and the cross-link that reaches it. A real outage cannot be driven from the
+// AX layer, so this asserts the shape: the chip exists and is addressable by name/role/state, the
+// empty state reads as good news rather than a failed search, and the preset survives the jump from
+// Network status — which is also the only thing that catches openActivityLog being wired straight
+// to an onClick, where React's MouseEvent would be spread into the filters.
+export default async function s114 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 1 })
+
+  try {
+    // macOS surfaces an aria-pressed button as a checkbox whose value carries the pressed state,
+    // which is how the five shipped chips already appear — the new one must match, or it is an a11y
+    // gap in the control rather than a miss in the test.
+    await r.ok('the Network chip is targetable by name, role and pressed state', async () => {
+      await A.launch()
+      await A.openActivityLog()
+      const chip = async () => flatten(await A.snap()).find((n) => n.role === 'checkbox' && n.name === 'Network')
+      const before = await chip()
+      if (!before) throw new Error('the Network filter chip is not in the accessibility tree')
+      if (before.value !== '0') throw new Error(`chip is not unpressed to begin with (value=${before.value})`)
+
+      await A.click({ role: 'checkbox', name: 'Network' })
+      const after = await chip()
+      if (after?.value !== '1') throw new Error(`aria-pressed did not reach the AX tree (value=${after?.value})`)
+    })
+
+    await r.ok('an empty network log reads as good news, not a failed search', async () => {
+      if (await A.hasText('No events match')) {
+        throw new Error('the generic filtered-empty copy is wrong here — nothing matching is the outcome you want')
+      }
+      await A.waitText('No connection problems recorded', 8000)
+      await A.shot('s114-network-empty', runDir)
+    })
+
+    await r.ok('Clear all restores the unfiltered list', async () => {
+      await A.click({ name: 'Clear all' })
+      await A.waitText('Nothing recorded yet', 8000)
+    })
+
+    await r.ok('every one of the six category chips is reachable', async () => {
+      for (const label of ['Members', 'Files', 'Folders', 'Security', 'Network', 'All']) {
+        await A.click({ role: 'checkbox', name: label })
+      }
+    })
+
+    await r.ok('Network status cross-links into the log, pre-filtered', async () => {
+      await A.openNetworkStatus()
+      await A.click({ name: 'Connection history' })
+      await A.waitText('No connection problems recorded', 8000)
+      await A.shot('s114-crosslink', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/integration/audit-log.test.js
+++ b/test/integration/audit-log.test.js
@@ -8,6 +8,7 @@ import {
   initAuditLog, record, flushAudit, queryAudit, auditSpaces, auditActors,
   auditStats, getAuditConfig, setAuditConfig, pruneAudit, purgeAudit, exportAudit,
   getPeerSubjectState, setPeerSubjectState, getSeenVersion, setSeenVersion,
+  getNetworkState, setNetworkState,
 } from '../../src/shared/audit/audit-log.js'
 
 let seq = 0
@@ -454,4 +455,120 @@ test('record() reports whether the row was admitted', async (t) => {
   await setAuditConfig({ enabled: false })
   t.is(record('member.joined', { actor: { type: 'self' }, space: { id: 'sp1', name: 'S' } }), false,
     'a disabled log admits nothing — callers must not mirror it as recorded')
+})
+
+function device (kind, code, subject = {}) {
+  record(kind, { actor: { type: 'system', key: null, name: null }, code, subject })
+}
+
+test('the standing network state round-trips and clears rather than tombstoning', async (t) => {
+  await boot(t)
+  t.is(await getNetworkState(), null, 'nothing recorded yet')
+
+  await setNetworkState({ kind: 'network.blocked', cause: 'peers-unreachable', since: 1000, session: 'run-0' })
+  t.is((await getNetworkState()).cause, 'peers-unreachable')
+
+  await setNetworkState(null)
+  t.is(await getNetworkState(), null, 'healthy drops the key')
+})
+
+test('a purge clears the standing network state — it is log content, like pstate', async (t) => {
+  await boot(t)
+  await setNetworkState({ kind: 'network.offline', cause: 'os-offline', since: 1000, session: 'run-0' })
+  await setPeerSubjectState('share|peer|sp1|s1', 'on')
+  await setSeenVersion('bee-1', 42)
+
+  await purgeAudit()
+
+  t.is(await getNetworkState(), null)
+  t.is(await getPeerSubjectState('share|peer|sp1|s1'), null)
+  t.is(await getSeenVersion('bee-1'), 42, 'the watermark IS written back — losing it replays every peer history')
+})
+
+test('a device-scoped row is still in a space timeline', async (t) => {
+  await boot(t)
+  member('member.joined', 'sp1', 'Design Team', 'Anna')
+  device('network.blocked', 'peers-unreachable', { sinceTs: 1 })
+  member('member.left', 'sp1', 'Design Team', 'Anna')
+  await flushAudit()
+
+  const { entries } = await queryAudit({ spaceId: 'sp1' })
+  t.is(entries.length, 3, 'the outage is why nothing arrived — it belongs in this space story')
+  t.alike(
+    entries.map((e) => e.kind),
+    ['member.left', 'network.blocked', 'member.joined'],
+    'merged in seq order, not appended',
+  )
+  t.is(entries[1].space, null, 'without being attributed to the space')
+})
+
+test('a device row appears once per space filter, never duplicated', async (t) => {
+  await boot(t)
+  member('member.joined', 'sp1', 'Design Team', 'Anna')
+  member('member.joined', 'sp2', 'Ops', 'Bob')
+  device('network.offline', 'os-offline', { sinceTs: 1 })
+  await flushAudit()
+
+  for (const spaceId of ['sp1', 'sp2']) {
+    const { entries } = await queryAudit({ spaceId })
+    t.is(entries.filter((e) => e.kind === 'network.offline').length, 1, spaceId + ' sees it exactly once')
+  }
+})
+
+test('the space-filtered merge paginates without dropping or repeating a row', async (t) => {
+  await boot(t)
+  for (let i = 0; i < 12; i++) {
+    if (i % 2 === 0) member('member.joined', 'sp1', 'Design Team', 'P' + i)
+    else device('network.at_risk', 'symmetric-nat', { sinceTs: i })
+  }
+  await flushAudit()
+
+  const seen = []
+  let cursor = null
+  do {
+    const page = await queryAudit({ spaceId: 'sp1', cursor, limit: 5 })
+    seen.push(...page.entries)
+    cursor = page.nextCursor
+  } while (cursor !== null)
+
+  t.is(seen.length, 12, 'every row surfaced across pages')
+  t.is(new Set(seen.map((e) => e.seq)).size, 12, 'and none twice')
+  t.alike(seen.map((e) => e.seq), [...seen.map((e) => e.seq)].sort((a, b) => b - a), 'still newest-first')
+})
+
+test('the category filter reaches the network family', async (t) => {
+  await boot(t)
+  member('member.joined', 'sp1', 'Design Team', 'Anna')
+  device('network.at_risk', 'symmetric-nat', { sinceTs: 1 })
+  await flushAudit()
+
+  const { entries } = await queryAudit({ categories: ['network'] })
+  t.is(entries.length, 1)
+  t.is(entries[0].category, 'network')
+  t.is(entries[0].tier, 'A')
+})
+
+test('a device row never pollutes the person filter', async (t) => {
+  await boot(t)
+  device('network.blocked', 'dht-unreachable', { sinceTs: 1 })
+  await flushAudit()
+  t.is((await auditActors()).length, 0, 'a system actor has no key, so it is not a filterable person')
+})
+
+// A dangling by-device entry resolves to null forever and silently shortens every space-filtered
+// page, so the prune has to drop the index with the row.
+test('pruning removes the device index with the row', async (t) => {
+  await boot(t)
+  for (let i = 0; i < 6; i++) device('network.blocked', 'dht-unreachable', { sinceTs: i })
+  await flushAudit()
+
+  await setAuditConfig({ maxEntries: 2 })
+  await pruneAudit()
+
+  member('member.joined', 'sp1', 'Design Team', 'Anna')
+  await flushAudit()
+
+  const { entries } = await queryAudit({ spaceId: 'sp1' })
+  t.ok(entries.every((e) => e && e.kind), 'no hole where a pruned device row used to be')
+  t.is(entries.filter((e) => e.kind === 'network.blocked').length, 2, 'only the surviving rows remain')
 })

--- a/test/integration/network-watch.test.js
+++ b/test/integration/network-watch.test.js
@@ -1,0 +1,258 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import os from 'bare-os'
+import path from 'bare-path'
+import crypto from 'hypercore-crypto'
+import { initStore, setMasterSecret } from '../../src/shared/core/store.js'
+import { initAuditLog, flushAudit, queryAudit, purgeAudit, setAuditConfig, getNetworkState } from '../../src/shared/audit/audit-log.js'
+import {
+  initNetworkWatch, resetNetworkWatch, observeReachability, peerLost, peerLostMeta, peerSeen, peerLeft,
+} from '../../src/shared/audit/network-watch.js'
+
+const DWELL = 60
+const META = { memberName: 'Anna Keller', spaceName: 'Design Team' }
+
+let seq = 0
+function tmpDir (label) {
+  const dir = path.join(os.tmpdir(), `netwatch-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}-${seq++}`)
+  fs.mkdirSync(dir, { recursive: true })
+  return dir
+}
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms))
+const settle = () => sleep(DWELL * 4)
+
+async function boot (t, { session = 'run-1' } = {}) {
+  const storage = tmpDir('store')
+  t.teardown(() => {
+    resetNetworkWatch()
+    try { fs.rmSync(storage, { recursive: true, force: true }) } catch {}
+  })
+  initStore(storage)
+  setMasterSecret(crypto.randomBytes(32))
+  await initAuditLog({ installId: 'install-under-test' })
+  await setAuditConfig({ enabled: true, retentionDays: 90, maxEntries: 200000 })
+  await purgeAudit()
+  initNetworkWatch({ sessionId: session, dwellMs: DWELL, peerDwellMs: DWELL })
+}
+
+function observe (verdict, cause = null, since = Date.now()) {
+  observeReachability({
+    verdict,
+    cause,
+    since,
+    evidence: { confidence: 'measured', peersDiscovered: 4, peersExhausted: 4, peersConnected: 0, publicPort: 0, interfaceKind: 'physical' },
+  })
+}
+
+async function kinds () {
+  await flushAudit()
+  const { entries } = await queryAudit({ limit: 200 })
+  return entries.map((e) => e.kind)
+}
+
+async function rowOf (kind) {
+  await flushAudit()
+  const { entries } = await queryAudit({ limit: 200 })
+  return entries.find((e) => e.kind === kind) || null
+}
+
+test('a held degradation is written once, with the cause and the real start', async (t) => {
+  await boot(t)
+  const since = Date.now()
+  observe('blocked', 'peers-unreachable', since)
+  await settle()
+
+  const row = await rowOf('network.blocked')
+  t.ok(row, 'the outage was recorded')
+  t.is(row.code, 'peers-unreachable')
+  t.is(row.category, 'network')
+  t.is(row.tier, 'A')
+  t.is(row.space, null, 'device-scoped')
+  t.is(row.actor.type, 'system')
+  t.is(row.subject.sinceTs, since, 'the row names the transition, not the write')
+  t.is(row.subject.peersExhausted, 4, 'and freezes the evidence that distinguishes the blocked shapes')
+
+  observe('blocked', 'peers-unreachable', since)
+  await settle()
+  t.is((await kinds()).filter((k) => k === 'network.blocked').length, 1, 'never a second row while it holds')
+})
+
+test('recovery closes the episode with a duration and clears the standing state', async (t) => {
+  await boot(t)
+  const start = Date.now()
+  observe('blocked', 'os-offline', start)
+  await settle()
+  t.ok(await getNetworkState(), 'the degradation is persisted')
+
+  const back = start + 5000
+  observe('healthy', null, back)
+  await settle()
+
+  const row = await rowOf('network.restored')
+  t.ok(row)
+  t.is(row.code, 'os-offline', 'the row names what it recovered from')
+  t.is(row.subject.fromKind, 'network.offline')
+  t.is(row.subject.durationMs, 5000)
+  t.is(await getNetworkState(), null, 'and the standing state is cleared')
+})
+
+test('a flap inside the hold-down leaves no trace at all', async (t) => {
+  await boot(t)
+  observe('blocked', 'os-offline')
+  observe('healthy')
+  await settle()
+  t.alike(await kinds(), [], 'no offline row and no restored row')
+  t.is(await getNetworkState(), null)
+})
+
+test('a peer absence past the floor is recorded, and its return closes it', async (t) => {
+  await boot(t)
+  observe('healthy')
+  await settle()
+
+  peerLost('anna', 'sp1', META)
+  await settle()
+
+  const lost = await rowOf('network.peer_lost')
+  t.ok(lost)
+  t.is(lost.tier, 'B')
+  t.is(lost.actor.key, 'anna')
+  t.is(lost.actor.name, 'Anna Keller', 'the name is snapshotted at loss')
+  t.is(lost.space.id, 'sp1')
+  t.is(lost.space.name, 'Design Team')
+
+  peerSeen('anna', 'sp1')
+  await flushAudit()
+  const back = await rowOf('network.peer_back')
+  t.ok(back)
+  t.ok(back.subject.durationMs >= DWELL)
+})
+
+test('a peer that returns below the floor produces nothing', async (t) => {
+  await boot(t)
+  observe('healthy')
+  await settle()
+
+  peerLost('anna', 'sp1', META)
+  peerSeen('anna', 'sp1')
+  await settle()
+  t.alike(await kinds(), [], 'not even a lone "is back online"')
+})
+
+// When we are the problem every peer looks unreachable, and the device row already says why.
+test('peer absences are suppressed while OUR OWN connectivity is degraded', async (t) => {
+  await boot(t)
+  observe('blocked', 'os-offline')
+  await settle()
+
+  peerLost('anna', 'sp1', META)
+  peerLost('bob', 'sp1', META)
+  await settle()
+
+  const seen = await kinds()
+  t.absent(seen.includes('network.peer_lost'), 'no peer is blamed for our outage')
+  t.ok(seen.includes('network.offline'), 'the device row carries the story instead')
+})
+
+test('an absence already open when we go degraded is abandoned, not recorded', async (t) => {
+  await boot(t)
+  observe('healthy')
+  peerLost('anna', 'sp1', META)
+  observe('blocked', 'os-offline')
+  await settle()
+
+  const seen = await kinds()
+  t.absent(seen.includes('network.peer_lost'), 'the pending absence was dropped when we became the cause')
+  t.ok(seen.includes('network.offline'))
+})
+
+test('a leave is not a disconnect', async (t) => {
+  await boot(t)
+  observe('healthy')
+  await settle()
+
+  peerLost('anna', 'sp1', META)
+  peerLeft('anna', 'sp1')
+  await settle()
+  t.alike(await kinds(), [], 'member.left carries a leave; this must not double it')
+})
+
+test('a disabled log records nothing and does not advance the standing state', async (t) => {
+  await boot(t)
+  await setAuditConfig({ enabled: false })
+  observe('blocked', 'dht-unreachable')
+  await settle()
+  t.is(await getNetworkState(), null, 'a refused write must not suppress the next one')
+
+  await setAuditConfig({ enabled: true })
+  observe('blocked', 'dht-unreachable')
+  await settle()
+  t.ok(await rowOf('network.blocked'), 're-enabling records the standing state')
+})
+
+test('relaunching on the same bad network is silent', async (t) => {
+  await boot(t)
+  observe('blocked', 'no-public-address')
+  await settle()
+  t.is((await kinds()).filter((k) => k === 'network.blocked').length, 1)
+
+  initNetworkWatch({ sessionId: 'run-2', dwellMs: DWELL, peerDwellMs: DWELL })
+  observe('blocked', 'no-public-address')
+  await settle()
+  t.is((await kinds()).filter((k) => k === 'network.blocked').length, 1, 'the first launch already said so')
+})
+
+test('an outage spanning a restart recovers without inventing a duration', async (t) => {
+  await boot(t)
+  observe('blocked', 'os-offline')
+  await settle()
+
+  initNetworkWatch({ sessionId: 'run-2', dwellMs: DWELL, peerDwellMs: DWELL })
+  observe('healthy')
+  await settle()
+
+  const row = await rowOf('network.restored')
+  t.ok(row)
+  t.is(row.subject.durationMs, null, 'the app was closed for an unknown part of it')
+  t.is(row.subject.fromKind, 'network.offline', 'but what it recovered from is still known')
+})
+
+// A step that produces no row returns from inside the try, so the pending-drain used to be dead
+// code: an observation arriving mid-step was dropped, and with a stable-blocked idle app nothing
+// re-triggers it.
+test('an observation arriving mid-step is not dropped', async (t) => {
+  await boot(t)
+  observe('healthy')
+  observe('blocked', 'os-offline')
+  await settle()
+  t.ok(await rowOf('network.offline'), 'the second observation still produced its row')
+})
+
+test('the space name can land after the loss is captured', async (t) => {
+  await boot(t)
+  observe('healthy')
+  await settle()
+
+  peerLost('anna', 'sp1', { memberName: 'Anna Keller', spaceName: null })
+  peerLostMeta('anna', 'sp1', { spaceName: 'Design Team' })
+  await settle()
+
+  const row = await rowOf('network.peer_lost')
+  t.is(row.space.name, 'Design Team', 'the async name lookup patched the open episode')
+  t.is(row.actor.name, 'Anna Keller')
+})
+
+// peerSeen and peerLeft are synchronous; the loss must be too, or a reconnect overtakes it.
+test('a reconnect racing the loss does not leave a phantom absence', async (t) => {
+  await boot(t)
+  observe('healthy')
+  await settle()
+
+  peerLost('anna', 'sp1', { memberName: 'Anna Keller', spaceName: 'Design Team' })
+  peerSeen('anna', 'sp1')
+  peerLostMeta('anna', 'sp1', { spaceName: 'Design Team' })
+  await settle()
+
+  t.alike(await kinds(), [], 'the episode closed before the floor, so nothing was recorded')
+})

--- a/test/unit/audit-kinds.test.js
+++ b/test/unit/audit-kinds.test.js
@@ -41,3 +41,29 @@ test('the security category is what remains of the old app bucket', (t) => {
     'security.serve_denied',
   ])
 })
+
+test('the network category is exactly the connectivity vocabulary', (t) => {
+  const network = Object.entries(KINDS).filter(([, m]) => m.category === CATEGORY.NETWORK).map(([k]) => k)
+  t.alike(network.sort(), [
+    'network.at_risk',
+    'network.blocked',
+    'network.offline',
+    'network.peer_back',
+    'network.peer_lost',
+    'network.restored',
+  ])
+})
+
+test('the device family is first-party and the peer family is handshake-attributed', (t) => {
+  for (const kind of ['network.offline', 'network.blocked', 'network.at_risk', 'network.restored']) {
+    t.is(tierOf(kind), 'A', kind + ' is measured on this device')
+  }
+  for (const kind of ['network.peer_lost', 'network.peer_back']) {
+    t.is(tierOf(kind), 'B', kind + ' rides the handshake identity binding')
+  }
+})
+
+test('a settling verdict and a canary result are deliberately not kinds', (t) => {
+  t.absent(isKnownKind('network.unknown'), 'one contentless row per app launch')
+  t.absent(isKnownKind('network.canary_failed'), 'our seeder being down must never become the user\'s verdict')
+})

--- a/test/unit/audit-row.test.js
+++ b/test/unit/audit-row.test.js
@@ -2,7 +2,7 @@ import test from 'brittle'
 import {
   actorInitials, actorLabel, avatarKind, dayKey, denialReasonKey, formatBytes, formatCount,
   groupByDay, isSystemRow, metaParts, rowBadge, sentenceKey, sentenceValues,
-  splitSentence, sentinelValues, FIELD_SENTINEL, SENTENCE_FIELDS,
+  splitSentence, sentinelValues, systemIcon, emptyStateFor, FIELD_SENTINEL, SENTENCE_FIELDS,
 } from '../../src/renderer/auditRow.js'
 
 const row = (over = {}) => ({
@@ -119,14 +119,24 @@ test('meta line leads with the space and folds in the aggregate totals', (t) => 
     kind: 'share.mounted',
     subject: { fileCount: 5180, bytes: 13314398617 },
   }))
-  t.is(parts[0], 'Design Team', 'the space is the strongest context, so it comes first')
-  t.ok(parts.some((p) => p.includes('files')), 'the aggregate file count is shown as one figure')
-  t.ok(parts.some((p) => p.includes('GB')))
+  t.is(parts[0].text, 'Design Team', 'the space is the strongest context, so it comes first')
+  t.ok(parts.some((p) => p.key === 'activityLog.metaFiles'), 'the aggregate file count is shown as one figure')
+  t.ok(parts.some((p) => p.text && p.text.includes('GB')))
+})
+
+// metaParts used to push `formatCount(n) + ' files'`, so a German reader saw "1.284 files".
+test("REGRESSION (FIX-META-I18N: the meta line's file count is translatable)", (t) => {
+  const parts = metaParts(row({ kind: 'share.mounted', subject: { fileCount: 1284 } }))
+  const files = parts.find((p) => p.key === 'activityLog.metaFiles')
+  t.ok(files, 'the count is a key, not a finished English string')
+  t.is(files.values.count, 1284, 'count drives the plural')
+  t.is(files.values.formatted, (1284).toLocaleString(), 'and the formatted number is interpolated')
+  for (const part of parts) t.ok(part.key || typeof part.text === 'string', 'every part is resolvable')
 })
 
 test('meta line omits absent detail rather than printing empties', (t) => {
   t.alike(metaParts(row({ space: null, subject: null })), [])
-  t.alike(metaParts(row({ subject: { bytes: null, fileCount: null } })), ['Design Team'])
+  t.alike(metaParts(row({ subject: { bytes: null, fileCount: null } })), [{ text: 'Design Team' }])
 })
 
 test('day bucketing keys today, yesterday and older dates', (t) => {
@@ -196,4 +206,99 @@ test('sentinelValues wraps every field the sentences can use', (t) => {
   for (const field of SENTENCE_FIELDS) {
     t.is(v[field], FIELD_SENTINEL + field + FIELD_SENTINEL, field + ' is wrapped')
   }
+})
+
+const netRow = (over = {}) => row({
+  kind: 'network.blocked',
+  category: 'network',
+  tier: 'A',
+  actor: { type: 'system', key: null, name: null },
+  space: null,
+  target: null,
+  code: 'peers-unreachable',
+  subject: { sinceTs: Date.now() - 90000 },
+  ...over,
+})
+
+// outcome:'error' would render FAILED, which on a network row reads as a failed transfer.
+test('a connectivity row is badged by KIND, because its outcome is not a failed action', (t) => {
+  t.is(rowBadge(netRow({ kind: 'network.offline' })).labelKey, 'connectivity.offline')
+  t.is(rowBadge(netRow({ kind: 'network.blocked' })).tone, 'error')
+  t.is(rowBadge(netRow({ kind: 'network.at_risk' })).labelKey, 'connectivity.limited')
+  t.is(rowBadge(netRow({ kind: 'network.at_risk' })).tone, 'passive', 'at-risk is not the red token')
+  t.is(rowBadge(netRow({ kind: 'network.restored' })), null, 'recovery is not exceptional')
+  t.is(rowBadge(netRow({ kind: 'network.peer_lost' })), null, 'a member closing a laptop is routine')
+})
+
+test('the device family gets the Network glyph; a peer row keeps the person', (t) => {
+  t.is(systemIcon(netRow()), 'hub')
+  t.is(systemIcon(row()), 'history', 'ordinary system rows are unchanged')
+  t.is(avatarKind(netRow()), 'system')
+  t.is(
+    avatarKind(netRow({ kind: 'network.peer_lost', actor: { type: 'peer', key: 'aa', name: 'Anna Keller' } })),
+    'peer',
+    'the row is about a person, so it shows one',
+  )
+})
+
+test('a connectivity row names its cause, its start and its duration', (t) => {
+  const ts = Date.now()
+  const parts = metaParts(netRow({ ts, subject: { sinceTs: ts - 90000 } }))
+  t.ok(parts.some((p) => p.key === 'activityLog.cause.peers-unreachable'))
+  t.ok(parts.some((p) => p.key === 'activityLog.startedAt'), 'the hold-down gap is named, not hidden')
+
+  // Production shape: the hold-down puts `ts` ~60s after the recovery, so a `sinceTs` here would
+  // always trip the start clause and date the outage to the moment it was fixed.
+  const restored = metaParts(netRow({
+    kind: 'network.restored',
+    code: 'os-offline',
+    ts,
+    subject: { durationMs: 732000, recoveredTs: ts - 60000, fromKind: 'network.offline' },
+  }))
+  t.ok(restored.some((p) => p.key === 'activityLog.wasOfflineFor'))
+  t.absent(
+    restored.some((p) => p.key === 'activityLog.startedAt'),
+    'the duration tells the story; a "started" time here would name the recovery',
+  )
+})
+
+test('an unknown cause and an unknown duration degrade to nothing', (t) => {
+  const parts = metaParts(netRow({ code: 'quantum-tunnel', subject: { durationMs: null, sinceTs: null } }))
+  t.absent(
+    parts.some((p) => p.key && p.key.startsWith('activityLog.cause.')),
+    'a cause from a newer version renders nothing, not a raw key',
+  )
+  t.absent(parts.some((p) => p.key === 'activityLog.wasOfflineFor'), 'a null duration is omitted, not invented')
+})
+
+test('a peer connectivity row still leads with its space', (t) => {
+  const parts = metaParts(netRow({
+    kind: 'network.peer_back',
+    code: null,
+    space: { id: 'sp1', name: 'Design Team' },
+    subject: { durationMs: 2460000 },
+  }))
+  t.is(parts[0].text, 'Design Team')
+  t.ok(parts.some((p) => p.key === 'activityLog.wasOfflineFor'))
+})
+
+const filters = (over = {}) => ({
+  spaceId: null, categories: [], actorKey: null, search: '', sinceDays: null, ...over,
+})
+
+test('an empty NETWORK log reads as good news, not as a failed search', (t) => {
+  t.alike(emptyStateFor(filters(), false), { key: 'empty', icon: 'history' }, 'nothing recorded yet')
+  t.alike(emptyStateFor(filters({ search: 'anna' }), true), { key: 'emptyFiltered', icon: 'search' })
+  t.alike(emptyStateFor(filters({ categories: ['network'] }), true), { key: 'emptyNetwork', icon: 'hub' })
+})
+
+// "Able to reach the network the whole time it has been running" is false the moment an outage
+// exists outside the window, so any other filter must disqualify the reassuring copy.
+test('the reassuring copy needs every other filter clear', (t) => {
+  for (const narrowing of [{ sinceDays: 7 }, { spaceId: 'sp1' }, { actorKey: 'aa' }, { search: 'x' }]) {
+    const state = emptyStateFor(filters({ categories: ['network'], ...narrowing }), true)
+    t.is(state.key, 'emptyFiltered', JSON.stringify(narrowing) + ' must not claim a clean history')
+  }
+  t.is(emptyStateFor(filters({ categories: ['network', 'files'] }), true).key, 'emptyFiltered',
+    'and a second category is not a network-only view')
 })

--- a/test/unit/bundle-axe-stripped.test.js
+++ b/test/unit/bundle-axe-stripped.test.js
@@ -40,15 +40,19 @@ test('REGRESSION (FIX-AXE-1): production bundle (__DEV__=false) strips axe-core'
   const out = await bundle(false)
   t.absent(out.includes('@axe-core'), 'no @axe-core module reference in prod bundle')
   t.absent(out.includes('color-contrast'), 'no axe-core rule ids in prod bundle')
-  // A backstop for the two string checks above, not a size budget: axe-core adds ~616KB,
-  // so any inclusion blows past this by a wide margin. Headroom is thin (~5KB) because the
-  // five statically-bundled locales are ~27% of the bundle, which makes this line the
-  // effective budget for new UI copy — lazy-loading them is the real fix.
-  t.ok(out.length < 1_000_000, `prod bundle is small without axe-core (${out.length} bytes)`)
+  // A backstop for the two string checks above, not a size budget: axe-core adds ~616KB, so any
+  // inclusion lands near the dev bundle's ~1.6MB and blows past this by a wide margin. The number
+  // was 1_000_000 with ~200 bytes of headroom, which quietly made it the budget for UI copy — the
+  // five statically-bundled locales are ~27% of the bundle, so a feature adding a few dozen strings
+  // in five languages failed a test about axe-core. Raised to keep the axe margin while letting
+  // copy grow. Lazy-loading the non-active locales is still the real fix for the 27%.
+  t.ok(out.length < 1_100_000, `prod bundle is small without axe-core (${out.length} bytes)`)
 })
 
 test('FIX-AXE-1 control: dev bundle (__DEV__=true) still ships axe-core', async (t) => {
   const out = await bundle(true)
   t.ok(out.includes('color-contrast'), 'axe-core present in dev bundle')
   t.ok(out.length > 1_200_000, `dev bundle is large with axe-core (${out.length} bytes)`)
+  // The prod threshold above is only meaningful while it sits well below an axe-carrying bundle.
+  t.ok(out.length - 1_100_000 > 400_000, 'the prod backstop still has a wide margin below axe-core')
 })

--- a/test/unit/diagnostics-bundle.test.js
+++ b/test/unit/diagnostics-bundle.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { buildDiagnostics, DIAGNOSTICS_SCHEMA } from '../../src/shared/transfer/diagnostics.js'
+import { buildDiagnostics, verdictHistoryFromAudit, VERDICT_KINDS, DIAGNOSTICS_SCHEMA } from '../../src/shared/transfer/diagnostics.js'
 
 const PUBLIC_HOST = '203.0.113.7'
 const PUBLIC_KEY = 'a'.repeat(64)
@@ -132,4 +132,46 @@ test('an empty swarm produces a well-formed bundle', (t) => {
   const bundle = buildDiagnostics(ctx, true)
   t.alike(bundle.peers.samples, [])
   t.alike(bundle.spaces.topics, [])
+})
+
+// The in-memory ring dies with the process, so a bundle collected after a restart — the one a user
+// actually sends — carried no history at all.
+test('the verdict history survives a restart by coming from the log', (t) => {
+  const history = verdictHistoryFromAudit([
+    { kind: 'network.restored', ts: 3000, code: 'os-offline', subject: { durationMs: 600000, sinceTs: 3000, peersConnected: 2 } },
+    { kind: 'network.blocked', ts: 2000, code: 'peers-unreachable', subject: { sinceTs: 1900, confidence: 'measured' } },
+  ])
+  t.alike(history.map((h) => h.verdict), ['blocked', 'healthy'], 'oldest first, matching the ring')
+  t.is(history[0].cause, 'peers-unreachable')
+  t.is(history[0].confidence, 'measured')
+  t.is(history[1].durationMs, 600000)
+})
+
+test('PRIVACY: peer-family rows never reach the bundle', (t) => {
+  const history = verdictHistoryFromAudit([{
+    kind: 'network.peer_lost',
+    ts: 1000,
+    code: null,
+    actor: { type: 'peer', key: 'deadbeef', name: 'Anna Keller' },
+    space: { id: 'sp1', name: 'Design Team' },
+    subject: { sinceTs: 900 },
+  }])
+  t.is(history.length, 0, 'they carry names; the device family does not')
+  t.absent(JSON.stringify(history).includes('Anna'))
+  t.absent(JSON.stringify(history).includes('Design Team'))
+})
+
+test('a row from an unknown kind is dropped rather than mapped to a bogus verdict', (t) => {
+  t.is(verdictHistoryFromAudit([{ kind: 'member.joined', ts: 1, subject: {} }]).length, 0)
+  t.is(verdictHistoryFromAudit().length, 0)
+})
+
+// Querying the whole `network` category would let peer-presence rows fill the page limit and crowd
+// the device history out of the bundle, so the query filters on exactly what the mapper reads.
+test('the query filter and the mapper cannot drift apart', (t) => {
+  t.alike(VERDICT_KINDS.slice().sort(), ['network.at_risk', 'network.blocked', 'network.offline', 'network.restored'])
+  for (const kind of VERDICT_KINDS) {
+    t.is(verdictHistoryFromAudit([{ kind, ts: 1, code: null, subject: {} }]).length, 1, kind + ' maps')
+  }
+  t.is(verdictHistoryFromAudit([{ kind: 'network.peer_lost', ts: 1, subject: {} }]).length, 0, 'and the peer family does not')
 })

--- a/test/unit/network-episodes.test.js
+++ b/test/unit/network-episodes.test.js
@@ -1,0 +1,188 @@
+import test from 'brittle'
+import {
+  createEpisodeTracker, kindFor, evidenceFor, EPISODE_DWELL_MS,
+  KIND_OFFLINE, KIND_BLOCKED, KIND_AT_RISK, KIND_RESTORED, NO_EPISODE, NO_OPINION,
+} from '../../src/shared/audit/network-episodes.js'
+
+const T0 = 1700000000000
+const SESSION = 'run-1'
+const DWELL = EPISODE_DWELL_MS
+
+// A driver so a test reads as a timeline rather than a pile of step() calls. `admit:false`
+// simulates record() refusing the row (log disabled / rate-limited).
+function driver ({ dwellMs = DWELL, persisted = null, session = SESSION } = {}) {
+  const tracker = createEpisodeTracker({ dwellMs })
+  let state = persisted
+  const rows = []
+  return {
+    rows,
+    get state () { return state },
+    at (offset, verdict, cause = null, { since = null, admit = true } = {}) {
+      const now = T0 + offset
+      const out = tracker.step({ verdict, cause, since: since ?? now, now, session, persisted: state })
+      if (out.row) {
+        rows.push({ ...out.row, at: now })
+        if (admit) state = out.next
+      }
+      return out
+    },
+  }
+}
+
+test('kindFor collapses causes into kinds, and splits only os-offline out', (t) => {
+  t.is(kindFor('unknown', null), NO_OPINION, 'unknown is not a state')
+  t.is(kindFor('healthy', null), NO_EPISODE)
+  t.is(kindFor('at-risk', 'symmetric-nat'), KIND_AT_RISK)
+  t.is(kindFor('blocked', 'os-offline'), KIND_OFFLINE)
+  t.is(kindFor('blocked', 'vpn-only-route'), KIND_BLOCKED, 'a VPN keeping the only route is not "you are offline"')
+  t.is(kindFor('blocked', 'dht-unreachable'), KIND_BLOCKED)
+  t.is(kindFor('blocked', 'peers-unreachable'), KIND_BLOCKED)
+})
+
+test('a degradation is recorded once, after the hold-down', (t) => {
+  const d = driver()
+  t.is(d.at(0, 'blocked', 'peers-unreachable').row, null, 'nothing at the transition itself')
+  t.is(d.at(DWELL - 1, 'blocked', 'peers-unreachable').row, null, 'nothing one ms early')
+
+  const out = d.at(DWELL, 'blocked', 'peers-unreachable')
+  t.is(out.row.kind, KIND_BLOCKED)
+  t.is(out.row.code, 'peers-unreachable')
+  t.is(out.row.subject.sinceTs, T0, 'the row names the REAL start, not the record time')
+  t.is(out.next.kind, KIND_BLOCKED, 'and the standing state advances')
+
+  t.is(d.at(DWELL + 60000, 'blocked', 'peers-unreachable').row, null, 'never again while it holds')
+  t.is(d.rows.length, 1)
+})
+
+test('a flap inside the hold-down writes nothing at all — in either direction', (t) => {
+  const d = driver()
+  d.at(0, 'blocked', 'os-offline')
+  d.at(5000, 'healthy')
+  d.at(60000, 'healthy')
+  t.is(d.rows.length, 0, 'no offline row and no restored row')
+  t.is(d.state, null, 'and nothing was persisted')
+})
+
+test('waitMs tells the caller when to look again — the emit path may never fire again', (t) => {
+  const d = driver()
+  t.is(d.at(0, 'blocked', 'dht-unreachable').waitMs, DWELL)
+  t.is(d.at(20000, 'blocked', 'dht-unreachable').waitMs, DWELL - 20000)
+  t.is(d.at(DWELL, 'blocked', 'dht-unreachable').waitMs, null, 'the row settled it')
+})
+
+test('unknown holds everything: a sleeping laptop is not an outage', (t) => {
+  const d = driver()
+  d.at(0, 'healthy')
+  d.at(1000, 'unknown')
+  d.at(8 * 3600000, 'unknown')
+  d.at(8 * 3600000 + 1000, 'healthy')
+  t.is(d.rows.length, 0)
+})
+
+test('unknown does not reset a hold-down it passes through', (t) => {
+  const d = driver()
+  d.at(0, 'blocked', 'dht-unreachable')
+  d.at(30000, 'unknown')
+  const out = d.at(DWELL, 'blocked', 'dht-unreachable')
+  t.ok(out.row, 'the wait kept running — the outage did not restart')
+})
+
+test('a cause refined inside the same kind writes no second row', (t) => {
+  const d = driver()
+  d.at(0, 'blocked', 'dht-unreachable')
+  d.at(DWELL, 'blocked', 'dht-unreachable')
+  d.at(DWELL + 1000, 'blocked', 'no-public-address')
+  d.at(DWELL * 3, 'blocked', 'no-public-address')
+  t.is(d.rows.length, 1, 'still one blocked episode')
+})
+
+test('os-offline and a blocked network are different kinds and both get a row', (t) => {
+  const d = driver()
+  d.at(0, 'blocked', 'os-offline')
+  d.at(DWELL, 'blocked', 'os-offline')
+  d.at(DWELL + 1000, 'blocked', 'vpn-only-route')
+  d.at(DWELL * 3, 'blocked', 'vpn-only-route')
+  t.alike(d.rows.map((r) => r.kind), [KIND_OFFLINE, KIND_BLOCKED])
+})
+
+test('at-risk escalating to blocked writes the escalation', (t) => {
+  const d = driver()
+  d.at(0, 'at-risk', 'symmetric-nat')
+  d.at(DWELL, 'at-risk', 'symmetric-nat')
+  d.at(DWELL + 1000, 'blocked', 'peers-unreachable')
+  d.at(DWELL * 3, 'blocked', 'peers-unreachable')
+  t.alike(d.rows.map((r) => r.kind), [KIND_AT_RISK, KIND_BLOCKED])
+})
+
+test('restored carries the duration of the episode it closes', (t) => {
+  const d = driver()
+  d.at(0, 'blocked', 'os-offline')
+  d.at(DWELL, 'blocked', 'os-offline')
+  d.at(600000, 'healthy', null, { since: T0 + 600000 })
+  const out = d.at(600000 + DWELL, 'healthy', null, { since: T0 + 600000 })
+
+  t.is(out.row.kind, KIND_RESTORED)
+  t.is(out.row.code, 'os-offline', 'the row names what it recovered FROM')
+  t.is(out.row.subject.fromKind, KIND_OFFLINE)
+  t.is(out.row.subject.durationMs, 600000, 'ten minutes offline')
+  t.is(out.row.subject.sinceTs, undefined, 'a recovery time must not ride the field meaning "started"')
+  t.is(out.row.subject.recoveredTs, T0 + 600000)
+  t.is(out.next, null, 'and the standing state is cleared')
+  t.is(d.state, null)
+})
+
+test('an outage spanning a restart has NO duration rather than an invented one', (t) => {
+  const d = driver({ persisted: { kind: KIND_BLOCKED, cause: 'peers-unreachable', since: T0, session: 'run-0' } })
+  d.at(3600000, 'healthy', null, { since: T0 + 3600000 })
+  const out = d.at(3600000 + DWELL, 'healthy', null, { since: T0 + 3600000 })
+
+  t.is(out.row.kind, KIND_RESTORED)
+  t.is(out.row.subject.durationMs, null, 'the app was closed for an unknown part of it')
+  t.is(out.row.subject.fromKind, KIND_BLOCKED, 'but what it recovered from is still known')
+})
+
+test('relaunching on the same bad network is silent', (t) => {
+  const first = driver()
+  first.at(0, 'at-risk', 'symmetric-nat')
+  first.at(DWELL, 'at-risk', 'symmetric-nat')
+  t.is(first.rows.length, 1)
+
+  const second = driver({ persisted: first.state })
+  second.at(0, 'at-risk', 'symmetric-nat')
+  second.at(DWELL * 5, 'at-risk', 'symmetric-nat')
+  t.is(second.rows.length, 0, 'the first launch on this network already said so')
+})
+
+test('a refused write does not advance the standing state', (t) => {
+  const d = driver()
+  d.at(0, 'blocked', 'os-offline')
+  d.at(DWELL, 'blocked', 'os-offline', { admit: false })
+  t.is(d.state, null, 'nothing persisted')
+
+  d.at(DWELL + 1000, 'blocked', 'os-offline')
+  const out = d.at(DWELL * 3, 'blocked', 'os-offline')
+  t.ok(out.row, 're-enabling the log records the standing state instead of suppressing it forever')
+})
+
+test('an emptied log restates a degradation that is still true', (t) => {
+  const afterPurge = driver({ persisted: null })
+  afterPurge.at(0, 'blocked', 'dht-unreachable')
+  t.ok(afterPurge.at(DWELL, 'blocked', 'dht-unreachable').row)
+})
+
+test('evidence is chosen per kind so the two blocked shapes stay distinguishable', (t) => {
+  // Every kind carries confidence, so the support bundle can say 'measured' vs 'predicted' for
+  // any transition, not only the two that happened to record it.
+  t.alike(evidenceFor(KIND_OFFLINE, { confidence: 'measured', interfaceKind: 'none' }), { confidence: 'measured', interfaceKind: 'none' })
+  t.alike(evidenceFor(KIND_AT_RISK, { confidence: 'predicted', publicPort: 0 }), { confidence: 'predicted', publicPort: 0 })
+  t.alike(
+    evidenceFor(KIND_BLOCKED, { confidence: 'measured', peersDiscovered: 4, peersExhausted: 4 }),
+    { confidence: 'measured', peersDiscovered: 4, peersExhausted: 4 },
+  )
+  t.alike(evidenceFor(KIND_RESTORED, { confidence: 'measured', peersConnected: 3 }), { confidence: 'measured', peersConnected: 3 })
+  t.alike(
+    evidenceFor(KIND_BLOCKED, {}),
+    { confidence: null, peersDiscovered: 0, peersExhausted: 0 },
+    'missing evidence degrades, never throws',
+  )
+})

--- a/test/unit/peer-episodes.test.js
+++ b/test/unit/peer-episodes.test.js
@@ -1,0 +1,162 @@
+import test from 'brittle'
+import {
+  createPeerPresenceTracker, peerKeyOf, PEER_DWELL_MS, KIND_PEER_LOST, KIND_PEER_BACK,
+} from '../../src/shared/audit/peer-episodes.js'
+
+const T0 = 1700000000000
+const META = { memberName: 'Anna Keller', spaceName: 'Design Team' }
+const D = PEER_DWELL_MS
+
+test('a blip below the floor produces nothing — not even a lone "is back"', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  t.is(p.step(T0 + 30000).rows.length, 0)
+  t.is(p.seen('anna', 'sp1', { now: T0 + 30000 }), null, 'no back row for an absence nobody saw')
+  t.is(p.step(T0 + D * 2).rows.length, 0, 'and the absence is gone, not merely quiet')
+  t.is(p.size(), 0)
+})
+
+test('a real absence writes one lost row, then one back row with the duration', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+
+  const { rows, waitMs } = p.step(T0 + D)
+  t.is(rows.length, 1)
+  t.is(rows[0].kind, KIND_PEER_LOST)
+  t.is(rows[0].subject.sinceTs, T0)
+  t.is(rows[0].meta.memberName, 'Anna Keller', 'the name is snapshotted at loss, not joined later')
+  t.is(waitMs, null)
+
+  const back = p.seen('anna', 'sp1', { now: T0 + D + 120000 })
+  t.is(back.kind, KIND_PEER_BACK)
+  t.is(back.subject.durationMs, D + 120000)
+  t.is(back.meta.spaceName, 'Design Team')
+})
+
+test('the same absence is not re-ripened on every tick', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  t.is(p.step(T0 + D).rows.length, 1)
+  t.is(p.step(T0 + D + 1000).rows.length, 0)
+  t.is(p.step(T0 + D * 5).rows.length, 0)
+})
+
+test('two sockets tearing down are one absence, timed from the first', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  p.lost('anna', 'sp1', { now: T0 + 4000, meta: META })
+  const { rows } = p.step(T0 + D)
+  t.is(rows.length, 1)
+  t.is(rows[0].subject.sinceTs, T0)
+})
+
+test('presence is per space: gone in one, present in another', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  p.lost('anna', 'sp2', { now: T0, meta: { ...META, spaceName: 'Ops' } })
+  const { rows } = p.step(T0 + D)
+  t.is(rows.length, 2)
+  t.alike(rows.map((r) => r.spaceId).sort(), ['sp1', 'sp2'])
+  t.is(peerKeyOf('anna', 'sp1'), 'anna|sp1')
+})
+
+test('abandon drops an absence without a row — a leave, or our own outage', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  p.abandon('anna', 'sp1')
+  t.is(p.step(T0 + D).rows.length, 0)
+
+  p.lost('bob', 'sp1', { now: T0, meta: META })
+  p.lost('cara', 'sp2', { now: T0, meta: META })
+  p.abandon()
+  t.is(p.step(T0 + D).rows.length, 0, 'our own outage abandons everything')
+  t.is(p.size(), 0)
+})
+
+test('abandoning one peer everywhere leaves the others alone', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  p.lost('anna', 'sp2', { now: T0, meta: META })
+  p.lost('bob', 'sp1', { now: T0, meta: META })
+  p.abandon('anna')
+  const { rows } = p.step(T0 + D)
+  t.is(rows.length, 1)
+  t.is(rows[0].publicKey, 'bob')
+})
+
+test('waitMs points at the EARLIEST pending absence', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  p.lost('bob', 'sp1', { now: T0 + 60000, meta: META })
+  t.is(p.step(T0 + 1000).waitMs, D - 1000, 'anna is due first')
+})
+
+// audit-log.js exempts audit.suppressed from its own rate guard, so a marker per over-cap absence
+// would bound nothing — the cap has to collapse them here, on the transition only.
+test('the per-pair cap emits ONE marker, not one per suppressed absence', (t) => {
+  const p = createPeerPresenceTracker({ cap: 2 })
+  let now = T0
+  const cycle = () => {
+    p.lost('anna', 'sp1', { now, meta: META })
+    const out = p.step(now + D)
+    now += D + 1000
+    const back = p.seen('anna', 'sp1', { now })
+    now += 1000
+    return { row: out.rows[0], back }
+  }
+  t.is(cycle().row.kind, KIND_PEER_LOST)
+  t.is(cycle().row.kind, KIND_PEER_LOST)
+
+  const third = cycle()
+  t.ok(third.row.suppressed, 'the transition into the capped state is visible')
+  t.is(third.row.kind, KIND_PEER_LOST, 'and still names what was suppressed')
+  t.is(third.row.cap, 2)
+
+  for (let i = 0; i < 5; i++) {
+    const later = cycle()
+    t.absent(later.row, 'no further rows while capped — otherwise the cap bounds nothing')
+  }
+})
+
+// The module header promises a peer_back row only ever closes an absence the reader saw.
+test('a cap-suppressed absence never emits a lone "is back online"', (t) => {
+  const p = createPeerPresenceTracker({ cap: 1 })
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  p.step(T0 + D)
+  p.seen('anna', 'sp1', { now: T0 + D + 1 })
+
+  p.lost('anna', 'sp1', { now: T0 + D + 2, meta: META })
+  const out = p.step(T0 + D * 2 + 3)
+  t.ok(out.rows[0].suppressed, 'this one is over the cap')
+  t.is(p.seen('anna', 'sp1', { now: T0 + D * 3 }), null, 'so its return closes nothing')
+})
+
+test('a recorded absence that never returns is eventually forgotten', (t) => {
+  const p = createPeerPresenceTracker({ staleMs: 1000 })
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  t.is(p.step(T0 + D).rows.length, 1)
+  t.is(p.size(), 1, 'held open so the return can close it')
+
+  p.step(T0 + D + 2000)
+  t.is(p.size(), 0, 'but not forever — an absent peer must not pin an entry')
+  t.is(p.seen('anna', 'sp1', { now: T0 + D + 3000 }), null)
+})
+
+test('the space name can land after the episode is captured', (t) => {
+  const p = createPeerPresenceTracker()
+  p.lost('anna', 'sp1', { now: T0, meta: { memberName: 'Anna Keller', spaceName: null } })
+  p.annotate('anna', 'sp1', { spaceName: 'Design Team' })
+  const { rows } = p.step(T0 + D)
+  t.is(rows[0].meta.spaceName, 'Design Team')
+  t.is(rows[0].meta.memberName, 'Anna Keller', 'without clobbering what was already known')
+})
+
+test('the cap window rolls, so yesterday does not bind today', (t) => {
+  const p = createPeerPresenceTracker({ cap: 1, capWindowMs: 10000 })
+  p.lost('anna', 'sp1', { now: T0, meta: META })
+  t.absent(p.step(T0 + D).rows[0].suppressed)
+  p.seen('anna', 'sp1', { now: T0 + D + 1 })
+
+  p.lost('anna', 'sp1', { now: T0 + D + 2, meta: META })
+  t.absent(p.step(T0 + D * 2 + 3).rows[0].suppressed, 'the earlier stamp aged out of the window')
+})


### PR DESCRIPTION
A fifth audit category, `network`, with six kinds in two families:

- **Device** (tier A, no space) — `network.offline` / `.blocked` / `.at_risk` / `.restored`,
  folded from the reachability verdict that already exists and was thrown away.
- **Peer** (tier B, space-scoped) — `network.peer_lost` / `.peer_back`, from the presence
  transitions `state/presence.js` already reports.

Plus the Network filter chip, a "Connection history" cross-link from Network status and
Connection problem, and a diagnostics verdict history that survives a restart.

### Design notes worth reviewing

- **A peer row is only honest while our own connectivity is healthy.** A blocked device makes
  every peer look gone, so peer absences are abandoned rather than recorded while a device
  episode is open — otherwise one pulled cable blames twenty members.
- **A leave is not a disconnect.** `member.left` covers leaving; the leave site abandons the
  episode explicitly rather than joining against live membership at write time.
- **`outcome` stays `ok`.** The vocabulary answers "did the described act succeed", and a
  network state is not an act — `error` would render the red FAILED badge. Severity is a
  kind-keyed badge reusing the shipped `connectivity.offline` / `.limited` strings.
- **Device rows are visible under a space filter** via a `by-device` index merged into the
  walk. Side effect worth a look: the rate guard's space-less `audit.suppressed` marker now
  rides along too.
- Two constants are tuning, not contract: `EPISODE_DWELL_MS` (60s) and the peer floor (5 min,
  overridable via `peerPresenceDwellMs` for the flow test).

### Riders

- `metaParts()` returned finished strings, which is how a hard-coded English `' files'` shipped
  to five locales. Now structured `{key, values}`.
- `bundle-axe-stripped`'s size assertion raised 1_000_000 → 1_100_000. It is a backstop for the
  two string checks beside it (axe adds ~616KB), and ~200 bytes of headroom had made it the
  de-facto budget for UI copy. The margin below an axe-carrying bundle is now asserted.
  Unrelated but measured: lazy-loading the four non-active locales would save 199,700 bytes
  (19.8% of the bundle) — worth its own change.

### Testing

Unit (`network-episodes`, `peer-episodes`, `audit-row`, `audit-kinds`, `diagnostics-bundle`),
integration (`network-watch` drives the real watch against a real bee, incl. both suppression
paths), flow (`audit-network-presence` — real two-peer kill/relaunch/leave), frontend (s114).

Local: `test:fe` s114 5/5 plus s17/s112/s113/s14 green. Manual VoiceOver spot-check outstanding.
