### PR TITLE
[fix] Charge one read budget per peer in files:list

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -28,6 +28,8 @@ Compact, actionable rules distilled from real debugging — gotchas, root causes
 
 ## Testing tactics
 
+**A regression test whose fixture no longer reaches the guarded path passes vacuously.** When a data path moves (profile-bee share prefixes to per-owner catalog keys), the old fixture is filtered out before the code under test runs — the tell is a timing assertion that is green on both sides of a revert. Assert the fixture was ADMITTED (a side effect of the read, a call count, a deficit marker) before asserting the bound.
+
 Testing/a11y **discipline** — the layers, the change-type→coverage matrix, the a11y bar, and frontend scenario authoring (file-sizing, offline-edge, async-probe waits, split-text `sr-only`, timeout-vs-absent) — lives in `testing.md`. Dep-bump baseline-diffing lives in `dependency-updates.md`. Only debugging tactics that aren't reference material stay here:
 
 **Never blanket-replace `console.log/warn/error` in a brittle test** — the runner emits its own TAP through them, so a blanket stub both miscounts (inflated by exactly the number of prior asserts) and swallows the failure diagnostic. Capture by discriminating on the code-under-test's own prefix/tag; forward everything else to the saved real console.

--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -230,7 +230,7 @@ Created via `store.namespace('space-drive-<spaceId>-<driveSuffix>')` → `new Hy
 
 **The drive carries no file bytes.** Its `driveKey` is the member's per-space identity: the handshake binding signs `noise||driveKey` (§16) and members are matched by it. `listFiles` reads the local drive solely for that key; `files:add` only checks it exists.
 
-**No peer drives are opened.** Peers' loose/folder metadata comes from their replicated, SCK-encrypted catalogs (§3.7), opened lazily per catalog key and cached (`peerCatalogs` in `share-catalog.js`) with bounded read timeouts so one offline peer can't stall a listing. File bytes travel only through the overlay backend (§7.7), addressed by content hash.
+**No peer drives are opened.** Peers' loose/folder metadata comes from their replicated, SCK-encrypted catalogs (§3.7), opened lazily per catalog key and cached (`peerCatalogs` in `share-catalog.js`), read **in parallel**, each under **one** interactive NETWORK budget covering head sync and drain together (a spent budget degrades the drain to a local-only read, bounded by a short guard that is reported as an incomplete read rather than as fewer files), so a listing costs about one budget however many members are unreachable. File bytes travel only through the overlay backend (§7.7), addressed by content hash.
 
 #### Canonical file-state model
 
@@ -425,7 +425,7 @@ When a new space is joined while connections already exist, Hyperswarm reuses th
 
 ### 4.3 Peer catalog caching
 
-Peer file metadata lives in replicated catalogs, not drives (§3.5). A peer catalog bee opens lazily on first read (`openPeerCatalog`, keyed by catalog key, decrypted with the space SCK) and caches in `peerCatalogs`; reads are bounded by an interactive timeout so an offline peer can't stall a listing. Catalog appends fire per-owner watches (`watchPeerCatalog`) that nudge foreign mirrors (§7.3) and re-drive pending downloads (§4.5).
+Peer file metadata lives in replicated catalogs, not drives (§3.5). A peer catalog bee opens lazily on first read (`openPeerCatalog`, keyed by catalog key, decrypted with the space SCK) and caches in `peerCatalogs`; reads fan out in parallel and are bounded by ONE interactive timeout per peer covering head sync and drain, so an offline peer can't stall a listing. A peer whose head sync spends the whole budget still has its drain run, with `wait: false` — only blocks already on disk are read, so previously replicated rows keep surfacing instead of the read parking for a second budget. Catalog appends fire per-owner watches (`watchPeerCatalog`) that nudge foreign mirrors (§7.3) and re-drive pending downloads (§4.5).
 
 ### 4.4 Disconnect & multi-socket handling
 
@@ -786,7 +786,7 @@ The worker also **receives** `event:owned-folder-fs-event { shareId, action, rel
 |---|---|---|
 | `useProfile` | `profile:get`, `profile:set` | `event:profile-needed` |
 | `useSpaces` | `spaces:list`, `space:create`/`join`/`leave`/`invite`/`update`/`toggle-favorite` | `event:state`, `event:reconcile` (members/join-requests), `event:membership-granted`/`-denied`/`-creator-divergence` |
-| `useFiles(spaceId)` | `files:list`/`remove`/`download`/`cancel-download`/`discard-partial`/`reveal`, uploads via `addFileToSpace()` | `event:reconcile` (files + members); publish/prepare progress from `useDecorations` |
+| `useFiles(spaceId)` | `files:list`/`remove`/`download`/`cancel-download`/`discard-partial`/`reveal`, uploads via `addFileToSpace()` | `event:reconcile` (files + members), refreshes coalesced (750 ms leading+trailing); publish/prepare progress from `useDecorations` |
 | `useMembers(spaceId)` | `space:members`, `members:online`, `space:pending-requests` | `event:reconcile` (members + join-requests) |
 | `useSpaceMembers(spaceId)` | `space:members` (module-cached full roster for card facepiles) | `event:reconcile` (members) |
 | `useUpdates` | — (passive: staged update + `dismiss`) | `bridge.onPearEvent('updated')` via `updates.ts` |

--- a/src/renderer/hooks/useFiles.ts
+++ b/src/renderer/hooks/useFiles.ts
@@ -1,7 +1,8 @@
-// Owns a space's loose-file listing (stale-while-revalidate cache, latest-wins refresh) plus publish/prepare progress; re-derives on event:reconcile.
+// Owns a space's loose-file listing (stale-while-revalidate cache, latest-wins + coalesced refreshes) plus publish/prepare progress; re-derives on event:reconcile.
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { request, subscribe, addFileToSpace } from '../ipc.js'
+import { makeCoalescer } from '../coalesce.js'
 import { useToast } from '../components/toast/useToast.js'
 import { errorCodeToI18nKey } from '../errorMessages.js'
 import { Scope, scopeMatches, type Scope as ScopeType } from '../scope.js'
@@ -63,7 +64,12 @@ export function useFiles(spaceId: string) {
       setLoading(true)
     }
     setError(null)
-    refresh()
+    // One leading + one trailing files:list per 750 ms window (the coalescer useShareFiles and
+    // useSpaceStorage run): a publish emits one files hint per catalog append and a handshake
+    // emits a members poke AND a files hint, neither of which should become concurrent full
+    // fan-outs. The first trigger fires immediately, so the initial load is not delayed.
+    const coalescer = makeCoalescer(() => { void refresh() }, { intervalMs: 750 })
+    coalescer.trigger()
     // Level-triggered: re-derive on the coalesced reconcile hint for this space (emitted 1:1 with
     // the files-updated poke). A lost hint self-corrects on the next one; the list is always
     // a projection of the worker's files:list, never a client-latched status.
@@ -71,9 +77,9 @@ export function useFiles(spaceId: string) {
       // A members change (a peer's catalog key committed post-handshake) can newly reveal that
       // peer's loose files, so re-derive on it too — the handshake's pre-persist files hint races
       // the member persist, but the post-persist members poke does not.
-      if (scopeMatches(msg.scope, Scope.files(spaceId)) || scopeMatches(msg.scope, Scope.members(spaceId))) refresh()
+      if (scopeMatches(msg.scope, Scope.files(spaceId)) || scopeMatches(msg.scope, Scope.members(spaceId))) coalescer.trigger()
     })
-    return () => { unsubFiles() }
+    return () => { coalescer.cancel(); unsubFiles() }
   }, [spaceId, refresh])
 
   async function addFiles(fileList: File[]) {

--- a/src/shared/core/with-timeout.js
+++ b/src/shared/core/with-timeout.js
@@ -27,6 +27,13 @@ export function withReadTimeout(promise, ms, fallback) {
   return Promise.race([p, guard]).finally(() => clearTimeout(timer))
 }
 
+// The budget left until `deadlineAt`, never negative: an inner read that follows one that
+// already spent part of the caller's allowance derives its own bound from this, so one
+// deadline covers the whole sequence instead of each step charging the full budget again.
+export function remainingMs(deadlineAt, now = Date.now()) {
+  return Math.max(0, deadlineAt - now)
+}
+
 // Budget for reading another peer's profile bee, comfortably under the renderer's
 // 30 s IPC timeout so a single unreachable member can't stall an IPC (e.g.
 // share:list, which fans out over every member) to the point of timing out.

--- a/src/shared/shares/share-catalog.js
+++ b/src/shared/shares/share-catalog.js
@@ -8,7 +8,7 @@ import Hyperbee from 'hyperbee'
 import b4a from 'b4a'
 import { createBee, getStore, isStorageInconsistency } from '../core/store.js'
 import { getSpace, getSpaceContentKey, purgeCoreDk, purgeAlias } from '../spaces/space.js'
-import { withReadTimeout, peerReadTimeoutMs } from '../core/with-timeout.js'
+import { withReadTimeout, peerReadTimeoutMs, remainingMs } from '../core/with-timeout.js'
 import { getRuntimeConfig } from '../core/runtime-config.js'
 import { relKeyEscapes } from '../folders/path-keys.js'
 import { createLogger } from '../core/logger.js'
@@ -244,6 +244,15 @@ export function watchPeerCatalog(catalogKeyHex, listenerId, onAppend, sck = null
 // catches up on its own. Mirrors shares.js::collectPeerShares. Bounded so an
 // offline owner (head never arrives) doesn't hang the listing.
 const HEAD_TIMED_OUT = Symbol('head-timed-out')
+// Runaway guard for a drain whose budget went to the head sync. With `wait:false` the walk does
+// not wait on a peer, but a read that yields nothing still ends on this timer, so it is also
+// what a stalled owner costs on top of the budget — keep it well under one. A 5k-row catalog
+// walks in tens of milliseconds, so this is ~10x margin; a slower machine that does hit the
+// timer truncates the read, which is reported complete:false and stalled, so the renderer keeps
+// its previous list for that owner and the convergence re-poke tries again. It is also the
+// floor for a drain left with a sliver of budget, so the call can exceed `timeoutMs` by at most
+// this much.
+const LOCAL_DRAIN_MS = 250
 async function syncPeerHead(bee, timeoutMs = peerReadTimeoutMs()) {
   await bee.ready()
   const res = await withReadTimeout(bee.core.update({ wait: true }), timeoutMs, HEAD_TIMED_OUT)
@@ -258,14 +267,29 @@ async function syncPeerHead(bee, timeoutMs = peerReadTimeoutMs()) {
 // budget AND the core to hold blocks (the per-(owner,space) catalog is shared across shares + the
 // loose channel, so length>0 alone is only a global proxy); a not-yet-replicated, mid-tree-timed-out,
 // or owner-unreachable read is flagged incomplete so the renderer keeps its last good list.
+// Bounded by ONE `timeoutMs` covering head sync and drain together (a spent budget degrades the
+// drain to a local-only read), so an unreachable owner costs the caller one budget, not two.
 export async function collectPeerShare(catalogKeyHex, shareId, { sck = null, limit = Infinity, timeoutMs = peerReadTimeoutMs(), onEach = null } = {}) {
   const bee = openPeerCatalog(catalogKeyHex, sck)
   if (!bee) return { entries: [], complete: false, stalled: true, total: 0, totalBytes: 0 }
+  // ONE NETWORK budget per peer: the head sync and the drain share this deadline, so an owner
+  // whose head never arrives costs `timeoutMs` once — not once here and once more inside the
+  // drain. The drain's own timer is floored at LOCAL_DRAIN_MS, so the call can exceed the
+  // deadline by that much; past the deadline the walk is disk-only and cannot park on a peer.
+  // The flip side is that a head sync which eats most of the budget leaves the drain less time
+  // than it used to have, so a very large peer share over a slow link reports complete:false
+  // more readily — the renderer keeps its last list, which is the intended degradation.
+  const deadlineAt = Date.now() + timeoutMs
   let headSynced = false
   try { headSynced = await syncPeerHead(bee, timeoutMs) } catch { return { entries: [], complete: false, stalled: true, total: 0, totalBytes: 0 } }
   const prefix = sharePrefixKey(shareId)
-  const stream = bee.createReadStream({ gte: prefix, lt: prefix + '\xff' })
-  const { entries, complete, total, totalBytes } = await drainWithTimeout(stream, prefix, timeoutMs, limit, onEach)
+  const left = remainingMs(deadlineAt)
+  // Budget spent on the head: read only what is already on disk. hyperbee forwards `wait` to
+  // core.get, so a missing block throws instead of parking for a peer — rows we replicated
+  // before still surface (an offline owner keeps its `unavailable` rows), and the drain can
+  // never park for a second budget.
+  const stream = bee.createReadStream({ gte: prefix, lt: prefix + '\xff', wait: left > 0 })
+  const { entries, complete, total, totalBytes } = await drainWithTimeout(stream, prefix, Math.max(left, LOCAL_DRAIN_MS), limit, onEach)
   // `complete` also requires blocks (length>0) so the renderer keeps its last list over an
   // empty read; `stalled` is the narrower "the read could not finish" signal (head-sync
   // failed or the traversal timed out) — a legitimately-empty catalog is fully read, NOT

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -9,6 +9,7 @@ import { readCatalogKey } from '../shares/share-catalog.js'
 import { createLocalBee } from '../core/store.js'
 import { isOwnerOnline } from './swarm.js'
 import { listPendingForSpace } from './pending-transfers.js'
+import { markListIncomplete } from './list-deficits.js'
 import { getLocalPublicKeyHex } from '../spaces/profile.js'
 import { AppError, ErrorCodes } from '../core/errors.js'
 import { isEphemeralSourcePath } from '../folders/temp-paths.js'
@@ -281,16 +282,32 @@ async function collectLooseInPlace(spaceId, members, localPublicKey, localDriveK
   const peerMembers = (members || []).filter((m) => m?.publicKey && m.publicKey !== localPublicKey && readCatalogKey(m).keyHex)
   if (peerMembers.length === 0) return out
   const pending = new Map((await listPendingForSpace(spaceId)).map((p) => [p.filePath, p]))
-  // Interactive fan-out (files:list): bound each peer catalog read to the short interactive budget
-  // so one offline/unreachable loose peer can't freeze the list — it self-heals on the next
-  // event:files-updated once that peer's catalog replicates (mirrors share-registry's share:list).
-  // Resolve the space record ONCE and thread it into looseListPeer so its per-member SCK lookup
-  // doesn't re-read the record M times per files:list (refetched on every event:files-updated).
+  // Interactive fan-out (files:list): every member's catalog is read AT ONCE, each under the
+  // short interactive budget, so the list costs one budget in total — not one per unreachable
+  // member (the same shape as share-registry's share:list). A member whose read fails
+  // contributes no rows instead of failing the listing; it self-heals on the next
+  // event:files-updated once that peer's catalog replicates. Resolve the space record ONCE and
+  // thread it into looseListPeer so its per-member SCK lookup doesn't re-read the record M
+  // times per files:list (refetched on every event:files-updated).
   const budget = interactiveReadTimeoutMs()
   const space = await getSpace(spaceId)
-  for (const member of peerMembers) {
+  const peerEntries = await Promise.all(peerMembers.map(async (member) => {
+    try {
+      return await looseListPeer(spaceId, member, budget, space)
+    } catch (err) {
+      // Flag the space the way a stalled read does: without this the convergence tick has no
+      // reason to re-poke, so a member whose read threw would stay missing from the listing
+      // until some unrelated files-updated arrived.
+      markListIncomplete(spaceId)
+      log.warn('loose catalog read failed for', member.publicKey.slice(0, 16) + '...', '-', err.message)
+      return []
+    }
+  }))
+  // Row mapping stays sequential in member order: claim verification has side effects
+  // (stale-claim pruning) and dedupeByHash breaks ties by candidate order.
+  for (const [i, member] of peerMembers.entries()) {
     const ownerOnline = isOwnerOnline(member.publicKey)
-    for (const e of await looseListPeer(spaceId, member, budget, space)) {
+    for (const e of peerEntries[i]) {
       const drivePath = '/' + e.relPath
       if (!e.contentHash) {
         // Owner advertised before hashing finished → 'preparing' while reachable, else 'unavailable'

--- a/test/integration/list-files.test.js
+++ b/test/integration/list-files.test.js
@@ -12,6 +12,8 @@ import { getStore, createBee } from '../../src/shared/core/store.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 import { initOverlay, teardownOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
 import { initContentBackendOverlay } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
+import { LOOSE_SHARE_ID } from '../../src/shared/transfer/transfer-id.js'
+import { takeIncompleteListSpaces } from '../../src/shared/transfer/list-deficits.js'
 
 // listFiles is the source of truth for the space's loose-file list and each
 // file's status. The single-peer-observable guarantees: own files show as
@@ -73,12 +75,28 @@ test('distinct loose files are each listed', async (t) => {
   t.alike(paths, ['/a.txt', '/b.txt'], 'both distinct files listed')
 })
 
-// REGRESSION (FIX-127: files:list froze ~8s per un-replicated member). readSharePrefixes read
-// each member's profile bee SERIALLY under the 8s peerReadTimeoutMs, so a peer that handshook
-// with members whose share records hadn't replicated saw files:list block N × 8s with an empty
-// file view (the Windows-joins-last symptom). The reads now run in PARALLEL under the short
-// interactiveReadTimeoutMs, so local files surface immediately and the list self-heals via
-// event:files-updated once a peer's bee lands.
+// A member whose loose catalog we replicated once (length known) but whose blocks are gone and
+// whom nobody serves — an owner that went offline before we read its rows. createBee gives a
+// writable core; clearing its blocks reproduces "length known, data missing", and the member
+// carries the catalog key, so collectLooseInPlace admits it and the read really happens.
+async function ghostCatalogMember (i) {
+  const ghost = createBee('ghost-catalog-' + i)
+  await ghost.ready()
+  await ghost.put('file/' + LOOSE_SHARE_ID + '/g' + i + '.bin', { size: 10, mtime: 1, contentHash: 'g'.repeat(63) + i })
+  const key = b4a.toString(ghost.core.key, 'hex')
+  const len = ghost.core.length
+  await ghost.close()
+  const core = getStore().get(b4a.from(key, 'hex'))
+  await core.ready()
+  await core.clear(0, len)
+  return { publicKey: 'ghost' + i + 'pub', driveKey: null, displayName: 'G' + i, looseCatalogKey: key }
+}
+
+// REGRESSION (FIX-127: files:list froze ~8s per un-replicated member) — the members are read
+// under the short interactiveReadTimeoutMs, in PARALLEL, so local files surface immediately and
+// the list self-heals via event:files-updated once a peer's catalog lands. The fixture carries a
+// looseCatalogKey because collectLooseInPlace filters members without one BEFORE any read: a
+// keyless ghost is never read, which made the original version of this test vacuous.
 test('REGRESSION (FIX-127): files:list bounds un-replicated members by the short interactive budget, in parallel', { timeout: 15000 }, async (t) => {
   const ctx = await setup(t)
   // The short interactive budget governs the list; peerReadTimeoutMs pinned high so a revert to
@@ -90,29 +108,46 @@ test('REGRESSION (FIX-127): files:list bounds un-replicated members by the short
   fs.writeFileSync(src, 'mine')
   await addFile(ctx.spaceId, src, 'mine.txt', 4, null)
 
-  // Three ghost members: profile bees that advertise a share but never replicate it (length known,
-  // blocks cleared, no serving peer), so each prefix read parks until the budget fires.
   const ghosts = []
-  for (let i = 0; i < 3; i++) {
-    const ghost = createBee('ghost-' + i)
-    await ghost.ready()
-    await ghost.put('caps/folder-shares', true)
-    await ghost.put('share/' + ctx.spaceId + '/s' + i, { id: 's' + i, name: 'G' + i, owner: 'ghost', createdAt: Date.now() })
-    const key = b4a.toString(ghost.core.key, 'hex')
-    const len = ghost.core.length
-    await ghost.close()
-    const core = getStore().get(b4a.from(key, 'hex'))
-    await core.ready()
-    await core.clear(0, len)
-    ghosts.push({ publicKey: key, driveKey: null, displayName: 'G' + i })
-  }
+  for (let i = 0; i < 3; i++) ghosts.push(await ghostCatalogMember(i))
 
   const t0 = Date.now()
   const files = await listFiles(ctx.spaceId, ghosts)
   const dt = Date.now() - t0
 
+  t.ok(takeIncompleteListSpaces().includes(ctx.spaceId), 'the ghosts were actually read (and stalled) — not filtered out')
   // Parallel under the 500ms budget ≈ 500ms; serial would be 3 × 500 = 1500ms; the peer budget
   // (if it leaked back in) would be 30s. < 1200ms proves BOTH: the short budget AND parallel reads.
   t.ok(dt < 1200, 'bounded + parallel (' + dt + 'ms), not serial 3× or the 30s peer budget')
   t.ok(files.some((f) => f.path === '/mine.txt'), 'own file surfaces immediately despite stalled peers')
+})
+
+// REGRESSION (FIX-LIST-DEADLINE: files:list awaited each member's catalog SERIALLY, so every
+// unreachable member added a full interactive budget — six offline owners were six budgets, and
+// at the production 1.5 s budget ten of them crossed the renderer's 30 s IPC timeout. The reads
+// now fan out at once, like share:list, so the listing costs ≈ one budget however many members
+// are unreachable; the rows we can read still surface and the space is flagged for the
+// convergence re-poke.)
+test('REGRESSION (FIX-LIST-DEADLINE): six unreachable members cost one budget, not six', { timeout: 20000 }, async (t) => {
+  const ctx = await setup(t)
+  const BUDGET = 300
+  setRuntimeConfig({ ...getRuntimeConfig(), peerReadTimeoutMs: 30000, interactiveReadTimeoutMs: BUDGET })
+
+  const src = path.join(ctx.tmpDir('src'), 'mine.txt')
+  fs.writeFileSync(src, 'mine')
+  await addFile(ctx.spaceId, src, 'mine.txt', 4, null)
+
+  const ghosts = []
+  for (let i = 0; i < 6; i++) ghosts.push(await ghostCatalogMember(10 + i))
+
+  const t0 = Date.now()
+  const files = await listFiles(ctx.spaceId, ghosts)
+  const dt = Date.now() - t0
+
+  t.ok(takeIncompleteListSpaces().includes(ctx.spaceId), 'every ghost was read and stalled')
+  // Serial: 6 × 300 = 1800 ms. Parallel: ≈ 300 ms. The bound leaves room for a slow CI box while
+  // staying far below two budgets, so a revert to serial (or a second budget per peer) fails.
+  t.ok(dt < 2 * BUDGET, 'six stalled members cost about one budget (' + dt + 'ms)')
+  t.ok(files.some((f) => f.path === '/mine.txt'), 'own file listed despite six stalled peers')
+  t.is(files.filter((f) => f.path.startsWith('/g')).length, 0, 'no rows for catalogs whose blocks never arrived')
 })

--- a/test/integration/peer-catalog-budget.test.js
+++ b/test/integration/peer-catalog-budget.test.js
@@ -1,0 +1,115 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import os from 'bare-os'
+import path from 'bare-path'
+import b4a from 'b4a'
+import Corestore from 'corestore'
+import Hyperbee from 'hyperbee'
+import { freshPeer } from '../helpers/store.js'
+import { getStore } from '../../src/shared/core/store.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { collectPeerShare } from '../../src/shared/shares/share-catalog.js'
+import { LOOSE_SHARE_ID } from '../../src/shared/transfer/transfer-id.js'
+
+const BUDGET = 300
+const PREFIX = 'file/' + LOOSE_SHARE_ID + '/'
+
+// collectPeerShare's drain timer is unref'd (the worker's IPC pipe keeps the loop alive); a
+// bare test has no such handle, so Bare would report a deadlock before the budget fires.
+async function setup (t) {
+  const keep = setInterval(() => {}, 500)
+  t.teardown(() => clearInterval(keep))
+  const ctx = await freshPeer(t)
+  setRuntimeConfig({ ...getRuntimeConfig(), peerReadTimeoutMs: 30000, interactiveReadTimeoutMs: BUDGET })
+  return ctx
+}
+
+// An owner in its own store. We replicate its catalog once so our read-only copy knows the
+// length; with `readFirst` we also read the rows so their blocks land on our disk. With `depart`
+// the owner then goes away: length known, no serving peer, blocks present or missing as configured.
+async function catalogOwner (t, { readFirst = false, depart = true } = {}) {
+  const dir = path.join(os.tmpdir(), 'mirall-test-owner-' + Date.now() + '-' + Math.random().toString(36).slice(2, 8))
+  fs.mkdirSync(dir, { recursive: true })
+  const store = new Corestore(dir)
+  await store.ready()
+  const core = store.get({ name: 'catalog' })
+  await core.ready()
+  const bee = new Hyperbee(core, { keyEncoding: 'utf-8', valueEncoding: 'json' })
+  for (let k = 0; k < 3; k++) await bee.put(PREFIX + 'f' + k + '.bin', { size: 10 + k, mtime: 1, contentHash: 'h'.repeat(63) + k })
+  const key = b4a.toString(core.key, 'hex')
+  const local = getStore().get(b4a.from(key, 'hex'))
+  await local.ready()
+  const s1 = getStore().replicate(true)
+  const s2 = store.replicate(false)
+  s1.on('error', () => {})
+  s2.on('error', () => {})
+  s1.pipe(s2).pipe(s1)
+  await local.update({ wait: true })
+  if (readFirst) {
+    const mine = new Hyperbee(local, { keyEncoding: 'utf-8', valueEncoding: 'json' })
+    let n = 0
+    for await (const row of mine.createReadStream({ gte: PREFIX, lt: PREFIX + '\xff' })) if (row) n++
+    t.is(n, 3, 'rows replicated to disk before the owner leaves')
+  }
+  const leave = async () => { s1.destroy(); s2.destroy(); try { await store.close() } catch {} }
+  t.teardown(async () => { await leave(); try { fs.rmSync(dir, { recursive: true, force: true }) } catch {} })
+  if (depart) await leave()
+  return key
+}
+
+// A replication stream whose handshake never completes. Every core attached to it counts it as
+// "a peer that may still have more", so update({ wait: true }) waits on it — the state of a
+// socket mid-handshake, or of an owner whose replication side has stalled.
+function socketMidHandshake (t) {
+  const s = getStore().replicate(true)
+  s.on('error', () => {})
+  t.teardown(() => { try { s.destroy() } catch {} })
+  return s
+}
+
+// REGRESSION (FIX-LIST-DEADLINE: collectPeerShare spent `timeoutMs` on the head sync and then
+// `timeoutMs` AGAIN on the drain. An owner whose head never arrives while any socket is still
+// handshaking therefore cost two budgets — the half of the files:list timeout that parallel
+// reads alone cannot fix. Head sync and drain now share one deadline.)
+test('REGRESSION (FIX-LIST-DEADLINE): a stalled owner costs one budget, not two', { timeout: 15000 }, async (t) => {
+  await setup(t)
+  const key = await catalogOwner(t)
+  socketMidHandshake(t)
+  await new Promise((r) => setTimeout(r, 50))
+
+  const t0 = Date.now()
+  const res = await collectPeerShare(key, LOOSE_SHARE_ID, { timeoutMs: BUDGET })
+  const dt = Date.now() - t0
+
+  t.ok(res.stalled, 'the read is reported stalled')
+  t.absent(res.complete, 'and not complete')
+  t.is(res.entries.length, 0, 'no rows: the blocks never arrived')
+  // Two budgets today (~600 ms); one budget after (~300 ms). 1.5 budgets separates them.
+  t.ok(dt < 1.5 * BUDGET, 'head sync and drain share one budget (' + dt + 'ms)')
+})
+
+// Never-blank guard for the fix above: a spent budget must not blank rows we already hold. An
+// owner we listed before, now offline, keeps its rows (the renderer shows them `unavailable`).
+test('rows already on disk survive a head-sync timeout', { timeout: 15000 }, async (t) => {
+  await setup(t)
+  const key = await catalogOwner(t, { readFirst: true })
+  socketMidHandshake(t)
+  await new Promise((r) => setTimeout(r, 50))
+
+  const t0 = Date.now()
+  const res = await collectPeerShare(key, LOOSE_SHARE_ID, { timeoutMs: BUDGET })
+  const dt = Date.now() - t0
+
+  t.is(res.entries.length, 3, 'the replicated rows are returned from disk')
+  t.ok(res.stalled, 'still flagged stalled — the head could not be confirmed')
+  t.ok(dt < 1.5 * BUDGET, 'within one budget (' + dt + 'ms)')
+})
+
+test('a live owner still reads complete', async (t) => {
+  await setup(t)
+  const key = await catalogOwner(t, { depart: false })
+  const res = await collectPeerShare(key, LOOSE_SHARE_ID, { timeoutMs: BUDGET })
+  t.is(res.entries.length, 3)
+  t.ok(res.complete, 'complete on a live owner')
+  t.absent(res.stalled)
+})

--- a/test/unit/with-timeout.test.js
+++ b/test/unit/with-timeout.test.js
@@ -1,0 +1,22 @@
+import test from 'brittle'
+import { remainingMs, withReadTimeout } from '../../src/shared/core/with-timeout.js'
+
+// REGRESSION (FIX-LIST-DEADLINE: two reads in sequence each charged the caller's full budget.
+// The remaining budget is derived from one deadline and can never go negative, so a second
+// read after an exhausted first one gets 0 — a fast fallback, never a negative or full timer.)
+test('remainingMs derives the leftover budget from one deadline and clamps at zero', (t) => {
+  t.is(remainingMs(1000, 400), 600, 'what is left after the first read')
+  t.is(remainingMs(1000, 1000), 0, 'exactly spent')
+  t.is(remainingMs(1000, 1500), 0, 'overspent clamps to zero, never negative')
+})
+
+test('remainingMs defaults `now` to the wall clock', (t) => {
+  t.is(remainingMs(Date.now() - 5), 0, 'a deadline already past leaves nothing')
+  t.ok(remainingMs(Date.now() + 5000) > 4000, 'a future deadline leaves roughly its distance')
+})
+
+test('withReadTimeout still resolves to the fallback on timeout and passes values through', async (t) => {
+  const slow = new Promise(() => {})
+  t.is(await withReadTimeout(slow, 20, 'FALLBACK'), 'FALLBACK', 'a read that never settles yields the fallback')
+  t.is(await withReadTimeout(Promise.resolve('value'), 1000, 'FALLBACK'), 'value', 'a fast read passes through')
+})


### PR DESCRIPTION
## What & why
`files:list` read every member's loose catalog **serially**, and `collectPeerShare` charged the interactive budget **twice** per unreachable owner (once on the head sync, once more inside the drain). Measured under Bare: one departed owner cost 2.01 budgets, six cost 6.05, and six departed owners with a socket mid-handshake cost 12.06 — at the production 1.5 s budget, ten offline members cross the renderer's 30 s IPC timeout and the main file list fails to load.

The member reads now fan out in parallel (the shape `share:list` already had), head sync and drain share one deadline, and a spent budget degrades the drain to a local-only read (`wait:false`) so rows already replicated still surface instead of the owner's files vanishing. `useFiles` gained the same 750 ms leading+trailing coalescer `useShareFiles` and `useSpaceStorage` run. Row mapping stays sequential in member order — claim verification has side effects and `dedupeByHash` tie-breaks by candidate order.

## Coverage
Integration: repaired the previously **vacuous** `REGRESSION (FIX-127)` fixture (its ghosts carried no `looseCatalogKey`, so they were filtered out before any read — green on both sides of a revert) and added an admission guard so it cannot go vacuous again; new `peer-catalog-budget.test.js` pins the double-charge with a never-completing replicate stream as the mid-handshake socket, plus never-blank and live-owner guards. Unit: `remainingMs`. Frontend skipped — the coalescer is the same primitive two sibling hooks already use, no rendered change.

## Ran locally
Red proven by reverting only the source: 1510 ms / 1818 ms / 603 ms → 500 ms / 330 ms / 303 ms. `test:bare` 786 pass, `test:unit` 1200 pass, typecheck + `lint:ci` green. Flow: list-files-status, loose-transfer, concurrent-download, folder-listing-monotonic, loose-preparing-offline, downloaded-claim-reset, space-storage-summary, spaces-list-slim, loose-resume-reconnect — all pass.
