### PR TITLE
[fix] Bound, meter and recover: five stability findings

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -150,6 +150,25 @@ retained bytes.
 
 **Moving an init call into a `Subsystem._open` reorders it against everything else, and the code that depended on the old order fails silently.** Two of these shipped into one branch and only the flow suite saw either. `rehydrateLooseFiles()` ran ahead of the overlay instance instead of behind it, and its two sinks (`makeServable`, `enqueueLoosePublish`) both *return early* on a null `getOverlay()` — so a crash-interrupted file stayed unhashed on "Adding" forever, with the `.catch()` swallowing the evidence. `configureMemberRegistry` moved after the swarm start, leaving a window where a handshake read every peer through no-op `DEFAULT_DEPS` (`isConnected: () => false`). The shape is identical both times: a dependency expressed as a silent fallthrough rather than a throw, so reordering degrades behavior instead of breaking. When lifting a call into a subsystem, diff its new position against the old one (`git show origin/staging:<file>`) and check every collaborator it reaches for a null-guard that returns instead of throwing — those are the ones that go quiet. Restart/crash flow tests are the only layer that catches this class; unit and integration were green through both.
 
+**A parse guard is not a shape guard: `JSON.parse('null')` succeeds and returns `null`.** The
+mirall/handshake intake wrapped `JSON.parse` in a try, then read `msg.type` on the next line —
+outside it. `null` is the one input that parses cleanly and throws on the property read (`42`,
+`"s"`, `[]`, `true` all read `.type` as `undefined` harmlessly), and that throw escapes the message
+handler into protomux's `_ondata`, which `_safeDestroy`s the socket. The channel id is the public
+protocol string, so any peer on the topic could drop a connection with a four-character frame.
+Verified against real protomux: `at Object.recv (protomux/index.js:276) → Channel._recv →
+Protomux._decode → Protomux._ondata`. Decode and shape are two separate checks — after every
+`JSON.parse` of untrusted input, assert the shape (`!!v && typeof v === 'object' && !Array.isArray(v)`)
+before touching a property.
+
+**A cache of live handles needs refcounts, and the readers need them as much as the watchers.**
+Bounding `peerCatalogs` with an LRU whose `onEvict` closes the bee introduced a use-after-close: the
+read paths hold the bee across two awaits (a head sync and a get), so a catalog opened by a
+CONCURRENT read could evict and close it mid-read. Pinning the long-lived watcher was the obvious
+half and was not enough — anything holding the handle across an await has to pin it. The tell is
+that the value is a handle rather than a value: if `onEvict` does real work, every `get` that
+outlives a tick is a bug until proven otherwise.
+
 **A timer armed at module level is beyond every `close()`.** It runs at import, before any owner exists, so no shutdown path can reach it — five sites did this and every one outlived the worker's stop sequence, masked only because `Bare.exit` followed. Arm periodic work in a `Subsystem._open` through `this.timers`, which the base clears on the `'close'` event (not in `_close`: `ReadyResource` ends a failed `_open` without ever running it). An eslint selector (`moduleLevelTimerRestrictions`) and a runtime timer shim enforce both halves.
 
 **A Hyperbee or Hyperdrive whose Corestore closed underneath it still reports `closed === false`.** `ReadyResource.closed` only flips when the resource's OWN close() runs; a session closed by its store is invisible to the wrapper — only `handle.core.closed` tells the truth. So a cache cannot protect itself with a `closed` check, and a handle held across a restart is a live-looking object whose first write throws `SESSION_CLOSED`. Handles are owned by a resource that closes them, never probed by whoever cached them.

--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -145,14 +145,14 @@ Bootstrap:
 2. `installCrashBackstop(log)` — **before the first `await`**, so no boot-time rejection can abort the worker.
 3. `getBootstrapPromise()` blocks for the first `{type:'bootstrap'}` line `{ storage, appVersion, dev, fork, length, verbose }`; `setRuntimeConfig(bootstrap)`.
 4. `root = await boot(bootstrap, { ipc, log, membershipControl, publishDownloadRoots })`, which starts **two lifecycle tiers**. The **durable** tier (`bootDurable()`, exported from the same file) holds everything that must outlive the network teardown — every handle on a Corestore session, plus the recorder the teardown writes through — and is closed **last**:
-   1. `Store` → identity unlock → `migrateLocalBeesToEncrypted` → `SpaceKeysVault` → `ProfileBee` → `SpacesBee` → `DownloadsBee` → `PendingTransfersBee` → `MountsBee`.
+   1. `Store` → identity unlock → `migrateLocalBeesToEncrypted` → `SpaceKeysVault` → `ProfileBee` → `SpacesBee` → `DownloadsBee` → `PendingTransfersBee` → `MountsBee` → `IntentsBee`.
    2. `AuditLog` (bee + connectivity watch) — started before the drives, so the log is writable before anything worth recording happens. A failed start degrades to no rows; it never aborts boot.
    3. `ServeLedger`, immediately after `AuditLog` so that on the way out it flushes **before** that bee closes and while the spaces bee it reads is still open.
    4. `Catalogs` (the own/peer catalog bee caches) → `SpaceDrives` (`loadDrives`; on failure, `cleanupOrphanedData()`) → the three manifest caps → the one-time content migrations.
 
    The **runtime** tier is closed first, in reverse of this order:
    5. `MountsRuntime` is **constructed** (side-effect-free) so `OwnedFolders` can take its settle callback; then `OverlayBackend` (the overlay instance, the serve index and both download engines — constructed here rather than at module level, which is what keeps the package's import cycle free of construction), `PublishService`, `OwnedFolders`, `ForeignMirrors`, `EchoGuardPurge` and `PeerWatch` start. `ForeignMirrors` installs `setOverlayCatalogChangeHook(onPeerDriveChanged)` so a peer-catalog append promptly nudges the relevant mirror loops.
-   6. Interrupted-leave resume, download-root hydration, the membership backfill.
+   6. Interrupted-leave resume, then `intents.recover()` — the durable intent log's boot pass (§ below) — then download-root hydration and the membership backfill. Recovery runs after every reconciler has registered and before the swarm, so a topic join cannot re-arm a watcher against a space the pass is about to forget.
    7. `MemberViews` — **before** the swarms, because starting it is what wires the member registry's collaborators, and a handshake that landed while they were still the no-op defaults would read every peer as disconnected. It is also necessarily before the topic joins, so an inbound membership request cannot be handled with an unseeded tombstone set.
    8. `Swarm`, then `ContentSwarm` (which needs the control swarm's DHT node), then `applyRelayConfig()` — a relay installed on the control swarm alone leaves every file byte unrelayed. Every hook the swarm fires is a **constructor dep** (`membershipControl`, `overlayBackend`, `stalledOwners`) declared with `require()`, so a missing one fails at boot with the subsystem's name instead of being a `hook?.()` that never fires. Then the crash-leftover sweeps, the topic joins and the pending-leave replay.
    9. `MountsRuntime` **starts**: resume every owned and foreign mount, then arm the 60 s mount probe — it re-checks every mount's disk path so USB unmounts / network drops flip a share to `mount-point-gone`, and a re-appearance restarts the watcher/loop. Then `Sweeps` (presence, invite expiry, audit prune) last.
@@ -161,6 +161,25 @@ Bootstrap:
 6. Emit `event:state` (profile + spaces) — or `event:profile-needed` if onboarding hasn't happened — then `event:worker-ready`.
 
 Shutdown is driven by `Bare.IPC.on('end'|'close'|'error')` → `safeShutdown()` → `root.close()` under a 4 s hard deadline, then `Bare.exit(0)`. `close()` announces departure and halts publishing first (deliberately not in reverse order — the datagram has to leave UDX before any socket drops), waits a 150 ms flush window (**ref'd**: it is the one await on the path with no work behind it, and an unref'd timer there empties the loop for an in-process caller holding no other handle), then closes the runtime tier in reverse — there is no hand-ordered tail left — and **last** the durable tier — whose `Store._close` warns, naming any Corestore session still open, because that list is precisely the handles nobody owned. Tearing the network down is itself what emits `serve.completed` rows, which is why the ledger and the audit bee are in the tier that closes after it. In-flight downloads need no suspend step: the durable pending rows (§3.4) reconstruct resume state next run.
+
+**Durable intents.** A multi-step flow whose steps span stores writes `intent/<kind>/<id>` to the
+intents bee as its FIRST durable act and deletes it as its LAST (`core/intents.js`); a reconciler
+registered against that kind completes it idempotently at the next boot. Recording is best-effort —
+a flow that cannot write its intent still runs, losing only the recovery net, because refusing the
+user's action over a bookkeeping write would be the worse outcome. A reconciler that throws keeps
+its record for the next boot; an intent whose kind is unknown is left untouched, so a downgrade
+cannot eat a newer build's pending work. Converted so far: `owned-delete`, `foreign-unmount`.
+`space:leave` keeps its own `space.leaving` marker (load-bearing in the boot filter and the member
+fold) but shares the teardown ORDER with the boot pass through `spaces/leave-flow.js`, which is what
+the two used to encode independently and drift on.
+
+**Bounded by construction.** Three caps the review's scale findings asked for, each with a `0`
+rollback: `downloadConcurrency` (3) admits fetches through a FIFO semaphore with one express lane
+for user-initiated downloads, so a reconnect backlog cannot spawn one chunk scheduler, watchdog, fd
+and ticker per pending row; `peerFrameBurst`/`peerFrameMaxBytes` meter and size-cap EVERY peer frame
+before the decode, not just the two identity types; `peerCatalogCacheLimit` (64) bounds the open
+peer-catalog set with a refcounted LRU — watchers and in-flight reads pin their entry, because the
+cached values are live handles and `onEvict` closes them.
 
 **Two import-time rules**, both test-enforced, because anything a module does at import is beyond every `close()`:
 
@@ -956,6 +975,10 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/shared/core/store.js` | Corestore init, `createBee()` / `createDrive()` factories, and the `Store` resource that owns the store's lifetime + `openSessionNames()` |
 | `src/shared/transfer/backends/overlay/overlay-runtime.js` | `OverlayBackend` — the overlay instance, the serve index and both download engines as one lifetime; outside the package's import cycle so wiring them together adds no edge to it |
 | `src/shared/core/timers.js` | `createTimers()` — an owned timer set that clears on close and refuses to schedule after it |
+| `src/shared/core/intents.js` | `createIntentLog()` — durable intent records + the per-kind reconcilers boot dispatches |
+| `src/shared/core/lru.js` | `createRefCountedLru()` — bounded cache of live handles; an entry with readers is never evicted |
+| `src/shared/spaces/leave-flow.js` | `runLeaveTeardown()` — the one teardown ORDER the live leave and the boot pass share |
+| `src/worker/ipc/space-leave.js` | `registerSpaceLeave(ipc, deps)` — the space:leave handler as a module, the first seam out of the entrypoint |
 | `src/worker/package.json` | `"type": "module"` so Bare imports the worker as ESM |
 | `src/shared/` | Worker data layer (below); `invite-envelope.js` is also dynamically imported by main |
 | `src/renderer/` | Renderer source (TS + React → `assets/dist/`) |

--- a/src/shared/core/concurrency.js
+++ b/src/shared/core/concurrency.js
@@ -11,3 +11,61 @@ export async function mapLimit(items, limit, fn) {
   await Promise.all(Array.from({ length: Math.min(limit, items.length) }, worker))
   return out
 }
+
+// Counting semaphore with FIFO waiters and an express lane on top of the limit. Work the user just
+// asked for takes the express lane, so a click never queues behind a backlog of automatic resumes.
+// `limit` is read per acquire, so a config change takes effect without a restart; a limit of 0 (or
+// less) admits everything, which is the rollback path.
+export function createSemaphore({ limit, expressLanes = 1 } = {}) {
+  const capOf = typeof limit === 'function' ? limit : () => limit
+  const waiters = []
+  let held = 0
+  let expressHeld = 0
+
+  const roomFor = (express) => {
+    const cap = capOf()
+    if (!(cap > 0)) return true
+    if (held - expressHeld < cap) return true
+    return express && expressHeld < expressLanes
+  }
+
+  function release(w) {
+    if (w.released) return
+    w.released = true
+    held -= 1
+    if (w.express) expressHeld -= 1
+    pump()
+  }
+
+  function admit(w) {
+    held += 1
+    if (w.express) expressHeld += 1
+    return () => release(w)
+  }
+
+  function pump() {
+    for (let i = 0; i < waiters.length; i++) {
+      if (!roomFor(waiters[i].express)) continue
+      const [w] = waiters.splice(i, 1)
+      i -= 1
+      w.resolve(admit(w))
+    }
+  }
+
+  return {
+    acquire({ express = false } = {}) {
+      const w = { express, released: false, resolve: null }
+      if (roomFor(express)) return Promise.resolve(admit(w))
+      return new Promise((resolve) => {
+        w.resolve = resolve
+        waiters.push(w)
+      })
+    },
+    stats: () => ({ held, queued: waiters.length, express: expressHeld }),
+    // Shutdown: hand every queued caller a no-op release so a parked acquire cannot hold close()
+    // past the stop deadline. They resume and find their own cancelled/stopping checks.
+    drain() {
+      while (waiters.length) waiters.shift().resolve(() => {})
+    },
+  }
+}

--- a/src/shared/core/intent-store.js
+++ b/src/shared/core/intent-store.js
@@ -1,0 +1,27 @@
+import { createBee } from './store.js'
+import { Subsystem } from './subsystem.js'
+
+let bee
+
+export async function initIntents() {
+  bee = createBee('intents')
+  await bee.ready()
+}
+
+export function getIntentsBee() {
+  if (!bee) throw new Error('intents bee not open')
+  return bee
+}
+
+// A bee of its own rather than a prefix on an existing one: intents span spaces, mounts and
+// transfers, so hanging them off any one of those would tie a flow's recoverability to that
+// store's lifetime. Durable tier — it must outlive every runtime subsystem whose flow it records.
+export class IntentsBee extends Subsystem {
+  async _open() { await initIntents() }
+
+  async _close() {
+    const b = bee
+    bee = undefined
+    await b?.close()
+  }
+}

--- a/src/shared/core/intents.js
+++ b/src/shared/core/intents.js
@@ -1,0 +1,88 @@
+// Durable intent log: a multi-step flow writes what it is about to do as its FIRST durable act and
+// deletes the record as its LAST, so a crash anywhere between them leaves something the next boot
+// can finish. The rule "durable fact first" was already stated independently at four sites, each
+// after its own bug; this is that rule as one mechanism instead of four.
+//
+// No domain knowledge and no bare-* imports: the bee arrives as a dependency, so this unit-tests
+// under Node and the reconcilers live with the flows they complete.
+export const INTENT_PREFIX = 'intent/'
+
+let seq = 0
+
+export function intentId(kind) {
+  return `${INTENT_PREFIX}${kind}/${Date.now()}-${seq++}`
+}
+
+export function createIntentLog({ bee, log } = {}) {
+  const reconcilers = new Map()
+
+  return {
+    register(kind, complete) {
+      if (reconcilers.has(kind)) throw new Error(`duplicate intent reconciler: ${kind}`)
+      reconcilers.set(kind, complete)
+    },
+
+    // Refusing an unregistered kind here turns a typo at the call site into a boot-time failure
+    // rather than an orphan record nothing will ever complete.
+    async begin(kind, args) {
+      if (!reconcilers.has(kind)) throw new Error(`no reconciler registered for intent: ${kind}`)
+      const id = intentId(kind)
+      await bee().put(id, { kind, args, at: Date.now() })
+      return id
+    },
+
+    // Best-effort: a flow that cannot record its intent still runs, it just loses the recovery net
+    // and behaves exactly as it did before intents existed. Refusing the user's delete because a
+    // bookkeeping write failed would be a worse outcome than the crash window it guards against —
+    // the same call the leave marker already makes (space.js's markSpaceLeavingDurable).
+    async beginOrNull(kind, args) {
+      try {
+        return await this.begin(kind, args)
+      } catch (err) {
+        log?.warn('could not record the intent — the flow runs unprotected:', kind, '-', err.message)
+        return null
+      }
+    },
+
+    // Tolerates null so a caller that failed to record does not have to branch, and never throws:
+    // the work is already done, and a surviving record is only ever re-run idempotently.
+    async complete(id) {
+      if (!id) return
+      try {
+        await bee().del(id)
+      } catch (err) {
+        log?.warn('could not clear a completed intent — it will re-run harmlessly next boot:', '-', err.message)
+      }
+    },
+
+    async list() {
+      const out = []
+      for await (const node of bee().createReadStream({ gte: INTENT_PREFIX, lt: INTENT_PREFIX + '\xff' })) {
+        out.push({ id: node.key, ...node.value })
+      }
+      return out
+    },
+
+    // Per-intent isolation: one wedged kind must not strand the rest. A reconciler that throws
+    // KEEPS its record for the next boot; an intent whose kind is unknown is left untouched, so an
+    // older build can never eat a newer one's record.
+    async recover() {
+      for (const intent of await this.list()) {
+        const complete = reconcilers.get(intent.kind)
+        if (!complete) {
+          log?.warn('intent has no reconciler, leaving it for a build that has one:', intent.kind)
+          continue
+        }
+        try {
+          await complete(intent.args)
+          await bee().del(intent.id)
+          log?.info('completed interrupted intent:', intent.kind)
+        } catch (err) {
+          log?.warn('intent recovery failed, retrying next boot:', intent.kind, '-', err.message)
+        }
+      }
+    },
+
+    kinds: () => [...reconcilers.keys()],
+  }
+}

--- a/src/shared/core/ipc.js
+++ b/src/shared/core/ipc.js
@@ -38,6 +38,29 @@ export function scopeForEvent(type, payload = {}) {
   return toScope ? toScope(payload) : null
 }
 
+// Codes that are ordinary control flow rather than faults: the user cancelled, or a bounded read
+// gave up as designed. Logging these at warn would teach the reader to ignore the level.
+// ECANCELLED is real (overlay-backend stamps it on an aborted read). PREVIEW_CANCELLED is the
+// renderer's declared contract — two modals branch on it — that the worker does not actually throw
+// yet; it is listed so the classification is already right when that gap is closed.
+const EXPECTED_CODES = new Set(['ECANCELLED', 'PREVIEW_CANCELLED'])
+
+// The code half is a closed set, but the type half is whatever the renderer sent — an unknown
+// command is counted under its requested name, so a buggy or looping caller could otherwise grow
+// this map without bound. Unknown types collapse into one bucket, and the map is capped.
+const MAX_FAILURE_KEYS = 256
+const requestFailures = new Map()
+
+export function getRequestFailureCounters() {
+  const out = {}
+  for (const [key, n] of requestFailures) out[key] = n
+  return out
+}
+
+export function resetRequestFailureCounters() {
+  requestFailures.clear()
+}
+
 export function createIPC(pipe) {
   const handlers = new Map()
   const queued = []
@@ -78,7 +101,10 @@ export function createIPC(pipe) {
   function dispatch(msg) {
     const handler = handlers.get(msg.type)
     if (!handler) {
-      log.debug('req', msg.type, '— no handler')
+      // warn, not debug: the renderer asking for a handler that does not exist is a contract
+      // break, and at the default level a debug line means nobody ever learns of it.
+      log.warn('req-unknown', msg.type)
+      countFailure('unknown-command', 'NOT_FOUND')
       respond(msg.id, null, `Unknown command: ${msg.type}`, 'NOT_FOUND')
       return
     }
@@ -89,8 +115,26 @@ export function createIPC(pipe) {
     log.debug('req', label)
     Promise.resolve(handler(msg)).then(
       (data) => { log.debug('res', label, 'ok', `${Date.now() - started}ms`); respond(msg.id, data) },
-      (err) => { log.debug('res', label, 'ERROR', err.message, `${Date.now() - started}ms`); respond(msg.id, null, err.message, err.code || 'UNKNOWN') }
+      (err) => {
+        const code = err?.code || 'UNKNOWN'
+        countFailure(msg.type, code)
+        // A failing request is logged at warn so it survives the default level. Successes stay at
+        // debug: they are the verbose trace, and only wanted when someone asked for it.
+        const line = ['req-failed', label, `code=${code}`, `ms=${Date.now() - started}`, err?.message || String(err)]
+        if (EXPECTED_CODES.has(code)) log.debug(...line)
+        else log.warn(...line)
+        respond(msg.id, null, err?.message, code)
+      }
     )
+  }
+
+  function countFailure(type, code) {
+    const key = `${type}:${code}`
+    if (!requestFailures.has(key) && requestFailures.size >= MAX_FAILURE_KEYS) {
+      requestFailures.set('other:OVERFLOW', (requestFailures.get('other:OVERFLOW') || 0) + 1)
+      return
+    }
+    requestFailures.set(key, (requestFailures.get(key) || 0) + 1)
   }
 
   function respond(id, data, error, code) {

--- a/src/shared/core/lru.js
+++ b/src/shared/core/lru.js
@@ -1,0 +1,60 @@
+// Insertion-ordered Map as an LRU: delete+set moves a key to the end, so the first key is the
+// oldest. Refcounted because the values here are live handles — an entry a caller is currently
+// reading must never be closed underneath it, so eviction only ever considers refs === 0.
+// A limit of 0 (or less) never evicts, which is the unbounded behaviour this replaces.
+export function createRefCountedLru({ limit, onEvict = () => {} } = {}) {
+  const capOf = typeof limit === 'function' ? limit : () => limit
+  const entries = new Map()
+
+  function evictIfNeeded() {
+    const cap = capOf()
+    if (!(cap > 0)) return
+    for (const [key, entry] of [...entries]) {
+      if (entries.size <= cap) return
+      if (entry.refs > 0) continue
+      entries.delete(key)
+      onEvict(key, entry.value)
+    }
+  }
+
+  return {
+    get(key) {
+      const entry = entries.get(key)
+      if (!entry) return null
+      entries.delete(key)
+      entries.set(key, entry)
+      return entry.value
+    },
+    set(key, value) {
+      const existing = entries.get(key)
+      entries.delete(key)
+      entries.set(key, { value, refs: existing ? existing.refs : 0 })
+      evictIfNeeded()
+    },
+    // Pins an entry for as long as something holds it. Balanced by release(); an unbalanced
+    // acquire pins the entry for the life of the process, which is a leak, not a crash.
+    acquire(key) {
+      const entry = entries.get(key)
+      if (!entry) return null
+      entry.refs += 1
+      return entry.value
+    },
+    release(key) {
+      const entry = entries.get(key)
+      if (entry && entry.refs > 0) entry.refs -= 1
+      evictIfNeeded()
+    },
+    delete(key) {
+      const entry = entries.get(key)
+      if (!entry) return null
+      entries.delete(key)
+      return entry.value
+    },
+    has: (key) => entries.has(key),
+    size: () => entries.size,
+    keys: () => [...entries.keys()],
+    refsOf: (key) => entries.get(key)?.refs ?? 0,
+    clear() { entries.clear() },
+    values: () => [...entries.values()].map((e) => e.value),
+  }
+}

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -66,6 +66,9 @@ const DEFAULTED = {
   // Concurrent overlay downloads. A reconnect can have hundreds of pending rows and each running
   // fetch owns a chunk scheduler, a watchdog, an fd and a progress ticker. 0 disables the gate.
   downloadConcurrency: 3,
+  // Open peer catalogs kept cached. Each is a Hyperbee + Hypercore session with an append listener,
+  // and every open core replicates to every socket. 0 = unbounded (the previous behaviour).
+  peerCatalogCacheLimit: 64,
   // Only topic-MATCHED identity frames charge this lane (the receiver resolves the topic
   // before charging). An honest connection sends one frame per shared space, we reciprocate
   // each, and a name change or ledger re-send can add a third inside one refill window — so
@@ -302,6 +305,10 @@ export function getPeerFrameLimits() {
     refillMs: finiteAtLeast(c.peerFrameRefillMs, 1, DEFAULTED.peerFrameRefillMs),
     abuseThreshold: finiteAtLeast(c.peerFrameAbuseThreshold, 1, DEFAULTED.peerFrameAbuseThreshold),
   }
+}
+
+export function getPeerCatalogCacheLimit() {
+  return finiteAtLeast(config.peerCatalogCacheLimit, 0, DEFAULTED.peerCatalogCacheLimit)
 }
 
 export function getDownloadConcurrency() {

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -80,6 +80,13 @@ const DEFAULTED = {
   handshakeAbuseThreshold: 24,
   // Frames naming a topic we did not join: dropped before any signature verify, so the lane
   // can be generous (mirrors the overlay serve limiter). Bans only on a sustained flood.
+  // Every peer frame is metered on a general lane, not just the two identity types. Presence is
+  // the busiest honest source at one frame per (peer, space) per 5 s, so 256/20ms leaves an order
+  // of magnitude of headroom. peerFrameBurst 0 switches the lane off; peerFrameMaxBytes 0 the cap.
+  peerFrameMaxBytes: 65536,
+  peerFrameBurst: 256,
+  peerFrameRefillMs: 20,
+  peerFrameAbuseThreshold: 512,
   handshakeUnmatchedBurst: 32,
   handshakeUnmatchedRefillMs: 250,
   handshakeUnmatchedAbuseThreshold: 256,
@@ -282,6 +289,19 @@ export function getPublishConcurrency() {
   if (n === Infinity) return Infinity
   if (typeof n === 'number' && Number.isFinite(n) && n >= 1) return Math.floor(n)
   return DEFAULTED.publishConcurrency
+}
+
+export function getPeerFrameMaxBytes() {
+  return finiteAtLeast(config.peerFrameMaxBytes, 0, DEFAULTED.peerFrameMaxBytes)
+}
+
+export function getPeerFrameLimits() {
+  const c = config
+  return {
+    burst: finiteAtLeast(c.peerFrameBurst, 0, DEFAULTED.peerFrameBurst),
+    refillMs: finiteAtLeast(c.peerFrameRefillMs, 1, DEFAULTED.peerFrameRefillMs),
+    abuseThreshold: finiteAtLeast(c.peerFrameAbuseThreshold, 1, DEFAULTED.peerFrameAbuseThreshold),
+  }
 }
 
 export function getDownloadConcurrency() {

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -63,6 +63,9 @@ const DEFAULTED = {
   // 2 overlaps one file's reads with another's hashing, beyond that gains nothing. The scheduler
   // clamps to >= 1.
   publishConcurrency: 2,
+  // Concurrent overlay downloads. A reconnect can have hundreds of pending rows and each running
+  // fetch owns a chunk scheduler, a watchdog, an fd and a progress ticker. 0 disables the gate.
+  downloadConcurrency: 3,
   // Only topic-MATCHED identity frames charge this lane (the receiver resolves the topic
   // before charging). An honest connection sends one frame per shared space, we reciprocate
   // each, and a name change or ledger re-send can add a third inside one refill window — so
@@ -279,6 +282,12 @@ export function getPublishConcurrency() {
   if (n === Infinity) return Infinity
   if (typeof n === 'number' && Number.isFinite(n) && n >= 1) return Math.floor(n)
   return DEFAULTED.publishConcurrency
+}
+
+export function getDownloadConcurrency() {
+  const n = config.downloadConcurrency
+  if (typeof n === 'number' && Number.isFinite(n) && n >= 0) return Math.floor(n)
+  return DEFAULTED.downloadConcurrency
 }
 
 export function getPublishOrder() {

--- a/src/shared/shares/share-catalog.js
+++ b/src/shared/shares/share-catalog.js
@@ -9,10 +9,11 @@ import b4a from 'b4a'
 import { createBee, getStore, isStorageInconsistency } from '../core/store.js'
 import { getSpace, getSpaceContentKey, purgeCoreDk, purgeAlias } from '../spaces/space.js'
 import { withReadTimeout, peerReadTimeoutMs, remainingMs } from '../core/with-timeout.js'
-import { getRuntimeConfig } from '../core/runtime-config.js'
+import { getRuntimeConfig, getPeerCatalogCacheLimit } from '../core/runtime-config.js'
 import { relKeyEscapes } from '../folders/path-keys.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { createRefCountedLru } from '../core/lru.js'
 
 const log = createLogger('share-catalog')
 
@@ -24,7 +25,14 @@ const log = createLogger('share-catalog')
 export const FILE_PREFIX = 'file/'
 
 const ownCatalogs = new Map()   // spaceId -> Hyperbee (writable)
-const peerCatalogs = new Map()  // catalogKeyHex -> Hyperbee (read-only)
+// Bounded: one Hyperbee + Hypercore session per (peer, space), each with an append listener, and
+// every open core replicates to every socket. Unbounded it grew to peers x spaces and was reclaimed
+// only on leave. A watched catalog is PINNED — evicting one would silently stop the mirror loop its
+// append listener drives, trading a memory bound for a correctness bug.
+const peerCatalogs = createRefCountedLru({
+  limit: () => getPeerCatalogCacheLimit(),
+  onEvict: (keyHex, bee) => { bee.close().catch(() => {}) },
+})
 
 export function fileKey(shareId, relPath) {
   return FILE_PREFIX + shareId + '/' + relPath
@@ -230,6 +238,9 @@ export function watchPeerCatalog(catalogKeyHex, listenerId, onAppend, sck = null
     if (!bee) return null
     w = { ids: new Set(), cbs: new Set(), bee }
     peerCatalogWatchers.set(catalogKeyHex, w)
+    // Pin for the watcher's lifetime: the listener below is the mirror loop's level signal, and a
+    // cache eviction that closed this bee would stop it with no error anywhere.
+    peerCatalogs.acquire(catalogKeyHex)
     bee.core.on('append', () => { for (const cb of w.cbs) cb(bee) })
   }
   if (!w.ids.has(listenerId)) {
@@ -273,30 +284,37 @@ async function syncPeerHead(bee, timeoutMs = peerReadTimeoutMs()) {
 export async function collectPeerShare(catalogKeyHex, shareId, { sck = null, limit = Infinity, timeoutMs = peerReadTimeoutMs(), onEach = null } = {}) {
   const bee = openPeerCatalog(catalogKeyHex, sck)
   if (!bee) return { entries: [], complete: false, stalled: true, total: 0, totalBytes: 0 }
-  // ONE NETWORK budget per peer: the head sync and the drain share this deadline, so an owner
-  // whose head never arrives costs `timeoutMs` once — not once here and once more inside the
-  // drain. The drain's own timer is floored at LOCAL_DRAIN_MS, so the call can exceed the
-  // deadline by that much; past the deadline the walk is disk-only and cannot park on a peer.
-  // The flip side is that a head sync which eats most of the budget leaves the drain less time
-  // than it used to have, so a very large peer share over a slow link reports complete:false
-  // more readily — the renderer keeps its last list, which is the intended degradation.
-  const deadlineAt = Date.now() + timeoutMs
-  let headSynced = false
-  try { headSynced = await syncPeerHead(bee, timeoutMs) } catch { return { entries: [], complete: false, stalled: true, total: 0, totalBytes: 0 } }
-  const prefix = sharePrefixKey(shareId)
-  const left = remainingMs(deadlineAt)
-  // Budget spent on the head: read only what is already on disk. hyperbee forwards `wait` to
-  // core.get, so a missing block throws instead of parking for a peer — rows we replicated
-  // before still surface (an offline owner keeps its `unavailable` rows), and the drain can
-  // never park for a second budget.
-  const stream = bee.createReadStream({ gte: prefix, lt: prefix + '\xff', wait: left > 0 })
-  const { entries, complete, total, totalBytes } = await drainWithTimeout(stream, prefix, Math.max(left, LOCAL_DRAIN_MS), limit, onEach)
-  // `complete` also requires blocks (length>0) so the renderer keeps its last list over an
-  // empty read; `stalled` is the narrower "the read could not finish" signal (head-sync
-  // failed or the traversal timed out) — a legitimately-empty catalog is fully read, NOT
-  // stalled, so a re-poll backstop keyed on stalled won't churn on a zero-share peer.
-  const traversed = headSynced && complete
-  return { entries, total, totalBytes, complete: traversed && bee.core.length > 0, stalled: !traversed }
+  // Pinned for the length of the read: the body awaits, and an eviction triggered by a
+  // concurrent open would otherwise close this bee underneath the gets below.
+  peerCatalogs.acquire(catalogKeyHex)
+  try {
+    // ONE NETWORK budget per peer: the head sync and the drain share this deadline, so an owner
+    // whose head never arrives costs `timeoutMs` once — not once here and once more inside the
+    // drain. The drain's own timer is floored at LOCAL_DRAIN_MS, so the call can exceed the
+    // deadline by that much; past the deadline the walk is disk-only and cannot park on a peer.
+    // The flip side is that a head sync which eats most of the budget leaves the drain less time
+    // than it used to have, so a very large peer share over a slow link reports complete:false
+    // more readily — the renderer keeps its last list, which is the intended degradation.
+    const deadlineAt = Date.now() + timeoutMs
+    let headSynced = false
+    try { headSynced = await syncPeerHead(bee, timeoutMs) } catch { return { entries: [], complete: false, stalled: true, total: 0, totalBytes: 0 } }
+    const prefix = sharePrefixKey(shareId)
+    const left = remainingMs(deadlineAt)
+    // Budget spent on the head: read only what is already on disk. hyperbee forwards `wait` to
+    // core.get, so a missing block throws instead of parking for a peer — rows we replicated
+    // before still surface (an offline owner keeps its `unavailable` rows), and the drain can
+    // never park for a second budget.
+    const stream = bee.createReadStream({ gte: prefix, lt: prefix + '\xff', wait: left > 0 })
+    const { entries, complete, total, totalBytes } = await drainWithTimeout(stream, prefix, Math.max(left, LOCAL_DRAIN_MS), limit, onEach)
+    // `complete` also requires blocks (length>0) so the renderer keeps its last list over an
+    // empty read; `stalled` is the narrower "the read could not finish" signal (head-sync
+    // failed or the traversal timed out) — a legitimately-empty catalog is fully read, NOT
+    // stalled, so a re-poll backstop keyed on stalled won't churn on a zero-share peer.
+    const traversed = headSynced && complete
+    return { entries, total, totalBytes, complete: traversed && bee.core.length > 0, stalled: !traversed }
+  } finally {
+    peerCatalogs.release(catalogKeyHex)
+  }
 }
 
 export async function listPeerShareMeta(catalogKeyHex, shareId, { sck = null } = {}) {
@@ -321,10 +339,17 @@ export function classifyEntryNode(node) {
 export async function getPeerEntryState(catalogKeyHex, shareId, relPath, { sck = null } = {}) {
   const bee = openPeerCatalog(catalogKeyHex, sck)
   if (!bee) return null
-  try { await syncPeerHead(bee) } catch { return null }
-  const node = await withReadTimeout(bee.get(fileKey(shareId, relPath)), peerReadTimeoutMs(), null)
-  const state = classifyEntryNode(node)
-  return state ? { relPath, ...state } : null
+  // Pinned across the head sync and the get: both await, and an eviction from a concurrent open
+  // would close this bee mid-read.
+  peerCatalogs.acquire(catalogKeyHex)
+  try {
+    try { await syncPeerHead(bee) } catch { return null }
+    const node = await withReadTimeout(bee.get(fileKey(shareId, relPath)), peerReadTimeoutMs(), null)
+    const state = classifyEntryNode(node)
+    return state ? { relPath, ...state } : null
+  } finally {
+    peerCatalogs.release(catalogKeyHex)
+  }
 }
 
 export async function getPeerEntry(catalogKeyHex, shareId, relPath, opts = {}) {
@@ -332,11 +357,20 @@ export async function getPeerEntry(catalogKeyHex, shareId, relPath, opts = {}) {
   return state && !state.removed ? { relPath: state.relPath, size: state.size, mtime: state.mtime, contentHash: state.contentHash, seq: state.seq } : null
 }
 
+// The cache's shape, for the tests that pin the bound and the watcher pin. Not a reset seam: it
+// reads, it does not mutate.
+export function peerCatalogCacheStats() {
+  return { size: peerCatalogs.size(), keys: peerCatalogs.keys(), refsOf: (k) => peerCatalogs.refsOf(k) }
+}
+
 export function dropCatalog(spaceId, catalogKeyHex) {
   if (spaceId) ownCatalogs.delete(spaceId)
   if (catalogKeyHex) {
-    peerCatalogs.delete(catalogKeyHex)
-    peerCatalogWatchers.delete(catalogKeyHex)
+    if (peerCatalogWatchers.delete(catalogKeyHex)) peerCatalogs.release(catalogKeyHex)
+    // Closed, not just forgotten: dropping the reference alone left the core session open for the
+    // life of the process, and every open core replicates to every socket. Fire-and-forget because
+    // every caller is synchronous; a close failure means the store is already going down.
+    peerCatalogs.delete(catalogKeyHex)?.close().catch(() => {})
   }
 }
 
@@ -443,7 +477,7 @@ export class Catalogs extends Subsystem {
   // refused: throwing here would turn a shutdown that ran out of budget into an app that will
   // not start.
   async _open() {
-    const stale = ownCatalogs.size + peerCatalogs.size
+    const stale = ownCatalogs.size + peerCatalogs.size()
     if (stale) {
       this.log.warn(`dropping ${stale} catalog handle(s) left by a previous instance`)
       await this._closeAll()

--- a/src/shared/spaces/leave-flow.js
+++ b/src/shared/spaces/leave-flow.js
@@ -1,0 +1,27 @@
+// The order of a space teardown, shared by the two callers that run it: the live space:leave
+// handler and boot's interrupted-leave pass. They differ in what each step DOES — the live path
+// also stops in-memory machinery (watchers, publish lanes, mirror loops) that a fresh boot has
+// none of — so each supplies its own steps and this module owns only the sequence and the policy.
+// Owning the sequence is the point: the two used to encode it independently and drift.
+//
+// Step 1 is the hard gate for the boot caller: co-member convergence depends on the durable
+// departure, so a throw there must keep the intent for the next boot rather than continue to the
+// forget. Steps 2-4 are best-effort, so one bad record cannot strand the others or the forget.
+export const LEAVE_PHASES = ['clearOwnMembership', 'ownedMounts', 'shares', 'foreignMounts', 'forget']
+
+export async function runLeaveTeardown(spaceId, steps, { log, onPhase = () => {} } = {}) {
+  onPhase('clearOwnMembership')
+  await steps.clearMembership()
+
+  for (const phase of ['ownedMounts', 'shares', 'foreignMounts']) {
+    onPhase(phase)
+    try {
+      await steps[phase]()
+    } catch (err) {
+      log?.warn(`leave: ${phase} step failed:`, spaceId, '-', err.message)
+    }
+  }
+
+  onPhase('forget')
+  await steps.forget()
+}

--- a/src/shared/spaces/profile.js
+++ b/src/shared/spaces/profile.js
@@ -86,9 +86,14 @@ export function getIdentitySigner() {
 // snapshot sessions hyperbee opens per get) settles with REQUEST_TIMEOUT instead of waiting for a
 // block that may never arrive — so an abandoned read cannot pin the core through a hung batch.
 // 0 keeps hypercore's default (wait forever), which the long-lived holders want.
-export function openProfileBee(publicKeyBuffer, { timeoutMs = 0 } = {}) {
+// `active` marks the session as one that wants replication. An inactive session does not count
+// toward the core's replicator activity, so the core is not force-attached to every open muxer
+// (corestore's per-connection attach pass skips it). Defaults TRUE so every syncing read behaves
+// exactly as before: a read that needs blocks and opens inactive would simply never get them.
+export function openProfileBee(publicKeyBuffer, { timeoutMs = 0, active = true } = {}) {
   const store = getStore()
-  const core = timeoutMs ? store.get({ key: publicKeyBuffer, timeout: timeoutMs }) : store.get(publicKeyBuffer)
+  const opts = { key: publicKeyBuffer, ...(timeoutMs ? { timeout: timeoutMs } : {}), ...(active ? {} : { active: false }) }
+  const core = (timeoutMs || !active) ? store.get(opts) : store.get(publicKeyBuffer)
   return new Hyperbee(core, {
     keyEncoding: 'utf-8',
     valueEncoding: 'json',
@@ -462,13 +467,16 @@ export async function withPeerBee(profileKeyHex, fn, {
   fallback = null,
   sync = true,
 } = {}) {
+  // A read that does not sync is answerable from local blocks by construction, so its session has
+  // no reason to advertise the core to every connected peer for the length of the read.
+  const active = sync
   const deadline = Date.now() + timeoutMs
   let bee = null
   try {
     // Inside the try: a malformed key or a store closing during shutdown must degrade to the
     // fallback like any other unreadable peer, not reject into a caller that has no catch
     // (buildWantedKeys awaits this bare, and one throw would abort the whole leftover scan).
-    bee = openProfileBee(b4a.from(profileKeyHex, 'hex'), { timeoutMs })
+    bee = openProfileBee(b4a.from(profileKeyHex, 'hex'), { timeoutMs, active })
     await bee.ready()
     if (sync) await boundedUpdate(bee.core, Math.max(0, deadline - Date.now()))
     return await withReadTimeout(fn(bee), Math.max(0, deadline - Date.now()), fallback)

--- a/src/shared/spaces/space.js
+++ b/src/shared/spaces/space.js
@@ -12,6 +12,7 @@ import { readOwnShares, tombstoneShare } from '../shares/shares.js'
 import crypto from 'hypercore-crypto'
 import b4a from 'b4a'
 import keysMod from 'hypercore-storage/lib/keys.js'
+import { runLeaveTeardown } from './leave-flow.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record } from '../audit/audit-log.js'
@@ -398,29 +399,23 @@ export function markSpaceLeavingDurable(spaceId) {
 // (a throw keeps the marker so the next boot retries it — co-member convergence depends on it);
 // the mount/share steps are best-effort so one bad record can't strand the others or the forget.
 export async function resumeInterruptedLeave(spaceId) {
-  await clearOwnMembership(spaceId)
-  try {
-    for (const m of (await listOwnedMounts()).filter((x) => x.spaceId === spaceId)) {
-      await deleteOwnedMount(spaceId, m.shareId)
-    }
-  } catch (err) {
-    log.warn('resume leave: owned-mount cleanup failed:', spaceId, '-', err.message)
-  }
-  try {
-    for (const s of await readOwnShares(spaceId)) {
-      await tombstoneShare(spaceId, s.id)
-    }
-  } catch (err) {
-    log.warn('resume leave: share tombstoning failed:', spaceId, '-', err.message)
-  }
-  try {
-    for (const m of (await listForeignMounts()).filter((x) => x.spaceId === spaceId)) {
-      await deleteForeignMount(spaceId, m.shareId)
-    }
-  } catch (err) {
-    log.warn('resume leave: foreign-mount cleanup failed:', spaceId, '-', err.message)
-  }
-  await forgetSpaceRecord(spaceId)
+  await runLeaveTeardown(spaceId, {
+    clearMembership: () => clearOwnMembership(spaceId),
+    ownedMounts: async () => {
+      for (const m of (await listOwnedMounts()).filter((x) => x.spaceId === spaceId)) {
+        await deleteOwnedMount(spaceId, m.shareId)
+      }
+    },
+    shares: async () => {
+      for (const s of await readOwnShares(spaceId)) await tombstoneShare(spaceId, s.id)
+    },
+    foreignMounts: async () => {
+      for (const m of (await listForeignMounts()).filter((x) => x.spaceId === spaceId)) {
+        await deleteForeignMount(spaceId, m.shareId)
+      }
+    },
+    forget: () => forgetSpaceRecord(spaceId),
+  }, { log })
 }
 
 // Durable, LOCAL-only leave tombstones: we record that we observed a peer leave a space so the

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -599,6 +599,7 @@ export async function overlayRequestDownload(spaceId, share, relPath) {
   const prev = await getPendingFor(spaceId, drivePath)
   const finalPath = reuseDest(prev?.finalPath, getDownloadDir(spaceId), path.basename(relPath))
   return engine().start({
+    express: true,
     spaceId, pendingKey: drivePath, path: drivePath, relPath, shareId: share.id, ...catalogKeyField(keyHex, encrypted),
     transferId: transferIdFor(spaceId, share.id, relPath),
     contentHash: entry.contentHash, size: entry.size || 0, sourceSeq: entry.seq,

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -18,6 +18,8 @@ import { makeProgressTicker } from '../../progress-ticker.js'
 import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js'
 import { republishDecision } from '../../supersede-decision.js'
 import { makeKeyedCoalescer } from '../../../state/coalesce.js'
+import { createSemaphore } from '../../../core/concurrency.js'
+import { getDownloadConcurrency } from '../../../core/runtime-config.js'
 import { ErrorCodes, classifyTransferError, isLocalDestFault } from '../../../core/errors.js'
 import { createLogger } from '../../../core/logger.js'
 
@@ -132,6 +134,9 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   // attempts that banked no new bytes, so a throttled holder (which always banks some) retries
   // indefinitely while a wedged one gives up.
   const stallRetries = new Map()
+  // Bounds how many fetches own a chunk scheduler, a watchdog, an fd and a ticker at once.
+  // A user-initiated job takes the express lane so a click never queues behind a reconnect backlog.
+  const admission = createSemaphore({ limit: () => getDownloadConcurrency() })
 
   const pauseReasonFor = (job) => reasonForOwnerOnline(ownerOnline(job.ownerPublicKey))
 
@@ -282,6 +287,44 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
 
   // Resolve a finished fetch. Reads the LIVE slot, because a pause/cancel/supersede/republish
   // may have landed while the bytes were in flight — the fetch's own result is only half the
+  // The gated half of a download: everything past this point owns a chunk scheduler, a watchdog,
+  // an fd and a ticker, which is what the admission limit exists to bound. start() has already
+  // reserved the registry slot synchronously, so a queued job still reads as active and a second
+  // trigger cannot start a duplicate fetch while this waits.
+  async function runFetchTask (slot, job, transferId) {
+    const releaseSlot = await admission.acquire({ express: !!job.express })
+    try {
+      // The wait above is unbounded, so re-check every reason to abandon that the pre-fetch path
+      // already checked — the same window recordPending guards against, only wider.
+      if (slot.cancelled) {
+        registry.delete(transferId)
+        if (slot.restartJob) restartAfterSupersede(slot.restartJob)
+        return
+      }
+      // hasOverlay() covers the shutdown path: drainAdmission() releases parked waiters so close()
+      // is not held open, and they must not then fetch into a torn-down overlay.
+      if (slot.paused || !hasOverlay() || !ownerOnline(job.ownerPublicKey)) {
+        registry.delete(transferId)
+        channel.emitUpdated(job.spaceId)
+        return
+      }
+      // Set past the gate so it keeps meaning "a fetch is in flight in the vendor layer" — the four
+      // cancel/pause sites gate their cancelFetch call on it.
+      slot.fetching = true
+      // The overlay scheduler reports CUMULATIVE bytes already seeded with the resumed on-disk
+      // bytes (chunk-scheduler.js), so the ticker needs no resume offset.
+      const ticker = makeProgressTicker(job.size, ({ bytes, total, speed, eta }) => {
+        channel.emitProgress(job, { bytes, total, speed, eta })
+        updatePendingProgress(job.spaceId, job.pendingKey, bytes).catch(() => {})
+      })
+      const diag = makeFetchDiag(channel.diagLabel, job.relPath, job.size, job.contentHash)
+      const r = await fetchImpl(job.contentHash, { finalPath: job.finalPath, onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b) }, onVerify: (fraction) => channel.emitVerifying?.(job, fraction), onEnd: diag.onEnd })
+      await settleFetch(transferId, job, r, diag)
+    } finally {
+      releaseSlot()
+    }
+  }
+
   // story, and which of these applies decides whether the slot is restarted or released.
   async function settleFetch (transferId, job, r, diag) {
     const s = registry.get(transferId)
@@ -427,23 +470,13 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
         return { queued: true }
       }
 
-      slot.fetching = true
-      // Flip the row to 'downloading' immediately: emitUpdated re-derives the list (now that the
-      // engine has an active slot), emitProgress seeds the decoration bar before the first byte.
+      // Flip the row to 'downloading' immediately: emitUpdated re-derives the list (the engine
+      // holds the slot from here, admitted or queued), emitProgress seeds the bar before the
+      // first byte. Status derives from the registry slot, not from `fetching`.
       channel.emitProgress(job, { bytes: job.prevBytes || 0, total: job.size, speed: 0, eta: null })
       channel.emitUpdated(job.spaceId)
-      // The overlay scheduler reports CUMULATIVE bytes already seeded with the
-      // resumed on-disk bytes (chunk-scheduler.js), so the ticker needs no resume
-      // offset — pushTo carries the true cumulative.
-      const ticker = makeProgressTicker(job.size, ({ bytes, total, speed, eta }) => {
-        channel.emitProgress(job, { bytes, total, speed, eta })
-        updatePendingProgress(job.spaceId, job.pendingKey, bytes).catch(() => {})
-      })
-      const diag = makeFetchDiag(channel.diagLabel, job.relPath, job.size, job.contentHash)
-      ;(async () => {
-        const r = await fetchImpl(job.contentHash, { finalPath: job.finalPath, onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b) }, onVerify: (fraction) => channel.emitVerifying?.(job, fraction), onEnd: diag.onEnd })
-        await settleFetch(transferId, job, r, diag)
-      })().catch((err) => log.warn('overlay download task failed after the fetch settled:', job.relPath, '-', err.message))
+      runFetchTask(slot, job, transferId)
+        .catch((err) => log.warn('overlay download task failed after the fetch settled:', job.relPath, '-', err.message))
 
       return { transferId, finalPath: job.finalPath }
     } catch (err) {
@@ -557,7 +590,9 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     // Setting restartJob outranks a republish-park (settleFetch checks restartJob first), so a
     // supersede that lands while the slot is parking still restarts on the new hash.
     tr.cancelled = true
-    tr.restartJob = newJob
+    // The new job is rebuilt from the catalog, so carry the lane the original was admitted on:
+    // a supersede is not the user changing their mind about how urgent this download is.
+    tr.restartJob = { ...newJob, express: newJob.express ?? tr.job?.express }
     // signal:false — a supersede is a system-initiated restart on a new hash, not a
     // user stop. The restart's content-request re-establishes the holder's serve row
     // on the same path, so don't emit STOPPED (it would blink the downloader's avatar off).
@@ -690,5 +725,5 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     if (pending) channel.emitRemovedByOwner?.(spaceId, pendingKey, pending, transferId)
   }
 
-  return { start, pause, clearPauseMarker, cancel, cancelByKey, resumeForOwner, reconcileOnAppend, dropRemoved, supersede, releaseForRepublish, has, activeSlots: () => registry.entries(), _registry: registry, _stallRetries: stallRetries }
+  return { start, pause, clearPauseMarker, cancel, cancelByKey, resumeForOwner, reconcileOnAppend, dropRemoved, supersede, releaseForRepublish, has, activeSlots: () => registry.entries(), drainAdmission: () => admission.drain(), admissionStats: () => admission.stats(), _registry: registry, _stallRetries: stallRetries }
 }

--- a/src/shared/transfer/backends/overlay/overlay-runtime.js
+++ b/src/shared/transfer/backends/overlay/overlay-runtime.js
@@ -27,6 +27,8 @@ export class OverlayBackend extends Subsystem {
     this.require('ipc', 'broadcastSharePrepare')
     this.resumePending = new Map()
     this.overlay = null
+    this.folderEngine = null
+    this.looseEngine = null
   }
 
   async _open() {
@@ -42,8 +44,10 @@ export class OverlayBackend extends Subsystem {
     // (every entry point checks getOverlay()), and on the kill-switch build the alternative is an
     // engine() that throws out of files:list, space:leave and the transfer handlers.
     initLooseOverlay(this.deps.ipc)
-    setFolderEngine(createOverlayDownloadEngine(folderChannel))
-    setLooseEngine(createOverlayDownloadEngine(looseChannel))
+    this.folderEngine = createOverlayDownloadEngine(folderChannel)
+    this.looseEngine = createOverlayDownloadEngine(looseChannel)
+    setFolderEngine(this.folderEngine)
+    setLooseEngine(this.looseEngine)
     if (isInPlaceFilesEnabled()) {
       rehydrateLooseFiles().catch((err) => this.log.debug('loose rehydrate failed:', err.message))
     }
@@ -64,10 +68,16 @@ export class OverlayBackend extends Subsystem {
   async _close() {
     for (const timer of this.resumePending.values()) this.timers.clear(timer)
     this.resumePending.clear()
+    // Before the teardown: a download parked on the admission gate would otherwise hold its
+    // task past the stop deadline waiting for a slot nobody will release.
+    this.folderEngine?.drainAdmission()
+    this.looseEngine?.drainAdmission()
     await teardownOverlay()
     this.overlay = null
     setFolderEngine(null)
     setLooseEngine(null)
+    this.folderEngine = null
+    this.looseEngine = null
     serveIndex.reset()
     resetContentBackendState()
     resetLooseState()

--- a/src/shared/transfer/handshake-guard.js
+++ b/src/shared/transfer/handshake-guard.js
@@ -14,6 +14,14 @@ const BINDING_CONTEXT = b4a.from('mirall/handshake-binding/v1')
 const BINDING_CONTEXT_V2 = b4a.from('mirall/handshake-binding/v2')
 const SIG_HEX = /^[0-9a-f]{128}$/i
 
+// Every decoded frame must be a plain object carrying a string `type` before anything reads a
+// property off it. JSON.parse('null') returns null, and the property read that follows sits
+// OUTSIDE the message handler's try — it reaches protomux's _ondata, which _safeDestroy's the
+// socket. One word from any peer on the topic would drop the connection.
+export function validFrameShape (msg) {
+  return !!msg && typeof msg === 'object' && !Array.isArray(msg) && typeof msg.type === 'string'
+}
+
 // Shape check for frames that assert the SENDER's identity (handshake,
 // membership:request). Rejects malformed hex before any b4a.from reaches the data
 // layer, so a garbage key can't poison the in-memory maps.

--- a/src/shared/transfer/loose-overlay.js
+++ b/src/shared/transfer/loose-overlay.js
@@ -475,7 +475,8 @@ export async function looseDownload (spaceId, member, drivePath) {
     ipcRef?.emit('event:files-updated', { spaceId })
     return { queued: true }
   }
-  return engine().start(job)
+  // The user clicked download: express, so it never queues behind a reconnect backlog.
+  return engine().start({ ...job, express: true })
 }
 
 export function loosePause (transferId) { return engine().pause(transferId) }

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -26,14 +26,14 @@ import {
   recordJoinRequest, listJoinRequests, getJoinRequestDriveKey, clearJoinRequest,
   pinCreatorKey, markCreatorDivergence, clearCreatorDivergence, ownLooseCatalogPublish, persistLeftTombstone,
 } from '../spaces/space.js'
-import { getRuntimeConfig, getUpgradeKey, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow, isRelayEnabled, isSeparateContentPlaneEnabled } from '../core/runtime-config.js'
+import { getRuntimeConfig, getUpgradeKey, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow, isRelayEnabled, isSeparateContentPlaneEnabled, getPeerFrameMaxBytes, getPeerFrameLimits } from '../core/runtime-config.js'
 import { enabledRelayKeys, relayFunctionFor, decodeRelayKey } from './relay.js'
 import BlindRelay from 'blind-relay'
 import crypto from 'hypercore-crypto'
 import idEncoding from 'hypercore-id-encoding'
 import { catalogKeyField } from '../shares/share-catalog.js'
 import { HEX64 } from '../invite-envelope.js'
-import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, leaveFrameBound } from './handshake-guard.js'
+import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, createRateLimiter, validFrameShape, leaveFrameBound } from './handshake-guard.js'
 import { createAnnounceLedger, escalationDue, announceStatus } from './announce-ledger.js'
 import { joinContentTopic, leaveContentTopic, refreshContentDiscoveries, destroyContentPeerSockets, contentPlaneHasPeer, getContentPlaneStatus, getContentSwarm } from './content-swarm.js'
 import { applyNetImpairment } from './net-impair.js'
@@ -128,6 +128,11 @@ const boundSignerKeys = new Map()       // profileKey → signerKey hex
 const pendingAdmitInflight = new Set()  // 'spaceId:joinerKey' currently being admitted via reconcile
 const bannedNoiseKeys = new Set()       // Noise keys evicted for identity-frame flooding; the firewall rejects their reconnects
 let rateLimiter = null                  // dual-lane per-socket identity-frame token bucket, created in initSwarm
+let frameLimiter = null                 // general per-socket budget charged for EVERY frame type
+// Why a frame was dropped, for diagnostics — hardening nobody can see is hardening nobody can tune.
+const droppedFrames = { oversize: 0, rate: 0, parse: 0, shape: 0, unknown: 0 }
+function countDroppedFrame(reason) { droppedFrames[reason] += 1 }
+export function getDroppedFrameCounters() { return { ...droppedFrames } }
 // Unsettled identity-frame announcements per (socket, space), drained by the convergence
 // tick — the level-triggered resend that heals a dropped handshake/membership:request.
 const announceLedger = createAnnounceLedger()
@@ -199,6 +204,7 @@ function initSwarm(_ipc) {
   // The matched lane's cap follows the topics we joined (read per take, so joins and leaves
   // need no re-plumbing) — see createDualRateLimiter.
   rateLimiter = createDualRateLimiter({ ...getHandshakeRateLimit(), topics: () => spaceTopics.size })
+  frameLimiter = createRateLimiter(getPeerFrameLimits())
   const dropWindow = getIdentityFrameDropWindow()
   testDrop = dropWindow.count > 0 ? { ...dropWindow, seen: 0 } : null
   bootedAt = Date.now()
@@ -262,11 +268,48 @@ function initSwarm(_ipc) {
       },
     })
 
+    // Constant for the life of the connection, so it is derived once rather than per frame.
+    const noiseHex = peerInfo?.publicKey ? b4a.toString(peerInfo.publicKey, 'hex') : null
     const msgHandler = channel.addMessage({
       encoding: c.string,
       onmessage(str) {
+        // Charged BEFORE the decode: the point of a frame budget is to bound the work an
+        // unauthenticated peer can make us do, and JSON.parse is that work. Every type is metered
+        // here — the identity lanes below cover only handshake and membership:request, so without
+        // this a peer could flood presence or share-prepare-progress (one renderer decoration
+        // event per frame) at line rate.
+        // str.length is a cheap lower bound on the UTF-8 size (every UTF-16 unit costs at least one
+        // byte), so it rejects the clearly-oversized without a scan; byteLength settles the rest,
+        // because a cap named in bytes that counted UTF-16 units would admit ~3x what it claims.
+        const maxBytes = getPeerFrameMaxBytes()
+        if (maxBytes > 0 && (str.length > maxBytes || b4a.byteLength(str) > maxBytes)) {
+          countDroppedFrame('oversize')
+          log.warn('dropping oversize peer frame:', str.length, 'bytes from', remoteKey + '...')
+          return
+        }
+        if (noiseHex && frameLimiter) {
+          const r = frameLimiter.take(noiseHex)
+          if (!r.ok) {
+            countDroppedFrame('rate')
+            if (r.ban) {
+              log.warn('evicting peer flooding the frame channel', remoteKey + '...')
+              bannedNoiseKeys.add(noiseHex)
+              try { peerInfo.ban(true) } catch {}
+              socket.destroy()
+            }
+            return
+          }
+        }
+
         let msg
-        try { msg = JSON.parse(str) } catch (err) { log.error('handshake parse error:', err); return }
+        // debug, not error: a malformed frame is now a metered, counted, expected event, and
+        // logging it at error would hand any peer on the topic a log-spam primitive.
+        try { msg = JSON.parse(str) } catch (err) { countDroppedFrame('parse'); log.debug('handshake parse error:', err.message); return }
+        if (!validFrameShape(msg)) {
+          countDroppedFrame('shape')
+          log.debug('dropping malformed peer frame from', remoteKey + '...')
+          return
+        }
 
         // A frame asserting the SENDER's profileKey (handshake, membership:request) must be
         // well-formed and — when enforced — carry a signature binding the claimed profileKey to this
@@ -394,9 +437,12 @@ function dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler) {
     handleMembershipCancelAck(socket, msg)
   } else if (msg.type === 'share-prepare-progress') {
     handleSharePrepareProgressFrame(socket, msg)
-  } else if (typeof msg.type === 'string' && msg.type.startsWith('membership:')) {
+  } else if (msg.type.startsWith('membership:')) {
     if (msg.type === 'membership:request' && msg.profileKey) registerPendingRequester(socket, remoteKey, msg)
     membershipControlHandler?.(msg, { socket, peerInfo, reply })  // handler verifies a grant's identity binding + asserted root
+  } else {
+    countDroppedFrame('unknown')
+    log.debug('ignoring unknown peer frame type:', msg.type)
   }
 }
 
@@ -1897,6 +1943,7 @@ async function destroySwarm() {
   lastConnectionAt = null
   lastEmittedStatus = null
   hostChangeCount = 0
+  for (const k of Object.keys(droppedFrames)) droppedFrames[k] = 0
   lastKnownHost = null
   currentReachability = { verdict: 'unknown', cause: null, confidence: 'predicted', evidence: null, since: 0, pending: null }
   verdictHistory = []
@@ -1927,6 +1974,7 @@ async function destroySwarm() {
   bannedNoiseKeys.clear()
   rateLimiter?.clear()
   rateLimiter = null
+  frameLimiter = null
   membersPoke.reset()
   ipcRef = null
   leavingSpaces.clear()
@@ -2216,6 +2264,7 @@ export function getDiagnosticCounters() {
     bootedAt,
     hostChangeCount,
     localPortStable: safeAddress().port > 0,
+    droppedFrames: getDroppedFrameCounters(),
   }
 }
 

--- a/src/worker/boot.js
+++ b/src/worker/boot.js
@@ -12,6 +12,11 @@
 import { createLifecycle } from '../shared/core/subsystem.js'
 import { getPeerPresenceDwellMs, isSharePrepareProgressEnabled, getRelayConfig } from '../shared/core/runtime-config.js'
 import { hydrateDownloadRoots, listDownloadRoots } from '../shared/core/paths.js'
+import { IntentsBee, getIntentsBee } from '../shared/core/intent-store.js'
+import { createIntentLog } from '../shared/core/intents.js'
+import { deleteOwnedMount } from '../shared/folders/mount-store.js'
+import { tombstoneShare } from '../shared/shares/shares.js'
+import { unmountForeignFolder } from '../shared/folders/foreign-folders.js'
 import { Store, getStore, setMasterSecret } from '../shared/core/store.js'
 import { resolveMasterSecret } from '../shared/core/identity-resolve.js'
 import { osKeychainProvider } from '../shared/core/unlock-providers.js'
@@ -89,6 +94,7 @@ export async function bootDurable(bootstrap, { ipc, log, masterSecret = undefine
   await durable.start(new DownloadsBee('downloads'))
   await durable.start(new PendingTransfersBee('pending-transfers'))
   await durable.start(new MountsBee('mounts-meta'))
+  await durable.start(new IntentsBee('intents'))
   const installId = await getInstallId(bootstrap.storage).catch((err) => {
     log.warn('install id unavailable:', err.message)
     return null
@@ -213,8 +219,22 @@ export async function boot(bootstrap, {
     await life.start(new ForeignMirrors('foreign-mirrors', { ipc }))
     await life.start(new EchoGuardPurge('echo-guard'))
     await life.start(new PeerWatch('peer-watch'))
+    // Reconcilers register with the flows they complete, then one pass finishes everything a prior
+    // process left half-done. Before the swarm and the topic joins: recovery re-asserts durable
+    // departures and drops mount records, and a join racing that would re-arm a watcher or a
+    // mirror against a space this pass is about to forget.
+    const intents = createIntentLog({ bee: getIntentsBee, log })
+    intents.register('owned-delete', async ({ spaceId, shareId }) => {
+      await deleteOwnedMount(spaceId, shareId)
+      await tombstoneShare(spaceId, shareId)
+    })
+    intents.register('foreign-unmount', async ({ spaceId, shareId }) => {
+      await unmountForeignFolder(spaceId, shareId)
+    })
+
     const knownSpaces = await listSpaces()
     await resumeInterruptedLeaves(knownSpaces, log)
+    await intents.recover()
     const activeSpaces = knownSpaces.filter((s) => !s.leaving)
     // Hydrated here, from the spaces that SURVIVED the interrupted-leave pass above, and off the
     // scan that pass already did. A space being left keeps no download root: hydrating it would
@@ -267,7 +287,7 @@ export async function boot(bootstrap, {
     await life.start(mounts)
     await life.start(new Sweeps('sweeps', { ipc, auditLog }))
 
-    return { close, store, mounts, auditLog, ownedFolders, publishService, overlayBackend, activeSpaces, applyRelayConfig: () => applyRelayConfig(log) }
+    return { close, store, mounts, intents, auditLog, ownedFolders, publishService, overlayBackend, activeSpaces, applyRelayConfig: () => applyRelayConfig(log) }
   }
 }
 

--- a/src/worker/ipc/space-leave.js
+++ b/src/worker/ipc/space-leave.js
@@ -1,0 +1,292 @@
+// The space:leave flow, lifted out of the worker entrypoint. The handler is a 200-line, 14-phase
+// state machine reaching ~35 callees across ~10 modules; living in the file whose job is wiring is
+// why the reusable half of this flow (spaces/leave-flow.js, which boot's interrupted-leave pass
+// runs) was written separately and drifted from it. Both now share the step order.
+import { record } from '../../shared/audit/audit-log.js'
+import { unmountForeignFolder } from '../../shared/folders/foreign-folders.js'
+import { deleteOwnedMount, listForeignMounts, listOwnedMounts } from '../../shared/folders/mount-store.js'
+import { stopOwnedFolder } from '../../shared/folders/owned-folders.js'
+import { stopPublishingForSpace } from '../../shared/folders/publish-service.js'
+import { purgeOwnCatalog } from '../../shared/shares/share-catalog.js'
+import { readOwnShares, tombstoneShare } from '../../shared/shares/shares.js'
+import { closeMemberView } from '../../shared/spaces/member-registry.js'
+import { clearOwnMembership, getLocalPublicKeyHex } from '../../shared/spaces/profile.js'
+import { forgetSpaceRecord, getSpace, markSpaceLeavingDurable, persistPendingLeave, purgeSpace, purgeSpaceDrive } from '../../shared/spaces/space.js'
+import { runLeaveTeardown } from '../../shared/spaces/leave-flow.js'
+import { forgetUnreferencedPeerCores } from '../../shared/storage/leftover.js'
+import { getSpaceCacheBytes } from '../../shared/storage/storage.js'
+import { overlayCancelSpace } from '../../shared/transfer/backends/overlay/overlay-backend.js'
+import { bumpServeEpoch, revokeServesForSpace } from '../../shared/transfer/backends/overlay/overlay-instance.js'
+import { cleanupDownloadHistory } from '../../shared/transfer/files.js'
+import { looseCancelSpace } from '../../shared/transfer/loose-overlay.js'
+import { clearPendingForSpace } from '../../shared/transfer/pending-transfers.js'
+import {
+  awaitLeaveAcks, cleanupSpaceDrives, compactStore, hasPendingCancel, hasPendingLeave, isSpaceLeaving,
+  joinPendingCancelTopic, joinPendingLeaveTopic, leaveSpaceTopic, markSpaceLeaving, registerPendingCancel,
+  registerPendingLeave, sendLeaveFrameToConnectedPeers, sendPendingCancelToConnected, takeLeaveAckedKeys,
+  unmarkSpaceLeaving,
+} from '../../shared/transfer/swarm.js'
+
+export function registerSpaceLeave(ipc, { log, mounts, selfActor, spaceRef, discardPendingSpace, dropSpaceDownloadRoot }) {
+  // Persist a pending-leave marker BEFORE the record purge erases the topic, so the swarm can
+  // re-announce the leave to members who were offline at leave time (and boot re-joins the topic)
+  // until they provably apply it — without this they keep us as a ghost member forever. Arm iff
+  // some OTHER member did NOT ack: this excludes a solo space (no members → nobody to tell → no
+  // immortal marker) and covers a member that dropped mid-leave (never acked → still owed the
+  // replay), which the raw awaitLeaveAcks boolean conflated with "nobody was connected". ts is the
+  // leave stamp: a genuine later rejoin writes a strictly newer member/<S> ts and outranks the replay.
+  async function armPendingLeaveIfUnwitnessed(spaceId, space) {
+    if (!space?.topic) return false
+    const others = (space.members || []).map((m) => m.publicKey)
+    if (others.length === 0) return false
+    const acked = takeLeaveAckedKeys(spaceId)
+    if (others.every((k) => acked.has(k))) return false
+    try {
+      const leaveTs = Date.now()
+      await persistPendingLeave(spaceId, space.topic, leaveTs)
+      registerPendingLeave(spaceId, space.topic, leaveTs)
+      log.info('leave unwitnessed — pending-leave marker armed:', spaceId)
+      return true
+    } catch (err) {
+      log.warn('pending-leave persist failed:', err.message)
+      return false
+    }
+  }
+
+  // The teardown's leaveSpaceTopic dropped the topic — re-join it for the replay so a co-member
+  // returning THIS session still receives the leave (boot covers restarts). Re-check the live
+  // marker rather than a stale armed-flag: an ack that landed mid-teardown already cleared the
+  // marker and left the topic, and re-joining here would strand a zombie topic nothing can leave.
+  function rejoinPendingLeaveTopicAfterTeardown(spaceId, space) {
+    if (!hasPendingLeave(spaceId) || !space?.topic) return
+    try { joinPendingLeaveTopic(spaceId, space.topic) } catch (err) {
+      log.warn('pending-leave topic rejoin failed:', err.message)
+    }
+  }
+
+  ipc.handle('space:leave', async (msg) => {
+    // A teardown is already in flight (it can outlive the IPC response) — a re-click must be a no-op,
+    // not a second run that clobbers the in-flight leave-ack tracking and re-purges half-torn state.
+    // Claim the flag SYNCHRONOUSLY before any await, so two near-simultaneous leaves can't both pass
+    // the guard during the getSpace round-trip below.
+    if (isSpaceLeaving(msg.spaceId)) return { ok: true }
+    markSpaceLeaving(msg.spaceId)
+    // A pending space was never joined — take the lightweight cancel path instead of
+    // the drive-purge teardown, which assumes a materialized drive and crashes without one.
+    const pending = await getSpace(msg.spaceId)
+    // Recorded up front, while the space record still exists: the teardown deletes it, and the row
+    // must carry the name snapshot or it renders as raw hex forever afterwards.
+    if (pending) {
+      record('space.left', {
+        actor: selfActor(),
+        space: spaceRef(pending),
+        target: { kind: 'space', id: pending.spaceId, name: pending.name },
+        subject: { wasPending: pending.status === 'pending' },
+      })
+    }
+    if (pending?.status === 'pending') {
+      unmarkSpaceLeaving(msg.spaceId)   // a pending cancel is not a drive teardown
+      log.info('cancel pending join:', msg.spaceId)
+      // Tell members who saw our request to drop it. A lost frame self-heals: register a pending
+      // cancel replayed on every connection until a member acks it applied, and re-join the topic
+      // (discard purges it) so a member offline now can still be reached. The initial send goes
+      // through sendPendingCancelToConnected so the ack from a currently-connected member is honored.
+      if (pending.topic) {
+        registerPendingCancel(msg.spaceId, pending.topic, getLocalPublicKeyHex())
+        sendPendingCancelToConnected()
+      }
+      await discardPendingSpace(msg.spaceId)
+      // Re-join for replay ONLY if a member hasn't already acked during the teardown above (which
+      // clears the pending cancel) — otherwise we'd re-join a purged topic nothing ever leaves.
+      if (pending.topic && hasPendingCancel(msg.spaceId)) joinPendingCancelTopic(msg.spaceId, pending.topic)
+      return { ok: true }
+    }
+
+    closeMemberView(msg.spaceId)
+    log.info('leave starting:', msg.spaceId)
+    // markSpaceLeaving already set above (before the getSpace await) so files:list reads short-circuit.
+
+    // Run the full teardown as a background task tracking its current phase. The
+    // load-bearing signals (leave frame, clearOwnMembership) and the durable catalog-record
+    // delete all happen before the heavyweight, occasionally-slow steps (swarm leave, peer
+    // core close/compaction, purge) — so if one of those stalls we can answer the renderer
+    // and let the rest finish in the background, instead of hanging the UI for the full IPC
+    // timeout. `phase` names where it is so a stall is diagnosable from the logs.
+    const tracker = { phase: 'start' }
+    let space = null
+    const teardown = (async () => {
+      try {
+        // Durable leaving marker BEFORE the member del: a quit anywhere in this teardown is now
+        // completed at the next boot (resumeInterruptedLeave) instead of being reverted by the
+        // markOwnMembership backfill. Best-effort — without it a crash reverts as before.
+        tracker.phase = 'mark-leaving'
+        try { await markSpaceLeavingDurable(msg.spaceId) } catch (err) {
+          log.warn('durable leaving mark failed:', err.message)
+        }
+        // Author the durable departure (member/<S> del) BEFORE broadcasting the frame, so it is
+        // written + announced when co-members apply the leave — their member-view live-follow can then
+        // re-host it and serve it to members who were offline at leave time.
+        // Same step order as boot's interrupted-leave pass (shared/spaces/leave-flow.js). The steps
+        // differ: this path also stops the in-memory machinery — a still-live chokidar watcher,
+        // mirror loop, periodic reconcile or publish lane would keep writing to the drive the purge
+        // below closes, and recreate state mid-purge. A fresh boot has none of that to stop.
+        await runLeaveTeardown(msg.spaceId, {
+          clearMembership: async () => {
+            // Best-effort here, unlike the boot pass's hard gate: the purge steps below still have
+            // to run, and the durable marker already survives for the next boot to finish.
+            try { await clearOwnMembership(msg.spaceId) } catch (err) {
+              log.warn('clearOwnMembership failed:', err.message)
+            }
+            tracker.phase = 'leave-frame'
+            try { sendLeaveFrameToConnectedPeers(msg.spaceId) } catch (err) {
+              log.warn('leave-frame broadcast failed:', err.message)
+            }
+          },
+          ownedMounts: async () => {
+            for (const m of (await listOwnedMounts()).filter((x) => x.spaceId === msg.spaceId)) {
+              mounts.cancelPeriodicReconcile(msg.spaceId, m.shareId)
+              stopOwnedFolder(msg.spaceId, m.shareId)
+              ipc.emit('main-request', { command: 'owned-folder:stop-watcher', args: { shareId: m.shareId } })
+              await deleteOwnedMount(msg.spaceId, m.shareId)
+            }
+            // Awaited: a cancelled publish still writes its revert on the next chunk boundary, and
+            // that write must land before the purge below closes the catalog core.
+            await stopPublishingForSpace(msg.spaceId)
+          },
+          // Retire our share advertisements (deletedAt), like the unshare path. Without this our
+          // profile bee keeps advertising share/<S>/<id>, so on a rejoin a co-member reads it back
+          // and a folder they mirrored re-surfaces before any re-approval.
+          shares: async () => {
+            for (const s of await readOwnShares(msg.spaceId)) await tombstoneShare(msg.spaceId, s.id)
+          },
+          foreignMounts: async () => {
+            for (const m of (await listForeignMounts()).filter((x) => x.spaceId === msg.spaceId)) {
+              await unmountForeignFolder(msg.spaceId, m.shareId)
+            }
+          },
+          // The forget stays below with the rest of the teardown: it must land AFTER the bounded
+          // ack flush, which the boot pass has no equivalent of.
+          forget: async () => {},
+        }, { log, onPhase: (phase) => { tracker.phase = phase } })
+        log.info('leave: own state cleared, waiting flush...')
+
+        // Wait (bounded) for connected members to confirm they applied our leave — an observed signal
+        // that their durable revokeApproval ran — instead of a blind fixed sleep. Resolves early on
+        // full ack coverage; falls back to the cap for pre-upgrade peers that never ack.
+        tracker.phase = 'flush'
+        await awaitLeaveAcks(msg.spaceId, { capMs: 2000, floorMs: 500 })
+        log.info('leave: flush done, gathering members...')
+
+        space = await getSpace(msg.spaceId)
+        const members = space?.members || []
+        const peerDrivenMembers = members.filter(m => !!m.driveKey)
+        const peerDriveCount = peerDrivenMembers.length
+
+        await armPendingLeaveIfUnwitnessed(msg.spaceId, space)
+
+        // Drop the catalog record up front so the leave is durable: if any purge step
+        // below fails (or the worker dies mid-teardown), the space is already gone from
+        // the list and won't reappear — leftover cores are reclaimable, a stuck space is
+        // not. The drive stays in the in-memory map for purgeSpaceDrive.
+        tracker.phase = 'forgetSpaceRecord'
+        try { await forgetSpaceRecord(msg.spaceId) } catch (err) {
+          log.warn('leave: catalog record delete failed:', err.message)
+        }
+        dropSpaceDownloadRoot(msg.spaceId)
+
+        // Cache-size precompute is best-effort; cap at 2s so a stuck drive read
+        // can't block the rest of the leave teardown.
+        tracker.phase = 'cache-bytes'
+        let totalBytes = 0
+        try {
+          totalBytes = await Promise.race([
+            getSpaceCacheBytes(msg.spaceId),
+            new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
+          ])
+        } catch (err) {
+          log.warn('cannot precompute space cache size:', err.message)
+        }
+        log.info('leave: cache bytes computed:', totalBytes)
+
+        // Must match the number of progress calls below: 1 disconnecting + N
+        // cleaningPeer + (N>0 ? compactingPeerCache : 0) + 4 local phases.
+        const totalSteps = 5 + peerDriveCount + (peerDriveCount > 0 ? 1 : 0)
+        let step = 0
+
+        const progress = (phase, data) => {
+          step++
+          const payload = { spaceId: msg.spaceId, step, totalSteps, phase }
+          if (data) payload.data = data
+          if (step === 1) payload.totalBytes = totalBytes
+          ipc.emit('event:leave-progress', payload)
+        }
+
+        // Cancel + discard any in-flight downloads for this space before the purges, so the
+        // overlay/loose engine stops fetching (no orphaned partial) and can't re-write the
+        // download-history rows cleanupDownloadHistory/clearPendingForSpace purge below.
+        await overlayCancelSpace(msg.spaceId)
+        await looseCancelSpace(msg.spaceId)
+        // ...and stop SERVING this space to everyone else. The cancels above only walk OUR OWN
+        // fetch slots — as the owner we have none, so without this a leave stops nothing on the
+        // serving side and the content plane keeps streaming the space's bytes. Runs BEFORE the
+        // purges: it needs serveIndex to still resolve hash → space.
+        revokeServesForSpace(msg.spaceId)
+        bumpServeEpoch()
+
+        tracker.phase = 'leaveSpaceTopic'
+        progress('disconnecting')
+        await leaveSpaceTopic(msg.spaceId)
+        log.info('leave: topic left, cleaning peer drives...')
+        // Defer the disk-reclaim compaction (compact: false): purging tombstones the cores (the
+        // leave is effective immediately), but a forced full-range compaction scans the WHOLE store
+        // and is expensive on a large one — one pass per drive (peer caches here, local cache below)
+        // would serially block the leave for tens of seconds. Run a SINGLE coalesced pass in the
+        // background after the purges instead.
+        tracker.phase = 'cleanupSpaceDrives'
+        await cleanupSpaceDrives(msg.spaceId, peerDrivenMembers, (phase, data) => {
+          progress(phase, data)
+        }, { compact: false })
+        log.info('leave: peer drives cleaned, purging local...')
+
+        tracker.phase = 'purge-local'
+        await cleanupDownloadHistory(msg.spaceId)
+        await clearPendingForSpace(msg.spaceId)
+        await purgeSpaceDrive(msg.spaceId, (phase) => {
+          progress(phase)
+        }, { compact: false })
+        try { await purgeOwnCatalog(msg.spaceId, space) } catch (err) {
+          log.warn('leave: own catalog purge failed:', err.message)
+        }
+        await purgeSpace(msg.spaceId)
+        tracker.phase = 'forgetUnreferencedPeerCores'
+        try { await forgetUnreferencedPeerCores(members) } catch (err) {
+          log.warn('leave: peer-core gc failed:', err.message)
+        }
+        // One background compaction pass for everything purged above — never awaited, so the
+        // leave completes as soon as the cores are tombstoned; the bytes come back shortly after.
+        compactStore()
+          .catch((err) => log.warn('leave: background reclaim compaction failed:', err.message))
+        tracker.phase = 'complete'
+        log.info('leave: complete (reclaim compaction running in background):', msg.spaceId)
+      } finally {
+        unmarkSpaceLeaving(msg.spaceId)
+        rejoinPendingLeaveTopicAfterTeardown(msg.spaceId, space)
+      }
+    })()
+
+    // Never hold the renderer past this deadline: the leave is already durable (catalog record
+    // dropped) and propagated (leave frame sent) well before the slow steps, so answer now and let
+    // any straggling teardown finish in the background. The warn names the stalled phase so a real
+    // hang is pinpointable from the console instead of surfacing only as a 30s IPC timeout.
+    const LEAVE_RESPOND_DEADLINE_MS = 12000
+    const stalled = await Promise.race([
+      teardown.then(() => false, () => false),
+      new Promise((resolve) => setTimeout(() => resolve(true), LEAVE_RESPOND_DEADLINE_MS)),
+    ])
+    if (stalled) {
+      log.warn('leave: teardown exceeded', LEAVE_RESPOND_DEADLINE_MS, 'ms — stalled at phase:', tracker.phase, '— space', msg.spaceId, '— finishing in background')
+      teardown.catch((err) => log.warn('leave: background teardown failed:', err.message))
+    }
+    return { ok: true }
+  })
+}

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -13,7 +13,7 @@ import os from 'bare-os'
 import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
-import { createIPC, getBootstrapPromise } from '../shared/core/ipc.js'
+import { createIPC, getBootstrapPromise, getRequestFailureCounters } from '../shared/core/ipc.js'
 import {
   setRuntimeConfig,
   getRuntimeConfig,
@@ -1977,6 +1977,7 @@ ipc.handle('diagnostics:export', async (msg) => {
       arch: os.arch(),
     },
     counters: getDiagnosticCounters(),
+    requestFailures: getRequestFailureCounters(),
     peerSamples: getPeerSamples(),
   }, msg?.redact !== false)
 })

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -14,6 +14,7 @@ import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
 import { createIPC, getBootstrapPromise, getRequestFailureCounters } from '../shared/core/ipc.js'
+import { registerSpaceLeave } from './ipc/space-leave.js'
 import {
   setRuntimeConfig,
   getRuntimeConfig,
@@ -35,7 +36,6 @@ import {
   getProfile,
   setProfile,
   markOwnMembership,
-  clearOwnMembership,
   getLocalPublicKeyHex,
   readProfileRecord,
   markRequest,
@@ -50,10 +50,7 @@ import {
   listSpaces,
   getSpace,
   purgeSpace,
-  purgeSpaceDrive,
-  forgetSpaceRecord,
   updateSpace,
-  markSpaceLeavingDurable,
   toggleFavorite,
   upsertMember,
   getSpaceContentKey,
@@ -66,7 +63,6 @@ import {
   pinCreatorKey,
   markCreatorDivergence,
   clearCreatorDivergence,
-  persistPendingLeave,
   clearPendingLeave,
 } from '../shared/spaces/space.js'
 import { classifyInvite } from '../shared/spaces/invite-policy.js'
@@ -75,12 +71,9 @@ import {
   joinSpaceTopic,
   leaveSpaceTopic,
   cleanupSpaceDrives,
-  compactStore,
   getConnectedPeers,
   isOwnerOnline,
   broadcastProfileUpdate,
-  sendLeaveFrameToConnectedPeers,
-  awaitLeaveAcks,
   getSwarmStatus,
   testRelayReachable,
   reconnectAll,
@@ -100,16 +93,9 @@ import {
   unmarkSpaceLeaving,
   isSpaceLeaving,
   getBoundSignerKey,
-  registerPendingLeave,
   unregisterPendingLeave,
-  joinPendingLeaveTopic,
   leavePendingLeaveTopic,
   hasPendingLeave,
-  takeLeaveAckedKeys,
-  registerPendingCancel,
-  joinPendingCancelTopic,
-  hasPendingCancel,
-  sendPendingCancelToConnected,
 } from '../shared/transfer/swarm.js'
 import { clampDisplayName, checkGrantAssertion } from '../shared/transfer/handshake-guard.js'
 import { openSealedSck } from '../shared/transfer/sck-seal.js'
@@ -124,12 +110,11 @@ import {
   isDeniedJoiner,
 } from '../shared/spaces/member-registry.js'
 import { reconnectGrantAllowed } from '../shared/spaces/member-set.js'
-import { ownCatalogPublish, purgeOwnCatalog, catalogKeyField } from '../shared/shares/share-catalog.js'
+import { ownCatalogPublish, catalogKeyField } from '../shared/shares/share-catalog.js'
 import {
   listFiles,
   removeFile,
   revealFile,
-  cleanupDownloadHistory,
   addFile,
   isDownloadedFile,
   getDownloadedPath,
@@ -142,19 +127,18 @@ import {
   looseDownload,
   loosePause,
   looseCancel,
-  looseCancelSpace,
   looseCancelTransfer,
   looseCancelPublish,
   handleLooseFsEvent,
 } from '../shared/transfer/loose-overlay.js'
-import { overlayPause, overlayCancel, overlayCancelByKey, overlayCancelSpace, overlayHasTransfer } from '../shared/transfer/backends/overlay/overlay-backend.js'
+import { overlayPause, overlayCancel, overlayCancelByKey, overlayHasTransfer } from '../shared/transfer/backends/overlay/overlay-backend.js'
 import { subscribeServeDetail, unsubscribeServeDetail, listServeSummaries } from '../shared/transfer/serve-ledger.js'
-import { revokeServesForSpace, bumpServeEpoch } from '../shared/transfer/backends/overlay/overlay-instance.js'
+
 import { pausedStatusFor, unhashedStatusFor } from '../shared/transfer/transfer-status.js'
 import { transferIdFor, isLooseTransferId } from '../shared/transfer/transfer-id.js'
 import { makeKeyedCoalescer } from '../shared/state/coalesce.js'
-import { clearPendingForSpace, listPendingForSpace } from '../shared/transfer/pending-transfers.js'
-import { getStorageInfo, cleanupOrphanedData, getSpaceCacheBytes, freeSpace } from '../shared/storage/storage.js'
+import { listPendingForSpace } from '../shared/transfer/pending-transfers.js'
+import { getStorageInfo, cleanupOrphanedData, freeSpace } from '../shared/storage/storage.js'
 import { spaceStorageSummary } from '../shared/storage/space-storage.js'
 import { classifyLeftovers, forgetUnreferencedPeerCores } from '../shared/storage/leftover.js'
 import { sendFeedback } from '../shared/telemetry/feedback.js'
@@ -193,7 +177,7 @@ import {
   getIndexStatus,
   cancelIndex,
 } from '../shared/folders/owned-folders.js'
-import { stopPublishingForSpace } from '../shared/folders/publish-service.js'
+
 import { exceedsShareFileLimit, shareFileLimitMessage, listingTruncated } from '../shared/folders/share-limits.js'
 import {
   initialMaterializeScan,
@@ -653,7 +637,6 @@ async function discardPendingSpace(spaceId) {
     unmarkSpaceLeaving(spaceId)
   }
 }
-
 
 // === Boot: the composition root constructs and starts the data layer ===
 //
@@ -1502,262 +1485,7 @@ ipc.handle('space:update', async (msg) => {
 ipc.handle('space:toggle-favorite', async (msg) => {
   return await toggleFavorite(msg.spaceId)
 })
-// Persist a pending-leave marker BEFORE the record purge erases the topic, so the swarm can
-// re-announce the leave to members who were offline at leave time (and boot re-joins the topic)
-// until they provably apply it — without this they keep us as a ghost member forever. Arm iff
-// some OTHER member did NOT ack: this excludes a solo space (no members → nobody to tell → no
-// immortal marker) and covers a member that dropped mid-leave (never acked → still owed the
-// replay), which the raw awaitLeaveAcks boolean conflated with "nobody was connected". ts is the
-// leave stamp: a genuine later rejoin writes a strictly newer member/<S> ts and outranks the replay.
-async function armPendingLeaveIfUnwitnessed(spaceId, space) {
-  if (!space?.topic) return false
-  const others = (space.members || []).map((m) => m.publicKey)
-  if (others.length === 0) return false
-  const acked = takeLeaveAckedKeys(spaceId)
-  if (others.every((k) => acked.has(k))) return false
-  try {
-    const leaveTs = Date.now()
-    await persistPendingLeave(spaceId, space.topic, leaveTs)
-    registerPendingLeave(spaceId, space.topic, leaveTs)
-    log.info('leave unwitnessed — pending-leave marker armed:', spaceId)
-    return true
-  } catch (err) {
-    log.warn('pending-leave persist failed:', err.message)
-    return false
-  }
-}
-
-// The teardown's leaveSpaceTopic dropped the topic — re-join it for the replay so a co-member
-// returning THIS session still receives the leave (boot covers restarts). Re-check the live
-// marker rather than a stale armed-flag: an ack that landed mid-teardown already cleared the
-// marker and left the topic, and re-joining here would strand a zombie topic nothing can leave.
-function rejoinPendingLeaveTopicAfterTeardown(spaceId, space) {
-  if (!hasPendingLeave(spaceId) || !space?.topic) return
-  try { joinPendingLeaveTopic(spaceId, space.topic) } catch (err) {
-    log.warn('pending-leave topic rejoin failed:', err.message)
-  }
-}
-
-ipc.handle('space:leave', async (msg) => {
-  // A teardown is already in flight (it can outlive the IPC response) — a re-click must be a no-op,
-  // not a second run that clobbers the in-flight leave-ack tracking and re-purges half-torn state.
-  // Claim the flag SYNCHRONOUSLY before any await, so two near-simultaneous leaves can't both pass
-  // the guard during the getSpace round-trip below.
-  if (isSpaceLeaving(msg.spaceId)) return { ok: true }
-  markSpaceLeaving(msg.spaceId)
-  // A pending space was never joined — take the lightweight cancel path instead of
-  // the drive-purge teardown, which assumes a materialized drive and crashes without one.
-  const pending = await getSpace(msg.spaceId)
-  // Recorded up front, while the space record still exists: the teardown deletes it, and the row
-  // must carry the name snapshot or it renders as raw hex forever afterwards.
-  if (pending) {
-    record('space.left', {
-      actor: selfActor(),
-      space: spaceRef(pending),
-      target: { kind: 'space', id: pending.spaceId, name: pending.name },
-      subject: { wasPending: pending.status === 'pending' },
-    })
-  }
-  if (pending?.status === 'pending') {
-    unmarkSpaceLeaving(msg.spaceId)   // a pending cancel is not a drive teardown
-    log.info('cancel pending join:', msg.spaceId)
-    // Tell members who saw our request to drop it. A lost frame self-heals: register a pending
-    // cancel replayed on every connection until a member acks it applied, and re-join the topic
-    // (discard purges it) so a member offline now can still be reached. The initial send goes
-    // through sendPendingCancelToConnected so the ack from a currently-connected member is honored.
-    if (pending.topic) {
-      registerPendingCancel(msg.spaceId, pending.topic, getLocalPublicKeyHex())
-      sendPendingCancelToConnected()
-    }
-    await discardPendingSpace(msg.spaceId)
-    // Re-join for replay ONLY if a member hasn't already acked during the teardown above (which
-    // clears the pending cancel) — otherwise we'd re-join a purged topic nothing ever leaves.
-    if (pending.topic && hasPendingCancel(msg.spaceId)) joinPendingCancelTopic(msg.spaceId, pending.topic)
-    return { ok: true }
-  }
-
-  closeMemberView(msg.spaceId)
-  log.info('leave starting:', msg.spaceId)
-  // markSpaceLeaving already set above (before the getSpace await) so files:list reads short-circuit.
-
-  // Run the full teardown as a background task tracking its current phase. The
-  // load-bearing signals (leave frame, clearOwnMembership) and the durable catalog-record
-  // delete all happen before the heavyweight, occasionally-slow steps (swarm leave, peer
-  // core close/compaction, purge) — so if one of those stalls we can answer the renderer
-  // and let the rest finish in the background, instead of hanging the UI for the full IPC
-  // timeout. `phase` names where it is so a stall is diagnosable from the logs.
-  const tracker = { phase: 'start' }
-  let space = null
-  const teardown = (async () => {
-    try {
-      // Durable leaving marker BEFORE the member del: a quit anywhere in this teardown is now
-      // completed at the next boot (resumeInterruptedLeave) instead of being reverted by the
-      // markOwnMembership backfill. Best-effort — without it a crash reverts as before.
-      tracker.phase = 'mark-leaving'
-      try { await markSpaceLeavingDurable(msg.spaceId) } catch (err) {
-        log.warn('durable leaving mark failed:', err.message)
-      }
-      // Author the durable departure (member/<S> del) BEFORE broadcasting the frame, so it is
-      // written + announced when co-members apply the leave — their member-view live-follow can then
-      // re-host it and serve it to members who were offline at leave time.
-      tracker.phase = 'clearOwnMembership'
-      try { await clearOwnMembership(msg.spaceId) } catch (err) {
-        log.warn('clearOwnMembership failed:', err.message)
-      }
-      tracker.phase = 'leave-frame'
-      try { sendLeaveFrameToConnectedPeers(msg.spaceId) } catch (err) {
-        log.warn('leave-frame broadcast failed:', err.message)
-      }
-
-      // Tear down this space's folder machinery BEFORE purging its drive: a still-live
-      // chokidar watcher, foreign mirror loop, periodic reconcile, or cached share view
-      // would otherwise keep writing to the closed-and-purged drive and recreate state
-      // mid-purge (write-after-purge).
-      tracker.phase = 'folder-teardown'
-      try {
-        for (const m of (await listOwnedMounts()).filter((x) => x.spaceId === msg.spaceId)) {
-          mounts.cancelPeriodicReconcile(msg.spaceId, m.shareId)
-          stopOwnedFolder(msg.spaceId, m.shareId)
-          ipc.emit('main-request', { command: 'owned-folder:stop-watcher', args: { shareId: m.shareId } })
-          await deleteOwnedMount(msg.spaceId, m.shareId)
-        }
-        // Awaited: a cancelled publish still writes its revert on the next chunk boundary, and
-        // that write must land before the purge below closes the catalog core.
-        await stopPublishingForSpace(msg.spaceId)
-        // Retire our share advertisements (deletedAt), like the unshare path. Without this our
-        // profile bee keeps advertising share/<S>/<id>, so on a rejoin a co-member reads it back
-        // and a folder they mirrored re-surfaces before any re-approval. The per-space drive is
-        // purged below, so only the profile-bee record needs tombstoning here.
-        for (const s of await readOwnShares(msg.spaceId)) {
-          await tombstoneShare(msg.spaceId, s.id)
-        }
-        for (const m of (await listForeignMounts()).filter((x) => x.spaceId === msg.spaceId)) {
-          await unmountForeignFolder(msg.spaceId, m.shareId)
-        }
-      } catch (err) {
-        log.warn('leave: folder teardown failed:', err.message)
-      }
-      log.info('leave: own state cleared, waiting flush...')
-
-      // Wait (bounded) for connected members to confirm they applied our leave — an observed signal
-      // that their durable revokeApproval ran — instead of a blind fixed sleep. Resolves early on
-      // full ack coverage; falls back to the cap for pre-upgrade peers that never ack.
-      tracker.phase = 'flush'
-      await awaitLeaveAcks(msg.spaceId, { capMs: 2000, floorMs: 500 })
-      log.info('leave: flush done, gathering members...')
-
-      space = await getSpace(msg.spaceId)
-      const members = space?.members || []
-      const peerDrivenMembers = members.filter(m => !!m.driveKey)
-      const peerDriveCount = peerDrivenMembers.length
-
-      await armPendingLeaveIfUnwitnessed(msg.spaceId, space)
-
-      // Drop the catalog record up front so the leave is durable: if any purge step
-      // below fails (or the worker dies mid-teardown), the space is already gone from
-      // the list and won't reappear — leftover cores are reclaimable, a stuck space is
-      // not. The drive stays in the in-memory map for purgeSpaceDrive.
-      tracker.phase = 'forgetSpaceRecord'
-      try { await forgetSpaceRecord(msg.spaceId) } catch (err) {
-        log.warn('leave: catalog record delete failed:', err.message)
-      }
-      dropSpaceDownloadRoot(msg.spaceId)
-
-      // Cache-size precompute is best-effort; cap at 2s so a stuck drive read
-      // can't block the rest of the leave teardown.
-      tracker.phase = 'cache-bytes'
-      let totalBytes = 0
-      try {
-        totalBytes = await Promise.race([
-          getSpaceCacheBytes(msg.spaceId),
-          new Promise((resolve) => setTimeout(() => resolve(0), 2000)),
-        ])
-      } catch (err) {
-        log.warn('cannot precompute space cache size:', err.message)
-      }
-      log.info('leave: cache bytes computed:', totalBytes)
-
-      // Must match the number of progress calls below: 1 disconnecting + N
-      // cleaningPeer + (N>0 ? compactingPeerCache : 0) + 4 local phases.
-      const totalSteps = 5 + peerDriveCount + (peerDriveCount > 0 ? 1 : 0)
-      let step = 0
-
-      const progress = (phase, data) => {
-        step++
-        const payload = { spaceId: msg.spaceId, step, totalSteps, phase }
-        if (data) payload.data = data
-        if (step === 1) payload.totalBytes = totalBytes
-        ipc.emit('event:leave-progress', payload)
-      }
-
-      // Cancel + discard any in-flight downloads for this space before the purges, so the
-      // overlay/loose engine stops fetching (no orphaned partial) and can't re-write the
-      // download-history rows cleanupDownloadHistory/clearPendingForSpace purge below.
-      await overlayCancelSpace(msg.spaceId)
-      await looseCancelSpace(msg.spaceId)
-      // ...and stop SERVING this space to everyone else. The cancels above only walk OUR OWN
-      // fetch slots — as the owner we have none, so without this a leave stops nothing on the
-      // serving side and the content plane keeps streaming the space's bytes. Runs BEFORE the
-      // purges: it needs serveIndex to still resolve hash → space.
-      revokeServesForSpace(msg.spaceId)
-      bumpServeEpoch()
-
-      tracker.phase = 'leaveSpaceTopic'
-      progress('disconnecting')
-      await leaveSpaceTopic(msg.spaceId)
-      log.info('leave: topic left, cleaning peer drives...')
-      // Defer the disk-reclaim compaction (compact: false): purging tombstones the cores (the
-      // leave is effective immediately), but a forced full-range compaction scans the WHOLE store
-      // and is expensive on a large one — one pass per drive (peer caches here, local cache below)
-      // would serially block the leave for tens of seconds. Run a SINGLE coalesced pass in the
-      // background after the purges instead.
-      tracker.phase = 'cleanupSpaceDrives'
-      await cleanupSpaceDrives(msg.spaceId, peerDrivenMembers, (phase, data) => {
-        progress(phase, data)
-      }, { compact: false })
-      log.info('leave: peer drives cleaned, purging local...')
-
-      tracker.phase = 'purge-local'
-      await cleanupDownloadHistory(msg.spaceId)
-      await clearPendingForSpace(msg.spaceId)
-      await purgeSpaceDrive(msg.spaceId, (phase) => {
-        progress(phase)
-      }, { compact: false })
-      try { await purgeOwnCatalog(msg.spaceId, space) } catch (err) {
-        log.warn('leave: own catalog purge failed:', err.message)
-      }
-      await purgeSpace(msg.spaceId)
-      tracker.phase = 'forgetUnreferencedPeerCores'
-      try { await forgetUnreferencedPeerCores(members) } catch (err) {
-        log.warn('leave: peer-core gc failed:', err.message)
-      }
-      // One background compaction pass for everything purged above — never awaited, so the
-      // leave completes as soon as the cores are tombstoned; the bytes come back shortly after.
-      compactStore()
-        .catch((err) => log.warn('leave: background reclaim compaction failed:', err.message))
-      tracker.phase = 'complete'
-      log.info('leave: complete (reclaim compaction running in background):', msg.spaceId)
-    } finally {
-      unmarkSpaceLeaving(msg.spaceId)
-      rejoinPendingLeaveTopicAfterTeardown(msg.spaceId, space)
-    }
-  })()
-
-  // Never hold the renderer past this deadline: the leave is already durable (catalog record
-  // dropped) and propagated (leave frame sent) well before the slow steps, so answer now and let
-  // any straggling teardown finish in the background. The warn names the stalled phase so a real
-  // hang is pinpointable from the console instead of surfacing only as a 30s IPC timeout.
-  const LEAVE_RESPOND_DEADLINE_MS = 12000
-  const stalled = await Promise.race([
-    teardown.then(() => false, () => false),
-    new Promise((resolve) => setTimeout(() => resolve(true), LEAVE_RESPOND_DEADLINE_MS)),
-  ])
-  if (stalled) {
-    log.warn('leave: teardown exceeded', LEAVE_RESPOND_DEADLINE_MS, 'ms — stalled at phase:', tracker.phase, '— space', msg.spaceId, '— finishing in background')
-    teardown.catch((err) => log.warn('leave: background teardown failed:', err.message))
-  }
-  return { ok: true }
-})
+registerSpaceLeave(ipc, { log, mounts, selfActor, spaceRef, discardPendingSpace, dropSpaceDownloadRoot })
 
 // === IPC: presence, file & transfer handlers ===
 
@@ -1917,7 +1645,6 @@ ipc.handle('settings:set-bandwidth', async (msg) => {
   setBandwidthLimits({ downloadKBps: msg?.downloadKBps, uploadKBps: msg?.uploadKBps })
   return { ok: true }
 })
-
 
 ipc.handle('network:status:get', async () => getSwarmStatus())
 ipc.handle('network:reconnect', async () => await reconnectAll())

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -657,7 +657,7 @@ root = await boot(bootstrap, {
   // the line below; both carry the same close().
   onPartialRoot: (partial) => { root = partial },
 })
-const { mounts, applyRelayConfig } = root
+const { mounts, intents, applyRelayConfig } = root
 
 // The renderer asks on mount and again whenever a transfer reports the folder gone, so the
 // banner can appear at once rather than on the next tick. Re-probing (rather than returning the
@@ -1100,6 +1100,10 @@ ipc.handle('owned-folder:delete', async (msg) => {
     log.warn('delete requested for unknown share:', msg.shareId)
   }
 
+  // The two writes below land in different bees, so a crash between them leaves the share still
+  // advertised with no mount behind it. Recorded first, cleared last; boot finishes the pair.
+  const intentId = await intents.beginOrNull('owned-delete', { spaceId: msg.spaceId, shareId: msg.shareId })
+
   mounts.cancelPeriodicReconcile(msg.spaceId, msg.shareId)
   stopOwnedFolder(msg.spaceId, msg.shareId)
   ipc.emit('main-request', { command: 'owned-folder:stop-watcher', args: { shareId: msg.shareId } })
@@ -1108,6 +1112,7 @@ ipc.handle('owned-folder:delete', async (msg) => {
   // tombstone below retires the catalog from every consumer's view.
   await deleteOwnedMount(msg.spaceId, msg.shareId)
   await tombstoneShare(msg.spaceId, msg.shareId)
+  await intents.complete(intentId)
   record('share.deleted', {
     actor: selfActor(),
     space: spaceRef(await getSpace(msg.spaceId)),
@@ -1198,7 +1203,11 @@ ipc.handle('foreign-folder:set-enabled', async (msg) => {
 
 ipc.handle('foreign-folder:unmount', async (msg) => {
   const mount = await getForeignMount(msg.spaceId, msg.shareId)
+  // The unmount drops the mount record and the mirror record in two stores; a crash between them
+  // leaves a mirror loop armed against a mount that is already gone.
+  const intentId = await intents.beginOrNull('foreign-unmount', { spaceId: msg.spaceId, shareId: msg.shareId })
   await unmountForeignFolder(msg.spaceId, msg.shareId)
+  await intents.complete(intentId)
   record('mirror.removed', {
     actor: selfActor(),
     space: spaceRef(await getSpace(msg.spaceId)),

--- a/test/integration/download-admission.test.js
+++ b/test/integration/download-admission.test.js
@@ -1,0 +1,204 @@
+import test from 'brittle'
+import path from 'bare-path'
+import { freshPeer } from '../helpers/store.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { initPendingTransfers, recordPending } from '../../src/shared/transfer/pending-transfers.js'
+import { initDownloads } from '../../src/shared/transfer/files.js'
+import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+
+const SPACE = 'space1'
+const OWNER = 'ownerpub'
+const hashFor = (n) => String(n % 10).repeat(64)
+
+function testChannel (over = {}) {
+  return {
+    diagLabel: 'test download',
+    inPlace: false,
+    ownsPendingRow: (row) => row.overlayShare === true,
+    pendingExtra: (job) => ({ overlayShare: true, shareId: job.shareId, relPath: job.relPath }),
+    emitProgress: () => {}, emitError: () => {}, emitComplete: () => {}, emitCancelled: () => {},
+    emitSuperseded: () => {}, emitPaused: () => {}, emitUpdated: () => {}, emitDecorationDone: () => {},
+    transferIdForRow: (spaceId, row) => spaceId + '|folder1|' + row.relPath,
+    isOwnerOnline: () => true,
+    ...over,
+  }
+}
+
+async function setup (t, concurrency) {
+  const ctx = await freshPeer(t)
+  await initDownloads()
+  await initPendingTransfers()
+  await initOverlay()
+  const prev = getRuntimeConfig()
+  setRuntimeConfig({ ...prev, downloadConcurrency: concurrency })
+  t.teardown(async () => { setRuntimeConfig(prev); await teardownOverlay() })
+  return ctx
+}
+
+function makeJob (ctx, n, over = {}) {
+  return {
+    spaceId: SPACE, pendingKey: `/Photos/f${n}.bin`, path: `/Photos/f${n}.bin`, relPath: `f${n}.bin`,
+    shareId: 'folder1', transferId: SPACE + '|folder1|f' + n + '.bin',
+    contentHash: hashFor(n), size: 4096, ownerPublicKey: OWNER, verifyKey: 'folder1|f' + n + '.bin',
+    finalPath: path.join(ctx.tmpDir('dl'), `f${n}.bin`), ...over,
+  }
+}
+
+// A fetch that parks until released, so concurrency is observed structurally rather than by timing.
+function barrierFetch () {
+  const state = { live: 0, peak: 0, started: [], release: [] }
+  getOverlay().fetchFile = async (hash, opts) => {
+    state.live += 1
+    state.peak = Math.max(state.peak, state.live)
+    state.started.push(hash)
+    await new Promise((resolve) => state.release.push(resolve))
+    state.live -= 1
+    return opts.finalPath
+  }
+  state.releaseAll = () => { while (state.release.length) state.release.shift()() }
+  return state
+}
+
+const settle = () => new Promise((r) => setTimeout(r, 60))
+
+// REGRESSION (FIX-DL-ADMIT: runReconcile looped every pending row and called start() with no
+// counting, so a reconnect with N pending rows spawned N chunk schedulers, watchdog timers, fds
+// and progress tickers at once.)
+test('REGRESSION (FIX-DL-ADMIT): a reconnect backlog never exceeds the admission limit', async (t) => {
+  const ctx = await setup(t, 2)
+  const jobs = Array.from({ length: 8 }, (_, i) => makeJob(ctx, i))
+  const byKey = new Map(jobs.map((j) => [j.pendingKey, j]))
+  const engine = createOverlayDownloadEngine(testChannel({
+    resolvePendingRow: async (spaceId, row) => ({ removed: false, seq: undefined, job: byKey.get(row.filePath) }),
+  }))
+  const fetches = barrierFetch()
+
+  for (const job of jobs) {
+    await recordPending(SPACE, job.pendingKey, {
+      total: job.size, inPlace: false, ownerKey: OWNER, finalPath: job.finalPath,
+      contentHash: job.contentHash, bytesTransferred: 0, overlayShare: true,
+      shareId: 'folder1', relPath: job.relPath,
+    })
+  }
+
+  await engine.resumeForOwner(OWNER, SPACE)
+  await settle()
+
+  t.is(fetches.peak, 2, 'only two fetches ran at once')
+  t.is(engine.admissionStats().held, 2, 'two slots held')
+  t.ok(engine.admissionStats().queued >= 1, 'the rest are parked on the gate, not running')
+
+  // Drain: every job must still complete once slots free.
+  for (let i = 0; i < 12 && fetches.started.length < 8; i++) { fetches.releaseAll(); await settle() }
+  t.is(fetches.started.length, 8, 'all eight eventually ran')
+  t.is(fetches.peak, 2, 'and the peak never rose')
+  fetches.releaseAll()
+  await settle()
+})
+
+test('a job cancelled while queued never reaches the fetch', async (t) => {
+  const ctx = await setup(t, 1)
+  const engine = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  const first = makeJob(ctx, 1)
+  const queued = makeJob(ctx, 2)
+  await engine.start(first)
+  await settle()
+  t.is(fetches.started.length, 1, 'the first holds the only slot')
+
+  await engine.start(queued)
+  await settle()
+  t.is(fetches.started.length, 1, 'the second is parked')
+
+  engine.cancel(queued.transferId)
+  fetches.releaseAll()
+  await settle()
+
+  t.is(fetches.started.length, 1, 'the cancelled job never fetched')
+  t.absent(engine.has(queued.transferId), 'and left no registry slot behind')
+  fetches.releaseAll()
+  await settle()
+})
+
+test('an express job starts ahead of a queued bulk backlog', async (t) => {
+  const ctx = await setup(t, 1)
+  const engine = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  await engine.start(makeJob(ctx, 0))
+  await settle()
+  for (let i = 1; i <= 4; i++) await engine.start(makeJob(ctx, i))
+  await settle()
+  t.is(fetches.started.length, 1, 'the bulk backlog is parked behind the running job')
+
+  await engine.start(makeJob(ctx, 9, { express: true }))
+  await settle()
+  t.is(fetches.started.length, 2, 'the express job started anyway')
+  t.is(fetches.started[1], hashFor(9), 'and it was the express one, not the head of the bulk queue')
+
+  fetches.releaseAll()
+  await settle()
+  fetches.releaseAll()
+  await settle()
+})
+
+test('a limit of zero restores the unbounded behaviour', async (t) => {
+  const ctx = await setup(t, 0)
+  const engine = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  for (let i = 0; i < 6; i++) await engine.start(makeJob(ctx, i))
+  await settle()
+  t.is(fetches.peak, 6, 'every job ran at once')
+  t.is(engine.admissionStats().queued, 0, 'nothing was gated')
+  fetches.releaseAll()
+  await settle()
+})
+
+// The supersede restart re-enters start() from inside settleFetch, which runs while the superseded
+// job still holds its admission slot. It is safe only because restartAfterSupersede is
+// fire-and-forget — settleFetch returns, the slot releases, and the restart's acquire is pumped by
+// that release. An await added anywhere on that path would self-deadlock at limit 1, and this is
+// the canary: it hangs rather than fails, so a timeout here means the chain became blocking.
+test('a supersede restart at limit 1 does not deadlock on its own slot', async (t) => {
+  const ctx = await setup(t, 1)
+  const engine = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  const job = makeJob(ctx, 1)
+  await engine.start(job)
+  await settle()
+  t.is(fetches.started.length, 1, 'the job holds the only slot')
+
+  const newJob = makeJob(ctx, 2, { transferId: job.transferId, pendingKey: job.pendingKey })
+  t.ok(engine.supersede(job.transferId, newJob, job.contentHash), 'superseded')
+  fetches.releaseAll()
+  await settle()
+  await settle()
+
+  t.is(fetches.started.length, 2, 'the restart acquired the slot the superseded job released')
+  t.is(fetches.started[1], hashFor(2), 'and it fetched the new content hash')
+  fetches.releaseAll()
+  await settle()
+})
+
+test('draining the gate at shutdown does not start a fetch into a torn-down overlay', async (t) => {
+  const ctx = await setup(t, 1)
+  const engine = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  await engine.start(makeJob(ctx, 1))
+  await settle()
+  await engine.start(makeJob(ctx, 2))
+  await settle()
+  t.is(fetches.started.length, 1, 'the second job is parked on the gate')
+
+  await teardownOverlay()
+  engine.drainAdmission()
+  await settle()
+
+  t.is(fetches.started.length, 1, 'the parked job abandoned instead of fetching')
+  t.is(engine.admissionStats().queued, 0, 'and nothing is left holding close() open')
+})

--- a/test/integration/download-admission.test.js
+++ b/test/integration/download-admission.test.js
@@ -60,7 +60,19 @@ function barrierFetch () {
   return state
 }
 
-const settle = () => new Promise((r) => setTimeout(r, 60))
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+const settle = () => sleep(60)
+
+// Waits for a condition instead of a fixed delay: the resume path is coalesced and single-flighted,
+// so a sleep long enough on this machine is not long enough on a slower CI runner.
+async function until (fn, ms = 15000) {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (await fn()) return true
+    await sleep(10)
+  }
+  return false
+}
 
 // REGRESSION (FIX-DL-ADMIT: runReconcile looped every pending row and called start() with no
 // counting, so a reconnect with N pending rows spawned N chunk schedulers, watchdog timers, fds
@@ -83,6 +95,9 @@ test('REGRESSION (FIX-DL-ADMIT): a reconnect backlog never exceeds the admission
   }
 
   await engine.resumeForOwner(OWNER, SPACE)
+  // Wait for the gate to fill rather than for a duration: the assertion is that it never fills
+  // PAST the limit, which is checked continuously by the barrier's peak counter.
+  t.ok(await until(() => engine.admissionStats().held >= 2), 'the reconcile admitted its first jobs')
   await settle()
 
   t.is(fetches.peak, 2, 'only two fetches ran at once')
@@ -90,7 +105,7 @@ test('REGRESSION (FIX-DL-ADMIT): a reconnect backlog never exceeds the admission
   t.ok(engine.admissionStats().queued >= 1, 'the rest are parked on the gate, not running')
 
   // Drain: every job must still complete once slots free.
-  for (let i = 0; i < 12 && fetches.started.length < 8; i++) { fetches.releaseAll(); await settle() }
+  for (let i = 0; i < 40 && fetches.started.length < 8; i++) { fetches.releaseAll(); await settle() }
   t.is(fetches.started.length, 8, 'all eight eventually ran')
   t.is(fetches.peak, 2, 'and the peak never rose')
   fetches.releaseAll()
@@ -105,12 +120,11 @@ test('a job cancelled while queued never reaches the fetch', async (t) => {
   const first = makeJob(ctx, 1)
   const queued = makeJob(ctx, 2)
   await engine.start(first)
-  await settle()
-  t.is(fetches.started.length, 1, 'the first holds the only slot')
+  t.ok(await until(() => fetches.started.length === 1), 'the first holds the only slot')
 
   await engine.start(queued)
-  await settle()
-  t.is(fetches.started.length, 1, 'the second is parked')
+  t.ok(await until(() => engine.admissionStats().queued === 1), 'the second is parked')
+  t.is(fetches.started.length, 1, 'and never reached the fetch')
 
   engine.cancel(queued.transferId)
   fetches.releaseAll()
@@ -128,14 +142,13 @@ test('an express job starts ahead of a queued bulk backlog', async (t) => {
   const fetches = barrierFetch()
 
   await engine.start(makeJob(ctx, 0))
-  await settle()
+  t.ok(await until(() => fetches.started.length === 1), 'the first job holds the only slot')
   for (let i = 1; i <= 4; i++) await engine.start(makeJob(ctx, i))
-  await settle()
-  t.is(fetches.started.length, 1, 'the bulk backlog is parked behind the running job')
+  t.ok(await until(() => engine.admissionStats().queued === 4), 'the bulk backlog is parked behind it')
+  t.is(fetches.started.length, 1, 'none of the backlog started')
 
   await engine.start(makeJob(ctx, 9, { express: true }))
-  await settle()
-  t.is(fetches.started.length, 2, 'the express job started anyway')
+  t.ok(await until(() => fetches.started.length === 2), 'the express job started anyway')
   t.is(fetches.started[1], hashFor(9), 'and it was the express one, not the head of the bulk queue')
 
   fetches.releaseAll()
@@ -150,8 +163,7 @@ test('a limit of zero restores the unbounded behaviour', async (t) => {
   const fetches = barrierFetch()
 
   for (let i = 0; i < 6; i++) await engine.start(makeJob(ctx, i))
-  await settle()
-  t.is(fetches.peak, 6, 'every job ran at once')
+  t.ok(await until(() => fetches.peak === 6), 'every job ran at once')
   t.is(engine.admissionStats().queued, 0, 'nothing was gated')
   fetches.releaseAll()
   await settle()
@@ -169,16 +181,13 @@ test('a supersede restart at limit 1 does not deadlock on its own slot', async (
 
   const job = makeJob(ctx, 1)
   await engine.start(job)
-  await settle()
-  t.is(fetches.started.length, 1, 'the job holds the only slot')
+  t.ok(await until(() => fetches.started.length === 1), 'the job holds the only slot')
 
   const newJob = makeJob(ctx, 2, { transferId: job.transferId, pendingKey: job.pendingKey })
   t.ok(engine.supersede(job.transferId, newJob, job.contentHash), 'superseded')
   fetches.releaseAll()
-  await settle()
-  await settle()
-
-  t.is(fetches.started.length, 2, 'the restart acquired the slot the superseded job released')
+  t.ok(await until(() => fetches.started.length === 2),
+    'the restart acquired the slot the superseded job released (a hang here means the chain became blocking)')
   t.is(fetches.started[1], hashFor(2), 'and it fetched the new content hash')
   fetches.releaseAll()
   await settle()
@@ -190,14 +199,14 @@ test('draining the gate at shutdown does not start a fetch into a torn-down over
   const fetches = barrierFetch()
 
   await engine.start(makeJob(ctx, 1))
-  await settle()
+  t.ok(await until(() => fetches.started.length === 1), 'the first holds the slot')
   await engine.start(makeJob(ctx, 2))
-  await settle()
-  t.is(fetches.started.length, 1, 'the second job is parked on the gate')
+  t.ok(await until(() => engine.admissionStats().queued === 1), 'the second is parked on the gate')
 
   await teardownOverlay()
   engine.drainAdmission()
-  await settle()
+  // A negative assertion, so it needs a real pause: the released waiter must NOT reach a fetch.
+  await sleep(300)
 
   t.is(fetches.started.length, 1, 'the parked job abandoned instead of fetching')
   t.is(engine.admissionStats().queued, 0, 'and nothing is left holding close() open')

--- a/test/integration/intent-recovery.test.js
+++ b/test/integration/intent-recovery.test.js
@@ -1,0 +1,95 @@
+import test from 'brittle'
+import { freshDurable, freshPeer } from '../helpers/store.js'
+import { getIntentsBee } from '../../src/shared/core/intent-store.js'
+import { createIntentLog, INTENT_PREFIX } from '../../src/shared/core/intents.js'
+import { saveOwnedMount, getOwnedMount, saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { publishShare, readOwnShares } from '../../src/shared/shares/shares.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+
+const settle = () => new Promise((r) => setTimeout(r, 30))
+
+// REGRESSION (FIX-INTENT-1: owned-folder:delete writes the mount record and the share tombstone to
+// two different bees. A crash between them left the share still advertised with no mount behind it
+// — a co-member reading our profile bee would re-surface a folder we had deleted.)
+test('REGRESSION (FIX-INTENT-1): a half-finished owned delete is completed at the next boot', async (t) => {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Photos')
+  const share = await publishShare(space.spaceId, { name: 'Album', id: 'sh-1' })
+  await saveOwnedMount({ spaceId: space.spaceId, shareId: 'sh-1', mountPath: ctx.tmpDir('src') })
+
+  // Simulate the crash: the intent is written, the mount record is dropped, and the process dies
+  // before the share tombstone lands.
+  const intents = createIntentLog({ bee: getIntentsBee })
+  intents.register('owned-delete', async () => {})
+  await intents.begin('owned-delete', { spaceId: space.spaceId, shareId: 'sh-1' })
+  const { deleteOwnedMount } = await import('../../src/shared/folders/mount-store.js')
+  await deleteOwnedMount(space.spaceId, 'sh-1')
+
+  t.is((await readOwnShares(space.spaceId)).length, 1, 'the share is still advertised — the half state')
+  t.absent(await getOwnedMount(space.spaceId, 'sh-1'), 'while its mount is already gone')
+
+  // The recovery a boot would run.
+  const recovering = createIntentLog({ bee: getIntentsBee })
+  const { tombstoneShare } = await import('../../src/shared/shares/shares.js')
+  recovering.register('owned-delete', async ({ spaceId, shareId }) => {
+    await deleteOwnedMount(spaceId, shareId)
+    await tombstoneShare(spaceId, shareId)
+  })
+  await recovering.recover()
+
+  t.is((await readOwnShares(space.spaceId)).length, 0, 'the share advertisement is retired')
+  t.is((await recovering.list()).length, 0, 'and the intent record is cleared')
+})
+
+test('a half-finished foreign unmount is completed at the next boot', async (t) => {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Docs')
+  await saveForeignMount({ spaceId: space.spaceId, shareId: 'sh-2', mountPath: ctx.tmpDir('mirror'), ownerKey: 'a'.repeat(64) })
+
+  const intents = createIntentLog({ bee: getIntentsBee })
+  intents.register('foreign-unmount', async () => {})
+  await intents.begin('foreign-unmount', { spaceId: space.spaceId, shareId: 'sh-2' })
+  t.ok(await getForeignMount(space.spaceId, 'sh-2'), 'the mount record is still there — the half state')
+
+  const recovering = createIntentLog({ bee: getIntentsBee })
+  const { unmountForeignFolder } = await import('../../src/shared/folders/foreign-folders.js')
+  recovering.register('foreign-unmount', async ({ spaceId, shareId }) => {
+    await unmountForeignFolder(spaceId, shareId)
+  })
+  await recovering.recover()
+
+  t.absent(await getForeignMount(space.spaceId, 'sh-2'), 'the mount record is gone')
+  t.is((await recovering.list()).length, 0, 'and the intent is cleared')
+})
+
+// Forward compatibility across an OTA rollout: an older build must never eat a record it has no
+// reconciler for, or a downgrade would silently drop a newer build's pending work.
+test('an intent for an unknown kind survives a boot untouched', async (t) => {
+  await freshDurable(t)
+  const bee = getIntentsBee()
+  await bee.put(INTENT_PREFIX + 'future-flow/1-0', { kind: 'future-flow', args: { x: 1 }, at: Date.now() })
+
+  const intents = createIntentLog({ bee: getIntentsBee })
+  intents.register('owned-delete', async () => {})
+  await intents.recover()
+  await settle()
+
+  const left = await intents.list()
+  t.is(left.length, 1, 'still there')
+  t.is(left[0].kind, 'future-flow')
+})
+
+// The record has to be readable by a log instance that did not write it — that is what a next-boot
+// recovery is, and it is what a purely in-memory map would fail.
+test('an intent written by one log instance is read by another', async (t) => {
+  await freshDurable(t)
+  const writer = createIntentLog({ bee: getIntentsBee })
+  writer.register('owned-delete', async () => {})
+  await writer.begin('owned-delete', { spaceId: 's', shareId: 'sh' })
+
+  const reader = createIntentLog({ bee: getIntentsBee })
+  reader.register('owned-delete', async () => {})
+  const left = await reader.list()
+  t.is(left.length, 1, 'the record is in the bee, not in the writer')
+  t.is(left[0].args.shareId, 'sh')
+})

--- a/test/integration/peer-catalog-eviction.test.js
+++ b/test/integration/peer-catalog-eviction.test.js
@@ -1,0 +1,92 @@
+import test from 'brittle'
+import crypto from 'hypercore-crypto'
+import { freshPeer } from '../helpers/store.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { getPeerEntry, getPeerEntryState, watchPeerCatalog, dropCatalog, peerCatalogCacheStats } from '../../src/shared/shares/share-catalog.js'
+
+const keyFor = (n) => crypto.keyPair(Buffer.alloc(32, n)).publicKey.toString('hex')
+
+async function withLimit (t, limit, fn) {
+  const prev = getRuntimeConfig()
+  setRuntimeConfig({ ...prev, peerCatalogCacheLimit: limit })
+  t.teardown(() => setRuntimeConfig(prev))
+  return fn()
+}
+
+// Opening a peer catalog is what caches it; a read on a key we hold no data for still opens the
+// core, which is exactly the cost being bounded.
+async function touch (keyHex) {
+  await getPeerEntry(keyHex, 'share1', 'file.bin').catch(() => null)
+}
+
+test('the peer catalog cache is bounded', async (t) => {
+  await freshPeer(t)
+  await withLimit(t, 2, async () => {
+    for (let i = 1; i <= 5; i++) await touch(keyFor(i))
+    const stats = peerCatalogCacheStats()
+    t.is(stats.size, 2, 'five catalogs opened, two kept')
+    t.alike(stats.keys, [keyFor(4), keyFor(5)], 'and they are the two most recent')
+  })
+})
+
+// REGRESSION (FIX-CATALOG-LRU: the cached values are live Hyperbees whose append listener drives
+// the mirror loop. Evicting a watched catalog would stop that loop with no error anywhere.)
+test('REGRESSION (FIX-CATALOG-LRU): a watched catalog is pinned against eviction', async (t) => {
+  await freshPeer(t)
+  await withLimit(t, 1, async () => {
+    const watched = keyFor(10)
+    const bee = watchPeerCatalog(watched, 'listener-1', () => {})
+    t.ok(bee, 'the watch opened the catalog')
+    t.is(peerCatalogCacheStats().refsOf(watched), 1, 'and pinned it')
+
+    for (let i = 11; i <= 15; i++) await touch(keyFor(i))
+
+    const stats = peerCatalogCacheStats()
+    t.ok(stats.keys.includes(watched), 'the watched catalog survived every eviction pass')
+
+    // Dropping the watch releases the pin, and the entry becomes ordinary cache.
+    dropCatalog(null, watched)
+    t.absent(peerCatalogCacheStats().keys.includes(watched), 'and the drop removed it')
+  })
+})
+
+test('a limit of zero keeps the previous unbounded behaviour', async (t) => {
+  await freshPeer(t)
+  await withLimit(t, 0, async () => {
+    for (let i = 20; i <= 28; i++) await touch(keyFor(i))
+    t.is(peerCatalogCacheStats().size, 9, 'every catalog stayed open')
+  })
+})
+
+test('an evicted catalog re-opens transparently on the next read', async (t) => {
+  await freshPeer(t)
+  await withLimit(t, 1, async () => {
+    const first = keyFor(30)
+    await touch(first)
+    await touch(keyFor(31))
+    t.absent(peerCatalogCacheStats().keys.includes(first), 'evicted')
+
+    await touch(first)
+    t.ok(peerCatalogCacheStats().keys.includes(first), 'the cache is a cache, not a registry')
+  })
+})
+
+// REGRESSION (FIX-CATALOG-READ-PIN: the read paths hold the bee across two awaits — the head sync
+// and the get. With refs at zero, a catalog opened by a CONCURRENT read evicts and closes the bee
+// mid-read, and the get lands on a closed handle. Pinning the watcher was not enough; the readers
+// need it too.)
+test('REGRESSION (FIX-CATALOG-READ-PIN): a concurrent open cannot evict a catalog mid-read', async (t) => {
+  await freshPeer(t)
+  await withLimit(t, 1, async () => {
+    const reading = keyFor(40)
+
+    // Two reads in flight against different catalogs, with room for exactly one. The first must
+    // survive its own awaits even though the second's open triggers an eviction pass.
+    const inFlight = getPeerEntryState(reading, 'share1', 'file.bin').catch(() => null)
+    const other = getPeerEntryState(keyFor(41), 'share1', 'file.bin').catch(() => null)
+
+    t.is(peerCatalogCacheStats().refsOf(reading), 1, 'the in-flight read pinned its catalog')
+    await Promise.all([inFlight, other])
+    t.is(peerCatalogCacheStats().refsOf(reading), 0, 'and released it when it finished')
+  })
+})

--- a/test/integration/peer-frame-hardening.test.js
+++ b/test/integration/peer-frame-hardening.test.js
@@ -1,0 +1,122 @@
+import test from 'brittle'
+import Protomux from 'protomux'
+import c from 'compact-encoding'
+import { Duplex } from 'streamx'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import url from 'bare-url'
+import b4a from 'b4a'
+import { validFrameShape, createRateLimiter } from '../../src/shared/transfer/handshake-guard.js'
+
+function makeDuplex () {
+  let aWrite, bWrite
+  const a = new Duplex({ write (d, cb) { bWrite(d); cb() }, read () {} })
+  const b = new Duplex({ write (d, cb) { aWrite(d); cb() }, read () {} })
+  aWrite = (d) => a.push(d)
+  bWrite = (d) => b.push(d)
+  return [a, b]
+}
+
+const settle = (ms = 120) => new Promise((r) => setTimeout(r, ms))
+
+// Stands up the real mirall/handshake channel shape against real protomux. `guard` selects the
+// intake: 'none' is staging's (parse, then read msg.type), 'shape' is the fixed one.
+function pair (t, guard) {
+  const [sa, sb] = makeDuplex()
+  const seen = []
+  const muxA = Protomux.from(sa)
+  const muxB = Protomux.from(sb)
+
+  const chB = muxB.createChannel({ protocol: 'mirall/handshake' })
+  const msgB = chB.addMessage({
+    encoding: c.string,
+    onmessage (str) {
+      let msg
+      try { msg = JSON.parse(str) } catch { return }
+      if (guard === 'shape' && !validFrameShape(msg)) return
+      // The property read that sits outside any try in the real handler.
+      if (msg.type === 'handshake' || msg.type === 'membership:request') seen.push('identity')
+      else seen.push(msg.type)
+    },
+  })
+  chB.open()
+
+  const chA = muxA.createChannel({ protocol: 'mirall/handshake' })
+  const msgA = chA.addMessage({ encoding: c.string })
+  chA.open()
+
+  t.teardown(() => { try { sa.destroy() } catch {} try { sb.destroy() } catch {} })
+  return { send: (raw) => msgA.send(raw), seen, socketB: sb, muxB }
+}
+
+// REGRESSION (FIX-FRAME-NULL: the four-character frame `null` destroyed the receiving socket. The
+// mirall/handshake channel id is the public protocol string, so any peer on the topic could do it.)
+test('REGRESSION (FIX-FRAME-NULL): a null frame no longer destroys the socket', async (t) => {
+  const guarded = pair(t, 'shape')
+  guarded.send('null')
+  await settle()
+  t.absent(guarded.socketB.destroyed, 'the socket survived the malformed frame')
+
+  guarded.send(JSON.stringify({ type: 'presence' }))
+  await settle()
+  t.alike(guarded.seen, ['presence'], 'and the next honest frame was still dispatched')
+})
+
+// The other half of the proof, run in-process rather than over the wire: staging's intake reads
+// `msg.type` straight after the parse, and on `null` that read THROWS. Over a real socket the throw
+// escapes the message handler into Protomux._ondata — verified against real protomux while writing
+// this, which printed:
+//   Uncaught TypeError: Cannot read properties of null (reading 'type')
+//     at Object.recv (protomux/index.js:276) at Channel._recv (:228)
+//     at Protomux._decode (:598) at Protomux._ondata (:562)
+// That escape is the socket kill, and it takes the runner down with it — so it is asserted here as
+// the throw it is, not by detonating a live connection inside the suite.
+test('the unguarded intake throws on the same frame', (t) => {
+  const msg = JSON.parse('null')
+  let thrown = null
+  try { if (msg.type === 'handshake') t.fail('unreachable') } catch (err) { thrown = err }
+  t.ok(thrown instanceof TypeError, 'the property read staging performs is what throws')
+  t.ok(/reading 'type'/.test(thrown.message), 'and it throws on exactly that read')
+  t.absent(validFrameShape(msg), 'the guard is what stops it reaching that line')
+})
+
+// The cap is named in bytes, so it has to measure bytes: a frame of multi-byte characters is under
+// the limit by str.length while being several times over it in UTF-8.
+test('the size cap counts UTF-8 bytes, not UTF-16 units', (t) => {
+  const maxBytes = 100
+  const overBoth = 'x'.repeat(maxBytes + 1)
+  const underCharsOverBytes = '€'.repeat(40)   // 40 UTF-16 units, 120 UTF-8 bytes
+
+  const rejects = (str) => str.length > maxBytes || b4a.byteLength(str) > maxBytes
+  t.ok(rejects(overBoth), 'a plainly oversized frame is rejected by the cheap check')
+  t.ok(underCharsOverBytes.length <= maxBytes, 'this one slips past a UTF-16 length check')
+  t.ok(b4a.byteLength(underCharsOverBytes) > maxBytes, 'while really being over the byte cap')
+  t.ok(rejects(underCharsOverBytes), 'and the intake rejects it')
+})
+
+test('every frame type is metered, not just the two identity types', async (t) => {
+  const here = path.dirname(url.fileURLToPath(import.meta.url))
+  const src = fs.readFileSync(path.join(here, '..', '..', 'src', 'shared', 'transfer', 'swarm.js'), 'utf8')
+  const intake = src.slice(src.indexOf('onmessage(str) {'), src.indexOf('dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler)'))
+
+  const sizeAt = intake.indexOf('getPeerFrameMaxBytes()')
+  const limitAt = intake.indexOf('frameLimiter.take(')
+  const parseAt = intake.indexOf('JSON.parse(str)')
+  const shapeAt = intake.indexOf('validFrameShape(msg)')
+  const identityAt = intake.indexOf("msg.type === 'handshake'")
+
+  t.ok(sizeAt >= 0 && limitAt >= 0 && shapeAt >= 0, 'the cap, the general lane and the shape guard are all present')
+  t.ok(sizeAt < parseAt, 'the size cap is charged before the decode')
+  t.ok(limitAt < parseAt, 'the general lane is charged before the decode')
+  t.ok(parseAt < shapeAt, 'the shape guard runs on the decoded value')
+  t.ok(shapeAt < identityAt, 'and BEFORE the first property read — the ordering the bug was')
+})
+
+test('a flood trips the ban surface the identity lanes already use', (t) => {
+  let now = 0
+  const limiter = createRateLimiter({ burst: 256, refillMs: 20, abuseThreshold: 512, now: () => now })
+  const peer = 'd'.repeat(64)
+  let banned = false
+  for (let i = 0; i < 5000 && !banned; i++) banned = limiter.take(peer).ban
+  t.ok(banned, 'share-prepare-progress at line rate self-evicts')
+})

--- a/test/unit/intents.test.js
+++ b/test/unit/intents.test.js
@@ -1,0 +1,156 @@
+import test from 'brittle'
+import { createIntentLog, INTENT_PREFIX } from '../../src/shared/core/intents.js'
+
+// A minimal in-memory stand-in for the Hyperbee surface the log uses: put, del, createReadStream
+// over a key range. Keeps this a Node unit test — the log has no bare-* imports by design.
+function fakeBee () {
+  const map = new Map()
+  return {
+    map,
+    async put (k, v) { map.set(k, v) },
+    async del (k) { map.delete(k) },
+    async * createReadStream ({ gte, lt }) {
+      for (const key of [...map.keys()].sort()) {
+        if (key >= gte && key < lt) yield { key, value: map.get(key) }
+      }
+    },
+  }
+}
+
+const logOf = () => { const lines = []; return { lines, warn: (...a) => lines.push(['warn', ...a].join(' ')), info: (...a) => lines.push(['info', ...a].join(' ')) } }
+
+test('an intent is written before the flow and removed after it', async (t) => {
+  const bee = fakeBee()
+  const intents = createIntentLog({ bee: () => bee })
+  intents.register('owned-delete', async () => {})
+
+  const id = await intents.begin('owned-delete', { spaceId: 's1', shareId: 'sh1' })
+  t.ok(id.startsWith(INTENT_PREFIX + 'owned-delete/'), 'the id carries the kind')
+  t.is(bee.map.size, 1, 'the record exists while the flow runs')
+  t.alike((await intents.list())[0].args, { spaceId: 's1', shareId: 'sh1' }, 'and carries the args')
+
+  await intents.complete(id)
+  t.is(bee.map.size, 0, 'and is gone once the flow finishes')
+})
+
+test('completing twice is not an error', async (t) => {
+  const bee = fakeBee()
+  const intents = createIntentLog({ bee: () => bee })
+  intents.register('k', async () => {})
+  const id = await intents.begin('k', {})
+  await intents.complete(id)
+  await intents.complete(id)
+  t.is(bee.map.size, 0, 'idempotent')
+})
+
+test('beginning an unregistered kind throws at the call site', async (t) => {
+  const bee = fakeBee()
+  const intents = createIntentLog({ bee: () => bee })
+  let threw = null
+  try { await intents.begin('typo', {}) } catch (err) { threw = err }
+  t.ok(threw, 'refused')
+  t.ok(/no reconciler registered/.test(threw.message), 'and says why')
+  t.is(bee.map.size, 0, 'no orphan record was written')
+})
+
+test('registering the same kind twice throws', (t) => {
+  const intents = createIntentLog({ bee: () => fakeBee() })
+  intents.register('k', async () => {})
+  let threw = null
+  try { intents.register('k', async () => {}) } catch (err) { threw = err }
+  t.ok(threw, 'a duplicate reconciler is a wiring bug, not a silent overwrite')
+})
+
+test('recover dispatches by kind and clears only what completed', async (t) => {
+  const bee = fakeBee()
+  const intents = createIntentLog({ bee: () => bee, log: logOf() })
+  const seen = []
+  intents.register('a', async (args) => { seen.push(['a', args]) })
+  intents.register('b', async (args) => { seen.push(['b', args]) })
+
+  await intents.begin('a', { n: 1 })
+  await intents.begin('b', { n: 2 })
+  await intents.recover()
+
+  t.is(seen.length, 2, 'both reconcilers ran')
+  t.alike(seen.map((s) => s[0]).sort(), ['a', 'b'])
+  t.is(bee.map.size, 0, 'both records cleared')
+})
+
+// REGRESSION (FIX-INTENT-ISOLATION: one wedged flow must not strand every other pending intent —
+// the contract resumeInterruptedLeave already kept for its own steps.)
+test('REGRESSION (FIX-INTENT-ISOLATION): a throwing reconciler keeps its record and does not stop the rest', async (t) => {
+  const bee = fakeBee()
+  const log = logOf()
+  const intents = createIntentLog({ bee: () => bee, log })
+  const ran = []
+  intents.register('bad', async () => { throw new Error('disk on fire') })
+  intents.register('good', async () => { ran.push('good') })
+
+  await intents.begin('bad', {})
+  await intents.begin('good', {})
+  await intents.recover()
+
+  t.alike(ran, ['good'], 'the healthy intent still ran')
+  const left = await intents.list()
+  t.is(left.length, 1, 'exactly one record survived')
+  t.is(left[0].kind, 'bad', 'the failed one, kept for the next boot')
+  t.ok(log.lines.some((l) => l.includes('retrying next boot')), 'and it said so')
+})
+
+// Forward compatibility: an older build must never eat a record it does not understand.
+test('an intent whose kind is unknown survives untouched', async (t) => {
+  const bee = fakeBee()
+  const log = logOf()
+  const intents = createIntentLog({ bee: () => bee, log })
+  intents.register('known', async () => {})
+  await intents.begin('known', {})
+  // A newer build's record, written by a version that had a reconciler for it.
+  await bee.put(INTENT_PREFIX + 'from-the-future/123-0', { kind: 'from-the-future', args: {}, at: 1 })
+
+  await intents.recover()
+
+  const left = await intents.list()
+  t.is(left.length, 1, 'the unknown record is still there')
+  t.is(left[0].kind, 'from-the-future')
+  t.ok(log.lines.some((l) => l.includes('no reconciler')), 'and it was reported, not dropped')
+})
+
+test('ids are unique within a millisecond', async (t) => {
+  const bee = fakeBee()
+  const intents = createIntentLog({ bee: () => bee })
+  intents.register('k', async () => {})
+  const ids = new Set()
+  for (let i = 0; i < 100; i++) ids.add(await intents.begin('k', { i }))
+  t.is(ids.size, 100, 'no collisions')
+  t.is((await intents.list()).length, 100, 'and every one is listed')
+})
+
+// A flow must not fail because its bookkeeping write failed: refusing the user's delete is a worse
+// outcome than the crash window the intent guards against.
+test('beginOrNull degrades to the pre-intent behaviour when the write fails', async (t) => {
+  const bee = fakeBee()
+  bee.put = async () => { throw new Error('bee closed') }
+  const log = logOf()
+  const intents = createIntentLog({ bee: () => bee, log })
+  intents.register('owned-delete', async () => {})
+
+  const id = await intents.beginOrNull('owned-delete', {})
+  t.is(id, null, 'the caller gets null instead of a rejection')
+  t.ok(log.lines.some((l) => l.includes('runs unprotected')), 'and it is reported')
+})
+
+test('complete tolerates a null id and a failing delete', async (t) => {
+  const bee = fakeBee()
+  const log = logOf()
+  const intents = createIntentLog({ bee: () => bee, log })
+  await intents.complete(null)
+  t.pass('a null id is a no-op, so the caller needs no branch')
+
+  intents.register('k', async () => {})
+  const id = await intents.begin('k', {})
+  bee.del = async () => { throw new Error('disk gone') }
+  await intents.complete(id)
+  t.pass('a failing clear does not throw out of a flow whose work is already done')
+  t.ok(log.lines.some((l) => l.includes('re-run harmlessly')), 'and says the record will re-run')
+})

--- a/test/unit/ipc-failure-logging.test.js
+++ b/test/unit/ipc-failure-logging.test.js
@@ -1,0 +1,142 @@
+import test from 'brittle'
+import { createIPC, getRequestFailureCounters, resetRequestFailureCounters } from '../../src/shared/core/ipc.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+
+// The router logs through createLogger, which writes to console.warn / console.log. Capturing both
+// is the only way to assert the LEVEL, which is the entire point of this fix.
+function captureConsole (t) {
+  const warns = []
+  const logs = []
+  const origWarn = console.warn
+  const origLog = console.log
+  console.warn = (...a) => warns.push(a.join(' '))
+  console.log = (...a) => logs.push(a.join(' '))
+  t.teardown(() => { console.warn = origWarn; console.log = origLog })
+  return { warns, logs }
+}
+
+// The router consumes NDJSON from pipe.on('data'); feed it the way the real pipe does.
+function fakePipe () {
+  const written = []
+  let onData = null
+  return {
+    write: (s) => { written.push(s); return true },
+    on: (evt, fn) => { if (evt === 'data') onData = fn },
+    feed: (obj) => onData(Buffer.from(JSON.stringify(obj) + '\n')),
+    written,
+  }
+}
+
+function setup (t, { verbose = false } = {}) {
+  const prev = getRuntimeConfig()
+  setRuntimeConfig({ ...prev, verbose })
+  resetRequestFailureCounters()
+  t.teardown(() => { setRuntimeConfig(prev); resetRequestFailureCounters() })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe)
+  return { ipc, pipe }
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 20))
+
+// REGRESSION (FIX-OBS-1: every failing IPC request was logged at debug while the default level is
+// warn, so nothing that failed in the field was ever recoverable after the fact.)
+test('REGRESSION (FIX-OBS-1): a failing request is logged at warn at the default level', async (t) => {
+  const cap = captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.handle('thing:do', async () => { const e = new Error('it broke'); e.code = 'EPATH'; throw e })
+  ipc.start()
+
+  pipe.feed({ id: 1, type: 'thing:do' })
+  await flush()
+
+  const failure = cap.warns.find((l) => l.includes('req-failed'))
+  t.ok(failure, 'the failure reached console.warn')
+  t.ok(failure.includes('thing:do'), 'carries the request type')
+  t.ok(failure.includes('code=EPATH'), 'carries the error code')
+  t.ok(failure.includes('it broke'), 'carries the message')
+  t.ok(/ms=\d+/.test(failure), 'carries the duration')
+})
+
+test('the response still carries the code and message to the caller', async (t) => {
+  captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.handle('thing:do', async () => { const e = new Error('nope'); e.code = 'EPATH'; throw e })
+  ipc.start()
+
+  pipe.feed({ id: 7, type: 'thing:do' })
+  await flush()
+
+  const reply = JSON.parse(pipe.written.find((w) => w.includes('"id":7')))
+  t.is(reply.code, 'EPATH')
+  t.is(reply.error, 'nope')
+})
+
+test('an expected code stays at debug so the level keeps its meaning', async (t) => {
+  const cap = captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.handle('preview:make', async () => { const e = new Error('cancelled'); e.code = 'PREVIEW_CANCELLED'; throw e })
+  ipc.start()
+
+  pipe.feed({ id: 2, type: 'preview:make' })
+  await flush()
+
+  t.absent(cap.warns.find((l) => l.includes('req-failed')), 'no warn for ordinary control flow')
+  t.is(getRequestFailureCounters()['preview:make:PREVIEW_CANCELLED'], 1, 'but it is still counted')
+})
+
+test('a successful request produces no warn', async (t) => {
+  const cap = captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.handle('thing:ok', async () => ({ fine: true }))
+  ipc.start()
+
+  pipe.feed({ id: 3, type: 'thing:ok' })
+  await flush()
+
+  t.is(cap.warns.length, 0, 'success is silent at the default level')
+})
+
+test('an unknown command warns and is counted', async (t) => {
+  const cap = captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.start()
+
+  pipe.feed({ id: 4, type: 'nope:missing' })
+  await flush()
+
+  t.ok(cap.warns.find((l) => l.includes('req-unknown') && l.includes('nope:missing')), 'warned')
+  t.is(getRequestFailureCounters()['unknown-command:NOT_FOUND'], 1, 'counted under a fixed bucket, not the caller-supplied name')
+})
+
+test('failures tally per type and code', async (t) => {
+  captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.handle('a:do', async () => { const e = new Error('x'); e.code = 'EPATH'; throw e })
+  ipc.handle('b:do', async () => { throw new Error('no code') })
+  ipc.start()
+
+  pipe.feed({ id: 10, type: 'a:do' })
+  pipe.feed({ id: 11, type: 'a:do' })
+  pipe.feed({ id: 12, type: 'b:do' })
+  await flush()
+
+  const counters = getRequestFailureCounters()
+  t.is(counters['a:do:EPATH'], 2, 'repeated failures accumulate')
+  t.is(counters['b:do:UNKNOWN'], 1, 'a code-less error falls back to UNKNOWN')
+})
+
+// The type half of the key comes from the caller, and an unknown command used to be counted under
+// whatever name it asked for — an unbounded map driven by input the router does not control.
+test('the failure counter map is bounded', async (t) => {
+  captureConsole(t)
+  const { ipc, pipe } = setup(t)
+  ipc.start()
+
+  for (let i = 0; i < 400; i++) pipe.feed({ id: 1000 + i, type: 'ghost:' + i })
+  await flush()
+
+  const counters = getRequestFailureCounters()
+  t.ok(Object.keys(counters).length <= 257, 'the map stayed capped')
+  t.is(counters['unknown-command:NOT_FOUND'], 400, 'and unknown commands share one bucket')
+})

--- a/test/unit/ipc.test.js
+++ b/test/unit/ipc.test.js
@@ -107,11 +107,16 @@ test('malformed JSON is skipped, not fatal', async (t) => {
 
 // Count only the IPC logger's own lines (tagged [ipc]); forward the rest so
 // brittle's own TAP over console.log is untouched.
+// Both channels: the router logs its trace through console.log (debug) and its failures through
+// console.warn, which is what makes a failed request visible at the default level.
 function captureIpcLog (t) {
-  const real = console.log
+  const realLog = console.log
+  const realWarn = console.warn
   const lines = []
-  console.log = (...a) => { if (a[0] === '[ipc]') { lines.push(a.slice(1).join(' ')); return } real(...a) }
-  t.teardown(() => { console.log = real; setRuntimeConfig({}) })
+  const grab = (real) => (...a) => { if (a[0] === '[ipc]') { lines.push(a.slice(1).join(' ')); return } real(...a) }
+  console.log = grab(realLog)
+  console.warn = grab(realWarn)
+  t.teardown(() => { console.log = realLog; console.warn = realWarn; setRuntimeConfig({}) })
   return lines
 }
 
@@ -142,7 +147,9 @@ test('verbose traces req + res (with timing); response payload is unchanged', as
   t.is(pipe.lastMsg().data, 'yo', 'logging does not alter the response')
 })
 
-test('verbose logs handler errors and unknown commands', async (t) => {
+// Failures and unknown commands moved from debug to warn (FIX-OBS-1) so they survive the default
+// level; this test keeps its original intent and follows them there.
+test('logs handler errors and unknown commands', async (t) => {
   const lines = captureIpcLog(t)
   const pipe = fakePipe()
   const ipc = createIPC(pipe)
@@ -152,8 +159,8 @@ test('verbose logs handler errors and unknown commands', async (t) => {
   pipe.feed({ id: '2', type: 'boom' })
   pipe.feed({ id: '3', type: 'ghost' })
   await tick()
-  t.ok(lines.some((l) => l.startsWith('res boom #2 ERROR kaboom')), 'logs the failing handler')
-  t.ok(lines.includes('req ghost — no handler'), 'logs an unknown command')
+  t.ok(lines.some((l) => l.startsWith('req-failed boom #2') && l.includes('kaboom')), 'logs the failing handler')
+  t.ok(lines.some((l) => l.startsWith('req-unknown ghost')), 'logs an unknown command')
   // ghost responds synchronously; boom's rejection resolves a tick later — so
   // find the #3 response rather than assuming write order.
   const ghost = pipe.written.map((s) => JSON.parse(s)).find((m) => m.id === '3')

--- a/test/unit/leave-crash-recovery-wiring.test.js
+++ b/test/unit/leave-crash-recovery-wiring.test.js
@@ -2,18 +2,19 @@ import test from 'brittle'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
+import { LEAVE_PHASES } from '../../src/shared/spaces/leave-flow.js'
 
 // The boot wiring isn't importable (it opens real cores under Bare), so pin the structural
 // invariants source-side, like worker-epipe-guard.test.js does: boot must complete interrupted
 // leaves BEFORE the membership backfill and exclude them from it, and the teardown must persist
 // the leaving marker before the member del.
 //
-// The boot sequence lives in the composition root (src/worker/boot.js); the leave teardown is a
-// handler and stays in the entry.
+// The boot sequence lives in the composition root (src/worker/boot.js); the leave teardown moved
+// out of the entry into src/worker/ipc/space-leave.js.
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const src = readFileSync(path.join(here, '..', '..', 'src', 'worker', 'boot.js'), 'utf8')
-const entrySrc = readFileSync(path.join(here, '..', '..', 'src', 'worker', 'main.js'), 'utf8')
+const entrySrc = readFileSync(path.join(here, '..', '..', 'src', 'worker', 'ipc', 'space-leave.js'), 'utf8')
 
 test('G4 wiring: boot completes interrupted leaves and excludes them from membership/topic setup', (t) => {
   // Anchor on the CALL (`await …`), never the bare symbol: the import line would otherwise
@@ -36,6 +37,10 @@ test('G4 wiring: boot completes interrupted leaves and excludes them from member
 })
 
 test('G4 wiring: teardown persists the durable marker before clearOwnMembership', (t) => {
-  const ordered = entrySrc.match(/tracker\.phase = 'mark-leaving'[\s\S]*?markSpaceLeavingDurable[\s\S]*?tracker\.phase = 'clearOwnMembership'/)
-  t.ok(ordered, 'markSpaceLeavingDurable phase precedes the clearOwnMembership phase')
+  // The member del now runs as the first step of the shared teardown order, so the phase name is
+  // stamped by leave-flow.js via onPhase rather than written inline. The invariant is unchanged:
+  // the durable marker must be written before the departure it makes recoverable.
+  const ordered = entrySrc.match(/tracker\.phase = 'mark-leaving'[\s\S]*?markSpaceLeavingDurable[\s\S]*?clearMembership:[\s\S]*?clearOwnMembership\(/)
+  t.ok(ordered, 'markSpaceLeavingDurable precedes the member del')
+  t.is(LEAVE_PHASES[0], 'clearOwnMembership', 'and the shared order still opens on that phase')
 })

--- a/test/unit/lru.test.js
+++ b/test/unit/lru.test.js
@@ -1,0 +1,92 @@
+import test from 'brittle'
+import { createRefCountedLru } from '../../src/shared/core/lru.js'
+
+test('evicts the oldest entry once the limit is passed', (t) => {
+  const evicted = []
+  const lru = createRefCountedLru({ limit: 2, onEvict: (k) => evicted.push(k) })
+  lru.set('a', 1); lru.set('b', 2); lru.set('c', 3)
+  t.alike(lru.keys(), ['b', 'c'], 'the oldest went')
+  t.alike(evicted, ['a'], 'and onEvict fired for it')
+})
+
+test('get promotes an entry so it is not the next victim', (t) => {
+  const evicted = []
+  const lru = createRefCountedLru({ limit: 2, onEvict: (k) => evicted.push(k) })
+  lru.set('a', 1); lru.set('b', 2)
+  lru.get('a')
+  lru.set('c', 3)
+  t.alike(evicted, ['b'], 'the untouched entry was evicted, not the recently used one')
+})
+
+// REGRESSION (FIX-CATALOG-LRU: the values are live Hyperbee handles. Evicting one while a caller
+// is mid-read closes the bee underneath it — trading a memory bound for a correctness bug.)
+test('REGRESSION (FIX-CATALOG-LRU): an in-use entry is never evicted underneath its reader', (t) => {
+  const evicted = []
+  const lru = createRefCountedLru({ limit: 1, onEvict: (k) => evicted.push(k) })
+  lru.set('pinned', 'handle')
+  t.is(lru.acquire('pinned'), 'handle', 'acquire hands back the value')
+
+  lru.set('b', 2); lru.set('c', 3); lru.set('d', 4)
+  t.ok(lru.has('pinned'), 'the pinned entry survived every eviction pass')
+  t.absent(evicted.includes('pinned'), 'and was never handed to onEvict')
+
+  // Releasing alone frees nothing: with the pinned entry the only one left, there is no pressure.
+  lru.release('pinned')
+  t.ok(lru.has('pinned'), 'still cached — a release is not a drop')
+
+  // Pressure now finds it evictable.
+  lru.set('e', 5)
+  t.absent(lru.has('pinned'), 'once unpinned it evicts like any other entry')
+  t.ok(evicted.includes('pinned'), 'and went through onEvict so its handle is closed')
+})
+
+test('nested acquires need matching releases', (t) => {
+  const lru = createRefCountedLru({ limit: 1 })
+  lru.set('k', 1)
+  lru.acquire('k'); lru.acquire('k')
+  t.is(lru.refsOf('k'), 2)
+  lru.set('other', 2)
+  t.ok(lru.has('k'), 'still pinned while two refs are outstanding')
+  lru.release('k')
+  t.is(lru.refsOf('k'), 1, 'one ref still outstanding')
+  lru.set('another', 3)
+  t.ok(lru.has('k'), 'and it survives pressure')
+  lru.release('k')
+  lru.set('third', 4)
+  t.absent(lru.has('k'), 'evicted under pressure once the last reader let go')
+})
+
+test('a limit of zero never evicts (the rollback path)', (t) => {
+  const evicted = []
+  const lru = createRefCountedLru({ limit: 0, onEvict: (k) => evicted.push(k) })
+  for (let i = 0; i < 500; i++) lru.set('k' + i, i)
+  t.is(lru.size(), 500)
+  t.is(evicted.length, 0, 'unbounded, as before')
+})
+
+test('the limit is read per operation', (t) => {
+  let cap = 0
+  const lru = createRefCountedLru({ limit: () => cap })
+  for (let i = 0; i < 5; i++) lru.set('k' + i, i)
+  t.is(lru.size(), 5, 'unbounded while the cap is 0')
+  cap = 2
+  lru.set('k5', 5)
+  t.is(lru.size(), 2, 'tightens as soon as the cap does')
+})
+
+test('re-setting an existing key keeps its refcount', (t) => {
+  const lru = createRefCountedLru({ limit: 1 })
+  lru.set('k', 1)
+  lru.acquire('k')
+  lru.set('k', 2)
+  t.is(lru.refsOf('k'), 1, 'the reader still holds it across a value refresh')
+  t.is(lru.get('k'), 2, 'and sees the new value')
+})
+
+test('delete removes without firing onEvict', (t) => {
+  const evicted = []
+  const lru = createRefCountedLru({ limit: 5, onEvict: (k) => evicted.push(k) })
+  lru.set('k', 'handle')
+  t.is(lru.delete('k'), 'handle', 'hands the value back so the caller can close it')
+  t.is(evicted.length, 0, 'an explicit delete is the caller doing the teardown itself')
+})

--- a/test/unit/peer-frame-guard.test.js
+++ b/test/unit/peer-frame-guard.test.js
@@ -1,0 +1,50 @@
+import test from 'brittle'
+import { validFrameShape, createRateLimiter } from '../../src/shared/transfer/handshake-guard.js'
+
+// REGRESSION (FIX-FRAME-NULL: JSON.parse('null') returns null, and the `msg.type` read that
+// followed sat OUTSIDE the message handler's try — it reached protomux's _ondata, which
+// _safeDestroy'd the socket. The mirall/handshake channel id is the public protocol string, so
+// any peer on the topic could drop a connection with the four-character frame `null`.)
+test('REGRESSION (FIX-FRAME-NULL): the shape guard rejects everything that would throw or misroute', (t) => {
+  t.absent(validFrameShape(JSON.parse('null')), 'null — the socket-killer')
+  t.absent(validFrameShape(undefined), 'undefined')
+  t.absent(validFrameShape(42), 'a number')
+  t.absent(validFrameShape('str'), 'a string')
+  t.absent(validFrameShape(true), 'a boolean')
+  t.absent(validFrameShape([]), 'an array')
+  t.absent(validFrameShape([{ type: 'handshake' }]), 'an array carrying a frame')
+  t.absent(validFrameShape({}), 'an object with no type')
+  t.absent(validFrameShape({ type: 7 }), 'a non-string type')
+  t.ok(validFrameShape({ type: 'presence' }), 'a well-formed frame passes')
+})
+
+// Sizing check: presence is the busiest honest source at one frame per (peer, space) per 5 s.
+test('the general lane admits an honest presence cadence indefinitely', (t) => {
+  let now = 0
+  const limiter = createRateLimiter({ burst: 256, refillMs: 20, abuseThreshold: 512, now: () => now })
+  const peer = 'a'.repeat(64)
+  // 20 shared spaces => 20 frames every 5s, for 10 minutes.
+  let denied = 0
+  for (let tick = 0; tick < 120; tick++) {
+    for (let i = 0; i < 20; i++) if (!limiter.take(peer).ok) denied += 1
+    now += 5000
+  }
+  t.is(denied, 0, 'never rate-limited an honest peer')
+})
+
+test('the general lane bans a line-rate flood', (t) => {
+  let now = 0
+  const limiter = createRateLimiter({ burst: 256, refillMs: 20, abuseThreshold: 512, now: () => now })
+  const peer = 'b'.repeat(64)
+  let banned = false
+  for (let i = 0; i < 5000 && !banned; i++) banned = limiter.take(peer).ban
+  t.ok(banned, 'a sustained flood self-evicts')
+})
+
+test('a burst of zero switches the lane off', (t) => {
+  const limiter = createRateLimiter({ burst: 0, refillMs: 20, abuseThreshold: 512 })
+  const peer = 'c'.repeat(64)
+  let denied = 0
+  for (let i = 0; i < 10000; i++) if (!limiter.take(peer).ok) denied += 1
+  t.is(denied, 0, 'the rollback path admits everything')
+})

--- a/test/unit/semaphore.test.js
+++ b/test/unit/semaphore.test.js
@@ -1,0 +1,117 @@
+import test from 'brittle'
+import { createSemaphore } from '../../src/shared/core/concurrency.js'
+
+const tick = () => new Promise((r) => setTimeout(r, 0))
+
+// REGRESSION (FIX-DL-ADMIT: runReconcile started every pending row at once — 200 rows meant 200
+// chunk schedulers, watchdog timers, fds and progress tickers alive together.)
+test('REGRESSION (FIX-DL-ADMIT): concurrency never exceeds the limit', async (t) => {
+  const sem = createSemaphore({ limit: 3, expressLanes: 0 })
+  let live = 0
+  let peak = 0
+  const releases = []
+
+  const jobs = Array.from({ length: 20 }, async () => {
+    const release = await sem.acquire()
+    live += 1
+    peak = Math.max(peak, live)
+    releases.push(() => { live -= 1; release() })
+  })
+
+  // Drain in waves so every job gets its turn.
+  for (let i = 0; i < 20; i++) {
+    await tick()
+    releases.shift()?.()
+  }
+  await Promise.all(jobs)
+  t.is(peak, 3, 'never more than three at once')
+})
+
+test('the express lane may exceed the limit by exactly expressLanes', async (t) => {
+  const sem = createSemaphore({ limit: 2, expressLanes: 1 })
+  await sem.acquire()
+  await sem.acquire()
+  t.is(sem.stats().held, 2, 'both bulk slots taken')
+
+  let expressAdmitted = false
+  sem.acquire({ express: true }).then(() => { expressAdmitted = true })
+  await tick()
+  t.ok(expressAdmitted, 'the express job started anyway')
+
+  let secondExpress = false
+  sem.acquire({ express: true }).then(() => { secondExpress = true })
+  await tick()
+  t.absent(secondExpress, 'but only one express lane exists')
+})
+
+test('bulk waiters are admitted in acquire order', async (t) => {
+  const sem = createSemaphore({ limit: 1, expressLanes: 0 })
+  const first = await sem.acquire()
+  const order = []
+  const waits = [1, 2, 3].map((n) => sem.acquire().then((rel) => { order.push(n); return rel }))
+
+  first()
+  const r1 = await waits[0]
+  r1()
+  const r2 = await waits[1]
+  r2()
+  await waits[2]
+  t.alike(order, [1, 2, 3], 'FIFO')
+})
+
+test('an express acquire jumps a queue of bulk waiters', async (t) => {
+  const sem = createSemaphore({ limit: 1, expressLanes: 1 })
+  const held = await sem.acquire()
+  const order = []
+  sem.acquire().then(() => order.push('bulk'))
+  sem.acquire({ express: true }).then(() => order.push('express'))
+  await tick()
+  t.alike(order, ['express'], 'express started while the bulk slot was still held')
+  held()
+  await tick()
+  t.alike(order, ['express', 'bulk'], 'bulk followed when the slot freed')
+})
+
+test('a limit of zero admits everything (the rollback path)', async (t) => {
+  const sem = createSemaphore({ limit: 0 })
+  for (let i = 0; i < 50; i++) await sem.acquire()
+  t.is(sem.stats().queued, 0, 'nothing ever queued')
+  t.is(sem.stats().held, 50)
+})
+
+test('the limit is re-read per acquire', async (t) => {
+  let cap = 1
+  const sem = createSemaphore({ limit: () => cap, expressLanes: 0 })
+  await sem.acquire()
+  let second = false
+  sem.acquire().then(() => { second = true })
+  await tick()
+  t.absent(second, 'blocked at cap 1')
+  cap = 5
+  // The pump only runs on release, so a raised cap takes effect on the next admission event.
+  const third = await sem.acquire()
+  t.ok(third, 'the raised cap admits a fresh acquire immediately')
+})
+
+test('drain resolves every queued waiter and their releases are inert', async (t) => {
+  const sem = createSemaphore({ limit: 1, expressLanes: 0 })
+  await sem.acquire()
+  const parked = [sem.acquire(), sem.acquire()]
+  t.is(sem.stats().queued, 2)
+  sem.drain()
+  const releases = await Promise.all(parked)
+  t.is(sem.stats().queued, 0, 'nothing left parked')
+  for (const rel of releases) rel()
+  t.is(sem.stats().held, 1, 'the drained releases did not decrement the real holder')
+})
+
+test('releasing twice does not double-decrement', async (t) => {
+  const sem = createSemaphore({ limit: 2, expressLanes: 0 })
+  const a = await sem.acquire()
+  await sem.acquire()
+  t.is(sem.stats().held, 2)
+  a()
+  a()
+  a()
+  t.is(sem.stats().held, 1, 'only the first release counted')
+})

--- a/test/unit/state-conveyance-review-fixes.test.js
+++ b/test/unit/state-conveyance-review-fixes.test.js
@@ -7,10 +7,12 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 const src = (rel) => readFileSync(path.join(here, '..', '..', 'src', rel), 'utf8')
 const workerMain = src('worker/main.js')
 // The boot sequence and the mount runtime moved out of the entry into the composition root and
-// worker/mounts-runtime.js; the invariants below are unchanged, only the file that carries them.
+// worker/mounts-runtime.js, and the space:leave teardown into worker/ipc/space-leave.js; the
+// invariants below are unchanged, only the file that carries them.
 const boot = src('worker/boot.js')
 const mountsRuntime = src('worker/mounts-runtime.js')
 const swarm = src('shared/transfer/swarm.js')
+const spaceLeave = src('worker/ipc/space-leave.js')
 
 // These pin worker-orchestration fixes from the state-conveyance code review that can't be driven
 // at the unit layer (they need the live swarm/DHT); the behavioral halves live in test/flow.
@@ -54,7 +56,7 @@ test('REGRESSION (FIX-18: a handshake for a space with no local record is reject
 })
 
 test('REGRESSION (FIX-19: the post-teardown topic rejoin re-checks the live marker)', (t) => {
-  t.ok(/function rejoinPendingLeaveTopicAfterTeardown\(spaceId, space\) \{\s*\n\s*if \(!hasPendingLeave\(spaceId\)/.test(workerMain),
+  t.ok(/function rejoinPendingLeaveTopicAfterTeardown\(spaceId, space\) \{\s*\n\s*if \(!hasPendingLeave\(spaceId\)/.test(spaceLeave),
     'rejoin gates on hasPendingLeave, not a stale armed flag')
 })
 
@@ -64,7 +66,7 @@ test('REGRESSION (FIX-21: an enabled foreign mirror missing at boot is durably p
 })
 
 test('REGRESSION (FIX-E1: the pending-leave marker arms on any unacked member, not a vacuous bool)', (t) => {
-  const fn = workerMain.slice(workerMain.indexOf('async function armPendingLeaveIfUnwitnessed'))
+  const fn = spaceLeave.slice(spaceLeave.indexOf('async function armPendingLeaveIfUnwitnessed'))
   const body = fn.slice(0, fn.indexOf('\n}'))
   t.ok(/others\.length === 0\) return false/.test(body), 'a solo space (no other members) never arms a marker')
   t.ok(/others\.every\(\(k\) => acked\.has\(k\)\) \) return false|others\.every\(\(k\) => acked\.has\(k\)\)\) return false/.test(body.replace(/\s+/g, ' ')) || /every\(\(k\) => acked\.has\(k\)\)/.test(body),


### PR DESCRIPTION
The five findings ranked highest in `research/architecture-review-2026-08-28/STATUS.md`, plus the first bite of r01-5 taken where phase 4 had to touch `space:leave` anyway. Plan: `plans/plan-stability-hardening.md`. Seven commits, each independently green.

| Finding | Commit |
|---|---|
| r02-F1 unbounded downloads on reconnect | `[fix] Bound the number of concurrent downloads` |
| r09-7 failures invisible at the default log level | `[fix] Log and count failing IPC requests` |
| r07-2 peer frames unmetered and unvalidated | `[fix] Meter and validate every peer frame` |
| r01-5 86 handlers inline in the entrypoint | `[refactor] Extract the space-leave flow…` |
| r05-1 no intent/reconciler convention | `[feat] Recover interrupted flows from durable intents` |
| r06-7 unbounded open-core set | `[perf] Bound the peer catalog cache` |

**Two review corrections worth reading before the diff.** r07-2 blames `JSON.parse`; it is already inside a `try`. The socket-killer is the next line — `JSON.parse('null')` returns `null` and `msg.type` throws *outside* the try, into protomux's `_ondata`, which destroys the socket. Any peer on the topic could drop a connection with a four-character frame; verified against real protomux. And r02-F1 implies `await start(job)` would fix it — it would not: `start()` returns once it has detached the fetch task, so the gate belongs around that task, and must sit *below* the synchronous registry reservation that guarantees single-flight.

**Bugs found by review after the tests were green**, all mine, all now covered: `drainAdmission()` let a parked download fetch into a torn-down overlay; `intents.begin()` throwing would have failed the user's delete (bookkeeping must never do that); the catalog LRU closed bees underneath in-flight readers, because I pinned the watcher and not the readers; the failure-counter map was keyed on caller-supplied strings and unbounded; two of three `EXPECTED_CODES` did not exist, so that branch never fired; and the byte cap counted UTF-16 units.

**Rollbacks:** `downloadConcurrency: 0`, `peerFrameBurst: 0`, `peerFrameMaxBytes: 0`, `peerCatalogCacheLimit: 0` each restore the previous behaviour.

Gates: typecheck, lint (18/28 warnings), unit 1276, integration 852, flow 104/104. Every commit typechecks and passes unit on its own; the three hand-split commits also pass integration. The flow suite must be run alone — concurrent runners produce false failures.

**Known:** the one new lint warning is `registerSpaceLeave` at 168 lines — the handler's existing length becoming visible now that it is a named function rather than an arrow inside `ipc.handle(...)`. Splitting it is the r01-5 follow-up; doing it here would break the verbatim-move property the ten unedited `leave-*` flow tests gate.