### PR TITLE
[chore] Require npm 11 so the lockfile stops losing libc metadata

### DIFF
--- a/.github/workflows/build-electron.yml
+++ b/.github/workflows/build-electron.yml
@@ -31,9 +31,6 @@ on:
           - linux-arm64
           - win32-x64
 
-env:
-  NODE_VERSION: '22'
-
 permissions:
   contents: write
 
@@ -152,7 +149,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: '24.20.0'
 
       - name: Patch package.json version
         shell: bash

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,7 @@
+# npm 10 and npm 11 disagree about package-lock.json: npm 11 records the `libc`
+# field (glibc/musl) for platform-specific optional deps, npm 10 does not understand
+# it and silently strips every entry on any lockfile rewrite. Renovate runs npm 11,
+# so a contributor on Node 22 re-deleted ~30 `libc` blocks in each feature branch and
+# Renovate restored them the next Monday. Pair this with engines.npm in package.json
+# so the wrong npm refuses to run instead of quietly rewriting the lock.
+engine-strict=true

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,6 +72,10 @@
         "tailwindcss": "^4.3.3",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.68.0"
+      },
+      "engines": {
+        "node": ">=22.9.0",
+        "npm": ">=11"
       }
     },
     "node_modules/@axe-core/react": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
   "author": "Oliver Kohl",
   "type": "commonjs",
   "main": "src/main/main.js",
+  "engines": {
+    "node": ">=22.9.0",
+    "npm": ">=11"
+  },
   "scripts": {
     "postinstall": "node -e \"const fs=require('fs');const p='node_modules/.bin/bare';try{if(!fs.existsSync(p))fs.symlinkSync('../bare-runtime/bin/bare',p)}catch{}\"",
     "build:js": "esbuild src/renderer/main.tsx --bundle --format=esm --target=es2022 --jsx=automatic --outfile=assets/dist/main.js --minify --define:__DEV__=false --sourcemap --sources-content=false --loader:.png=file --loader:.jpg=file --loader:.svg=file",


### PR DESCRIPTION
npm 10 silently strips the `libc` metadata npm 11 records for platform-specific
optional deps. Renovate runs npm 11, local installs ran npm 10, so the two rewrote
`package-lock.json` against each other in every feature branch — 30 entries removed,
restored the following Monday.

- `engines.npm >= 11` plus `engine-strict=true`: the wrong npm now fails with
  `EBADENGINE` instead of quietly rewriting the lock.
- `build-electron.yml` takes a literal `node-version` (24.20.0) rather than the custom
  `NODE_VERSION` env var. Renovate tracks the literals only — #127 bumped `test.yml`
  to 24.20.0 and left the build workflow on 22.

Verified: npm 10.9.2 blocked, npm 11.19.0 installs clean, 30 `libc` entries stable.
macOS packaging smoke-tested end-to-end on Node 24.20.0 (unsigned DMG, 141 MB).
Signing/notarization and the Linux/Windows makers are not covered locally.