### PR TITLE
[feat] Structured request telemetry and a worker health snapshot

### DIFF
--- a/src/shared/core/errors.js
+++ b/src/shared/core/errors.js
@@ -10,9 +10,13 @@ import { CODES } from '../contract/errors.js'
 export const ErrorCodes = CODES
 
 export class AppError extends Error {
-  constructor(code, message) {
+  // `fields` is structured context the router logs and returns on the response frame, so a caller
+  // can branch on the failing ids instead of parsing the English message. Optional: all 58 existing
+  // call sites pass two arguments and keep working unchanged.
+  constructor(code, message, fields = null) {
     super(message)
     this.code = code
+    this.fields = fields
   }
 }
 

--- a/src/shared/core/health.js
+++ b/src/shared/core/health.js
@@ -1,0 +1,47 @@
+// Process-level health the diagnostics export did not have: five swarm counters were the whole
+// picture. Loop lag is the signal that says the worker is wedged rather than merely busy, which is
+// the one probe a per-subsystem supervisor needs and the one number no per-request metric can give.
+//
+// The clock and timer are injectable for the same reason the request vocabulary is: a test drives
+// them directly instead of sleeping, which is what keeps this out of check-test-timing.sh.
+const LAG_INTERVAL_MS = 1000
+
+export function createHealthMonitor({
+  now = Date.now,
+  setInterval: setIv = setInterval,
+  clearInterval: clearIv = clearInterval,
+  intervalMs = LAG_INTERVAL_MS,
+} = {}) {
+  let lastLagMs = 0
+  let maxLagMs = 0
+  let timer = null
+  let expected = 0
+
+  function tick() {
+    const drift = now() - expected
+    expected = now() + intervalMs
+    // A clock stepping backwards is not a healthy loop; clamping keeps a wedged worker from
+    // reading as fast and keeps the max from being reset by a time correction.
+    lastLagMs = drift > 0 ? drift : 0
+    if (lastLagMs > maxLagMs) maxLagMs = lastLagMs
+  }
+
+  return {
+    start() {
+      if (timer) return
+      expected = now() + intervalMs
+      timer = setIv(tick, intervalMs)
+      timer?.unref?.()
+    },
+    stop() {
+      if (!timer) return
+      clearIv(timer)
+      timer = null
+    },
+    tick,
+    snapshot(extra = {}) {
+      return { loopLagMs: lastLagMs, loopLagMaxMs: maxLagMs, ...extra }
+    },
+    reset() { lastLagMs = 0; maxLagMs = 0 },
+  }
+}

--- a/src/shared/core/ipc.js
+++ b/src/shared/core/ipc.js
@@ -266,10 +266,17 @@ export function createIPC(pipe, { requests, maxFrameBytes = IPC_MAX_FRAME_BYTES,
   }
 
   ipcSingleton.bootstrapPromise = bootstrapPromise
+  ipcSingleton.queueDepth = () => queued.length
   return { handle, emit, respond, start }
 }
 
-const ipcSingleton = { bootstrapPromise: null }
+const ipcSingleton = { bootstrapPromise: null, queueDepth: null }
+
+// The pre-start queue is otherwise invisible: it is bounded now, and a caller that keeps hitting
+// that bound during a slow boot is exactly the condition worth surfacing.
+export function getQueueDepth() {
+  return ipcSingleton.queueDepth ? ipcSingleton.queueDepth() : 0
+}
 
 export function getBootstrapPromise() {
   if (!ipcSingleton.bootstrapPromise) {

--- a/src/shared/core/ipc.js
+++ b/src/shared/core/ipc.js
@@ -201,7 +201,12 @@ export function createIPC(pipe, { requests, maxFrameBytes = IPC_MAX_FRAME_BYTES,
     // The second argument is the request's context. `signal` is null until cancellation is wired
     // (r07-3): the seam costs one line now and re-plumbing 86 handlers later. Every handler takes
     // one parameter today and ignores this one.
-    Promise.resolve(entry.fn(msg, { id: msg.id ?? null, signal: null })).then(
+    // `new Promise(resolve => resolve(...))`, not `Promise.resolve(...)`: the latter EVALUATES the
+    // handler before the promise exists, so a handler that throws synchronously unwound into the
+    // frame-parse catch around dispatch() — reported as an unparseable frame at debug, never
+    // answered (the caller hung to the renderer's 30s timeout), never counted, and with the
+    // in-flight metric already incremented and no settle to match it.
+    new Promise((resolve) => resolve(entry.fn(msg, { id: msg.id ?? null, signal: null }))).then(
       (data) => { log.debug('res', label, 'ok', `${settle(true)}ms`); respond(msg.id, data) },
       (err) => {
         const ms = settle(false)

--- a/src/shared/core/ipc.js
+++ b/src/shared/core/ipc.js
@@ -1,7 +1,7 @@
 // The worker end of the renderer↔worker pipe: NDJSON request/response framing with a
 // handler table, `event:*` pushes, and the coalesced reconcile hint bus. Frames arriving
 // before start() are queued so no request is lost during boot.
-import { createLogger } from './logger.js'
+import { createLogger, fields } from './logger.js'
 import { createHintBus } from '../state/hints.js'
 import { Scope } from '../contract/scope.js'
 import { EXPECTED_CODES as CONTRACT_EXPECTED_CODES, INVALID_ARGUMENT } from '../contract/errors.js'
@@ -75,10 +75,13 @@ export function resetRequestMetrics() {
 // Ordered key=value rather than JSON: the transport is a console line forwarded to main and read by
 // a human with grep. The router is the one place with enough structure to be worth it — converting
 // the other 400 positional call sites is a separate, mechanical change.
-function logRequestFailure(log, { req, code, ms, message }) {
-  const line = `req-failed req=${req} code=${code} ms=${ms} — ${message}`
-  if (EXPECTED.has(code)) log.debug(line)
-  else log.warn(line)
+// Every part of the line is key=value now, message included — the previous format concatenated the
+// type and id into one `req=boom #2` token, which is unreadable to anything but a human. The error's
+// own fields are spread FIRST so the router's canonical keys win a name clash.
+function logRequestFailure(log, { req, id, code, ms, message, extra }) {
+  const bag = fields({ ...(extra || {}), req, id, code, ms, msg: message })
+  if (EXPECTED.has(code)) log.debug('req-failed', bag)
+  else log.warn('req-failed', bag)
 }
 
 export function getRequestFailureCounters() {
@@ -214,8 +217,12 @@ export function createIPC(pipe, { requests, maxFrameBytes = IPC_MAX_FRAME_BYTES,
         countFailure(msg.type, code)
         // A failing request logs at warn so it survives the default level. Successes stay at debug:
         // they are the verbose trace, and only wanted when someone asked for it.
-        logRequestFailure(log, { req: label, code, ms, message: err?.message || String(err) })
-        respond(msg.id, null, err?.message, code)
+        logRequestFailure(log, {
+          req: msg.type, id: msg.id ?? null, code, ms,
+          message: err?.message || String(err),
+          extra: err?.fields || null,
+        })
+        respond(msg.id, null, err?.message, code, err?.fields || null)
       }
     )
   }
@@ -229,10 +236,10 @@ export function createIPC(pipe, { requests, maxFrameBytes = IPC_MAX_FRAME_BYTES,
     requestFailures.set(key, (requestFailures.get(key) || 0) + 1)
   }
 
-  function respond(id, data, error, code) {
+  function respond(id, data, error, code, errorFields) {
     if (!id) return
     const msg = error
-      ? { id, type: 'response', error, code }
+      ? { id, type: 'response', error, code, ...(errorFields ? { fields: errorFields } : {}) }
       : { id, type: 'response', data }
     pipe.write(JSON.stringify(msg) + '\n')
   }

--- a/src/shared/core/logger.js
+++ b/src/shared/core/logger.js
@@ -5,6 +5,34 @@ import { getRuntimeConfig } from './runtime-config.js'
 
 const LOG_LEVELS = { debug: 0, info: 1, warn: 2, error: 3 }
 
+// Ordered key=value appended to the message, not JSON: the transport is a console line forwarded
+// to main and read by a human with grep. Tagged with a symbol rather than recognised by shape, so
+// the ~330 positional call sites that already log a plain object keep printing exactly as they do
+// now. Symbol.for and not Symbol(): a module loaded through two specifiers would otherwise mint
+// two tags, and a bag created under one would render as an object under the other.
+const FIELDS = Symbol.for('mirall.logFields')
+
+export function fields(bag) {
+  return { [FIELDS]: bag }
+}
+
+function renderValue(value) {
+  if (typeof value !== 'string') return value
+  return value.includes(' ') || value === '' ? JSON.stringify(value) : value
+}
+
+function render(args) {
+  const last = args[args.length - 1]
+  if (!last || typeof last !== 'object' || !last[FIELDS]) return args
+  const pairs = []
+  for (const [key, value] of Object.entries(last[FIELDS])) {
+    if (value === undefined || value === null) continue
+    pairs.push(`${key}=${renderValue(value)}`)
+  }
+  const head = args.slice(0, -1)
+  return pairs.length ? [...head, pairs.join(' ')] : head
+}
+
 function level() {
   const cfg = getRuntimeConfig()
   return cfg.verbose ? LOG_LEVELS.debug : LOG_LEVELS.warn
@@ -12,9 +40,9 @@ function level() {
 
 export function createLogger(module) {
   return {
-    debug: (...args) => { if (level() <= 0) console.log(`[${module}]`, ...args) },
-    info: (...args) => { if (level() <= 1) console.log(`[${module}]`, ...args) },
-    warn: (...args) => { if (level() <= 2) console.warn(`[${module}]`, ...args) },
-    error: (...args) => { if (level() <= 3) console.error(`[${module}]`, ...args) },
+    debug: (...args) => { if (level() <= 0) console.log(`[${module}]`, ...render(args)) },
+    info: (...args) => { if (level() <= 1) console.log(`[${module}]`, ...render(args)) },
+    warn: (...args) => { if (level() <= 2) console.warn(`[${module}]`, ...render(args)) },
+    error: (...args) => { if (level() <= 3) console.error(`[${module}]`, ...render(args)) },
   }
 }

--- a/src/shared/transfer/diagnostics.js
+++ b/src/shared/transfer/diagnostics.js
@@ -35,7 +35,7 @@ export function verdictHistoryFromAudit(entries = []) {
 // form, is the port 0, did it change, how many dials opened — is answerable without the
 // actual IP, the real keys, or space names.
 export function buildDiagnostics(ctx, redact = true) {
-  const { status, history, env, counters, peerSamples, requestFailures = {}, requestMetrics = {} } = ctx
+  const { status, history, env, counters, peerSamples, requestFailures = {}, requestMetrics = {}, health = {} } = ctx
   const topicAlias = makeAliaser('t')
   const samples = peerSamples.map((peer) => ({
     peer: redact ? shortId(peer.publicKey) : peer.publicKey,
@@ -98,6 +98,8 @@ export function buildDiagnostics(ctx, redact = true) {
     // neither is redacted. Carried explicitly because a key the builder does not name is dropped,
     // which is how the failure counters shipped dead.
     requests: { metrics: requestMetrics, failures: requestFailures },
+
+    health,
 
     spaces: {
       count: status.topics,

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -13,7 +13,8 @@ import os from 'bare-os'
 import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
-import { createIPC, getBootstrapPromise, getRequestFailureCounters, getRequestMetrics } from '../shared/core/ipc.js'
+import { createIPC, getBootstrapPromise, getRequestFailureCounters, getRequestMetrics, getQueueDepth } from '../shared/core/ipc.js'
+import { createHealthMonitor } from '../shared/core/health.js'
 import { registerSpaceLeave } from './ipc/space-leave.js'
 import {
   setRuntimeConfig,
@@ -192,6 +193,11 @@ import { saveForeignMount as persistForeignMount, getForeignMount, listForeignMo
 const ipc = createIPC(Bare.IPC)
 const log = createLogger('worklet')
 
+// Started next to ipc.start() rather than here: before the router goes live the loop is busy with
+// boot I/O by design, and sampling that would report a wedge that is really just a large library
+// being opened.
+const health = createHealthMonitor()
+
 // Main authorizes "reveal in folder" against these, and cannot read the space records
 // that hold the per-space overrides, so the set is pushed to it on every change.
 function publishDownloadRoots() {
@@ -231,6 +237,7 @@ async function safeShutdown(reason) {
   // reaps that case.)
   const deadline = setTimeout(() => { try { Bare.exit(0) } catch {} }, 4000)
   deadline.unref?.()
+  health.stop()
   // The whole stop sequence — the departure announce, the flush window, then every subsystem in
   // the reverse of its start order — lives in the composition root. `root` is null until boot()
   // returns, which is what lets the pipe-close hooks below fire at any point during startup.
@@ -1711,6 +1718,7 @@ ipc.handle('diagnostics:export', async (msg) => {
     counters: getDiagnosticCounters(),
     requestFailures: getRequestFailureCounters(),
     requestMetrics: getRequestMetrics(),
+    health: health.snapshot({ queueDepth: getQueueDepth() }),
     peerSamples: getPeerSamples(),
   }, msg?.redact !== false)
 })
@@ -1754,6 +1762,7 @@ ipc.handle('audit:export', async (msg) => ({
 
 // === Go live: flush queued frames, announce ready ===
 
+health.start()
 ipc.start()
 
 ipc.emit('event:worker-ready')

--- a/test/unit/diagnostics-bundle.test.js
+++ b/test/unit/diagnostics-bundle.test.js
@@ -175,3 +175,31 @@ test('the query filter and the mapper cannot drift apart', (t) => {
   }
   t.is(verdictHistoryFromAudit([{ kind: 'network.peer_lost', ts: 1, subject: {} }]).length, 0, 'and the peer family does not')
 })
+
+// buildDiagnostics names every key it carries and silently drops the rest. That is not a
+// hypothetical: requestFailures (#118) and requestMetrics (#120) each shipped as a no-op because
+// the producer was wired and the builder never named the key. These are the guards that were
+// missing both times.
+test('REGRESSION (FIX-R09-7): the health block survives the builder', (t) => {
+  const bundle = buildDiagnostics(makeCtx({ health: { loopLagMs: 42, loopLagMaxMs: 900, queueDepth: 3 } }), true)
+  t.alike(bundle.health, { loopLagMs: 42, loopLagMaxMs: 900, queueDepth: 3 })
+})
+
+test('REGRESSION (FIX-OBS-1/R09-7): the requests block survives the builder', (t) => {
+  const bundle = buildDiagnostics(makeCtx({
+    requestMetrics: { 'space:members': { calls: 11, failures: 1, inFlight: 0, avgMs: 7, maxMs: 30, slow: 0 } },
+    requestFailures: { 'space:members:NOT_FOUND': 1 },
+  }), true)
+  t.is(bundle.requests.metrics['space:members'].calls, 11)
+  t.is(bundle.requests.failures['space:members:NOT_FOUND'], 1)
+})
+
+test('an absent health block defaults rather than throwing', (t) => {
+  // The worker always supplies it, but a caller that predates the field must not crash the export.
+  t.alike(buildDiagnostics(makeCtx(), true).health, {})
+})
+
+test('the health block carries no identifying values, so redaction is a no-op for it', (t) => {
+  const health = { loopLagMs: 5, loopLagMaxMs: 5, queueDepth: 0 }
+  t.alike(buildDiagnostics(makeCtx({ health }), true).health, buildDiagnostics(makeCtx({ health }), false).health)
+})

--- a/test/unit/health.test.js
+++ b/test/unit/health.test.js
@@ -1,0 +1,93 @@
+import test from 'brittle'
+import { createHealthMonitor } from '../../src/shared/core/health.js'
+
+// A fake clock and a fake timer, so lag is asserted structurally rather than by sleeping — which is
+// also what keeps this file out of check-test-timing.sh.
+function harness (startAt = 1000) {
+  let t = startAt
+  let armed = null
+  const monitor = createHealthMonitor({
+    now: () => t,
+    setInterval: (fn) => { armed = fn; return { unref () {} } },
+    clearInterval: () => { armed = null },
+    intervalMs: 1000,
+  })
+  return {
+    monitor,
+    advance: (ms) => { t += ms },
+    set: (v) => { t = v },
+    fire: () => armed && armed(),
+    armed: () => armed !== null,
+  }
+}
+
+test('a punctual loop reports no lag', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.advance(1000)
+  h.fire()
+  t.alike(h.monitor.snapshot(), { loopLagMs: 0, loopLagMaxMs: 0 })
+})
+
+test('a late tick records the drift past its deadline', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.advance(1450)
+  h.fire()
+  t.is(h.monitor.snapshot().loopLagMs, 450, 'lag is measured against the expected deadline, not the interval')
+})
+
+test('the max is retained after the loop recovers', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.advance(1900); h.fire()
+  h.advance(1000); h.fire()
+  const s = h.monitor.snapshot()
+  t.is(s.loopLagMs, 0, 'the current reading recovers')
+  t.is(s.loopLagMaxMs, 900, 'the worst reading is kept')
+})
+
+// A time correction must not make a wedged worker look fast, nor wipe the worst reading recorded
+// so far — the two ways a naive `now() - expected` misreports.
+test('REGRESSION (FIX-R09-7): a backwards clock step does not read as a healthy loop', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.advance(1800); h.fire()
+  t.is(h.monitor.snapshot().loopLagMaxMs, 800)
+  h.set(500); h.fire()
+  const s = h.monitor.snapshot()
+  t.is(s.loopLagMs, 0, 'clamped, never negative')
+  t.is(s.loopLagMaxMs, 800, 'and the max survives the correction')
+})
+
+test('snapshot merges caller counters without losing the lag fields', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.advance(1200); h.fire()
+  t.alike(h.monitor.snapshot({ queueDepth: 7 }), { loopLagMs: 200, loopLagMaxMs: 200, queueDepth: 7 })
+})
+
+test('stop() clears the timer so the monitor cannot outlive the worker', (t) => {
+  const h = harness()
+  h.monitor.start()
+  t.ok(h.armed(), 'armed after start')
+  h.monitor.stop()
+  t.absent(h.armed(), 'disarmed after stop')
+})
+
+test('start() twice arms one timer, and stop() is idempotent', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.monitor.start()
+  h.monitor.stop()
+  h.monitor.stop()
+  t.absent(h.armed())
+})
+
+test('reset clears both readings', (t) => {
+  const h = harness()
+  h.monitor.start()
+  h.advance(2000); h.fire()
+  h.monitor.reset()
+  t.alike(h.monitor.snapshot(), { loopLagMs: 0, loopLagMaxMs: 0 })
+})

--- a/test/unit/ipc-failure-logging.test.js
+++ b/test/unit/ipc-failure-logging.test.js
@@ -1,11 +1,14 @@
 import test from 'brittle'
 import { createIPC, getRequestFailureCounters, resetRequestFailureCounters, getRequestMetrics, resetRequestMetrics } from '../../src/shared/core/ipc.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { AppError } from '../../src/shared/core/errors.js'
 
 // The router is strict about names it does not know, which is the point in production. A test
 // declares the small vocabulary it exercises instead of registering into the real contract.
 const TEST_REQUESTS = Object.freeze({
   'thing:sync-boom': { kind: 'command', args: {} },
+  'thing:fields': { kind: 'command', args: {} },
+  'thing:cancel': { kind: 'command', args: {} },
   'thing:do': { kind: 'command', args: {} },
   'thing:ok': { kind: 'command', args: {} },
   'preview:make': { kind: 'command', args: {} },
@@ -184,3 +187,86 @@ test('REGRESSION (FIX-R09-7): a synchronous handler throw is answered, counted, 
   t.absent(warns.some((l) => l.includes('unparseable')), 'never misreported as a malformed frame')
 })
 
+
+test('the failure line carries req, id, code and ms as separate fields', async (t) => {
+  const { warns } = captureConsole(t)
+  setRuntimeConfig({ verbose: false })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('thing:do', async () => { throw new AppError('NOT_FOUND', 'gone') })
+  ipc.start()
+  pipe.feed({ id: '9', type: 'thing:do' })
+  await new Promise((r) => setImmediate(r))
+
+  const line = warns.find((l) => l.includes('req-failed'))
+  t.ok(line, 'the failure is logged')
+  t.ok(line.includes('req=thing:do'), 'the type is its own field')
+  t.ok(line.includes('id=9'), 'and the id is too — previously both were fused into one token')
+  t.ok(line.includes('code=NOT_FOUND'), 'the code is a field')
+  t.ok(/\bms=\d+/.test(line), 'and the duration is a numeric field')
+})
+
+// AppError carried a code and nothing else, so a handler that knew exactly which space and share
+// had failed could only say so in English that the renderer had to parse back.
+test("REGRESSION (FIX-R09-7): an AppError's fields reach both the log and the caller", async (t) => {
+  const { warns } = captureConsole(t)
+  setRuntimeConfig({ verbose: false })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('thing:fields', async () => {
+    throw new AppError('EOWNERSHIP', 'not yours', { spaceId: 'S1', shareId: 'F2' })
+  })
+  ipc.start()
+  pipe.feed({ id: '4', type: 'thing:fields' })
+  await new Promise((r) => setImmediate(r))
+
+  const res = pipe.written.map((s) => JSON.parse(s)).find((m) => m.id === '4')
+  t.is(res.code, 'EOWNERSHIP')
+  t.alike(res.fields, { spaceId: 'S1', shareId: 'F2' }, 'structure crosses the boundary, not only prose')
+
+  const line = warns.find((l) => l.includes('req-failed'))
+  t.ok(line.includes('spaceId=S1') && line.includes('shareId=F2'), 'and the same fields reach the log')
+})
+
+test('an error without fields produces a response with no fields key at all', async (t) => {
+  captureConsole(t)
+  setRuntimeConfig({ verbose: false })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('thing:do', async () => { throw new AppError('NOT_FOUND', 'gone') })
+  ipc.start()
+  pipe.feed({ id: '5', type: 'thing:do' })
+  await new Promise((r) => setImmediate(r))
+  const res = pipe.written.map((s) => JSON.parse(s)).find((m) => m.id === '5')
+  t.absent('fields' in res, 'absent, not null — a consumer should not have to tell the two apart')
+})
+
+test("an error's own fields cannot overwrite the router's canonical ones", async (t) => {
+  const { warns } = captureConsole(t)
+  setRuntimeConfig({ verbose: false })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('thing:fields', async () => {
+    throw new AppError('NOT_FOUND', 'gone', { code: 'FORGED', req: 'forged' })
+  })
+  ipc.start()
+  pipe.feed({ id: '6', type: 'thing:fields' })
+  await new Promise((r) => setImmediate(r))
+  const line = warns.find((l) => l.includes('req-failed'))
+  t.ok(line.includes('code=NOT_FOUND'), 'the router wins the code')
+  t.ok(line.includes('req=thing:fields'), 'and the request name')
+  t.absent(line.includes('FORGED'), 'the forged value never appears')
+})
+
+test('an expected code still logs at debug once it carries fields', async (t) => {
+  const { warns, logs } = captureConsole(t)
+  setRuntimeConfig({ verbose: true })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('thing:cancel', async () => { throw new AppError('ECANCELLED', 'user cancelled', { spaceId: 'S1' }) })
+  ipc.start()
+  pipe.feed({ id: '8', type: 'thing:cancel' })
+  await new Promise((r) => setImmediate(r))
+  t.absent(warns.some((l) => l.includes('req-failed')), 'the #118 level policy survives the change')
+  t.ok(logs.some((l) => l.includes('req-failed') && l.includes('spaceId=S1')), 'it is at debug, with its fields')
+})

--- a/test/unit/ipc-failure-logging.test.js
+++ b/test/unit/ipc-failure-logging.test.js
@@ -1,10 +1,11 @@
 import test from 'brittle'
-import { createIPC, getRequestFailureCounters, resetRequestFailureCounters } from '../../src/shared/core/ipc.js'
+import { createIPC, getRequestFailureCounters, resetRequestFailureCounters, getRequestMetrics, resetRequestMetrics } from '../../src/shared/core/ipc.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 
 // The router is strict about names it does not know, which is the point in production. A test
 // declares the small vocabulary it exercises instead of registering into the real contract.
 const TEST_REQUESTS = Object.freeze({
+  'thing:sync-boom': { kind: 'command', args: {} },
   'thing:do': { kind: 'command', args: {} },
   'thing:ok': { kind: 'command', args: {} },
   'preview:make': { kind: 'command', args: {} },
@@ -151,3 +152,35 @@ test('the failure counter map is bounded', async (t) => {
   t.ok(Object.keys(counters).length <= 257, 'the map stayed capped')
   t.is(counters['unknown-command:NOT_FOUND'], 400, 'and unknown commands share one bucket')
 })
+
+// A handler that throws SYNCHRONOUSLY (not from an async body) escaped through
+// `Promise.resolve(entry.fn(...))` — the call is evaluated before the promise exists, so the throw
+// unwound into the frame-parse catch that wraps dispatch(). Three consequences, all silent:
+// the caller got no response and hung to the renderer's 30s timeout, the failure was counted
+// nowhere, and requestMetrics.begin() had already incremented inFlight with no settle to match.
+// Only `shutdown` is non-async in the worker today, but the metrics leak is what makes this
+// load-bearing here: a monotonically rising inFlight reads as saturation.
+test('REGRESSION (FIX-R09-7): a synchronous handler throw is answered, counted, and settled', async (t) => {
+  resetRequestFailureCounters()
+  resetRequestMetrics()
+  t.teardown(() => { resetRequestFailureCounters(); resetRequestMetrics() })
+  const { warns } = captureConsole(t)
+  setRuntimeConfig({ verbose: false })
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: TEST_REQUESTS })
+  ipc.handle('thing:sync-boom', () => { throw new Error('sync throw') })
+  ipc.start()
+
+  pipe.feed({ id: '1', type: 'thing:sync-boom' })
+  await new Promise((r) => setImmediate(r))
+
+  const res = pipe.written.map((s) => JSON.parse(s)).find((m) => m.id === '1')
+  t.ok(res, 'the caller is answered rather than left to time out')
+  t.is(res.code, 'UNKNOWN', 'with a code')
+  t.is(res.error, 'sync throw', 'and the message')
+  t.is(getRequestFailureCounters()['thing:sync-boom:UNKNOWN'], 1, 'the failure is counted')
+  t.is(getRequestMetrics()['thing:sync-boom'].inFlight, 0, 'in-flight settles back to zero')
+  t.is(getRequestMetrics()['thing:sync-boom'].failures, 1, 'and is recorded as a failure')
+  t.absent(warns.some((l) => l.includes('unparseable')), 'never misreported as a malformed frame')
+})
+

--- a/test/unit/ipc.test.js
+++ b/test/unit/ipc.test.js
@@ -172,7 +172,11 @@ test('logs handler errors and unknown commands', async (t) => {
   pipe.feed({ id: '2', type: 'boom' })
   pipe.feed({ id: '3', type: 'ghost' })
   await tick()
-  t.ok(lines.some((l) => l.startsWith('req-failed req=boom #2') && l.includes('kaboom')), 'logs the failing handler')
+  const failed = lines.find((l) => l.startsWith('req-failed'))
+  t.ok(failed, 'logs the failing handler')
+  t.ok(failed.includes('req=boom'), 'with the request type as its own field')
+  t.ok(failed.includes('id=2'), 'and the request id as its own field, not concatenated into the type')
+  t.ok(failed.includes('kaboom'), 'and the error message')
   t.ok(lines.some((l) => l.startsWith('req-unknown ghost')), 'logs an unknown command')
   // ghost responds synchronously; boom's rejection resolves a tick later — so
   // find the #3 response rather than assuming write order.

--- a/test/unit/logger-fields.test.js
+++ b/test/unit/logger-fields.test.js
@@ -1,0 +1,79 @@
+import test from 'brittle'
+import { createLogger, fields } from '../../src/shared/core/logger.js'
+import { setRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+
+function capture (t) {
+  const lines = []
+  const realLog = console.log
+  const realWarn = console.warn
+  const grab = (real) => (...a) => { if (a[0] === '[probe]') { lines.push(a.slice(1)); return } real(...a) }
+  console.log = grab(realLog)
+  console.warn = grab(realWarn)
+  setRuntimeConfig({ verbose: true })
+  t.teardown(() => { console.log = realLog; console.warn = realWarn; setRuntimeConfig({}) })
+  return lines
+}
+
+const joined = (lines) => lines.map((a) => a.join(' '))
+
+test('a field bag renders as ordered key=value after the message', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('mirror stalled', fields({ spaceId: 'S1', shareId: 'F2', attempt: 3 }))
+  t.is(joined(lines)[0], 'mirror stalled spaceId=S1 shareId=F2 attempt=3')
+})
+
+// The property that makes this safe to land without auditing the ~330 positional call sites: a bag
+// is recognised by a symbol tag, never by shape, so an object someone logs today is untouched.
+test('REGRESSION (FIX-R09-7): a plain object argument is not read as a field bag', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('peer state', { spaceId: 'S1' })
+  t.alike(lines[0], ['peer state', { spaceId: 'S1' }], 'the object prints exactly as it did before')
+})
+
+test('null and undefined fields are omitted rather than printed', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('partial', fields({ a: 1, b: null, c: undefined, d: 2 }))
+  t.is(joined(lines)[0], 'partial a=1 d=2')
+})
+
+test('a value containing a space is quoted so key=value stays parseable', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('msg', fields({ note: 'two words', plain: 'one' }))
+  t.is(joined(lines)[0], 'msg note="two words" plain=one')
+})
+
+test('an empty string is quoted rather than rendering as a bare key=', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('msg', fields({ empty: '' }))
+  t.is(joined(lines)[0], 'msg empty=""')
+})
+
+test('a bag with nothing renderable drops the argument entirely', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('bare', fields({ a: null }))
+  t.alike(lines[0], ['bare'], 'no trailing empty string')
+})
+
+test('false and zero are rendered, not treated as absent', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('flags', fields({ ok: false, count: 0 }))
+  t.is(joined(lines)[0], 'flags ok=false count=0')
+})
+
+test('the level gate still applies to a line carrying fields', (t) => {
+  const lines = capture(t)
+  setRuntimeConfig({ verbose: false })
+  const log = createLogger('probe')
+  log.debug('hidden', fields({ a: 1 }))
+  t.is(lines.length, 0, 'debug stays below the default level')
+  log.warn('shown', fields({ a: 1 }))
+  t.is(joined(lines)[0], 'shown a=1', 'warn survives it')
+})
+
+// Symbol.for and not Symbol(): a module reached through two specifiers would otherwise mint two
+// tags, and a bag built under one would render as a raw object under the other.
+test('the field tag is registry-global so two module copies agree', (t) => {
+  const lines = capture(t)
+  createLogger('probe').warn('cross', { [Symbol.for('mirall.logFields')]: { a: 1 } })
+  t.is(joined(lines)[0], 'cross a=1')
+})

--- a/test/unit/telemetry-wiring.test.js
+++ b/test/unit/telemetry-wiring.test.js
@@ -1,0 +1,53 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { EventEmitter } from 'events'
+import { createIPC, getQueueDepth } from '../../src/shared/core/ipc.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const entry = readFileSync(path.join(here, '..', '..', 'src', 'worker', 'main.js'), 'utf8')
+
+// The producer being correct proves nothing about the export: requestFailures (#118) and
+// requestMetrics (#120) were both built, tested and shipped as no-ops because the entry never
+// handed them to buildDiagnostics. That wiring is module-scope code in worker/main.js — importing
+// it would boot the data layer and exit the process — so it is pinned by source text, the same way
+// the crash-backstop suite pins the core-opening call sites in boot.js.
+test('REGRESSION (FIX-R09-7): the entry feeds the health block into the diagnostics context', (t) => {
+  t.ok(/health:\s*health\.snapshot\(/.test(entry), 'diagnostics ctx carries health: health.snapshot(...)')
+  t.ok(/queueDepth:\s*getQueueDepth\(\)/.test(entry), 'and the queue depth is measured, not hard-coded')
+})
+
+test('REGRESSION (FIX-R09-7): the entry starts and stops the monitor', (t) => {
+  t.ok(/health\.start\(\)/.test(entry), 'started when the router goes live')
+  t.ok(/health\.stop\(\)/.test(entry), 'and stopped on shutdown, so it cannot outlive the worker')
+  // Statement positions, not the first textual match: a prose comment near the top of the entry
+  // also names ipc.start(), and indexOf would score that instead.
+  const startedAt = entry.search(/^health\.start\(\)$/m)
+  const liveAt = entry.search(/^ipc\.start\(\)$/m)
+  t.ok(startedAt > 0 && liveAt > 0, 'both are real statements, not only mentioned in comments')
+  t.ok(startedAt < liveAt, 'armed just before the router admits its first frame, not during boot I/O')
+})
+
+function fakePipe () {
+  const pipe = new EventEmitter()
+  pipe.written = []
+  pipe.write = (s) => { pipe.written.push(s); return true }
+  pipe.feed = (obj) => pipe.emit('data', Buffer.from(JSON.stringify(obj) + '\n'))
+  return pipe
+}
+
+const QUEUE_REQUESTS = Object.freeze({ 'q:one': { kind: 'command', args: {} } })
+
+test('getQueueDepth reports frames parked before the router goes live', async (t) => {
+  const pipe = fakePipe()
+  const ipc = createIPC(pipe, { requests: QUEUE_REQUESTS })
+  ipc.handle('q:one', async () => null)
+  pipe.feed({ id: '1', type: 'q:one' })
+  pipe.feed({ id: '2', type: 'q:one' })
+  await new Promise((r) => setImmediate(r))
+  t.is(getQueueDepth(), 2, 'the parked frames are visible')
+  ipc.start()
+  await new Promise((r) => setImmediate(r))
+  t.is(getQueueDepth(), 0, 'and the queue drains when it goes live')
+})


### PR DESCRIPTION
Finishes r09-7 from the architecture review. Plan: `plan-structured-telemetry.md`.
The metrics half shipped in #118/#120; this is the rest — structured fields, the
request id actually reaching the log, and process-level health.

Four commits, each standalone under `git bisect`:

1. **Logger field bag.** Tagged with a registry-global symbol, not recognised by shape,
   so the ~330 positional call sites that already log a plain object are untouched.
2. **`[fix]` A handler that throws synchronously is answered.** Found while smoke-testing:
   `Promise.resolve(entry.fn(...))` evaluates the handler *before* the promise exists, so
   a sync throw unwound into the frame-parse catch around `dispatch()` — logged as an
   unparseable frame at debug, **never answered** (caller hung to the renderer's 30 s
   timeout), never counted, and with `inFlight` incremented and no settle to match.
   Pre-existing; `shutdown` is non-async today. The leaked counter reads as saturation,
   which is what makes it load-bearing here.
3. **AppError carries fields** through to the failure log and the response frame. The line
   is now wholly key=value — the old format fused type and id into one `req=boom #2` token.
   The error's own fields are spread first so the router's canonical keys win a clash.
4. **Loop lag + queue depth in diagnostics.** Lag is measured against the loop's own
   deadline, clamped so a backwards clock step can't read as healthy.

`buildDiagnostics` had **no** assertions on the requests block — which is why
`requestFailures` (#118) and `requestMetrics` (#120) each shipped as no-ops. That guard is
backfilled, and the entry wiring is pinned by source text (the same technique the
crash-backstop suite uses for `boot.js`), since it is module-scope code no unit test can import.

Gates: typecheck, lint:ci, unit 1406/1406, integration 852/852.

Not fixed here: `respond()` still returns early on falsy `id`, so a request with id `0`
would never be answered. Pre-existing, ids are strings today, belongs with cancellation (r07-3).