### PR TITLE
[perf] Memoize the list rows and finish the renderer's fetching split

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "test:layout:modaltitle": "node test/frontend-layout/run-modaltitle.mjs",
     "test:layout:logohover": "node test/frontend-layout/run-logohover.mjs",
     "test:layout:mirrorers": "node test/frontend-layout/run-mirrorers.mjs",
-    "test:layout:indexing": "node test/frontend-layout/run-indexing.mjs"
+    "test:layout:indexing": "node test/frontend-layout/run-indexing.mjs",
+    "test:layout:memo": "node test/frontend-layout/run-memo.mjs"
   },
   "devDependencies": {
     "@axe-core/react": "^4.13.0",

--- a/src/renderer/components/cards/FileCard.tsx
+++ b/src/renderer/components/cards/FileCard.tsx
@@ -1,6 +1,6 @@
 // A file row in a space's list: derives the action buttons from file status and swaps the
 // right-hand lane between publish/verify/download progress, the who-is-downloading indicator, and the status pill.
-import { useState, useEffect, useId } from 'react'
+import { memo, useState, useEffect, useId } from 'react'
 import { useTranslation } from 'react-i18next'
 import { formatSize, getFileIcon, fileName } from '../../utils.js'
 import { errorCodeToI18nKey } from '../../errorMessages.js'
@@ -140,7 +140,7 @@ function ActionSlot({
   )
 }
 
-export default function FileCard({
+function FileCard({
   file,
   decoration,
   onDownload,
@@ -234,3 +234,10 @@ export default function FileCard({
     </div>
   )
 }
+
+// The decoration heartbeat re-renders SpaceView once a second for as long as any transfer is live.
+// Without this every row re-rendered with it; with it, only the rows whose own file, decoration or
+// download summary actually changed do. The default shallow compare is what we want: every prop is
+// a primitive, a row object reconciled for identity, a per-key value from a Map (decoration,
+// downloadSummary), or a stable handler.
+export default memo(FileCard)

--- a/src/renderer/components/cards/MemberCard.tsx
+++ b/src/renderer/components/cards/MemberCard.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { SpaceMember } from '../../types.js'
 import Icon from '../primitives/Icon.js'
@@ -7,7 +8,7 @@ interface MemberCardProps {
   member: SpaceMember
 }
 
-export default function MemberCard({ member }: MemberCardProps) {
+function MemberCard({ member }: MemberCardProps) {
   const { t } = useTranslation()
   const isOnline = member.online !== false
 
@@ -29,3 +30,8 @@ export default function MemberCard({ member }: MemberCardProps) {
     </div>
   )
 }
+
+// `member` is the only prop and it keeps its identity while the roster is unchanged (useMembers
+// memoizes the projection), so this row sits out the decoration heartbeat entirely. A presence
+// transition rebuilds every member object and re-renders the roster, which is correct.
+export default memo(MemberCard)

--- a/src/renderer/components/cards/ShareCard.tsx
+++ b/src/renderer/components/cards/ShareCard.tsx
@@ -1,5 +1,6 @@
 // A folder-share row on the space screen: the whole card opens the folder, and the
 // action menu adapts to the share's role (owned, mirrored to disk, or browse-only).
+import { memo } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { ShareWithRole } from '../../hooks/useShares.js'
 import type { Profile, SpaceMember } from '../../types.js'
@@ -49,7 +50,7 @@ function OwnerAvatar({ owner, isYou, selfProfile }: { owner: SpaceMember | null;
   )
 }
 
-export default function ShareCard({
+function ShareCard({
   share,
   owner,
   selfProfile,
@@ -169,3 +170,8 @@ export default function ShareCard({
   )
 }
 
+// SpaceView re-renders once a second under the decoration heartbeat, and a share card's content
+// has nothing to do with a transfer's progress. Every handler prop is useCallback'd at the call
+// site; the role gating that used to build them conditionally lives in menuItems above, which is
+// where it was already being applied.
+export default memo(ShareCard)

--- a/src/renderer/components/cards/ShareFileRow.tsx
+++ b/src/renderer/components/cards/ShareFileRow.tsx
@@ -1,7 +1,7 @@
 // One file row in a folder share: transfer status/progress, per-file actions, and the
 // owner-side who-is-downloading indicator. Extracted from FolderView so the collapsible
 // tree and the flat list can share it.
-import { useState, useId, useEffect } from 'react'
+import { memo, useState, useId, useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 import Icon from '../primitives/Icon.js'
 import IconButton from '../primitives/IconButton.js'
@@ -94,7 +94,7 @@ function FileRowActions({ action, relPath, transferId, busyLabel, onDownload, on
   return <div className="w-10 h-10" />
 }
 
-export default function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadSummary, onDownload, onReveal, onPause, onCancel, onDiscardPartial, displayName, leadingGutter }: ShareFileRowProps) {
+function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadSummary, onDownload, onReveal, onPause, onCancel, onDiscardPartial, displayName, leadingGutter }: ShareFileRowProps) {
   const { t } = useTranslation()
   const { t: tErr } = useTranslation('errors')
   const isDownloading = file.status === 'downloading'
@@ -255,3 +255,8 @@ export default function ShareFileRow({ file, isOwn, manualControls, spaceId, mem
     </div>
   )
 }
+
+// Same reason as FileCard: the folder tree's rows must not repaint on every decoration heartbeat.
+// `file` keeps its identity across a listing refetch (shareFilesReconcile.js), `members` is the
+// memoized roster, `downloadSummary` is a per-path Map value, and the five handlers are stable.
+export default memo(ShareFileRow)

--- a/src/renderer/components/modals/AddFolderShareModal.tsx
+++ b/src/renderer/components/modals/AddFolderShareModal.tsx
@@ -151,6 +151,11 @@ export default function AddFolderShareModal({
     return () => { cancelPreview() }
   }, [isOpen, initialMountPath])
 
+  // Deliberately NOT on the query store, though it is param-keyed and looks like a query: this is
+  // a point-in-time filesystem probe. The folder can be deleted, unmounted or filled between two
+  // opens of the modal, and a cached verdict would show a stale answer for a path the user just
+  // changed — a correctness regression traded for a round-trip nobody is waiting on. The cancel
+  // flag stays.
   useEffect(() => {
     if (!isOpen || !mountPath) return
     let cancelled = false

--- a/src/renderer/hooks/useFiles.ts
+++ b/src/renderer/hooks/useFiles.ts
@@ -81,7 +81,10 @@ export function useFiles(spaceId: string) {
     }
   }
 
-  async function downloadFile(file: FileEntry) {
+  // Stable identities, like useShareFiles' equivalents: these are handed straight to memoized file
+  // rows, and a fresh closure per render made every row's shallow compare fail — so the list
+  // re-rendered whole on each decoration heartbeat. They close over nothing but spaceId.
+  const downloadFile = useCallback(async (file: FileEntry) => {
     return await request('files:download', {
       spaceId,
       driveKey: file.driveKey,
@@ -89,23 +92,23 @@ export function useFiles(spaceId: string) {
       inPlace: file.inPlace ?? false,
       ownerKey: file.owner.publicKey,
     })
-  }
+  }, [spaceId])
 
-  async function unshareFile(path: string) {
+  const unshareFile = useCallback(async (path: string) => {
     await request('files:remove', { spaceId, path })
-  }
+  }, [spaceId])
 
-  async function discardPartial(file: FileEntry) {
+  const discardPartial = useCallback(async (file: FileEntry) => {
     await request('files:discard-partial', { spaceId, path: file.path, inPlace: file.inPlace ?? false })
-  }
+  }, [spaceId])
 
-  async function cancelPublish(path: string) {
+  const cancelPublish = useCallback(async (path: string) => {
     await request('files:cancel-publish', { spaceId, path })
-  }
+  }, [spaceId])
 
-  async function revealFile(path: string) {
+  const revealFile = useCallback(async (path: string) => {
     await request('files:reveal', { spaceId, path })
-  }
+  }, [spaceId])
 
   const allFiles = useMemo(
     () => mergeOptimistic(files, [...uploadingFiles.values()]),

--- a/src/renderer/hooks/useTransferControls.ts
+++ b/src/renderer/hooks/useTransferControls.ts
@@ -2,9 +2,16 @@ import { request } from '../ipc.js'
 
 // Fire-and-forget transfer controls. No local status is kept: the worker re-derives the row and
 // emits a reconcile hint, so the view converges without a client-side optimistic latch.
+//
+// Module-level rather than closed over per render: these go straight into memoized rows as props,
+// and a fresh arrow per render made every row's shallow compare fail — the hook handed out two new
+// identities a second under the decoration heartbeat, which is exactly what the memo exists to
+// stop. They close over nothing, so there is nothing to capture.
+const cancelDownload = (transferId: string): void => { void request('files:cancel-download', { transferId }) }
+const pauseDownload = (transferId: string): void => { void request('files:pause-download', { transferId }) }
+
+const CONTROLS = Object.freeze({ cancelDownload, pauseDownload })
+
 export function useTransferControls() {
-  return {
-    cancelDownload: (transferId: string) => { void request('files:cancel-download', { transferId }) },
-    pauseDownload: (transferId: string) => { void request('files:pause-download', { transferId }) },
-  }
+  return CONTROLS
 }

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -6,11 +6,13 @@ import { createRoot } from 'react-dom/client'
 import App from './app.js'
 import { request } from './ipc.js'
 import { configureQueryStore } from './store/query-store.js'
+import { configurePrefsStore } from './store/prefs-store.js'
 import { installReconcileBridge } from './store/reconcile.js'
 
 // Before the first render: the store's transport, and the single reconcile subscription every
 // store-backed view re-derives from.
 configureQueryStore({ request })
+configurePrefsStore({ getPrefs: () => window.bridge.getPrefs(), setPrefs: (patch) => window.bridge.setPrefs(patch) })
 installReconcileBridge()
 
 if (__DEV__ && window.bridge?.isDev?.()) {

--- a/src/renderer/screens/Account.tsx
+++ b/src/renderer/screens/Account.tsx
@@ -8,6 +8,7 @@ import { connectionDesc, activityDesc } from '../profileRows.js'
 import type { AuditConfig, AuditStats, Profile } from '../types.js'
 import type { IdentityProtection } from '../global.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import { useQuery } from '../store/useQuery.js'
 import { useConnectionStatus } from '../hooks/useConnectionStatus.js'
 import { useUpdates } from '../hooks/useUpdates.js'
 import { useKeyboard } from '../keyboard/KeyboardProvider.js'
@@ -183,28 +184,16 @@ function DeviceGroup({ onOpenNetworkStatus, onOpenActivityLog }: Pick<AccountPro
   const { t } = useTranslation()
   const { state: connectivityState, status: networkStatus } = useConnectionStatus()
   const [identity, setIdentity] = useState<IdentityProtection | null>(null)
-  const [auditConfig, setAuditConfig] = useState<AuditConfig | null>(null)
-  const [auditStats, setAuditStats] = useState<AuditStats | null>(null)
+  // Through the query store for the dedup and the cache — but with NO scopes, deliberately. The
+  // audit scope exists and would invalidate on every event:audit-updated; this is a summary line,
+  // not a live counter, and a subscription would repaint the row on every recorded event for no
+  // user benefit. Scope-less still re-reads on each mount (fetchQuery only dedups an in-flight
+  // request), so the row is as fresh as the hand-rolled effect was — minus its cancel flag.
+  const { data: auditConfig } = useQuery<AuditConfig>('audit:get-config', {}, null)
+  const { data: auditStats } = useQuery<AuditStats>('audit:stats', {}, null)
 
   useEffect(() => {
     window.bridge.getIdentityProtection().then(setIdentity).catch(() => {})
-  }, [])
-
-  // Read once on mount: this is a summary line, not a live counter — a subscription would repaint
-  // the row on every recorded event for no user benefit.
-  useEffect(() => {
-    let cancelled = false
-    Promise.all([
-      request('audit:get-config') as Promise<AuditConfig>,
-      request('audit:stats') as Promise<AuditStats>,
-    ])
-      .then(([config, stats]) => {
-        if (cancelled) return
-        setAuditConfig(config)
-        setAuditStats(stats)
-      })
-      .catch(() => {})
-    return () => { cancelled = true }
   }, [])
 
   return (
@@ -231,7 +220,7 @@ function DeviceGroup({ onOpenNetworkStatus, onOpenActivityLog }: Pick<AccountPro
         <ActionRow
           icon="history"
           label={t('settings.activityLog')}
-          desc={activityDesc(t, auditConfig, auditStats)}
+          desc={activityDesc(t, auditConfig ?? null, auditStats ?? null)}
           onClick={onOpenActivityLog}
         />
       </div>

--- a/src/renderer/screens/AppearanceSettings.tsx
+++ b/src/renderer/screens/AppearanceSettings.tsx
@@ -1,11 +1,11 @@
 // Appearance settings: theme (light/dark/system), language, and UI zoom.
-import { useEffect, useState } from 'react'
+import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import i18n, { setLocale, SUPPORTED_LANGUAGES, type SupportedLanguage } from '../i18n.js'
 import { applyTheme, getStoredTheme, type ThemeMode } from '../theme.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import { usePrefs } from '../store/usePrefs.js'
 import { useZoom, ZOOM_LEVELS, isSameZoom } from '../hooks/useZoom.js'
-import type { AppPrefs } from '../global.js'
 import Icon from '../components/primitives/Icon.js'
 import PageHeader from '../components/layout/PageHeader.js'
 import SectionHeading from '../components/layout/SectionHeading.js'
@@ -22,21 +22,9 @@ export default function AppearanceSettings({ onBack }: AppearanceSettingsProps) 
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
   const currentLang = i18n.language
   const showMenuBarToggle = window.bridge.getPlatform() !== 'darwin'
-  const [prefs, setLocalPrefs] = useState<AppPrefs | null>(null)
-
-  useEffect(() => {
-    if (!showMenuBarToggle) return
-    let cancelled = false
-    window.bridge.getPrefs().then((p) => { if (!cancelled) setLocalPrefs(p) })
-    return () => { cancelled = true }
-  }, [showMenuBarToggle])
-
-  async function updatePrefs(partial: Partial<AppPrefs>) {
-    if (!prefs) return
-    setLocalPrefs({ ...prefs, ...partial })
-    const next = await window.bridge.setPrefs(partial)
-    setLocalPrefs(next)
-  }
+  // macOS has no menu-bar toggle, and prefs are read here for nothing else — so this screen does
+  // not pull them there. Everywhere else it shares the one copy with GeneralSettings.
+  const { prefs, update: updatePrefs } = usePrefs({ enabled: showMenuBarToggle })
 
   function handleTheme(mode: ThemeMode) {
     setTheme(mode)

--- a/src/renderer/screens/GeneralSettings.tsx
+++ b/src/renderer/screens/GeneralSettings.tsx
@@ -1,8 +1,7 @@
 // General settings: minimize-to-tray and open-at-login toggles persisted via main's app prefs.
-import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
-import type { AppPrefs } from '../global.js'
+import { usePrefs } from '../store/usePrefs.js'
 import Icon from '../components/primitives/Icon.js'
 import PageHeader from '../components/layout/PageHeader.js'
 import Toggle from '../components/primitives/Toggle.js'
@@ -13,26 +12,12 @@ interface GeneralSettingsProps {
 
 export default function GeneralSettings({ onBack }: GeneralSettingsProps) {
   const { t } = useTranslation()
-  const [prefs, setLocalPrefs] = useState<AppPrefs | null>(null)
+  const { prefs, update } = usePrefs()
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
   const isMac = window.bridge.getPlatform() === 'darwin'
   const introKey = isMac ? 'generalSettings.introMac' : 'generalSettings.intro'
   const minimizeKey = isMac ? 'generalSettings.minimizeToTrayMac' : 'generalSettings.minimizeToTray'
   const minimizeDescKey = isMac ? 'generalSettings.minimizeToTrayDescMac' : 'generalSettings.minimizeToTrayDesc'
-
-  useEffect(() => {
-    let cancelled = false
-    window.bridge.getPrefs().then((p) => { if (!cancelled) setLocalPrefs(p) })
-    return () => { cancelled = true }
-  }, [])
-
-  async function update(partial: Partial<AppPrefs>) {
-    if (!prefs) return
-    const optimistic = { ...prefs, ...partial }
-    setLocalPrefs(optimistic)
-    const next = await window.bridge.setPrefs(partial)
-    setLocalPrefs(next)
-  }
 
   return (
     <div

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -1,5 +1,5 @@
 // Space screen: loose files and folder shares with drag-drop adding, transfer controls, member presence, and invites.
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { FileEntry } from '../types.js'
 import { useFiles } from '../hooks/useFiles.js'
@@ -141,7 +141,10 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
     }
   }
 
-  async function handleLocate(share: ShareWithRole) {
+  // The row handlers below are useCallback'd because they are props of memoized rows (ShareCard,
+  // FileCard): an identity that changes every render defeats the memo, and the decoration
+  // heartbeat re-renders this screen once a second for as long as a transfer is live.
+  const handleLocate = useCallback(async (share: ShareWithRole) => {
     const picked = await window.bridge.browseShareFolder()
     if (!picked) return
     try {
@@ -150,7 +153,28 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
     } catch (err) {
       toast.error(err instanceof Error ? err.message : String(err))
     }
-  }
+  }, [spaceId, toast, t])
+
+  const handleOpenShare = useCallback((share: ShareWithRole) => { onOpenShare?.(share) }, [onOpenShare])
+
+  const handleOpenInFinder = useCallback(async (share: ShareWithRole) => {
+    try { await request('share:reveal-folder', { spaceId, ownerKey: share.owner, shareId: share.id }) } catch {}
+  }, [spaceId])
+
+  const handleDeleteRequest = useCallback((share: ShareWithRole) => { setShareToDelete(share) }, [])
+  const handleMirrorRequest = useCallback((share: ShareWithRole) => { setShareToMirror(share) }, [])
+
+  const handleUnmount = useCallback(async (share: ShareWithRole) => {
+    await unmountForeignMount(share.spaceId, share.id)
+  }, [])
+
+  const handlePauseMirror = useCallback(async (share: ShareWithRole) => {
+    await setForeignMountEnabled(share.spaceId, share.id, false)
+  }, [])
+
+  const handleResumeMirror = useCallback(async (share: ShareWithRole) => {
+    await setForeignMountEnabled(share.spaceId, share.id, true)
+  }, [])
 
   useEffect(() => {
     function handle(event: Event) {
@@ -186,10 +210,6 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
     onBack()
   }
 
-  async function handleDownload(file: FileEntry) {
-    await downloadFile(file)
-  }
-
   async function handleLeave() {
     await leaveSpace(spaceId)
   }
@@ -200,13 +220,13 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
     setFileToRemove(null)
   }
 
-  async function handleDiscardPartial(file: FileEntry) {
-    await discardPartial(file)
-  }
-
-  async function handleReveal(file: FileEntry) {
+  const handleReveal = useCallback(async (file: FileEntry) => {
     await revealFile(file.path)
-  }
+  }, [revealFile])
+
+  const handleRemoveRequest = useCallback((file: FileEntry) => { setFileToRemove(file) }, [])
+
+  const handleCancelPublish = useCallback((file: FileEntry) => { void cancelPublish(file.path) }, [cancelPublish])
 
   return (
     <div className="max-w-7xl mx-auto px-8 flex flex-col h-[calc(100vh-5rem-var(--banner-h,0px))]">
@@ -410,22 +430,14 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
                           share={share}
                           owner={owner}
                           selfProfile={profile}
-                          onOpen={(s) => onOpenShare?.(s)}
-                          onOpenInFinder={share.role === 'mine' || share.role === 'mirrored' ? async (s) => {
-                            try { await request('share:reveal-folder', { spaceId, ownerKey: s.owner, shareId: s.id }) } catch {}
-                          } : undefined}
-                          onDelete={share.role === 'mine' ? (s) => setShareToDelete(s) : undefined}
-                          onLocate={share.role === 'mine' ? handleLocate : undefined}
-                          onMirror={share.role === 'browse' ? (s) => setShareToMirror(s) : undefined}
-                          onUnmount={share.role === 'mirrored' ? async (s) => {
-                            await unmountForeignMount(s.spaceId, s.id)
-                          } : undefined}
-                          onPauseMirror={share.role === 'mirrored' ? async (s) => {
-                            await setForeignMountEnabled(s.spaceId, s.id, false)
-                          } : undefined}
-                          onResumeMirror={share.role === 'mirrored' ? async (s) => {
-                            await setForeignMountEnabled(s.spaceId, s.id, true)
-                          } : undefined}
+                          onOpen={handleOpenShare}
+                          onOpenInFinder={handleOpenInFinder}
+                          onDelete={handleDeleteRequest}
+                          onLocate={handleLocate}
+                          onMirror={handleMirrorRequest}
+                          onUnmount={handleUnmount}
+                          onPauseMirror={handlePauseMirror}
+                          onResumeMirror={handleResumeMirror}
                         />
                       )
                     })}
@@ -460,18 +472,18 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
                     </span>
                   </div>
                   <div className="grid grid-cols-1 gap-4">
-                    {files.map((file, i) => (
+                    {files.map((file) => (
                       <FileCard
-                        key={`${file.driveKey}-${file.path}-${i}`}
+                        key={`${file.driveKey}-${file.path}`}
                         file={file}
                         decoration={getDecoration(file.path)}
-                        onDownload={handleDownload}
+                        onDownload={downloadFile}
                         onCancel={cancelDownload}
                         onPause={pauseDownload}
                         onReveal={handleReveal}
-                        onUnshare={(f) => setFileToRemove(f)}
-                        onDiscardPartial={handleDiscardPartial}
-                        onCancelPublish={(f) => cancelPublish(f.path)}
+                        onUnshare={handleRemoveRequest}
+                        onDiscardPartial={discardPartial}
+                        onCancelPublish={handleCancelPublish}
                         members={members}
                         downloadSummary={getDownloadSummary(file.path)}
                       />

--- a/src/renderer/screens/StorageSettings.tsx
+++ b/src/renderer/screens/StorageSettings.tsx
@@ -5,12 +5,17 @@ import { request } from '../ipc.js'
 import { formatSize } from '../utils.js'
 import { mountErrorI18nKey } from '../errorMessages.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import { useQuery } from '../store/useQuery.js'
+import { refetchQuery } from '../store/query-store.js'
 import { useDownloadRootStatus } from '../hooks/useDownloadRootStatus.js'
 import CopyButton from '../components/primitives/CopyButton.js'
 import FilePath from '../components/widgets/FilePath.js'
 import Icon from '../components/primitives/Icon.js'
 import PageHeader from '../components/layout/PageHeader.js'
 import SectionHeading from '../components/layout/SectionHeading.js'
+
+// Module-level so the entry's scope list is one array, not a fresh literal per render.
+const STORAGE_SCOPES = [{ kind: 'files' }, { kind: 'shares' }, { kind: 'share-files' }]
 
 interface StorageInfo {
   totalDiskUsage: number
@@ -86,8 +91,6 @@ function samePath(a: string, b: string) {
 export default function StorageSettings({ onBack }: StorageSettingsProps) {
   const { t } = useTranslation()
   const { t: tErr } = useTranslation('errors')
-  const [info, setInfo] = useState<StorageInfo | null>(null)
-  const [loading, setLoading] = useState(true)
   const [downloadFolder, setDownloadFolder] = useState<string>('')
   const [folderError, setFolderError] = useState<string | null>(null)
   const [detailsOpen, setDetailsOpen] = useState(false)
@@ -96,11 +99,14 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
   const [freedBytes, setFreedBytes] = useState<number | null>(null)
   const freeingRef = useRef(false)
 
+  // storage:info is a cross-space disk aggregate, so it watches the file, share and share-file
+  // scopes without pinning a spaceId — a hint for any space matches (scopeMatches only compares an
+  // id the VIEW pins). The coalesce window matters here: an owned-folder scan pokes files-updated
+  // in bursts, and this read walks the store.
+  const { data: info, loading } = useQuery<StorageInfo>('storage:info', {}, STORAGE_SCOPES, { coalesceMs: 750 })
+
   const refreshInfo = useCallback(() => {
-    return request('storage:info').then((data) => {
-      setInfo(data as StorageInfo)
-      setLoading(false)
-    })
+    return refetchQuery<StorageInfo>('storage:info', {}, STORAGE_SCOPES).catch(() => {})
   }, [])
 
   const toggleDetails = useCallback(() => setDetailsOpen((open) => !open), [])
@@ -119,8 +125,6 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
       freeingRef.current = false
     }
   }, [refreshInfo])
-
-  useEffect(() => { refreshInfo() }, [refreshInfo])
 
   useEffect(() => {
     let cancelled = false
@@ -167,7 +171,10 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
       <div className="pt-8 px-8 max-w-2xl mx-auto">
       <PageHeader title={t('storageSettings.title')} subtitle={t('storageSettings.intro')} onBack={onBack} />
 
-      {loading ? (
+      {/* Only a COLD read shows the calculating line. A hint-driven refetch keeps the numbers on
+          screen while it runs — the store keeps the last value precisely so a background
+          invalidation can't blank a panel the user is reading. */}
+      {loading && !info ? (
         <p role="status" className="text-on-surface-variant py-8 text-center">{t('storageSettings.calculating')}</p>
       ) : info && (
         <div className="space-y-10">

--- a/src/renderer/shareFilesReconcile.js
+++ b/src/renderer/shareFilesReconcile.js
@@ -8,13 +8,34 @@
 // Both prev and next arrive sorted by relPath (the catalog read-stream is key-ordered), so the
 // partial-path merge is one O(n) two-pointer pass that returns the prev reference unchanged when
 // nothing moved — letting React skip the re-render.
+//
+// Identity matters as much as content: a row that did not change keeps its PREVIOUS object, so a
+// memoized row component can skip it. Content is still always the fresh row's — see adoptIdentity.
+
+// Every field toEntry (useShareFiles.ts) puts on a row EXCEPT relPath, which is the merge key and
+// is compared by the callers below.
+//
+// This list is the contract: a row is "unchanged" only if it is unchanged in every field the view
+// can render, because an unchanged row keeps its old object and its old values with it. Adding a
+// field to toEntry without adding it here means that field's updates are silently dropped — the
+// row keeps painting the stale value until one of the fields listed here happens to move.
+//
+// `progress` and `verifyFraction` are deliberately absent: they are NOT on toEntry. useShareFiles
+// merges them over the reconciled row at render from the decoration channel, and `progress` is a
+// fresh object on every decoration frame — comparing them here would make every active row unequal
+// and defeat the identity adoption this function exists for.
 function sameRow(a, b) {
   return a.size === b.size && a.hash === b.hash && a.mtime === b.mtime &&
-    a.status === b.status && a.localPath === b.localPath
+    a.status === b.status && a.localPath === b.localPath &&
+    a.verified === b.verified && a.pendingBytes === b.pendingBytes &&
+    a.errorCode === b.errorCode && a.transferId === b.transferId
 }
 
 export function reconcileFiles(prev, next, { complete }) {
-  if (complete) return next
+  // A complete read is authoritative for CONTENT — adds, updates and removals all apply. It is not
+  // a reason to hand every unchanged row a new object identity: doing so defeats React.memo on the
+  // row, which is the whole point of reconciling rather than replacing.
+  if (complete) return adoptIdentity(prev, next)
   if (next.length === 0) return prev
   const out = []
   let i = 0
@@ -24,8 +45,11 @@ export function reconcileFiles(prev, next, { complete }) {
     const a = prev[i]
     const b = next[j]
     if (a.relPath === b.relPath) {
-      out.push(b)
-      if (!sameRow(a, b)) changed = true
+      const same = sameRow(a, b)
+      // Keep the PREVIOUS object when the row is unchanged. Pushing `b` unconditionally gave every
+      // row a new identity whenever any one row changed.
+      out.push(same ? a : b)
+      if (!same) changed = true
       i++
       j++
     } else if (a.relPath < b.relPath) {
@@ -39,5 +63,32 @@ export function reconcileFiles(prev, next, { complete }) {
   }
   while (i < prev.length) out.push(prev[i++])
   while (j < next.length) { out.push(next[j++]); changed = true }
+  return changed ? out : prev
+}
+
+// Both lists are sorted by relPath, so this is the same O(n) walk: adopt the fresh row's content
+// but keep the previous OBJECT wherever the two agree.
+//
+// Safe under a violated sort order: `out` is built entirely from `next`, one slot per entry, so
+// the RESULT ALWAYS HAS EXACTLY next's CONTENT. An unsorted input only costs identity adoption
+// (rows fall through to the fresh object), never correctness.
+function adoptIdentity(prev, next) {
+  if (prev.length === 0) return next
+  const out = new Array(next.length)
+  let i = 0
+  let changed = false
+  for (let j = 0; j < next.length; j++) {
+    const b = next[j]
+    // Rows in prev that next skipped past are removals — the authoritative read dropped them.
+    while (i < prev.length && prev[i].relPath < b.relPath) { i++; changed = true }
+    const a = i < prev.length && prev[i].relPath === b.relPath ? prev[i] : null
+    if (a && sameRow(a, b)) out[j] = a
+    else { out[j] = b; changed = true }
+    if (a) i++
+  }
+  // Anything left in prev is a removal too (next ended first).
+  if (i < prev.length) changed = true
+  // Returning `prev` when the lists are genuinely identical keeps the ARRAY reference stable as
+  // well — the property the header comment claims and the partial branch already delivers.
   return changed ? out : prev
 }

--- a/src/renderer/store/prefs-store.d.ts
+++ b/src/renderer/store/prefs-store.d.ts
@@ -1,0 +1,11 @@
+import type { AppPrefs } from '../global.js'
+
+export declare function configurePrefsStore (bridge: {
+  getPrefs: () => Promise<AppPrefs>
+  setPrefs: (patch: Partial<AppPrefs>) => Promise<AppPrefs>
+}): void
+export declare function peekPrefs (): AppPrefs | null
+export declare function subscribePrefs (notify: () => void): () => void
+export declare function loadPrefs (): Promise<AppPrefs>
+export declare function writePrefs (patch: Partial<AppPrefs>): Promise<void>
+export declare function resetPrefsStore (): void

--- a/src/renderer/store/prefs-store.js
+++ b/src/renderer/store/prefs-store.js
@@ -1,0 +1,62 @@
+// One shared copy of main's app prefs, for the settings screens that read them.
+//
+// Deliberately NOT the query store: useQuery is typed to RequestName — the WORKER contract — and
+// prefs:get/prefs:set are Electron MAIN calls (preload.js). Routing them through it would mean
+// either widening RequestName to a lie or adding an untyped escape hatch. This is the query
+// store's shape with none of its scope/invalidation machinery, because prefs change only when
+// this app writes them — there is no hint to consume. If that ever stops being true, this store
+// needs an event and the screens need to stop assuming their own write is the only one.
+//
+// Plain JS with an injected transport so it unit-tests under brittle-node, like query-store.js.
+let cache = null
+let inFlight = null
+const subscribers = new Set()
+
+let bridge = {
+  getPrefs: () => Promise.reject(new Error('prefs store: no transport configured')),
+  setPrefs: () => Promise.reject(new Error('prefs store: no transport configured')),
+}
+
+export function configurePrefsStore ({ getPrefs, setPrefs }) {
+  bridge = { getPrefs, setPrefs }
+}
+
+function publish (next) {
+  cache = next
+  for (const notify of subscribers) notify()
+}
+
+// The value itself, never a fresh object: useSyncExternalStore compares snapshots by identity, so
+// an allocating getSnapshot warns in DEV and can loop forever.
+export function peekPrefs () {
+  return cache
+}
+
+export function subscribePrefs (notify) {
+  subscribers.add(notify)
+  return () => { subscribers.delete(notify) }
+}
+
+// The dedup: settings screens mounting in one session each issued their own prefs:get and each
+// kept a private copy in component state, which could disagree with the other after a write.
+export function loadPrefs () {
+  if (cache !== null) return Promise.resolve(cache)
+  if (inFlight) return inFlight
+  inFlight = bridge.getPrefs()
+    .then((p) => { publish(p); return p })
+    .finally(() => { inFlight = null })
+  return inFlight
+}
+
+// Optimistic, then authoritative — the shape both screens already used, but now visible to every
+// screen at once instead of only the one that issued the write.
+export async function writePrefs (patch) {
+  if (cache) publish({ ...cache, ...patch })
+  publish(await bridge.setPrefs(patch))
+}
+
+export function resetPrefsStore () {
+  cache = null
+  inFlight = null
+  subscribers.clear()
+}

--- a/src/renderer/store/usePrefs.ts
+++ b/src/renderer/store/usePrefs.ts
@@ -1,0 +1,26 @@
+import { useCallback, useSyncExternalStore } from 'react'
+import { loadPrefs, peekPrefs, subscribePrefs, writePrefs } from './prefs-store.js'
+import type { AppPrefs } from '../global.js'
+
+// The thin hook over prefs-store.js, mirroring useQuery over query-store.js: the store owns the
+// fetching, dedup and caching; this owns only the React binding.
+//
+// `enabled: false` means "this screen does not need prefs on this platform" — AppearanceSettings
+// reads them only for the menu-bar toggle, which does not exist on macOS. Without it, moving that
+// screen onto the store would add a prefs round-trip on every Mac.
+export function usePrefs(opts: { enabled?: boolean } = {}): {
+  prefs: AppPrefs | null
+  update: (patch: Partial<AppPrefs>) => Promise<void>
+} {
+  const enabled = opts.enabled !== false
+  const subscribe = useCallback((notify: () => void) => {
+    const unsubscribe = subscribePrefs(notify)
+    if (enabled) void loadPrefs().catch(() => {})
+    return unsubscribe
+  }, [enabled])
+
+  const prefs = useSyncExternalStore(subscribe, peekPrefs, peekPrefs)
+  const update = useCallback((patch: Partial<AppPrefs>) => writePrefs(patch), [])
+
+  return { prefs, update }
+}

--- a/test/frontend-layout/build.mjs
+++ b/test/frontend-layout/build.mjs
@@ -80,4 +80,9 @@ await build({
   entryPoints: [path.join(HERE, 'harness-indexing-entry.tsx')],
   outfile: path.join(HERE, 'dist/harness-indexing.js'),
 })
+await build({
+  ...common,
+  entryPoints: [path.join(HERE, 'harness-memo-entry.tsx')],
+  outfile: path.join(HERE, 'dist/harness-memo.js'),
+})
 console.error('[build] harness bundled')

--- a/test/frontend-layout/harness-memo-entry.tsx
+++ b/test/frontend-layout/harness-memo-entry.tsx
@@ -1,0 +1,201 @@
+// Real-Chromium render-count harness for the row memo discipline (r04-7 / r03-9).
+//
+// The complaint this guards: while a transfer is live, useDecorations' 1 Hz heartbeat sets state
+// on the SCREEN, so the screen and every row under it re-rendered once a second. Fixing that has
+// two halves and this harness fails if either regresses:
+//   1. the rows are memoized, and
+//   2. the props they receive keep their identity — the listing rows across a reconcile
+//      (shareFilesReconcile.js) and the handlers across a render (useFiles/useTransferControls).
+//
+// HOW THE COUNT IS HONEST. The counter cannot live inside the real ShareFileRow without editing
+// it, and a plain unmemoized wrapper around it would count the WRAPPER's renders — which happen on
+// every parent render regardless of whether the memo bailed, so it would fail even against a
+// perfect implementation. Instead `Counted` is itself memo()'d with the DEFAULT shallow compare,
+// the same comparator the real `memo(ShareFileRow)` uses, and receives the same props. Its
+// bail-out condition is therefore identical to the real component's. `memoized()` below closes the
+// remaining gap by asserting the real export really is a memo with the default compare, so the two
+// checks together are equivalent to counting the real component.
+import { memo, useCallback, useMemo, useState } from 'react'
+import { createRoot } from 'react-dom/client'
+import './../../src/renderer/i18n.js'
+import ShareFileRow, { type ShareFileRowProps } from './../../src/renderer/components/cards/ShareFileRow.js'
+import { reconcileFiles } from './../../src/renderer/shareFilesReconcile.js'
+import type { ShareFileEntry, SpaceMember, PeerDownloadSummary } from './../../src/renderer/types.js'
+
+interface HarnessResults {
+  pass: boolean
+  error: string | null
+  isMemo: boolean
+  mountCounts: Record<string, number>
+  afterIdleTick: Record<string, number>
+  afterOneSummary: Record<string, number>
+  afterUnchangedRefetch: Record<string, number>
+  afterOneRowChanged: Record<string, number>
+}
+
+declare global {
+  interface Window {
+    __results: HarnessResults
+    __tick: () => void
+    __setSummary: (relPath: string) => void
+    __refetch: (changed: string | null) => void
+  }
+}
+
+const PATHS = ['a.txt', 'b.txt', 'c.txt', 'd.txt']
+
+function entry(relPath: string, extra: Partial<ShareFileEntry> = {}): ShareFileEntry {
+  return { relPath, size: 1024, hash: 'h-' + relPath, mtime: 0, status: 'remote', ...extra }
+}
+
+// A fresh listing straight off the wire: every row is a NEW object, exactly as toEntry produces
+// them. Whether the rows keep their identity is reconcileFiles' job, which is the point.
+function freshListing(changed: string | null): ShareFileEntry[] {
+  return PATHS.map((p) => entry(p, changed === p ? { size: 2048 } : {}))
+}
+
+// Module-level: these stand in for the stable identities useFiles / useTransferControls now hand
+// out. A fresh arrow here would make every assertion below fail, which is the regression this
+// harness exists to catch.
+const noop = () => {}
+const HANDLERS = {
+  onDownload: noop,
+  onReveal: noop,
+  onPause: noop,
+  onCancel: noop,
+  onDiscardPartial: noop,
+}
+const MEMBERS: SpaceMember[] = []
+
+const renders: Record<string, number> = {}
+function snapshot(): Record<string, number> {
+  return { ...renders }
+}
+
+const Counted = memo(function Counted(props: ShareFileRowProps) {
+  renders[props.file.relPath] = (renders[props.file.relPath] ?? 0) + 1
+  return <ShareFileRow {...props} />
+})
+
+// The real export must be a memo with the DEFAULT compare — memo(fn) with no comparator. React
+// stores the comparator as `compare`, null when it was omitted.
+function memoized(component: unknown): boolean {
+  const c = component as { $$typeof?: symbol; compare?: unknown } | null
+  return !!c && c.$$typeof === Symbol.for('react.memo') && (c.compare === null || c.compare === undefined)
+}
+
+function Harness() {
+  // Stands in for useDecorations' heartbeat: state on the SCREEN, re-rendering it every tick.
+  const [, setTick] = useState(0)
+  const [files, setFiles] = useState<ShareFileEntry[]>(() => freshListing(null))
+  const [summaries, setSummaries] = useState<Map<string, PeerDownloadSummary>>(() => new Map())
+
+  window.__tick = useCallback(() => { setTick((t) => t + 1) }, [])
+
+  // One path's summary changes; the other entries keep their identity, as usePeerDownloads' Map
+  // updates do.
+  window.__setSummary = useCallback((relPath: string) => {
+    setSummaries((prev) => {
+      const next = new Map(prev)
+      next.set(relPath, { spaceId: 's', path: relPath, peerKeys: ['peer'], pausedKeys: [], bytes: 512, total: 1024, avgSpeed: 100 })
+      return next
+    })
+  }, [])
+
+  // A listing refetch through the REAL reconciler, complete:true — the ordinary owner-side read.
+  window.__refetch = useCallback((changed: string | null) => {
+    setFiles((prev) => reconcileFiles(prev, freshListing(changed), { complete: true }))
+  }, [])
+
+  const rows = useMemo(() => files.map((file) => (
+    <Counted
+      key={file.relPath}
+      file={file}
+      isOwn={false}
+      manualControls={false}
+      spaceId="s"
+      members={MEMBERS}
+      downloadSummary={summaries.get(file.relPath) ?? null}
+      {...HANDLERS}
+    />
+  )), [files, summaries])
+
+  return <div id="rows-host" className="max-w-3xl">{rows}</div>
+}
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <div className="bg-surface p-8"><Harness /></div>,
+)
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+function publishError(error: string): void {
+  window.__results = {
+    pass: false,
+    error,
+    isMemo: false,
+    mountCounts: {},
+    afterIdleTick: {},
+    afterOneSummary: {},
+    afterUnchangedRefetch: {},
+    afterOneRowChanged: {},
+  }
+}
+
+function delta(before: Record<string, number>, after: Record<string, number>): string[] {
+  return PATHS.filter((p) => (after[p] ?? 0) !== (before[p] ?? 0))
+}
+
+async function run(): Promise<void> {
+  const deadline = Date.now() + 5000
+  while (Object.keys(renders).length < PATHS.length && Date.now() < deadline) await sleep(50)
+  if (Object.keys(renders).length < PATHS.length) {
+    return publishError(`expected ${PATHS.length} rows, got ${Object.keys(renders).length}`)
+  }
+  await document.fonts.ready
+  await sleep(100)
+
+  const isMemo = memoized(ShareFileRow)
+  const mountCounts = snapshot()
+  const mountedOnce = PATHS.every((p) => mountCounts[p] === 1)
+
+  // 1. A heartbeat tick that changes nothing must not reach a single row. This is the assertion
+  //    that maps directly to the user-visible complaint.
+  window.__tick()
+  await sleep(100)
+  const afterIdleTick = snapshot()
+  const idleTickQuiet = delta(mountCounts, afterIdleTick).length === 0
+
+  // 2. One row's peer-download summary changes → only that row re-renders.
+  window.__setSummary('b.txt')
+  await sleep(100)
+  const afterOneSummary = snapshot()
+  const oneSummaryScoped = delta(afterIdleTick, afterOneSummary).join(',') === 'b.txt'
+
+  // 3. A complete listing refetch whose content is unchanged must not re-render anything: every
+  //    row arrives as a new object and reconcileFiles has to hand back the previous ones.
+  window.__refetch(null)
+  await sleep(100)
+  const afterUnchangedRefetch = snapshot()
+  const unchangedRefetchQuiet = delta(afterOneSummary, afterUnchangedRefetch).length === 0
+
+  // 4. …but a row that genuinely changed MUST re-render, and only it. Guards the opposite failure:
+  //    a memo that hides a real update.
+  window.__refetch('c.txt')
+  await sleep(100)
+  const afterOneRowChanged = snapshot()
+  const oneRowScoped = delta(afterUnchangedRefetch, afterOneRowChanged).join(',') === 'c.txt'
+
+  window.__results = {
+    pass: isMemo && mountedOnce && idleTickQuiet && oneSummaryScoped && unchangedRefetchQuiet && oneRowScoped,
+    error: null,
+    isMemo,
+    mountCounts,
+    afterIdleTick,
+    afterOneSummary,
+    afterUnchangedRefetch,
+    afterOneRowChanged,
+  }
+}
+
+run()

--- a/test/frontend-layout/harness-memo.html
+++ b/test/frontend-layout/harness-memo.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mirall row memo / render-count harness</title>
+  <!-- The REAL built stylesheet, so the harness uses the app's actual CSS. -->
+  <link rel="stylesheet" href="../../assets/dist/app.css" />
+  <!-- Classic script: installs window.bridge BEFORE the ESM bundle imports ipc.ts. -->
+  <script src="./fake-bridge.js"></script>
+</head>
+<body style="background: var(--color-background);">
+  <div id="root"></div>
+  <script type="module" src="./dist/harness-memo.js"></script>
+</body>
+</html>

--- a/test/frontend-layout/run-memo.mjs
+++ b/test/frontend-layout/run-memo.mjs
@@ -1,0 +1,24 @@
+// REGRESSION (FIX-R04-7 / FIX-R03-9: with zero memoized rows, useDecorations' 1 Hz heartbeat
+// re-rendered every row in the list once a second for as long as a transfer was live) — LOCAL/
+// dev-machine only, spawns a real Electron GUI process. Mounts real <ShareFileRow>s and counts
+// renders across an idle heartbeat tick, a single-row summary change, and a listing refetch.
+//
+//   node test/frontend-layout/run-memo.mjs            (builds, then runs)
+//   node test/frontend-layout/run-memo.mjs --no-build (reuse existing bundle)
+import { runHarness } from './run-harness.mjs'
+
+const out = await runHarness({ html: 'harness-memo.html', height: 700 })
+
+const counts = (o) => Object.entries(o).map(([k, v]) => `${k}=${v}`).join(' ')
+
+console.log('\n──────── ShareFileRow render-count harness ────────')
+console.log(`real export is memo()      : ${out.isMemo}`)
+console.log(`mount                      : ${counts(out.mountCounts)} (each must be 1)`)
+console.log(`+ idle heartbeat tick      : ${counts(out.afterIdleTick)} (must be unchanged)`)
+console.log(`+ b.txt summary change     : ${counts(out.afterOneSummary)} (only b.txt may move)`)
+console.log(`+ unchanged full refetch   : ${counts(out.afterUnchangedRefetch)} (must be unchanged)`)
+console.log(`+ c.txt content change     : ${counts(out.afterOneRowChanged)} (only c.txt may move)`)
+
+const pass = out.pass === true
+console.log(`\n${pass ? 'ok  ' : 'FAIL'} only the rows that actually changed re-render`)
+process.exit(pass ? 0 : 1)

--- a/test/unit/prefs-store.test.js
+++ b/test/unit/prefs-store.test.js
@@ -1,0 +1,131 @@
+import test from 'brittle'
+import {
+  configurePrefsStore, loadPrefs, peekPrefs, subscribePrefs, writePrefs, resetPrefsStore,
+} from '../../src/renderer/store/prefs-store.js'
+
+// A bridge that records every call and lets a test settle each one by hand, so the dedup is
+// asserted structurally rather than by timing — same shape as query-store.test.js's transport.
+function fakeBridge () {
+  const getCalls = []
+  const setCalls = []
+  const pendingGet = []
+  return {
+    getPrefs: () => { getCalls.push(1); return new Promise((resolve) => pendingGet.push(resolve)) },
+    setPrefs: (patch) => { setCalls.push(patch); return Promise.resolve({ ...LOADED, ...patch }) },
+    getCalls,
+    setCalls,
+    settleGet: (i, value) => pendingGet[i](value),
+  }
+}
+
+const LOADED = { minimizeToTray: true, openAtLogin: false, showMenuBar: true }
+
+function setup (t) {
+  resetPrefsStore()
+  const bridge = fakeBridge()
+  configurePrefsStore(bridge)
+  t.teardown(() => resetPrefsStore())
+  return bridge
+}
+
+// REGRESSION (FIX-R04-8: each settings screen ran its own getPrefs() effect behind a hand-rolled
+// `let cancelled` flag and kept a private copy in component state. Two screens meant two
+// round-trips and two copies that could disagree after a write.)
+test('REGRESSION (FIX-R04-8): concurrent consumers share ONE prefs:get round-trip', async (t) => {
+  const bridge = setup(t)
+
+  const a = loadPrefs()
+  const b = loadPrefs()
+  const c = loadPrefs()
+  t.is(bridge.getCalls.length, 1, 'three consumers, one request')
+
+  bridge.settleGet(0, LOADED)
+  t.alike(await a, LOADED, 'the first caller resolves')
+  t.alike(await b, LOADED, 'so does the second')
+  t.alike(await c, LOADED, 'and the third')
+  t.is(bridge.getCalls.length, 1, 'still one request')
+})
+
+test('a warm cache serves later consumers without another round-trip', async (t) => {
+  const bridge = setup(t)
+  const first = loadPrefs()
+  bridge.settleGet(0, LOADED)
+  await first
+
+  t.alike(await loadPrefs(), LOADED, 'served from cache')
+  t.is(bridge.getCalls.length, 1, 'no second prefs:get')
+})
+
+test('a write publishes to EVERY subscriber, not only the writer', async (t) => {
+  const bridge = setup(t)
+  let writerNotified = 0
+  let otherNotified = 0
+  subscribePrefs(() => { writerNotified++ })
+  subscribePrefs(() => { otherNotified++ })
+
+  const load = loadPrefs()
+  bridge.settleGet(0, LOADED)
+  await load
+  t.is(otherNotified, 1, 'the load reached the second subscriber')
+
+  await writePrefs({ openAtLogin: true })
+  t.ok(writerNotified >= 2, 'the writer saw the write')
+  t.is(writerNotified, otherNotified, 'both subscribers saw exactly the same notifications')
+  t.is(peekPrefs().openAtLogin, true, 'and the cache carries the new value')
+})
+
+test('a write is optimistic, then authoritative', async (t) => {
+  const bridge = setup(t)
+  const seen = []
+  subscribePrefs(() => { seen.push(peekPrefs().openAtLogin) })
+
+  const load = loadPrefs()
+  bridge.settleGet(0, LOADED)
+  await load
+
+  await writePrefs({ openAtLogin: true })
+  // The optimistic publish paints before the round-trip; the authoritative one confirms it.
+  t.alike(seen, [false, true, true], 'load, optimistic, authoritative')
+  t.alike(bridge.setCalls, [{ openAtLogin: true }], 'the patch went to main once')
+})
+
+// The React 19 contract for useSyncExternalStore: getSnapshot is compared by identity, so a
+// getSnapshot that allocates warns in DEV and can loop forever.
+test('peekPrefs returns a cached value, never a fresh object', async (t) => {
+  const bridge = setup(t)
+  t.is(peekPrefs(), null, 'null before the first load, and the SAME null every call')
+  t.is(peekPrefs(), peekPrefs(), 'stable while cold')
+
+  const load = loadPrefs()
+  bridge.settleGet(0, LOADED)
+  await load
+
+  t.is(peekPrefs(), peekPrefs(), 'stable while warm — no allocation per read')
+})
+
+test('unsubscribing the last consumer does not clear the cache', async (t) => {
+  const bridge = setup(t)
+  const unsubscribe = subscribePrefs(() => {})
+  const load = loadPrefs()
+  bridge.settleGet(0, LOADED)
+  await load
+
+  unsubscribe()
+  t.alike(peekPrefs(), LOADED, 'the value survives the last unsubscribe')
+  t.alike(await loadPrefs(), LOADED, 'and a remounting screen paints instantly')
+  t.is(bridge.getCalls.length, 1, 'with no fresh round-trip')
+})
+
+test('a failed load leaves the store cold and retryable', async (t) => {
+  resetPrefsStore()
+  let attempts = 0
+  configurePrefsStore({
+    getPrefs: () => { attempts++; return attempts === 1 ? Promise.reject(new Error('main is not up')) : Promise.resolve(LOADED) },
+    setPrefs: (patch) => Promise.resolve({ ...LOADED, ...patch }),
+  })
+  t.teardown(() => resetPrefsStore())
+
+  await t.exception(loadPrefs(), 'the rejection reaches the caller')
+  t.is(peekPrefs(), null, 'nothing cached')
+  t.alike(await loadPrefs(), LOADED, 'a later mount retries rather than being stuck on the dead promise')
+})

--- a/test/unit/share-files-reconcile.test.js
+++ b/test/unit/share-files-reconcile.test.js
@@ -25,3 +25,114 @@ test('an unchanged incomplete read returns the prev reference (no needless re-re
   t.is(reconcileFiles(prev, [row('a'), row('b'), row('c')], { complete: false }), prev, 'identical partial → same reference')
   t.is(reconcileFiles(prev, [row('a'), row('c')], { complete: false }), prev, 'subset partial with identical values → same reference')
 })
+
+// ── Row identity ──────────────────────────────────────────────────────────────
+// reconcileFiles is what lets a memoized row skip a re-render, so identity is the assertion here,
+// not deep equality: `t.alike` passes on exactly the bug these cover. `t.is` is Object.is.
+
+// REGRESSION (FIX-R04-7: `if (complete) return next` handed EVERY row a new object on every
+// complete read — the ordinary owner-side listing — so React.memo on the row could never bail.)
+test('REGRESSION (FIX-R04-7): a complete read must not replace unchanged row objects', (t) => {
+  const prev = [row('a.txt'), row('b.txt')]
+  const next = [row('a.txt'), row('b.txt', { size: 99 })]
+  const out = reconcileFiles(prev, next, { complete: true })
+
+  t.is(out[0], prev[0], 'the unchanged row keeps its identity')
+  t.not(out[1], prev[1], 'the changed row does not')
+  t.is(out[1].size, 99, 'and carries the fresh content')
+})
+
+// REGRESSION (FIX-R04-7: the partial branch pushed `b` unconditionally, so one changed row gave
+// every OTHER row a new object too.)
+test('REGRESSION (FIX-R04-7): one changed row must not re-identify the others', (t) => {
+  const prev = [row('a.txt'), row('b.txt'), row('c.txt')]
+  const next = [row('a.txt'), row('b.txt', { status: 'downloaded' }), row('c.txt')]
+  const out = reconcileFiles(prev, next, { complete: false })
+
+  t.is(out[0], prev[0], 'a.txt keeps its identity')
+  t.not(out[1], prev[1], 'b.txt, which changed, does not')
+  t.is(out[2], prev[2], 'c.txt keeps its identity')
+})
+
+test('an unchanged complete read returns the previous ARRAY', (t) => {
+  const prev = [row('a.txt'), row('b.txt')]
+  t.is(reconcileFiles(prev, [row('a.txt'), row('b.txt')], { complete: true }), prev, 'identical complete → same reference')
+})
+
+test('a complete read against an empty prev adopts next wholesale', (t) => {
+  const next = [row('a.txt')]
+  t.is(reconcileFiles([], next, { complete: true }), next, 'nothing to adopt identity from')
+})
+
+// The authoritative-read contract the `complete` flag exists for. An over-clever identity walk
+// resurrects a row that is absent from `next`; this is the test that catches it.
+test('a complete read still applies removals, additions and content updates', (t) => {
+  const prev = [row('a.txt'), row('b.txt'), row('c.txt')]
+
+  const removed = reconcileFiles(prev, [row('a.txt'), row('c.txt')], { complete: true })
+  t.alike(removed.map((f) => f.relPath), ['a.txt', 'c.txt'], 'b.txt is gone')
+  t.is(removed[0], prev[0], 'a.txt survives the removal with its identity')
+  t.is(removed[1], prev[2], 'c.txt does too')
+
+  const added = reconcileFiles(prev, [row('a.txt'), row('b.txt'), row('b2.txt'), row('c.txt')], { complete: true })
+  t.alike(added.map((f) => f.relPath), ['a.txt', 'b.txt', 'b2.txt', 'c.txt'], 'b2.txt is inserted in order')
+  t.is(added[3], prev[2], 'c.txt keeps its identity across the insertion')
+
+  const trailing = reconcileFiles(prev, [row('a.txt')], { complete: true })
+  t.alike(trailing.map((f) => f.relPath), ['a.txt'], 'a trailing removal applies')
+})
+
+// REGRESSION (FIX-R04-7: sameRow compared five fields; toEntry produces four MORE that the row
+// renders — verified (the check), errorCode (a role="alert" line), transferId (what pause/cancel
+// act on) and pendingBytes (the paused byte count). A row changing only one of them was "unchanged",
+// so it kept its previous object AND its previous values, and the update was dropped for good.)
+test('REGRESSION (FIX-R04-7): every field toEntry produces counts as a change', (t) => {
+  const fields = {
+    size: 2,
+    hash: 'h2',
+    mtime: 1,
+    status: 'downloading',
+    localPath: '/tmp/a.txt',
+    verified: true,
+    pendingBytes: 512,
+    errorCode: 'EPEER',
+    transferId: 'tx-2',
+  }
+  const base = { relPath: 'a.txt', size: 1, hash: 'h', mtime: 0, status: 'remote' }
+
+  for (const [field, value] of Object.entries(fields)) {
+    const prev = [{ ...base }]
+    const next = [{ ...base, [field]: value }]
+
+    const complete = reconcileFiles(prev, next, { complete: true })
+    t.not(complete[0], prev[0], `complete: a changed ${field} yields a fresh row`)
+    t.is(complete[0][field], value, `complete: the fresh ${field} lands`)
+
+    const partial = reconcileFiles(prev, next, { complete: false })
+    t.not(partial, prev, `partial: a changed ${field} is not discarded as unchanged`)
+    t.is(partial[0][field], value, `partial: the fresh ${field} lands`)
+  }
+})
+
+// 'publishing' joined SHARE_FILE_STATUS with the indexing-vs-downloading split; it is a value in
+// the `status` field sameRow already compares, and must move a row like any other status.
+test('a publishing→downloading transition is a change', (t) => {
+  const prev = [row('a.txt', { status: 'publishing' })]
+  const out = reconcileFiles(prev, [row('a.txt', { status: 'downloading' })], { complete: true })
+  t.not(out[0], prev[0], 'the row is re-identified')
+  t.is(out[0].status, 'downloading', 'and carries the new status')
+})
+
+// The safety property behind adoptIdentity's two-pointer walk. Both lists are sorted by relPath by
+// contract (the catalog read-stream is key-ordered), and a reordering that is not an add or remove
+// therefore cannot occur — but if that contract were ever broken, the result must still be exactly
+// next's CONTENT. `out` is built one slot per next entry, so bad ordering costs identity adoption
+// and nothing else.
+test('a complete read with an out-of-order next still yields exactly next content', (t) => {
+  const prev = [row('a.txt'), row('b.txt'), row('c.txt')]
+  const next = [row('c.txt'), row('a.txt'), row('b.txt', { size: 42 })]
+  const out = reconcileFiles(prev, next, { complete: true })
+
+  t.alike(out.map((f) => f.relPath), ['c.txt', 'a.txt', 'b.txt'], 'order and membership follow next')
+  t.is(out[2].size, 42, 'content follows next')
+})


### PR DESCRIPTION
## What & why

`useDecorations` sets state on the *screen* once a second while any transfer is live, so `SpaceView`/`FolderView` and every row under them re-rendered on the heartbeat. There were 82 `useCallback`s in the renderer and **zero** `React.memo` — the mechanism was built and never connected.

Connecting it needed two halves, and the second was the actual work:

1. **Row identity.** `reconcileFiles` returned the fresh array wholesale on a complete read, so every row object was replaced on every listing read and a memoized row could never bail. `adoptIdentity` keeps the previous object wherever the two agree; it builds its result entirely from `next`, so a violated sort order costs identity adoption and never content.
2. **Prop identity.** `useTransferControls` returned two fresh arrows per render and `useFiles` returned five plain `async function`s — both fed straight into rows. Fixed at the source. The `ShareCard` role-ternaries turned out to be redundant (the card already gates every handler behind the same `share.role` check), so removing them is behavior-neutral.

Along the way `sameRow` compared only five of the nine fields `toEntry` produces. `verified`, `pendingBytes`, `errorCode` and `transferId` are all rendered — the error line is a `role="alert"`, and a stale `transferId` points pause/cancel at a dead transfer. A partial read changing only one of them was already being discarded, so commit 1 is a fix in its own right and ships alone.

`prefs`/`storage:info`/`audit:*` were the remaining hand-rolled `let cancelled` reads. Prefs get their own store rather than the query one: `useQuery` is typed to `RequestName` — the *worker* contract — and prefs are an Electron **main** call, so routing them through it would mean widening that type to a lie.

**Scoped out on purpose:** `PeerDownloadRow` (the props that change are `bytes`/`avgSpeed`, exactly what it renders) and `SpaceCard` (`SharedSpaces` has no heartbeat) — memoizing either costs an API change for no measurable gain. `AddFolderShareModal` keeps its cancel flag: it is a point-in-time filesystem probe, not a query, and now says so in a comment. The audit reads take **no** scope, preserving the existing "summary line, not a live counter" decision.

## Coverage

Unit: 10 reconcile tests (`REGRESSION (FIX-R04-7)`), including one that walks *every* field `toEntry` emits, plus 7 for the prefs store. Verified red on the pre-fix implementation — 5/10 fail, and the four newly-compared fields fail on the partial path, which is the pre-existing bug.

New `frontend-layout` harness, `npm run test:layout:memo`: mounts real `<ShareFileRow>`s and counts renders across an idle heartbeat tick, a one-row summary change, an unchanged full refetch and a one-row content change. Verified red with commit 1 reverted (`unchanged full refetch: a.txt=2 b.txt=3 c.txt=2 d.txt=2`).

The counter is itself `memo()`'d with the default comparator rather than wrapping the real component in an unmemoized shim — a shim re-renders on every parent render regardless of whether the memo bailed, so it would fail against a correct implementation. A separate assertion checks the real export is a `memo` with no custom compare; the two together are equivalent to counting the real component.

## Ran locally

`test:layout:memo`, `:filecard`, `:indexing`, `:sharecard` green. `test:fe` s14 s15 s16 s8 (settings/account, incl. the launch-at-login toggle now served by the store) and s118 s103 s10 s119 s6 s23 s24 s25 (folder listing, a real two-peer download, and every ShareCard action path rewired here) — 12/12. Typecheck, `lint:ci`, `build` and 1391 unit tests green.

`test:layout:members` fails on this branch **and on `staging`** — "expand (Show all) button not found", reproduced with the `MemberCard` memo reverted. Pre-existing and unrelated; it is local-only so CI never caught it drifting.

No a11y regressions: no interactive elements, roles or names change. Memo alters *when* a row renders, never what it renders, and the `role="alert"` error line is strictly more reliable now that `errorCode` is compared. No VoiceOver pass.
