### PR TITLE
[refactor] Move the file-listing hooks onto the query store

### DIFF
--- a/src/renderer/hooks/useFiles.ts
+++ b/src/renderer/hooks/useFiles.ts
@@ -1,86 +1,51 @@
-// Owns a space's loose-file listing (stale-while-revalidate cache, latest-wins + coalesced refreshes) plus publish/prepare progress; re-derives on event:reconcile.
-import { useState, useEffect, useCallback, useRef } from 'react'
+// A space's loose-file listing, read through the query store, plus the optimistic rows a publish
+// shows before the worker has indexed the file.
+import { useState, useCallback, useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import { request, subscribe, addFileToSpace } from '../ipc.js'
-import { makeCoalescer } from '../coalesce.js'
+import { request, addFileToSpace } from '../ipc.js'
+import { useQuery } from '../store/useQuery.js'
+import { refetchQuery } from '../store/query-store.js'
+import { mergeOptimistic } from '../optimisticRows.js'
 import { useToast } from '../components/toast/useToast.js'
 import { errorCodeToI18nKey } from '../errorMessages.js'
-import { Scope, scopeMatches, type Scope as ScopeType } from '../scope.js'
 import type { FileEntry } from '../types.js'
 
-// Last-known listing per space, kept across mounts and space switches. Lets a
-// reopened space render its files instantly (stale-while-revalidate) instead of
-// flashing "Loading files…" while files:list drains peer drives again — the
-// fresh result then quietly replaces the cached one.
-const listingCache = new Map<string, FileEntry[]>()
+const EMPTY: FileEntry[] = []
+
+// A members change (a peer's catalog key committed post-handshake) can newly reveal that peer's
+// loose files, so the listing re-derives on it too — the handshake's pre-persist files hint races
+// the member persist, but the post-persist members poke does not.
+function filesScopes(spaceId: string) {
+  return [{ kind: 'files', spaceId }, { kind: 'members', spaceId }]
+}
 
 export function useFiles(spaceId: string) {
   const toast = useToast()
   const { t: tErr } = useTranslation('errors')
-  const [files, setFiles] = useState<FileEntry[]>(() => listingCache.get(spaceId) ?? [])
-  const [loading, setLoading] = useState(() => !listingCache.has(spaceId))
-  const [error, setError] = useState<string | null>(null)
   const [uploadingFiles, setUploadingFiles] = useState<Map<string, FileEntry>>(new Map())
-  const seqRef = useRef(0)
+
+  // One leading + one trailing files:list per 750 ms window: a publish emits one files hint per
+  // catalog append and a handshake emits a members poke AND a files hint, neither of which should
+  // become concurrent full fan-outs.
+  const { data, error: queryError, loading: fetching } = useQuery<FileEntry[]>(
+    'files:list',
+    { spaceId },
+    filesScopes(spaceId),
+    { coalesceMs: 750, enabled: Boolean(spaceId) },
+  )
+
+  const files = data ?? EMPTY
+  // Only a genuinely cold space shows "Loading files…". A hint-driven refetch keeps the rows on
+  // screen, which is what stops the list collapsing and resetting scroll.
+  const loading = data === undefined && fetching
+  // The rows survive a failed read; the message is surfaced beside them and clears on the next
+  // successful one.
+  const error = queryError ? queryError.message : null
 
   const refresh = useCallback(async () => {
     if (!spaceId) return
-    // Latest-wins guard (mirrors useShareFiles): files:list reads bound each peer catalog to a
-    // ~1.5s budget and IPC resolves concurrently, so a slow refresh can return AFTER a newer one.
-    // Without this a stale snapshot overwrites fresh rows (and poisons listingCache), reverting an
-    // actively-downloading/available file back to its pre-replication state.
-    const seq = ++seqRef.current
-    // `files:list` can reject (IPC timeout, worker churn while the user moves
-    // source files around). Without this guard the rejection is uncaught and
-    // `setLoading(false)` never runs, wedging the view on "Loading files…"
-    // forever. Mirror the useShareFiles contract: surface the error, keep the
-    // last-known list, and let a later event-driven refresh clear it.
-    try {
-      const data = await request('files:list', { spaceId }) as FileEntry[]
-      if (seq !== seqRef.current) return
-      listingCache.set(spaceId, data)
-      setFiles(data)
-      setError(null)
-    } catch (err) {
-      if (seq !== seqRef.current) return
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      if (seq === seqRef.current) setLoading(false)
-    }
+    await refetchQuery<FileEntry[]>('files:list', { spaceId }, filesScopes(spaceId)).catch(() => {})
   }, [spaceId])
-
-  useEffect(() => {
-    if (!spaceId) return
-    // Stale-while-revalidate: if we've listed this space before, show that
-    // listing immediately and revalidate quietly. Only a genuinely cold space
-    // (never listed) shows "Loading files…". Event-driven refreshes below never
-    // flip loading either — that would collapse the list and reset scroll.
-    const cached = listingCache.get(spaceId)
-    if (cached) {
-      setFiles(cached)
-      setLoading(false)
-    } else {
-      setFiles([])
-      setLoading(true)
-    }
-    setError(null)
-    // One leading + one trailing files:list per 750 ms window (the coalescer useShareFiles and
-    // useSpaceStorage run): a publish emits one files hint per catalog append and a handshake
-    // emits a members poke AND a files hint, neither of which should become concurrent full
-    // fan-outs. The first trigger fires immediately, so the initial load is not delayed.
-    const coalescer = makeCoalescer(() => { void refresh() }, { intervalMs: 750 })
-    coalescer.trigger()
-    // Level-triggered: re-derive on the coalesced reconcile hint for this space (emitted 1:1 with
-    // the files-updated poke). A lost hint self-corrects on the next one; the list is always
-    // a projection of the worker's files:list, never a client-latched status.
-    const unsubFiles = subscribe<{ scope: ScopeType }>('event:reconcile', (msg) => {
-      // A members change (a peer's catalog key committed post-handshake) can newly reveal that
-      // peer's loose files, so re-derive on it too — the handshake's pre-persist files hint races
-      // the member persist, but the post-persist members poke does not.
-      if (scopeMatches(msg.scope, Scope.files(spaceId)) || scopeMatches(msg.scope, Scope.members(spaceId))) coalescer.trigger()
-    })
-    return () => { coalescer.cancel(); unsubFiles() }
-  }, [spaceId, refresh])
 
   async function addFiles(fileList: File[]) {
     for (const file of fileList) {
@@ -142,11 +107,10 @@ export function useFiles(spaceId: string) {
     await request('files:reveal', { spaceId, path })
   }
 
-  // Drop an optimistic publishing row once the server list surfaces the same path
-  // (the worker advertises the still-hashing file, so listFiles carries it) — avoids
-  // a duplicate row, and the server row survives a remount where uploadingFiles can't.
-  const optimistic = [...uploadingFiles.values()].filter((u) => !files.some((f) => f.path === u.path))
-  const allFiles = [...optimistic, ...files]
+  const allFiles = useMemo(
+    () => mergeOptimistic(files, [...uploadingFiles.values()]),
+    [files, uploadingFiles],
+  )
 
   return {
     files: allFiles,

--- a/src/renderer/hooks/useShareFiles.ts
+++ b/src/renderer/hooks/useShareFiles.ts
@@ -1,10 +1,12 @@
-// Owns a folder share's file listing (never-blank reconcile, latest-wins reads, coalesced refreshes) plus per-file transfer/prepare progress; re-derives on reconcile hints, paints progress from the decoration channel.
-import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
-import { request, subscribe } from '../ipc.js'
-import { reconcileFiles } from '../shareFilesReconcile.js'
-import { deriveFolderInfo } from '../folderInfo.js'
-import { makeCoalescer } from '../coalesce.js'
-import { Scope, scopeMatches, type Scope as ScopeType } from '../scope.js'
+// A folder share's file listing. The query store holds the raw share:list-files response; this hook
+// keeps the parts that are judgements about what a folder listing MEANS — the never-blank fold
+// across successive reads, the header totals derived from both, and which failures are terminal —
+// and paints per-file progress from the decoration channel at render.
+import { useState, useCallback, useMemo } from 'react'
+import { request } from '../ipc.js'
+import { useQuery } from '../store/useQuery.js'
+import { refetchQuery } from '../store/query-store.js'
+import { foldListing, emptyFold, resetFold, resolveListing, type Fold } from '../shareFilesFold.js'
 import { shareDecoKey } from '../decoration-key.js'
 import { useDecorations } from './useDecorations.js'
 import type { ShareFileEntry, ShareFileStatus } from '../types.js'
@@ -50,87 +52,69 @@ interface ListResult {
   fileLimit?: number | null
 }
 
+function toEntry(e: ServerEntry): ShareFileEntry {
+  return {
+    relPath: e.relPath,
+    size: e.size,
+    hash: e.hash,
+    mtime: e.mtime,
+    status: e.status,
+    localPath: e.localPath ?? undefined,
+    verified: e.verified,
+    pendingBytes: e.pendingBytes,
+    errorCode: e.errorCode,
+    transferId: e.transferId,
+  }
+}
+
 export function useShareFiles(spaceId: string, ownerKey: string, shareId: string, _role: 'mine' | 'browse' | 'mirrored') {
-  const [files, setFiles] = useState<ShareFileEntry[]>([])
-  const [info, setInfo] = useState<FolderInfo | null>(null)
-  const [loading, setLoading] = useState(true)
-  const [error, setError] = useState<string | null>(null)
-  const seqRef = useRef(0)
-  const filesRef = useRef<ShareFileEntry[]>([])
   const { byKey: decorations } = useDecorations('transfer', spaceId, shareDecoKey(shareId, ''))
 
-  const refresh = useCallback(async () => {
-    if (!spaceId || !shareId || !ownerKey) return
-    const seq = ++seqRef.current
-    try {
-      const res = await request('share:list-files', { spaceId, ownerKey, shareId }) as ListResult
-      if (seq !== seqRef.current) return
-      const mapped: ShareFileEntry[] = res.entries.map((e) => ({
-        relPath: e.relPath,
-        size: e.size,
-        hash: e.hash,
-        mtime: e.mtime,
-        status: e.status,
-        localPath: e.localPath ?? undefined,
-        verified: e.verified,
-        pendingBytes: e.pendingBytes,
-        errorCode: e.errorCode,
-        transferId: e.transferId,
-      }))
-      // One read carries both the rows and their completeness; an incomplete/partial peer
-      // read must not blank or shrink the list (reconcileFiles keeps the last good rows).
-      const next: ShareFileEntry[] = reconcileFiles(filesRef.current, mapped, { complete: res.complete })
-      filesRef.current = next
-      setFiles(next)
-      // On a complete read fileCount is the TRUE total (res.total) and `next` may be capped to
-      // listFilesCap, which the over-limit banner reports; on an incomplete read the count can only
-      // rise above the reconciled rows, never fall below them. (see deriveFolderInfo)
-      setInfo(deriveFolderInfo(res, next))
-      setError(null)
-    } catch (err) {
-      if (seq !== seqRef.current) return
-      const code = err instanceof Error ? (err as Error & { code?: string }).code : undefined
-      // A timeout / peer-unavailable read is transient → keep the last good list. A gone or
-      // access-revoked share (NOT_FOUND / EOWNERSHIP) is terminal → clear and surface it so a
-      // deleted share doesn't linger as a phantom listing.
-      const terminal = code === 'NOT_FOUND' || code === 'EOWNERSHIP'
-      if (filesRef.current.length > 0 && !terminal) {
-        setError(null)
-      } else {
-        filesRef.current = []
-        setFiles([])
-        setInfo(null)
-        setError(err instanceof Error ? err.message : String(err))
-      }
-    } finally {
-      if (seq === seqRef.current) setLoading(false)
-    }
-  }, [spaceId, ownerKey, shareId])
+  // Two scopes feed this view: the share's own rows, and the space's peer/presence transitions,
+  // which change row status (remote/unavailable, paused-offline) without touching the catalog.
+  const scopes = useMemo(
+    () => [{ kind: 'share-files', spaceId, shareId }, { kind: 'files', spaceId }],
+    [spaceId, shareId],
+  )
+  const ready = Boolean(spaceId && shareId && ownerKey)
+  // The store holds the RAW response. It never learns what `complete` or `truncated` mean — those
+  // are share:list-files concepts, and the fold below is where they are read.
+  const { data, error: queryError, loading: fetching } = useQuery<ListResult>(
+    'share:list-files',
+    { spaceId, ownerKey, shareId },
+    scopes,
+    { coalesceMs: 750, enabled: ready },
+  )
 
-  useEffect(() => {
-    // Reset list state when the share changes so the never-blank merge can't carry the
-    // previous share's rows into this one (FolderView is reused, not keyed per share).
-    filesRef.current = []
-    setFiles([])
-    setInfo(null)
-    setError(null)
-    // Loading state only on first load / when the share changes — not on the
-    // event-driven refreshes below, which would otherwise collapse the list and
-    // reset scroll position (e.g. after downloading a file).
-    setLoading(true)
-    // Coalesce the per-append refresh storm during a large index into one trailing
-    // refresh per window; the first load is immediate.
-    const coalescer = makeCoalescer(() => { void refresh() }, { intervalMs: 750 })
-    void refresh()
-    // Level-triggered: two scopes feed this view — the share's own rows (share-files) and the
-    // space's peer/presence transitions (files), which affect row status (remote/unavailable,
-    // paused-offline/-interrupted) without touching the share catalog.
-    const unsubReconcile = subscribe<{ scope: ScopeType }>('event:reconcile', (msg) => {
-      if (scopeMatches(msg.scope, Scope.shareFiles(spaceId, shareId)) ||
-          scopeMatches(msg.scope, Scope.files(spaceId))) coalescer.trigger()
-    })
-    return () => { coalescer.cancel(); unsubReconcile() }
-  }, [refresh, spaceId, shareId])
+  // The fold across successive responses, advanced DURING RENDER. reconcileFiles needs the previous
+  // reconciled list, which the store cannot supply — it holds the latest answer, not the history.
+  // React's documented way to carry a value between renders is to hold it in state and update it
+  // conditionally here; an effect would be the derived-state-in-effect anti-pattern, a memo has no
+  // memory of its own output, and a ref written in render is not a render input.
+  const [fold, setFold] = useState<Fold>(emptyFold)
+  const [foldedShare, setFoldedShare] = useState(shareId)
+  // Paths whose download was just requested. An override rather than a write into the list: seeded
+  // into the rows it would be dropped by the next refetch, and the seed exists only to cover the
+  // gap before the first decoration frame arrives.
+  const [seeded, setSeeded] = useState<ReadonlySet<string>>(new Set())
+
+  if (foldedShare !== shareId) {
+    // FolderView is reused, not keyed per share, so the previous share's rows must not merge in.
+    setFoldedShare(shareId)
+    setFold(resetFold())
+  } else if (data && data !== fold.res) {
+    setFold(foldListing(fold, data, toEntry))
+  }
+
+  const { rows: files, info, error } = resolveListing(fold, queryError as (Error & { code?: string }) | null)
+  // Only a genuinely cold share reports loading; a hint-driven refetch keeps the rows and the
+  // scroll position.
+  const loading = ready && fold.res === null && fetching && !queryError
+
+  const refresh = useCallback(async () => {
+    if (!ready) return
+    await refetchQuery<ListResult>('share:list-files', { spaceId, ownerKey, shareId }, scopes).catch(() => {})
+  }, [ready, spaceId, ownerKey, shareId, scopes])
 
   // Per-file transfer progress rides the unified decoration channel (keyed shareId:relPath) and is
   // merged at render — never into the list state, so a late frame can't outlive a refresh. The gate
@@ -139,6 +123,11 @@ export function useShareFiles(spaceId: string, ownerKey: string, shareId: string
   // this share, so the memo recomputes only for this share's frames or a fresh listing.
   const decorated = useMemo(() => files.map((f) => {
     const d = decorations.get(shareDecoKey(shareId, f.relPath))
+    // The seed only paints while there is no real frame yet and the row has not left the transfer
+    // states — a decoration, or any other status, outranks it.
+    if (!d && seeded.has(f.relPath) && (f.status === 'downloading' || f.status === 'preparing')) {
+      return { ...f, progress: { bytes: f.pendingBytes ?? 0, total: f.size, speed: 0, eta: null } }
+    }
     if (!d) return f
     // Match the decoration phase to the row's status: the shared key has no receiver-side terminal
     // done, so a lingering cross-phase frame (a preparing frame left on a now-downloading row) must
@@ -157,7 +146,7 @@ export function useShareFiles(spaceId: string, ownerKey: string, shareId: string
       return { ...f, verifyFraction: undefined, progress: { bytes: d.bytes, total: d.total, speed: 0, eta: d.eta } }
     }
     return f
-  }), [files, decorations, shareId])
+  }), [files, decorations, shareId, seeded])
 
   const downloadFile = useCallback(
     async (relPath: string) => {
@@ -166,11 +155,7 @@ export function useShareFiles(spaceId: string, ownerKey: string, shareId: string
       if (!transferId) return
       // Seed the progress bar; the row's status flips to 'downloading' from the worker's re-derive
       // (the engine emits share-files-updated on start), not a client override.
-      setFiles((prev) => prev.map((f) => (
-        f.relPath === relPath
-          ? { ...f, progress: { bytes: f.pendingBytes ?? 0, total: f.size, speed: 0, eta: null } }
-          : f
-      )))
+      setSeeded((prev) => { const next = new Set(prev); next.add(relPath); return next })
     },
     [spaceId, ownerKey, shareId]
   )

--- a/src/renderer/optimisticRows.d.ts
+++ b/src/renderer/optimisticRows.d.ts
@@ -1,0 +1,3 @@
+import type { FileEntry } from './types.js'
+
+export declare function mergeOptimistic (serverRows: FileEntry[], optimisticRows: FileEntry[]): FileEntry[]

--- a/src/renderer/optimisticRows.js
+++ b/src/renderer/optimisticRows.js
@@ -1,0 +1,11 @@
+// An optimistic row is dropped once the server listing surfaces the same path: the worker
+// advertises a file while it is still hashing, so files:list carries it before the publish
+// finishes. Keeping both would show the file twice, and the server row is the one that survives a
+// remount.
+export function mergeOptimistic (serverRows, optimisticRows) {
+  if (optimisticRows.length === 0) return serverRows
+  const known = new Set(serverRows.map((row) => row.path))
+  const pending = optimisticRows.filter((row) => !known.has(row.path))
+  if (pending.length === 0) return serverRows
+  return [...pending, ...serverRows]
+}

--- a/src/renderer/shareFilesFold.d.ts
+++ b/src/renderer/shareFilesFold.d.ts
@@ -1,0 +1,37 @@
+import type { ShareFileEntry } from './types.js'
+
+export interface ListResult {
+  entries: unknown[]
+  complete: boolean
+  total?: number
+  totalBytes?: number
+  truncated?: boolean
+  fileLimit?: number | null
+}
+
+export interface FolderInfo {
+  fileCount: number
+  totalBytes: number
+  blobsLength: number | null
+  truncated: boolean
+  fileLimit: number | null
+}
+
+export interface Fold {
+  res: ListResult | null
+  rows: ShareFileEntry[]
+  info: FolderInfo | null
+}
+
+export declare const emptyFold: Fold
+export declare function foldListing (prev: Fold, res: ListResult | null, toEntry: (entry: never) => ShareFileEntry): Fold
+export declare function resetFold (): Fold
+
+export interface ResolvedListing {
+  rows: ShareFileEntry[]
+  info: FolderInfo | null
+  error: string | null
+  terminal: boolean
+}
+
+export declare function resolveListing (fold: Fold, error: (Error & { code?: string }) | null): ResolvedListing

--- a/src/renderer/shareFilesFold.js
+++ b/src/renderer/shareFilesFold.js
@@ -1,0 +1,40 @@
+import { reconcileFiles } from './shareFilesReconcile.js'
+import { deriveFolderInfo } from './folderInfo.js'
+
+// The listing folded across successive share:list-files responses. A peer read can come back empty
+// or partial while the owner is still indexing, so a response is merged into what is on screen
+// rather than replacing it — reconcileFiles decides how, from the worker's `complete` flag.
+//
+// Kept as a pure fold so the never-blank rule is testable without React, and so the query store
+// never has to interpret a response: the store holds the raw answer, this turns a sequence of
+// answers into the list.
+export const emptyFold = Object.freeze({ res: null, rows: [], info: null })
+
+export function foldListing (prev, res, toEntry) {
+  if (!res) return prev
+  if (res === prev.res) return prev
+  const mapped = res.entries.map(toEntry)
+  // reconcileFiles returns the PREVIOUS array reference when nothing moved, which is what lets
+  // React skip the row subtree on a listing that did not change.
+  const rows = reconcileFiles(prev.rows, mapped, { complete: res.complete })
+  return { res, rows, info: deriveFolderInfo(res, rows) }
+}
+
+// FolderView is reused rather than keyed per share, so a share change must clear the fold or the
+// previous share's rows merge into the next one.
+export function resetFold () {
+  return emptyFold
+}
+
+// A gone or access-revoked share is terminal: the rows must be cleared, or a deleted share lingers
+// as a phantom listing. Every other failure — a timeout, a peer that went quiet mid-read — keeps
+// what is on screen, because blanking a folder on a blip is the worse outcome. The message is
+// surfaced only when there is nothing left to look at.
+const TERMINAL_CODES = new Set(['NOT_FOUND', 'EOWNERSHIP'])
+
+export function resolveListing (fold, error) {
+  const terminal = !!error && TERMINAL_CODES.has(error.code)
+  if (terminal) return { rows: emptyFold.rows, info: null, error: error.message, terminal }
+  const message = error && fold.rows.length === 0 ? error.message : null
+  return { rows: fold.rows, info: fold.info, error: message, terminal }
+}

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -116,6 +116,7 @@ import s114 from './scenarios/s114-waiting-docs-card.mjs'
 import s115 from './scenarios/s115-activity-log-network.mjs'
 import s116 from './scenarios/s116-keyboard-coverage.mjs'
 import s117 from './scenarios/s117-space-switch-no-empty-flash.mjs'
+import s118 from './scenarios/s118-folder-never-blanks.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -182,7 +183,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s53, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s118-folder-never-blanks.mjs
+++ b/test/frontend/scenarios/s118-folder-never-blanks.mjs
@@ -1,0 +1,76 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport } from '../assert.mjs'
+import { workDir } from '../paths.mjs'
+
+// A user browsing a folder keeps their rows when the owner drops offline.
+//
+// What this does and does NOT prove, measured rather than assumed. An offline owner fails the head
+// sync, so share:list-files reports complete:false — but the entries still come from the catalog
+// blocks already replicated locally, so the read is incomplete-and-PARTIAL, not empty. That is the
+// common real-world shape and it is worth holding, but it does not discriminate the never-blank
+// fold: adopting such a response wholesale yields the same rows. Verified by breaking the fold to
+// adopt wholesale and re-running this scenario, which still passed.
+//
+// The incomplete-and-EMPTY case — where wholesale adoption would blank the folder — needs a peer
+// catalog that cannot be opened or has no local blocks, which the UI cannot stage deterministically.
+// test/unit/share-files-fold.test.js is the gate for that one, and 4 of its 9 tests do fail against
+// a wholesale-adopt fold.
+export default async function s118 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('blank-own-'), 'Reports')
+  mkdirSync(ownDir, { recursive: true })
+  for (const name of ['alpha.txt', 'beta.txt', 'gamma.txt']) {
+    writeFileSync(path.join(ownDir, name), name.repeat(64))
+  }
+
+  try {
+    await r.ok('A shares a folder; B opens it and sees every file', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      await A.addOwnedFolder(ownDir)
+      await B.waitText('Reports', 90000)
+      await B.click({ role: 'button', contains: 'Reports' })
+      await B.waitText('alpha.txt', 60000)
+      await B.waitText('beta.txt', 30000)
+      await B.waitText('gamma.txt', 30000)
+      await B.shot('s118-B-folder-populated', runDir)
+    })
+
+    await r.ok('the owner drops while B is IN the folder — the rows stay on screen', async () => {
+      await A.quit()
+      // Let B's listing re-read several times against an owner that is gone. Each read comes back
+      // incomplete; every one of them must leave the rows alone.
+      await new Promise((resolve) => setTimeout(resolve, 20000))
+
+      for (const name of ['alpha.txt', 'beta.txt', 'gamma.txt']) {
+        if (!(await B.has({ contains: name }))) {
+          throw new Error(`${name} vanished from the folder while the owner was offline`)
+        }
+      }
+      await B.shot('s118-B-owner-offline-rows-kept', runDir)
+    })
+
+    await r.ok('the header still agrees with the rows', async () => {
+      // deriveFolderInfo may only ever raise the count above the visible rows on an incomplete
+      // read; a header reading fewer files than are listed is always wrong.
+      if (await B.has({ contains: '0 files' })) {
+        throw new Error('the folder header collapsed to zero while rows were still on screen')
+      }
+    })
+
+    await r.ok('the owner returns and the listing is still correct', async () => {
+      await A.launch({ onboard: false })
+      await B.waitText('alpha.txt', 90000)
+      await B.shot('s118-B-owner-returned', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/unit/optimistic-rows.test.js
+++ b/test/unit/optimistic-rows.test.js
@@ -1,0 +1,29 @@
+import test from 'brittle'
+import { mergeOptimistic } from '../../src/renderer/optimisticRows.js'
+
+const row = (path, status = 'available') => ({ path, status })
+
+test('an optimistic row shows while the server does not know the path', (t) => {
+  const merged = mergeOptimistic([row('/a')], [row('/b', 'publishing')])
+  t.alike(merged.map((r) => r.path), ['/b', '/a'], 'pending rows lead')
+})
+
+test('an optimistic row is dropped once the server surfaces the same path', (t) => {
+  // The worker advertises a file while it is still hashing, so the server row appears BEFORE the
+  // publish finishes. Without this the file would render twice.
+  const merged = mergeOptimistic([row('/a'), row('/b', 'publishing')], [row('/b', 'publishing')])
+  t.alike(merged.map((r) => r.path), ['/a', '/b'], 'no duplicate row')
+  t.is(merged.length, 2)
+})
+
+test('the server list is returned unchanged when nothing is pending', (t) => {
+  const server = [row('/a'), row('/b')]
+  t.is(mergeOptimistic(server, []), server, 'same reference — React skips the subtree')
+  t.is(mergeOptimistic(server, [row('/a', 'publishing')]), server,
+    'and also when every pending row is already known')
+})
+
+test('server row order is preserved', (t) => {
+  const merged = mergeOptimistic([row('/c'), row('/a'), row('/b')], [row('/z', 'publishing')])
+  t.alike(merged.map((r) => r.path), ['/z', '/c', '/a', '/b'])
+})

--- a/test/unit/share-files-errors.test.js
+++ b/test/unit/share-files-errors.test.js
@@ -1,0 +1,51 @@
+import test from 'brittle'
+import { foldListing, emptyFold, resolveListing } from '../../src/renderer/shareFilesFold.js'
+
+const toEntry = (e) => ({ relPath: e.relPath, size: 1, hash: 'h', mtime: 1, status: 'remote' })
+const res = (paths) => ({ entries: paths.map((relPath) => ({ relPath })), complete: true })
+const err = (message, code) => Object.assign(new Error(message), code ? { code } : {})
+
+const seeded = () => foldListing(emptyFold, res(['a', 'b']), toEntry)
+
+test('no error passes the rows through untouched', (t) => {
+  const fold = seeded()
+  const out = resolveListing(fold, null)
+  t.is(out.rows, fold.rows, 'same reference')
+  t.is(out.error, null)
+  t.is(out.info, fold.info)
+})
+
+// A deleted or access-revoked share must clear the list, or the user keeps browsing a folder that
+// no longer exists.
+test('a terminal code clears the rows and surfaces the message', (t) => {
+  for (const code of ['NOT_FOUND', 'EOWNERSHIP']) {
+    const out = resolveListing(seeded(), err('gone', code))
+    t.alike(out.rows, [], `${code} clears the listing`)
+    t.is(out.info, null, 'and its header')
+    t.is(out.error, 'gone', 'and says why')
+    t.ok(out.terminal)
+  }
+})
+
+// REGRESSION (FIX-NEVER-BLANK-STORE: a timeout is a transient read failure, not a statement about
+// the folder's contents. Clearing on it would empty a folder during an ordinary network hiccup.)
+test('REGRESSION (FIX-NEVER-BLANK-STORE): a transient failure keeps the rows and stays silent', (t) => {
+  const fold = seeded()
+  const out = resolveListing(fold, err('IPC timeout: share:list-files'))
+  t.is(out.rows, fold.rows, 'the rows on screen survive')
+  t.is(out.error, null, 'and no error is shown over a list that is still good')
+  t.absent(out.terminal)
+})
+
+test('a transient failure with nothing on screen does surface', (t) => {
+  const out = resolveListing(emptyFold, err('IPC timeout: share:list-files'))
+  t.alike(out.rows, [])
+  t.is(out.error, 'IPC timeout: share:list-files', 'a blank view must explain itself')
+})
+
+test('an unknown code is treated as transient', (t) => {
+  const fold = seeded()
+  const out = resolveListing(fold, err('peer unavailable', 'PEER_GONE'))
+  t.is(out.rows, fold.rows, 'only the two known terminal codes clear the list')
+  t.absent(out.terminal)
+})

--- a/test/unit/share-files-fold.test.js
+++ b/test/unit/share-files-fold.test.js
@@ -1,0 +1,87 @@
+import test from 'brittle'
+import { foldListing, emptyFold, resetFold } from '../../src/renderer/shareFilesFold.js'
+
+// The hook's mapper, reduced to what the fold needs. Rows arrive sorted by relPath — the catalog
+// read stream is key-ordered — which is what reconcileFiles' two-pointer merge relies on.
+const toEntry = (e) => ({
+  relPath: e.relPath, size: e.size ?? 0, hash: e.hash ?? '', mtime: e.mtime ?? 0,
+  status: e.status ?? 'remote', localPath: e.localPath ?? undefined,
+})
+const entry = (relPath, over = {}) => ({ relPath, size: 1, hash: 'h-' + relPath, mtime: 1, status: 'remote', ...over })
+const res = (entries, over = {}) => ({ entries, complete: true, ...over })
+
+test('a complete response is adopted wholesale, removals included', (t) => {
+  const first = foldListing(emptyFold, res([entry('a'), entry('b')]), toEntry)
+  t.alike(first.rows.map((r) => r.relPath), ['a', 'b'])
+
+  const second = foldListing(first, res([entry('a')]), toEntry)
+  t.alike(second.rows.map((r) => r.relPath), ['a'], 'an authoritative read may delete rows')
+})
+
+// REGRESSION (FIX-NEVER-BLANK-STORE: a peer read can return empty simply because the owner is
+// mid-index or briefly unreachable. Adopting that response would empty a folder the user is looking
+// at, and it is the specific failure that kept these two hooks off the query store.)
+test('REGRESSION (FIX-NEVER-BLANK-STORE): an incomplete empty response keeps every row', (t) => {
+  const seeded = foldListing(emptyFold, res([entry('a'), entry('b')]), toEntry)
+  const after = foldListing(seeded, res([], { complete: false }), toEntry)
+
+  t.alike(after.rows.map((r) => r.relPath), ['a', 'b'], 'the rows on screen survive')
+  t.is(after.rows, seeded.rows, 'and keep their identity, so React does not re-render the list')
+})
+
+test('an incomplete partial response unions by relPath, preferring the fresh row', (t) => {
+  const seeded = foldListing(emptyFold, res([entry('a', { size: 1 }), entry('b')]), toEntry)
+  const after = foldListing(seeded, res([entry('a', { size: 99 })], { complete: false }), toEntry)
+
+  t.alike(after.rows.map((r) => r.relPath), ['a', 'b'], 'the unseen row is kept')
+  t.is(after.rows.find((r) => r.relPath === 'a').size, 99, 'the fresh row wins where they overlap')
+})
+
+test('an unchanged listing returns the same rows reference', (t) => {
+  const seeded = foldListing(emptyFold, res([entry('a'), entry('b')]), toEntry)
+  const again = foldListing(seeded, res([entry('a'), entry('b')], { complete: false }), toEntry)
+  t.is(again.rows, seeded.rows, 'row identity is preserved when nothing moved')
+})
+
+test('the same response object folds once', (t) => {
+  const first = foldListing(emptyFold, res([entry('a')]), toEntry)
+  const same = foldListing(first, first.res, toEntry)
+  t.is(same, first, 're-rendering with the same response is a no-op, not a re-fold')
+})
+
+test('a null response leaves the fold alone', (t) => {
+  const seeded = foldListing(emptyFold, res([entry('a')]), toEntry)
+  t.is(foldListing(seeded, null, toEntry), seeded, 'nothing to fold before the first read lands')
+})
+
+// FolderView is reused rather than keyed per share.
+test('resetting clears the fold so one share cannot bleed into the next', (t) => {
+  const seeded = foldListing(emptyFold, res([entry('a')]), toEntry)
+  const cleared = resetFold()
+  t.alike(cleared.rows, [], 'no rows carry over')
+  t.is(cleared.res, null)
+  const next = foldListing(cleared, res([entry('z')]), toEntry)
+  t.alike(next.rows.map((r) => r.relPath), ['z'], 'the new share starts from its own read')
+  t.absent(next.rows.some((r) => r.relPath === 'a'), 'the previous share is gone')
+  t.ok(seeded.rows.length === 1, 'and the old fold was not mutated')
+})
+
+test('the header never reports fewer files than are on screen', (t) => {
+  const seeded = foldListing(emptyFold, res([entry('a'), entry('b')], { total: 2, totalBytes: 2 }), toEntry)
+  t.is(seeded.info.fileCount, 2)
+
+  // An incomplete read saw only one file, but two are rendered — a header reading 1 over a list of
+  // 2 is always wrong.
+  const after = foldListing(seeded, res([entry('a')], { complete: false, total: 1, totalBytes: 1 }), toEntry)
+  t.is(after.rows.length, 2)
+  t.is(after.info.fileCount, 2, 'the count may only rise above the visible rows')
+  t.ok(after.info.totalBytes >= 2, 'and so may the size')
+})
+
+test('a complete read trusts the worker totals over the row count', (t) => {
+  // Rows are capped at listFilesCap; total is the real figure the over-limit banner reports.
+  const folded = foldListing(emptyFold, res([entry('a')], { total: 5000, totalBytes: 99, truncated: true, fileLimit: 1 }), toEntry)
+  t.is(folded.info.fileCount, 5000, 'the true total, not the capped row count')
+  t.ok(folded.info.truncated, 'and truncation is reported, never inferred')
+  t.is(folded.info.fileLimit, 1)
+})


### PR DESCRIPTION
The last two hooks r04 identified, and the two held back from #120 as "last, and each alone". Plan: `plans/plan-migrate-file-listing-hooks.md`.

`useFiles` (163 → 126 lines) is a straight store read. `useShareFiles` keeps the three things that are judgements about what a folder listing *means* — the never-blank fold across successive reads, header totals that can never report below the visible rows, and which failures are terminal — extracted into `shareFilesFold.js` so they are testable without React. The store holds the raw response and never learns what `complete` or `truncated` mean.

A member-set change with SpaceView open now costs **9 distinct reads**, down from 13 before the store existed. Only `useAuditLog` still holds its own reconcile subscription, which is correct — it is cursor-paginated and deliberately out of scope.

### The fold advances during render, deliberately

`reconcileFiles` needs the previous *reconciled* list, which the store cannot supply — it holds the latest answer, not the history. React's documented way to carry a value across renders is to hold it in state and update it conditionally in the render body. An effect would be the derived-state-in-effect pattern React's own compiler rejects; a memo has no memory of its own output, and the fold's input *is* its output; a ref written during render is not a render input. This came from reading the React 19 source, not from recall.

Two changes are strictly safer than what they replace. The download progress seed moves out of the list into a render-time override — written into the rows it could be dropped by the next refetch. And the share-change reset is explicit, because `FolderView` is reused rather than keyed per share.

### A test that would have lied

`s118` asserts a browsing user keeps their rows when the owner drops. It passed — so I broke the fold to adopt responses wholesale, the exact naive-store behaviour, and **it passed again**. It is not a gate.

An offline owner fails the head sync, so the read is `complete: false`, but the entries still come from locally replicated catalog blocks: incomplete-and-*partial*, where wholesale adoption yields identical rows. The incomplete-and-**empty** case that would blank a folder needs a peer catalog with no local blocks, which the UI cannot stage deterministically. The unit tests are the gate for that one — **4 of 9 fail** against a wholesale-adopt fold, including the never-blank regression. s118's header now states exactly this, because a scenario named "folder never blanks" that survives a broken fold is worse than none.

### Gates

typecheck · full `lint:ci` · unit **1361** · integration **852** · flow **104/104** run alone · bundle builds. Every commit typechecks and passes unit standalone; commit 2 lands the fold and its tests *before* the hook uses it, so a regression in commit 3 reverts alone.

**UI is targeted, not complete** — 10/10 scenarios, 30 assertions, chosen against what this change touches: s77 (monotonic growth, never flashes empty), s35 (an open FolderView refreshing itself), s89 (terminal error), s38 (fold reset between shares), s78 (truncation), s117 (loading gate), s85 (optimistic rows), s48 (progress seed), s79, s118. A separate partial run covered 33/111 with 0 failures before it was stopped. The untouched families read through hooks that migrated in #120 and passed the full 110/110 the day before — an argument, not evidence. `s103-folder-tree` is the one adjacent scenario worth adding if more confidence is wanted.