### PR TITLE
[fix] Bound the worker's IPC read buffer and pre-start queue

### DIFF
--- a/src/shared/contract/index.d.ts
+++ b/src/shared/contract/index.d.ts
@@ -2,5 +2,5 @@ export { CODES, CODE_NAMES, EXPECTED_CODES, UNUSED_CODES, INVALID_ARGUMENT } fro
 export { ARG, REQUESTS, REQUEST_NAMES, UNREFERENCED_REQUESTS } from './requests.js'
 export type { ArgType, ArgRule, RequestSpec, RequestName } from './requests.js'
 export { EVENTS, EVENT_NAMES } from './events.js'
-export { AVATAR_MAX_BYTES, NAME_MAX } from './limits.js'
+export { AVATAR_MAX_BYTES, NAME_MAX, IPC_MAX_FRAME_BYTES } from './limits.js'
 export { FILE_STATUS, BADGE_STATUS, SHARE_FILE_STATUS } from './statuses.js'

--- a/src/shared/contract/index.js
+++ b/src/shared/contract/index.js
@@ -5,5 +5,5 @@
 export { CODES, CODE_NAMES, EXPECTED_CODES, UNUSED_CODES, INVALID_ARGUMENT } from './errors.js'
 export { ARG, REQUESTS, REQUEST_NAMES, UNREFERENCED_REQUESTS } from './requests.js'
 export { EVENTS, EVENT_NAMES } from './events.js'
-export { AVATAR_MAX_BYTES, NAME_MAX } from './limits.js'
+export { AVATAR_MAX_BYTES, NAME_MAX, IPC_MAX_FRAME_BYTES } from './limits.js'
 export { FILE_STATUS, BADGE_STATUS, SHARE_FILE_STATUS } from './statuses.js'

--- a/src/shared/contract/limits.d.ts
+++ b/src/shared/contract/limits.d.ts
@@ -1,2 +1,3 @@
 export declare const AVATAR_MAX_BYTES: number
 export declare const NAME_MAX: number
+export declare const IPC_MAX_FRAME_BYTES: number

--- a/src/shared/contract/limits.js
+++ b/src/shared/contract/limits.js
@@ -4,3 +4,12 @@ export const AVATAR_MAX_BYTES = 256 * 1024
 
 // The display-name cap applied to a profile name and to the name carried in an invite envelope.
 export const NAME_MAX = 80
+
+// The worker's NDJSON reader accumulates bytes until a newline. Uncapped, a sender that never
+// terminates a frame grows worker memory without limit. Both sides must agree on this one: it is
+// the largest frame a sender may put on the pipe, not just what the reader happens to tolerate.
+// 1 MB is >2x the largest legitimate inbound frame — a profile update carrying a base64 avatar,
+// AVATAR_MAX_BYTES inflated 4/3 plus JSON escaping. Deliberately NOT main's MAIN_REQUEST_MAX_LINE
+// (64 KB): that gate guards the opposite direction (keeping a multi-MB worker->renderer response
+// off main's UI thread) and would reject every avatar update.
+export const IPC_MAX_FRAME_BYTES = 1024 * 1024

--- a/src/shared/core/ipc.js
+++ b/src/shared/core/ipc.js
@@ -5,6 +5,7 @@ import { createLogger } from './logger.js'
 import { createHintBus } from '../state/hints.js'
 import { Scope } from '../contract/scope.js'
 import { EXPECTED_CODES as CONTRACT_EXPECTED_CODES, INVALID_ARGUMENT } from '../contract/errors.js'
+import { IPC_MAX_FRAME_BYTES } from '../contract/limits.js'
 import { createHandlerTable, validateArgs } from './handler-table.js'
 import { createRequestMetrics } from './request-metrics.js'
 
@@ -52,6 +53,12 @@ const EXPECTED = new Set(CONTRACT_EXPECTED_CODES)
 const MAX_FAILURE_KEYS = 256
 const requestFailures = new Map()
 
+// Frames arriving before start() are queued so no request is lost during boot — which runs the
+// migrations and the drive load and can take seconds on a large library. Uncapped, a caller
+// retrying across that window grows this without bound. Worker-internal capacity with no
+// counterpart on the sender's side, so unlike IPC_MAX_FRAME_BYTES it is NOT contract vocabulary.
+const MAX_QUEUED_FRAMES = 1000
+
 // Per-request timing and outcomes. The router already had the numbers and discarded them; keeping
 // them is what makes a claim like "one member change costs eleven round-trips" checkable instead of
 // estimated.
@@ -87,18 +94,49 @@ export function resetRequestFailureCounters() {
 // `requests` is injectable so a test can declare the small vocabulary it exercises. Production
 // passes nothing and gets the real contract, which is what makes an unknown handler name a boot
 // failure rather than a 404 discovered in the field.
-export function createIPC(pipe, { requests } = {}) {
+export function createIPC(pipe, { requests, maxFrameBytes = IPC_MAX_FRAME_BYTES, maxQueuedFrames = MAX_QUEUED_FRAMES } = {}) {
   // The table owns the request metadata; `handle` below is a thin shim onto it so all 85 existing
   // registrations keep working while domains move onto register(ipc, deps) one at a time.
   const table = createHandlerTable(requests ? { requests } : {})
   const queued = []
   let ready = false
   let buffer = ''
+  // After an oversized frame the bytes still arriving belong to the frame being discarded. Without
+  // this, the TAIL of that frame is parsed as though it were a fresh one — turning one oversized
+  // frame into one forged frame, which is worse than the unbounded buffer it replaces.
+  let skipping = false
   let bootstrapResolve
   const bootstrapPromise = new Promise((resolve) => { bootstrapResolve = resolve })
 
   pipe.on('data', (chunk) => {
     buffer += chunk.toString()
+
+    // Resync first: drop bytes until the newline that ends the frame already given up on.
+    if (skipping) {
+      const nl = buffer.indexOf('\n')
+      if (nl === -1) { buffer = ''; return }
+      buffer = buffer.slice(nl + 1)
+      skipping = false
+    }
+
+    // Refused on SIZE, before the frame is ever materialised as a JSON string — and before any
+    // newline arrives to make it a parse failure instead. The `indexOf` test is what scopes the cap
+    // to ONE FRAME rather than to the read buffer: a chunk carrying many small frames can exceed
+    // the cap in total and every one of them is still legitimate.
+    //
+    // `.length` is UTF-16 code units, not bytes, so a multi-byte frame is measured smaller than a
+    // sender computing Buffer.byteLength would. That asymmetry is deliberately in the safe
+    // direction: a frame the sender believes is legal is never rejected here. The memory bound
+    // still holds — a string of N code units is O(N) — and for the JSON+base64 traffic this
+    // carries the two are identical anyway.
+    if (buffer.length > maxFrameBytes && buffer.indexOf('\n') === -1) {
+      log.warn('oversized frame discarded:', buffer.length, 'bytes exceeds', maxFrameBytes)
+      countFailure('oversized-frame', INVALID_ARGUMENT)
+      buffer = ''
+      skipping = true
+      return
+    }
+
     const lines = buffer.split('\n')
     buffer = lines.pop()
     for (const line of lines) {
@@ -114,6 +152,13 @@ export function createIPC(pipe, { requests } = {}) {
         }
         if (ready) {
           dispatch(msg)
+        } else if (queued.length >= maxQueuedFrames) {
+          // Refused, not silently dropped: a caller awaiting a response must not hang on a promise
+          // nothing will ever settle. Keeping the OLDEST keeps the frames most likely to be the
+          // session's real first requests.
+          log.warn('pre-start queue full, frame refused:', msg.type)
+          countFailure(msg.type || 'unknown-command', INVALID_ARGUMENT)
+          respond(msg.id, null, 'worker is still starting', INVALID_ARGUMENT)
         } else {
           queued.push(msg)
         }

--- a/test/unit/ipc.test.js
+++ b/test/unit/ipc.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
 import { EventEmitter } from 'events'
-import { createIPC, getBootstrapPromise, scopeForEvent } from '../../src/shared/core/ipc.js'
+import { createIPC, getBootstrapPromise, scopeForEvent, getRequestFailureCounters, resetRequestFailureCounters } from '../../src/shared/core/ipc.js'
 import { setRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 
 // The router is strict about names it does not know, which is the point in production. A test
@@ -239,4 +239,138 @@ test('emitting a members poke fans a members reconcile hint on the wire', (t) =>
   ipc.emit('event:members-updated', { spaceId: 'S9' })
   const msgs = pipe.written.map((s) => JSON.parse(s))
   t.alike(msgs.find((m) => m.type === 'event:reconcile')?.scope, { kind: 'members', spaceId: 'S9' })
+})
+
+// --- read-buffer and pre-start queue bounds (r07-1) ---
+//
+// The caps are injectable for the same reason `requests` is: a test declares the small bound it
+// exercises instead of allocating megabytes. One test below deliberately uses the REAL default,
+// because a cap that is sane in a test and wrong in production is the failure worth guarding.
+
+test('REGRESSION (FIX-IPC-CAP: an unterminated frame grew the read buffer without bound)', async (t) => {
+  const pipe = fakePipe()
+  resetRequestFailureCounters()
+  t.teardown(() => resetRequestFailureCounters())
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS, maxFrameBytes: 1024 })
+  ipc.handle('echo', (m) => m.v)
+  ipc.start()
+
+  // NO newline, ever. This is the whole defect: without a cap these bytes sit in `buffer` for the
+  // life of the process and nothing observable happens — which is also why "no response was
+  // written" does NOT prove the fix. The counter is the discriminator: it can only fire if the
+  // reader refused the frame on SIZE, before any frame boundary arrived to parse.
+  pipe.feedRaw('x'.repeat(4096))
+  await tick()
+  t.is(getRequestFailureCounters()['oversized-frame:INVALID_ARGUMENT'], 1,
+    'the oversized frame was refused on size, with no newline to trigger a parse failure')
+  t.is(pipe.written.length, 0, 'and it was not answered')
+
+  pipe.feedRaw('\n')
+  pipe.feed({ id: '1', type: 'echo', v: 42 })
+  await tick()
+  t.alike(pipe.lastMsg(), { id: '1', type: 'response', data: 42 }, 'the reader resynced and still serves')
+})
+
+test('REGRESSION (FIX-IPC-CAP: the tail of a discarded frame was parsed as a fresh frame)', async (t) => {
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS, maxFrameBytes: 1024 })
+  let calls = 0
+  ipc.handle('echo', (m) => { calls++; return m.v })
+  ipc.start()
+
+  // An oversized frame whose TAIL is itself a valid request. Without a "still skipping" flag the
+  // reader drops the head, then parses this tail and dispatches it — turning one oversized frame
+  // into one forged frame, which is worse than the unbounded buffer it replaced.
+  pipe.feedRaw('x'.repeat(2048))
+  await tick()
+  pipe.feedRaw(JSON.stringify({ id: 'forged', type: 'echo', v: 1 }) + '\n')
+  await tick()
+  t.is(calls, 0, 'the tail of a discarded frame is never dispatched')
+
+  pipe.feed({ id: '2', type: 'echo', v: 7 })
+  await tick()
+  t.is(calls, 1, 'and the reader is live again afterwards')
+})
+
+test('a frame just under the REAL cap is delivered intact', async (t) => {
+  const pipe = fakePipe()
+  // The real default on purpose: the largest legitimate inbound frame is a profile update carrying
+  // a base64 avatar (AVATAR_MAX_BYTES * 4/3 plus JSON escaping). A cap chosen too low — main's
+  // 64 KB MAIN_REQUEST_MAX_LINE, say — would break avatar upload and no other test would notice.
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('echo', (m) => m.v.length)
+  ipc.start()
+
+  const big = 'a'.repeat(700_000)
+  pipe.feed({ id: '1', type: 'echo', v: big })
+  await tick()
+  t.alike(pipe.lastMsg(), { id: '1', type: 'response', data: 700_000 })
+})
+
+test('many small frames arriving in one oversized chunk all dispatch', async (t) => {
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS, maxFrameBytes: 1024 })
+  let calls = 0
+  ipc.handle('echo', () => { calls++; return null })
+  ipc.start()
+
+  // Twenty ~200-byte frames in ONE chunk, well past the 1 KB cap in total. Every frame is small;
+  // only the read buffer is large. A cap that bounded the BUFFER rather than one FRAME would
+  // discard all twenty.
+  const one = JSON.stringify({ type: 'echo', v: 'b'.repeat(150) }) + '\n'
+  pipe.feedRaw(one.repeat(20))
+  await tick()
+  t.is(calls, 20, 'the cap bounds one frame, not the read buffer')
+})
+
+test('a frame exactly at the cap is accepted, one byte over is refused', async (t) => {
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS, maxFrameBytes: 200 })
+  let calls = 0
+  ipc.handle('echo', () => { calls++; return null })
+  ipc.start()
+
+  const exact = JSON.stringify({ type: 'echo', v: 'x'.repeat(200 - 30) })
+  t.ok(exact.length <= 200, 'fixture is at or under the cap')
+  pipe.feedRaw(exact + '\n')
+  await tick()
+  t.is(calls, 1, 'a frame at the cap is served')
+
+  // Again the counter, not the absence of a reply: unparseable garbage produces no reply either way.
+  resetRequestFailureCounters()
+  pipe.feedRaw('y'.repeat(201))
+  await tick()
+  t.is(getRequestFailureCounters()['oversized-frame:INVALID_ARGUMENT'], 1, 'one byte over is refused on size')
+  t.is(calls, 1, 'and no handler ran')
+})
+
+test('REGRESSION (FIX-IPC-CAP: the pre-start queue was unbounded)', async (t) => {
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS, maxQueuedFrames: 10 })
+  let calls = 0
+  ipc.handle('echo', () => { calls++; return null })
+
+  for (let i = 0; i < 25; i++) pipe.feed({ id: String(i), type: 'echo' })
+  await tick()
+
+  // Refused, not silently dropped: a caller awaiting a response must not hang forever on a
+  // promise nothing will ever settle.
+  const refusals = pipe.written.map((s) => JSON.parse(s)).filter((m) => m.code === 'INVALID_ARGUMENT')
+  t.is(refusals.length, 15, 'every frame past the cap was answered with a refusal')
+
+  ipc.start()
+  await tick()
+  t.is(calls, 10, 'exactly the capped number were queued and then dispatched')
+})
+
+test('the pre-start queue cap does not apply once started', async (t) => {
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS, maxQueuedFrames: 2 })
+  let calls = 0
+  ipc.handle('echo', () => { calls++; return null })
+  ipc.start()
+
+  for (let i = 0; i < 20; i++) pipe.feed({ id: String(i), type: 'echo' })
+  await tick()
+  t.is(calls, 20, 'a live router dispatches without queueing')
 })


### PR DESCRIPTION
Closes r07-1 from the architecture review. Plan: `plan-ipc-read-buffer-cap.md`.

`src/shared/core/ipc.js` accumulated bytes until a newline with no cap — a sender
that never terminated a frame grew worker memory without limit. The 64 KB
`MAIN_REQUEST_MAX_LINE` that exists guards main's opposite direction (keeping a
multi-MB worker→renderer response off the UI thread), not this path.

- One frame capped at 1 MB (`IPC_MAX_FRAME_BYTES`, contract package — both sides
  must agree on what a sender may put on the pipe). Sized >2× the largest
  legitimate inbound frame: a `profile:update` carrying a base64 avatar.
- The cap is scoped to one **frame**, not the read buffer — a chunk carrying many
  small frames legitimately exceeds it.
- Overflow discards and resyncs at the next newline. A "still skipping" flag stops
  the tail of a discarded frame being parsed as a fresh one.
- The pre-start queue (unbounded, same file, same class) capped at 1000, refusing
  overflow rather than dropping it so no caller hangs.

Gates: typecheck, lint:ci, unit 1368/1368, integration 852/852. No flow — single-process
framing, no P2P behaviour.

Note for the telemetry branch (r09-7): it edits `dispatch`/`respond` in this same file
and should rebase onto this.