### PR TITLE
[fix] Size the handshake burst by the shared topic count

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -28,6 +28,8 @@ Compact, actionable rules distilled from real debugging — gotchas, root causes
 
 ## Testing tactics
 
+**`launchPeer` on a relaunch re-sends every handshake twice and doubles the announce backoff.** It calls `profile:set` after boot, which runs `broadcastProfileUpdate` on top of `onopen` and increments the announce ledger's `attempts`, so a relaunched peer's exchange is `2K + 8` frames and its first ledger retry is 20 s out, not 10. Account for it when a flow test's frame count or timing budget depends on the reconnect burst.
+
 Testing/a11y **discipline** — the layers, the change-type→coverage matrix, the a11y bar, and frontend scenario authoring (file-sizing, offline-edge, async-probe waits, split-text `sr-only`, timeout-vs-absent) — lives in `testing.md`. Dep-bump baseline-diffing lives in `dependency-updates.md`. Only debugging tactics that aren't reference material stay here:
 
 **Never blanket-replace `console.log/warn/error` in a brittle test** — the runner emits its own TAP through them, so a blanket stub both miscounts (inflated by exactly the number of prior asserts) and swallows the failure diagnostic. Capture by discriminating on the code-under-test's own prefix/tag; forward everything else to the saved real console.
@@ -167,6 +169,8 @@ retained bytes.
 **Before calling plaintext replicated state a "leak," classify each field.** (a) Needed BEFORE the gating key exists (identity used to negotiate membership) → necessarily public, working as intended; (b) a key/pointer whose target is encrypted → safe by the plaintext-key→encrypted-data invariant; (c) actual sensitive DATA not required pre-membership → the genuine residual (the only bug). Never propose "just encrypt the bee" without checking key granularity: one identity spanning N spaces with N distinct SCKs has no single key — the fix is a per-scope encrypted projection or relocating the data into the correctly-keyed store.
 
 ## Network / streams
+
+**A per-socket burst allowance must be sized by what an honest peer legitimately sends per round, not a constant.** When the legitimate burst grows with a count the receiver can observe (spaces shared), a fixed burst plus a consecutive-drop ban is a cliff at `burst + threshold` — here 24 shared spaces on a reconnect, since the peer's dropped reciprocals count toward the ban too. The tell is `evicting flooding peer` for a *known* peer on every reconnect, and spaces that stay empty for 10-60 s below that. Size the cap by what THIS socket has proven (distinct matched topics), not by your own total, or a peer that matches one topic inherits an allowance that grows with every space you join; keep the bucket as decaying debt so a growing cap admits at once, and decay the drop counter at the refill rate so a peer that paces itself can never accumulate a ban.
 
 **Never destroy a peer's socket to "heal" a wedged hypercore replication session.** That socket is the single Noise mux carrying every core, transfer, and control channel for that peer, so the "recovery" is itself the outage. A wedged session starves even explicit `core.get()` calls (it is per-core, not per-request) — recover by capturing what you need through an explicit get with a bounded timeout, falling back to `bee.checkout(core.contiguousLength)` when the peer is offline.
 

--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -408,6 +408,8 @@ Every identity-asserting frame carries a signature binding sender → socket Noi
 
 **Handshake:** one per local space per connection. `channel.onopen` iterates every joined topic (`sendHandshakeMessages`).
 
+**Identity-frame rate limit.** `admitIdentityFrame` charges a per-socket dual-lane token bucket (`handshake-guard.js`) keyed on the Noise key: frames for a topic we joined ride the *matched* lane, everything else the generous *unmatched* lane, so a multi-space peer's foreign-topic frames can't starve the one that matters. The matched lane's burst is `handshakeBurst + handshakeBurstPerTopic x the distinct topics THAT SOCKET has matched` (8 + 3 per shared space, re-read per take and never counted past the topics we hold), because an honest reconnect legitimately sends one frame per shared space plus our reciprocal — a fixed burst banned any pair sharing 24+ spaces, while scaling by our own space count instead would hand a peer that matched one topic an allowance that grows with every space we join. Refill is 1/s; the drop counter decays at the same rate, and 24 consecutive drops on either lane evict the Noise key (`bannedNoiseKeys` -> the swarm firewall) for the process lifetime.
+
 **Leave frame:** broadcast by `space:leave` to every connected socket *before* local teardown (§6). `handleLeaveFrame` verifies the claimed `profileKey` is already authenticated on this socket via `socketToPeers` — **spoof guard**; without it any connected peer could kick a third party out of others' member lists — then prunes the leaver from persisted `members`, evicts from `connectedPeers`/`socketToPeers` (so the eventual disconnect doesn't fire a duplicate `event:member-left`), and emits `event:member-left`.
 
 **On receipt (`handleHandshake`):**
@@ -1155,7 +1157,7 @@ Locally the reasons are kept apart: only `UNAUTHENTICATED` and `NOT_A_MEMBER` ar
 
 ### Resource bounds
 
-`core/runtime-config.js` centralizes DoS/resource budgets: caps on peer-supplied data (e.g. avatar data-URI length), read timeouts bounding how long an offline peer can stall aggregation, and the serve-gate rate limiter.
+`core/runtime-config.js` centralizes DoS/resource budgets: caps on peer-supplied data (e.g. avatar data-URI length), read timeouts bounding how long an offline peer can stall aggregation, the identity-frame limiter (matched burst scaled by the topics a socket has proven it shares) and the serve-gate rate limiter. A budget that is multiplied by a live count is clamped finite and non-negative where it is read, so a hand-edited `Infinity` cannot silently disable the lane it is meant to bound.
 
 ---
 

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -64,8 +64,15 @@ const DEFAULTED = {
   // clamps to >= 1.
   publishConcurrency: 2,
   // Only topic-MATCHED identity frames charge this lane (the receiver resolves the topic
-  // before charging), so the burst covers the spaces two peers actually share.
+  // before charging). An honest connection sends one frame per shared space, we reciprocate
+  // each, and a name change or ledger re-send can add a third inside one refill window — so
+  // the lane's burst is handshakeBurst + handshakeBurstPerTopic x the topics THIS peer joined
+  // (createDualRateLimiter reads the count per take). Refill and the consecutive-drop ban are
+  // unchanged: a flood is anything past that cap at 1 frame/s. A fixed burst of 8 banned a
+  // peer sharing 24+ spaces on every reconnect. burstPerTopic 0 restores the fixed burst;
+  // handshakeBurst 0 still switches the lane off.
   handshakeBurst: 8,
+  handshakeBurstPerTopic: 3,
   handshakeRefillMs: 1000,
   handshakeAbuseThreshold: 24,
   // Frames naming a topic we did not join: dropped before any signature verify, so the lane
@@ -254,6 +261,13 @@ export function getDeepReconcileEvery() {
   return config.deepReconcileEvery
 }
 
+// A budget that is multiplied by a live count must be finite and non-negative: Infinity yields
+// NaN against a zero count (which reads as "lane disabled" and fails OPEN), a negative yields a
+// cap no frame can meet (fails closed on honest peers). Anything else falls back to the default.
+function finiteAtLeast(value, min, fallback) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= min ? value : fallback
+}
+
 export function getPublishConcurrency() {
   const n = config.publishConcurrency
   if (n === Infinity) return Infinity
@@ -307,7 +321,10 @@ export function getCaptureMemberRecordMs() {
 export function getHandshakeRateLimit() {
   const c = config
   return {
-    matched: { burst: c.handshakeBurst, refillMs: c.handshakeRefillMs, abuseThreshold: c.handshakeAbuseThreshold },
+    // burstPerTopic multiplies a per-socket count, so it is clamped to a finite non-negative
+    // number: Infinity would make the product NaN for a peer with no matched topic yet and
+    // silently switch the lane OFF, and a negative would drop every honest frame.
+    matched: { burst: c.handshakeBurst, burstPerTopic: finiteAtLeast(c.handshakeBurstPerTopic, 0, DEFAULTED.handshakeBurstPerTopic), refillMs: c.handshakeRefillMs, abuseThreshold: c.handshakeAbuseThreshold },
     unmatched: { burst: c.handshakeUnmatchedBurst, refillMs: c.handshakeUnmatchedRefillMs, abuseThreshold: c.handshakeUnmatchedAbuseThreshold },
   }
 }

--- a/src/shared/transfer/handshake-guard.js
+++ b/src/shared/transfer/handshake-guard.js
@@ -103,21 +103,35 @@ export function checkInboundSender (peerInfo, msg, { enforceBinding }) {
 }
 
 // Per-socket token bucket keyed on the connection's Noise key (unspoofable, vs the
-// spoofable msg.profileKey). burst tokens, +1 token / refillMs; take() reports ban:true
-// after abuseThreshold *consecutive* drops so a sustained flood self-evicts while a
-// transient over-burst (a multi-space peer's reconnect storm) recovers on the next grant.
-export function createRateLimiter ({ burst, refillMs, abuseThreshold, now = Date.now }) {
+// spoofable msg.profileKey). `burst` is a number or a getter re-read on every take, passed the
+// count of distinct scopes this socket has presented (see trackScopes). The bucket keeps the
+// debt (frames used, decaying at +1 / refillMs) rather than the tokens left, so a cap that
+// grows admits the frames its growth allows at once, and a cap that shrinks tightens at once.
+// take() reports ban:true after abuseThreshold consecutive drops — the drop counter resets on
+// any grant and decays at the refill rate, so a sustained flood self-evicts while a peer that
+// backs off, or one whose honest burst simply outran the window, never accumulates a ban.
+//
+// trackScopes records the distinct scope strings a socket presents (the caller passes one per
+// take) so the cap can follow what THIS peer has actually proven rather than a global figure.
+// The caller must only pass scopes it has already validated against its own set, which is what
+// bounds the per-socket memory.
+export function createRateLimiter ({ burst, refillMs, abuseThreshold, now = Date.now, trackScopes = false }) {
+  const capOf = typeof burst === 'function' ? burst : () => burst
   const buckets = new Map()
   return {
-    take (noiseKeyHex) {
-      if (!burst) return { ok: true, ban: false }
+    take (noiseKeyHex, scope = null) {
       const t = now()
       let b = buckets.get(noiseKeyHex)
-      if (!b) buckets.set(noiseKeyHex, b = { tokens: burst, last: t, drops: 0 })
-      b.tokens = Math.min(burst, b.tokens + (t - b.last) / refillMs)
+      if (!b) buckets.set(noiseKeyHex, b = { used: 0, last: t, drops: 0, scopes: trackScopes ? new Set() : null })
+      if (b.scopes && typeof scope === 'string') b.scopes.add(scope)
+      const cap = capOf(b.scopes ? b.scopes.size : 0)
+      if (!cap) return { ok: true, ban: false }
+      const decayed = (t - b.last) / refillMs
+      b.used = Math.max(0, b.used - decayed)
+      b.drops = Math.max(0, b.drops - decayed)
       b.last = t
-      if (b.tokens < 1) { b.drops += 1; return { ok: false, ban: b.drops >= abuseThreshold } }
-      b.tokens -= 1
+      if (b.used + 1 > cap) { b.drops += 1; return { ok: false, ban: b.drops >= abuseThreshold } }
+      b.used += 1
       b.drops = 0
       return { ok: true, ban: false }
     },
@@ -131,15 +145,24 @@ export function createRateLimiter ({ burst, refillMs, abuseThreshold, now = Date
 // frames for topics we DON'T have (dropped cheaply, before any signature verify) can never
 // starve the one frame for a topic we DO have. Lane pick is the caller's topic match; each
 // lane bans on its own consecutive-drop threshold — a flood is a flood whichever lane it
-// lands in.
-export function createDualRateLimiter ({ matched, unmatched, now = Date.now }) {
+// lands in. The matched lane's honest burst is one frame per space the two peers SHARE, our
+// reciprocal, and one re-send inside a refill window — so its cap is
+// burst + burstPerTopic x (the distinct topics THIS socket has matched), re-read per take and
+// never counted past the topics we actually hold. Scaling by the shared count rather than by
+// our own total is what keeps a peer that matched a single topic at a small cap no matter how
+// many spaces we are in. burst 0 still switches the lane off.
+export function createDualRateLimiter ({ matched, unmatched, now = Date.now, topics = () => 0 }) {
+  const perTopic = matched.burstPerTopic || 0
+  const matchedBurst = (matchedTopics) => (matched.burst ? matched.burst + perTopic * Math.min(matchedTopics, topics()) : 0)
   const lanes = {
-    matched: createRateLimiter({ ...matched, now }),
+    matched: createRateLimiter({ ...matched, burst: matchedBurst, now, trackScopes: true }),
     unmatched: createRateLimiter({ ...unmatched, now }),
   }
   return {
-    take (noiseKeyHex, isMatched) {
-      return lanes[isMatched ? 'matched' : 'unmatched'].take(noiseKeyHex)
+    // `topic` is charged only on the matched lane, and the caller has already resolved it
+    // against our own topics — so the per-socket scope set can never exceed our space count.
+    take (noiseKeyHex, isMatched, topic = null) {
+      return isMatched ? lanes.matched.take(noiseKeyHex, topic) : lanes.unmatched.take(noiseKeyHex)
     },
     forget (noiseKeyHex) {
       lanes.matched.forget(noiseKeyHex)

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -194,7 +194,9 @@ export function initSwarm(_ipc) {
     // firewall returns true to REJECT — drop reconnects from a Noise key we evicted for flooding.
     firewall: (remoteKey) => bannedNoiseKeys.has(b4a.toString(remoteKey, 'hex')),
   })
-  rateLimiter = createDualRateLimiter(getHandshakeRateLimit())
+  // The matched lane's cap follows the topics we joined (read per take, so joins and leaves
+  // need no re-plumbing) — see createDualRateLimiter.
+  rateLimiter = createDualRateLimiter({ ...getHandshakeRateLimit(), topics: () => spaceTopics.size })
   const dropWindow = getIdentityFrameDropWindow()
   testDrop = dropWindow.count > 0 ? { ...dropWindow, seen: 0 } : null
   bootedAt = Date.now()
@@ -330,7 +332,9 @@ function admitIdentityFrame(socket, peerInfo, remoteKey, msg) {
     HEX64.test(msg.spaceTopic) && !!resolveSpaceIdForTopic(msg.spaceTopic)
   const noiseHex = peerInfo?.publicKey ? b4a.toString(peerInfo.publicKey, 'hex') : null
   if (noiseHex && rateLimiter) {
-    const r = rateLimiter.take(noiseHex, matched)
+    // The topic is charged only when it matched one of ours, so the lane's cap grows with the
+    // spaces this peer has actually proven it shares — not with our own space count.
+    const r = rateLimiter.take(noiseHex, matched, matched ? msg.spaceTopic : null)
     if (!r.ok) {
       log.debug('rate-limited', msg.type, 'from', remoteKey + '...')
       if (r.ban) {

--- a/test/flow-shard.mjs
+++ b/test/flow-shard.mjs
@@ -24,6 +24,7 @@ const WEIGHTS = {
   'resume-transfer.test.js': 16,
   'readd-different-content.test.js': 16,
   'leave-no-rejoin-request.test.js': 14,
+  'handshake-burst-cliff.test.js': 12,
 }
 const DEFAULT_WEIGHT = 5
 const weightOf = (f) => WEIGHTS[f] ?? DEFAULT_WEIGHT

--- a/test/flow/handshake-burst-cliff.test.js
+++ b/test/flow/handshake-burst-cliff.test.js
@@ -1,0 +1,71 @@
+import test from 'brittle'
+import path from 'path'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled, unscaled } from '../helpers/timing.js'
+
+// REGRESSION (FIX-HANDSHAKE-BURST: the receiver's matched identity-frame lane had a fixed
+// burst of 8 and banned after 24 consecutive drops. A reconnect puts N + min(N, 8)
+// back-to-back frames on each side's lane — the opening burst plus reciprocals — so two
+// peers sharing 24 spaces evicted each other's Noise key for the process lifetime, and
+// below that, spaces 9+ waited 10-25 s for the announce ledger. Joining spaces in a row
+// stalled every fifth join the same way. The lane's burst now scales with the topics the
+// receiver joined, so the whole exchange lands in one round trip.)
+//
+// Deadlines are ABSOLUTE (unscaled / raw ms): every failure mode here races an unscaled
+// production constant — the ledger's 10 s base on a 15 s tick, or a ban that never heals —
+// so a scaled deadline on a slow runner would pass through the very retry path the fix
+// removes. launchPeer's relaunch also re-sends every handshake once more (profile:set ->
+// broadcastProfileUpdate), which makes the exchange 2N + 8 frames — still under the cap.
+const N = 24
+
+test('REGRESSION (FIX-HANDSHAKE-BURST): peers sharing 24 spaces reconnect in one round trip, unbanned', { timeout: scaled(300000) }, async (t) => {
+  const bootstrap = await localTestnet(t)
+  const aStore = path.join(mkTmpDir(t), 'app-storage')
+  const aDownloads = mkTmpDir(t)
+  let A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, downloads: aDownloads })
+  const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
+  const aKey = (await A.request('profile:get')).publicKey
+  const bKey = (await B.request('profile:get')).publicKey
+
+  // Joining N spaces back-to-back costs the creator's lane 2 frames per space; the fixed
+  // burst dropped the fifth join's frame and it waited 10-25 s for the ledger. Bound each
+  // join absolutely: a healthy join is ~30 ms and a stalled one is >= 10 s (the ledger's
+  // unscaled base), so 9 s sits two orders of magnitude above the pass case and below the
+  // failure case. connectInSpace polls at 1 s, so this tolerates eight missed polls before it
+  // could report runner load rather than a stall — if it ever fails alone on a loaded shard,
+  // that is the flake, and the bound must not be SCALED (a scaled deadline would pass through
+  // the very ledger retry this test exists to catch).
+  const spaceIds = []
+  let slowestJoinMs = 0
+  for (let i = 0; i < N; i++) {
+    const started = Date.now()
+    spaceIds.push(await connectInSpace(t, A, B, 'Space ' + i))
+    slowestJoinMs = Math.max(slowestJoinMs, Date.now() - started)
+  }
+  t.ok(slowestJoinMs < 9000, `slowest of ${N} back-to-back joins took ${slowestJoinMs}ms — no ledger stall`)
+
+  // A goes away and comes back with the same identity and drives: both sides fire a fresh
+  // opening burst for all N spaces on the new socket. Keep the pre-kill stderr: reassigning A
+  // below drops the original handle, and the join loop above is one of the two bursts that
+  // could have evicted.
+  const stderrBeforeRelaunch = A.readStderr()
+  A.kill()
+  await B.until('members:online', { spaceId: spaceIds[0] }, (o) => !o.includes(aKey), { ms: 90000 })
+  const relaunchedAt = Date.now()
+  A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore, downloads: aDownloads })
+
+  // Presence is leased on handshake admission, so members:online is the end-state signal
+  // for "this side admitted the peer's frame for this space" — no reliance on catching an
+  // event that may fire before the listener is attached.
+  for (const spaceId of spaceIds) {
+    await A.until('members:online', { spaceId }, (o) => o.includes(bKey), { ms: unscaled(9000) })
+  }
+  t.pass(`A re-admitted B in all ${N} spaces ${Date.now() - relaunchedAt}ms after relaunch`)
+  for (const spaceId of spaceIds) {
+    await B.until('members:online', { spaceId }, (o) => o.includes(aKey), { ms: unscaled(9000) })
+  }
+  t.pass(`B re-admitted A in all ${N} spaces`)
+  t.absent(/evicting flooding peer/.test(stderrBeforeRelaunch + A.readStderr() + B.readStderr()), 'neither side evicted the other, in either burst')
+})

--- a/test/unit/handshake-rate-limit.test.js
+++ b/test/unit/handshake-rate-limit.test.js
@@ -106,3 +106,126 @@ test('dual limiter honors per-lane refill and the burst-0 disabled escape hatch'
   t.ok(rl.take(K, true).ok, 'matched refills on its own cadence')
   for (let i = 0; i < 20; i++) t.ok(rl.take(K, false).ok, `disabled unmatched lane never throttles (${i + 1})`)
 })
+
+// The shipped matched-lane constants, as literals. runtime-config.test.js asserts
+// getHandshakeRateLimit() returns exactly these, so this file never reads the process-global
+// config — a sibling unit file mutating it cannot silently change the numbers asserted here.
+const SHIPPED_MATCHED = { burst: 8, burstPerTopic: 3, refillMs: 1000, abuseThreshold: 24 }
+const SHIPPED_UNMATCHED = { burst: 32, refillMs: 250, abuseThreshold: 256 }
+// A distinct 64-hex topic per shared space, the shape swarm.js charges the lane with.
+const TOPIC = (i) => i.toString(16).padStart(64, '0')
+
+function shippedLanes (topicCount, c) {
+  return createDualRateLimiter({ matched: SHIPPED_MATCHED, unmatched: SHIPPED_UNMATCHED, now: c.now, topics: () => topicCount })
+}
+
+// REGRESSION (FIX-HANDSHAKE-BURST: a reconnect between peers sharing K spaces puts K + K
+// back-to-back matched frames on the lane — their opening burst plus their reciprocals to
+// ours. With a fixed burst of 8 the lane admitted 8, dropped 24 in a row and evicted the
+// peer's Noise key for the process lifetime. K = 24 is exactly the cliff.)
+test('REGRESSION (FIX-HANDSHAKE-BURST): a 24-space reconnect is admitted whole, nobody is banned', (t) => {
+  const c = clock()
+  const rl = shippedLanes(24, c)
+  for (let i = 0; i < 24; i++) {
+    const r = rl.take(K, true, TOPIC(i))
+    t.ok(r.ok, `opening frame for space ${i + 1} of 24 admitted`)
+    t.is(r.ban, false, `no ban on opening frame ${i + 1}`)
+  }
+  for (let i = 0; i < 24; i++) {
+    const r = rl.take(K, true, TOPIC(i))
+    t.ok(r.ok, `reciprocal for space ${i + 1} of 24 admitted`)
+    t.is(r.ban, false, `no ban on reciprocal ${i + 1}`)
+  }
+})
+
+// REGRESSION (FIX-HANDSHAKE-BURST: below the cliff, frames 9+ were dropped and only the
+// announce ledger re-sent them, 10-60 s later. Twelve shared spaces must land in one round.)
+test('REGRESSION (FIX-HANDSHAKE-BURST): twelve shared spaces do not wait for the ledger', (t) => {
+  const c = clock()
+  const rl = shippedLanes(12, c)
+  for (let i = 0; i < 12; i++) t.ok(rl.take(K, true, TOPIC(i)).ok, `opening frame ${i + 1} of 12 admitted`)
+  for (let i = 0; i < 12; i++) t.ok(rl.take(K, true, TOPIC(i)).ok, `reciprocal ${i + 1} of 12 admitted`)
+})
+
+// The cap follows what THIS socket proved it shares, so holding many spaces does not hand a
+// peer that matched one topic a large allowance — the amplification a global count would give.
+test('the cap scales with the topics this socket matched, not with our own space count', (t) => {
+  const c = clock()
+  const rl = shippedLanes(100, c)             // we are in 100 spaces
+  let admitted = 0
+  let bannedAt = -1
+  for (let i = 0; i < 200 && bannedAt < 0; i++) {
+    const r = rl.take(K, true, TOPIC(0))      // ... but this peer only ever matches one
+    if (r.ok) admitted++
+    if (r.ban) bannedAt = i
+  }
+  t.is(admitted, 11, 'one shared topic buys 8 + 3, not 8 + 3 x 100')
+  t.is(bannedAt, 11 + 24 - 1, 'and a flood on that one topic still evicts')
+})
+
+// The anti-spam property survives: past the topic-scaled cap the lane drops, and 24
+// consecutive drops still evict — one socket, however many topics it legitimately shares.
+test('a matched flood past the topic-scaled cap still bans', (t) => {
+  const c = clock()
+  const rl = shippedLanes(10, c)
+  let admitted = 0
+  let bannedAt = -1
+  for (let i = 0; i < 200 && bannedAt < 0; i++) {
+    const r = rl.take(K, true, TOPIC(i % 10)) // all ten shared topics: cap = 8 + 3 x 10 = 38
+    if (r.ok) admitted++
+    if (r.ban) bannedAt = i
+  }
+  t.is(admitted, 38, 'exactly cap frames admitted')
+  t.is(bannedAt, 38 + 24 - 1, 'ban on the 24th consecutive drop, not before')
+})
+
+// A peer that backs off to the refill rate is never banned, however long it stays connected:
+// the drop counter decays with the debt, so drops must be CONSECUTIVE in time, not merely
+// consecutive in sequence across a long-lived socket.
+test('drops decay with the bucket, so a slow peer never accumulates a ban', (t) => {
+  const c = clock()
+  const rl = shippedLanes(1, c)
+  for (let i = 0; i < 11; i++) t.ok(rl.take(K, true, TOPIC(0)).ok, `filling the cap (${i + 1})`)
+  for (let i = 0; i < 60; i++) {
+    const r = rl.take(K, true, TOPIC(0))      // one frame, then wait a whole refill: never banned
+    t.is(r.ban, false, `no ban on a peer pacing itself (${i + 1})`)
+    c.advance(1000)
+  }
+})
+
+test('the unmatched lane ignores the topic count entirely', (t) => {
+  const c = clock()
+  const rl = shippedLanes(100, c)
+  for (let i = 0; i < 32; i++) t.ok(rl.take(K, false).ok, `unmatched burst ${i + 1} of 32`)
+  let bannedAt = -1
+  for (let i = 32; i < 400 && bannedAt < 0; i++) if (rl.take(K, false).ban) bannedAt = i
+  t.is(bannedAt, 32 + 256 - 1, 'unmatched lane bans after its own 256 consecutive drops')
+})
+
+test('handshakeBurst 0 keeps the matched lane off regardless of topics', (t) => {
+  const c = clock()
+  const rl = createDualRateLimiter({
+    matched: { burst: 0, burstPerTopic: 3, refillMs: 1000, abuseThreshold: 24 },
+    unmatched: { burst: 1, refillMs: 250, abuseThreshold: 256 },
+    now: c.now,
+    topics: () => 50,
+  })
+  for (let i = 0; i < 300; i++) t.ok(rl.take(K, true, TOPIC(i)).ok, `disabled matched lane never throttles (${i + 1})`)
+})
+
+test('a cap getter applies to existing buckets: growth admits at once, shrink tightens at once', (t) => {
+  const c = clock()
+  let cap = 2
+  const rl = createRateLimiter({ burst: () => cap, refillMs: 1000, abuseThreshold: 24, now: c.now })
+  t.ok(rl.take(K).ok); t.ok(rl.take(K).ok)
+  t.absent(rl.take(K).ok, 'cap 2 exhausted')
+  cap = 5
+  t.ok(rl.take(K).ok, 'a larger cap grants headroom without waiting for refill')
+  t.ok(rl.take(K).ok); t.ok(rl.take(K).ok)
+  t.absent(rl.take(K).ok, 'cap 5 exhausted')
+  cap = 1
+  c.advance(1000)
+  t.absent(rl.take(K).ok, 'one token refilled but the debt (4) still exceeds the smaller cap')
+  c.advance(4000)
+  t.ok(rl.take(K).ok, 'debt decayed to zero: one token under cap 1')
+})

--- a/test/unit/runtime-config.test.js
+++ b/test/unit/runtime-config.test.js
@@ -93,6 +93,7 @@ test('DoS resource caps + rate limit default to the documented values', (t) => {
 
   const rl = getHandshakeRateLimit()
   t.is(rl.matched.burst, 8, 'matched-lane burst')
+  t.is(rl.matched.burstPerTopic, 3, 'matched-lane burst per joined topic')
   t.is(rl.matched.refillMs, 1000, 'matched-lane refill')
   t.is(rl.matched.abuseThreshold, 24, 'matched-lane abuse threshold')
   t.is(rl.unmatched.burst, 32, 'unmatched-lane burst')


### PR DESCRIPTION
## What & why
Two peers sharing 24+ spaces banned each other's Noise key on every reconnect (unrecoverable until one side restarts); 9+ shared spaces waited 10–60 s on the announce ledger; joining spaces in a row stalled every fifth join ~15 s. The receiver's matched handshake lane had a fixed burst of 8 with a ban after 24 consecutive drops, while an honest reconnect legitimately sends one frame per shared space plus our reciprocal.

The lane's burst now scales with the distinct topics **that socket** has matched (`handshakeBurst + handshakeBurstPerTopic × matched`, capped by the topics we hold) rather than with our own space count — a peer matching one topic stays at a small cap however many spaces we are in. The drop counter now decays at the refill rate, so a peer pacing itself can never accumulate a ban. Refill, ban threshold and the unmatched anti-spam lane are unchanged. Receiver-side only, no wire change; `handshakeBurstPerTopic: 0` restores the old fixed burst without a code change.

## Coverage
Unit: 2 red-first regressions (24-space reconnect admitted whole; 12 shared spaces need no ledger), plus guards that a flood past the cap still bans, that a single-topic peer gets 8+3 and not 8+3×100, that a self-pacing peer is never banned, and that the unmatched lane is untouched. Config defaults asserted. Flow: red-first two-peer reconnect with 24 shared spaces (join loop + kill/relaunch + no eviction). Integration skipped — no bare-only import, nothing persisted. Frontend skipped — no renderer change.

## Ran locally
Unit + `test:bare` (782 pass) + typecheck + `lint:ci` green. Flow: the new file plus handshake-starvation, membership-flood/-presence/-approval/-convergence, identity-binding, leave-reconcile, rejoin-after-leave, multi-mirror — all pass. Red proven by flipping `handshakeBurstPerTopic: 0`: slowest join 14,960 ms vs 28 ms with the fix. No UI change, so no test:fe / axe / VoiceOver.
