### PR TITLE
[test] Restore the frontend-layout harnesses to green

### DIFF
--- a/test/frontend-layout/fake-bridge.js
+++ b/test/frontend-layout/fake-bridge.js
@@ -146,6 +146,10 @@
     onFirstHideNotice: noop,
     onHiddenToTray: noop,
     onKeyboardCommand: noop,
+    // ConnectionStatusProvider reads these on mount; a missing method throws during render and
+    // takes the whole tree down, so any harness mounting a real screen renders nothing at all.
+    getNetOnline: () => Promise.resolve(true),
+    onNetOnlineChange: () => noop,
     deepLink: { subscribe: () => noop },
   }
 })()

--- a/test/frontend-layout/harness-approval-entry.tsx
+++ b/test/frontend-layout/harness-approval-entry.tsx
@@ -4,6 +4,7 @@
 // is in flight, that the derived request row is NEVER hidden (Fix B keeps the projection as the
 // sole source of truth — no reconcile hint is emitted here), and that the button re-enables once
 // the call settles. window.bridge is installed by fake-bridge.js loaded first in the HTML.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import { ToastProvider } from './../../src/renderer/components/toast/ToastProvider.js'

--- a/test/frontend-layout/harness-bootstrap.ts
+++ b/test/frontend-layout/harness-bootstrap.ts
@@ -1,0 +1,18 @@
+// What main.tsx does before the first render, minus the app shell: the query store's transport
+// and the single reconcile subscription every store-backed view re-derives from.
+//
+// A harness that mounts a real screen mounts its real hooks, and those read through the query
+// store. Without this the store's transport is the default reject ("query store: no transport
+// configured"), so EVERY query fails and the screen renders its empty state — a members panel
+// with no members, an approval row with nothing to approve. The harness then fails looking for a
+// control that was never going to exist, naming the symptom rather than the cause.
+//
+// Imported for side effect by every harness entry, not only the ones that mount screens today:
+// the failure is silent and arrives whenever a harness later grows a real hook, and these
+// harnesses are local-only, so CI never catches the drift.
+import { request } from './../../src/renderer/ipc.js'
+import { configureQueryStore } from './../../src/renderer/store/query-store.js'
+import { installReconcileBridge } from './../../src/renderer/store/reconcile.js'
+
+configureQueryStore({ request })
+installReconcileBridge()

--- a/test/frontend-layout/harness-dropoverlay-entry.tsx
+++ b/test/frontend-layout/harness-dropoverlay-entry.tsx
@@ -2,6 +2,7 @@
 // <SpaceView> (the only place that can't be exercised by agent-desktop, since it
 // drives the AX tree and can't synthesize a native file-drag), dispatches synthetic
 // DragEvents, and asserts the crossfade + geometry + copy in real layout.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import { ToastProvider } from './../../src/renderer/components/toast/ToastProvider.js'

--- a/test/frontend-layout/harness-entry.tsx
+++ b/test/frontend-layout/harness-entry.tsx
@@ -6,6 +6,7 @@
 //
 // `window.bridge` is installed by fake-bridge.js (a classic script loaded first
 // in harness.html), so `ipc.ts` and every hook/component run unmodified.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import './../../src/renderer/i18n.js'
 import { ToastProvider } from './../../src/renderer/components/toast/ToastProvider.js'

--- a/test/frontend-layout/harness-filecard-entry.tsx
+++ b/test/frontend-layout/harness-filecard-entry.tsx
@@ -4,6 +4,7 @@
 // live inside the existing meta line, not add a third text row). Also mounts the
 // real <ToastContainer> and asserts a long message grows the toast to its 720px
 // cap while a short one stays at content width.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import FileCard from './../../src/renderer/components/cards/FileCard.js'

--- a/test/frontend-layout/harness-indexing-entry.tsx
+++ b/test/frontend-layout/harness-indexing-entry.tsx
@@ -3,6 +3,7 @@
 // index, and a member's folder with a real download alongside — and reads back what each one
 // actually says. Indexing is not a transfer: neither side may be told anything is downloading,
 // and the bar over an indexing row must be named for the indexing it measures.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import './../../src/renderer/i18n.js'
 import FolderTree from './../../src/renderer/components/widgets/FolderTree.js'

--- a/test/frontend-layout/harness-logohover-entry.tsx
+++ b/test/frontend-layout/harness-logohover-entry.tsx
@@ -7,6 +7,7 @@
 // Mounts the REAL <TopNav> and walks the REAL stylesheet for any :hover rule
 // that repaints the logo, so it catches the whole class (opacity, color, fill,
 // filter) rather than one utility by name.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import './../../src/renderer/i18n.js'
 import TopNav from './../../src/renderer/components/layout/TopNav.js'

--- a/test/frontend-layout/harness-members-entry.tsx
+++ b/test/frontend-layout/harness-members-entry.tsx
@@ -7,6 +7,7 @@
 //
 // `window.bridge` is installed by fake-bridge.js (a classic script loaded first
 // in harness-members.html), so `ipc.ts` and every hook/component run unmodified.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import { ToastProvider } from './../../src/renderer/components/toast/ToastProvider.js'

--- a/test/frontend-layout/harness-mirrorers-entry.tsx
+++ b/test/frontend-layout/harness-mirrorers-entry.tsx
@@ -3,6 +3,7 @@
 // stack + "+N" overflow chip, encodes each peer's sync state as a ring colour (synced/synced-pulse/
 // paused — never opacity), shows the heading, and carries an accessible name listing the mirrors and
 // their states — the a11y + colour contract can't be measured without a real AX tree + CSS.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import MirroredByWidget from './../../src/renderer/components/cards/MirroredByWidget.js'

--- a/test/frontend-layout/harness-modaltitle-entry.tsx
+++ b/test/frontend-layout/harness-modaltitle-entry.tsx
@@ -4,6 +4,7 @@
 // the extension (`XXX-X002_…final.mov`, not just `.mov`), (4) stay within two
 // lines, while (5) a short name renders in full and (6) the full name still
 // reaches assistive tech. Mounts the REAL <RemoveFileModal> twice.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import RemoveFileModal from './../../src/renderer/components/modals/RemoveFileModal.js'
 

--- a/test/frontend-layout/harness-peerdownload-entry.tsx
+++ b/test/frontend-layout/harness-peerdownload-entry.tsx
@@ -7,6 +7,7 @@
 //   - aria-valuetext still carries count · speed · ETA even where the visible line is compacted;
 //   - the per-peer row puts the name on the left and right-aligns the avatar + bar at ~half width,
 //     the name yields under pressure while speed · ETA stays whole, and a warmup row shows a "%".
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import PeerDownloadIndicator from './../../src/renderer/components/cards/PeerDownloadIndicator.js'

--- a/test/frontend-layout/harness-progress-entry.tsx
+++ b/test/frontend-layout/harness-progress-entry.tsx
@@ -4,6 +4,7 @@
 // exposes aria-valuenow + a valuetext that carries the percentage. Also checks the
 // real resolveEta logic: null = "Estimating…"/indeterminate, 0/undefined = hidden,
 // > 0 = formatted, and a >0 eta with a decayed (0) speed = stalled → hidden.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import './../../src/renderer/i18n.js'
 import DownloadProgressLane from './../../src/renderer/components/widgets/DownloadProgressLane.js'

--- a/test/frontend-layout/harness-sharecard-entry.tsx
+++ b/test/frontend-layout/harness-sharecard-entry.tsx
@@ -4,6 +4,7 @@
 // (the whole card navigates), while the action buttons stay clickable on top. A
 // second mount checks `isolate` confines the action cluster's z-10 so an earlier
 // sibling at z-10 (the sticky section header) paints over the card.
+import './harness-bootstrap.js'
 import { createRoot } from 'react-dom/client'
 import i18n from './../../src/renderer/i18n.js'
 import ShareCard from './../../src/renderer/components/cards/ShareCard.js'


### PR DESCRIPTION
## What & why

`npm run test:layout:members` fails on `staging` today, and it is not alone — four of the twelve harnesses were red before this branch: `members`, `approval`, `logohover`, `mirrorers`. Two causes, both test-only.

**1. The query store was never given a transport.** `configureQueryStore({ request })` and `installReconcileBridge()` run in `main.tsx`, before the first render. A harness mounts a screen directly, so neither ran: the store's transport stayed the default reject, every `useQuery` failed, and the screen rendered its empty state. The members panel reported `Members 0` / "No members connected yet", so the harness failed looking for a "Show all" button that was never going to exist — naming the symptom, not the cause.

**2. `fake-bridge` was missing `getNetOnline`/`onNetOnlineChange`.** `ConnectionStatusProvider` calls both on mount; the missing method threw *during render*, so `logohover` mounted an entirely empty document (`Uncaught TypeError: window.bridge.getNetOnline is not a function`).

Both are the same underlying drift: these harnesses mount real code but reproduce the app's bootstrap by hand, and they are local-only, so CI never noticed the app's bootstrap growing past them.

The fix is a shared `harness-bootstrap.ts` that does what `main.tsx` does before first render, imported for side effect by **all twelve** entries — not only the four that need it today. The failure is silent and arrives whenever a harness later grows a real hook, so the uniform import is the point.

## Ran locally

All twelve green: `layout`, `members`, `approval`, `dropoverlay`, `sharecard`, `progress`, `peerdownload`, `filecard`, `modaltitle`, `logohover`, `mirrorers`, `indexing`. Verified red before the change and green after, per harness. Typecheck and `lint:ci` green.

No `src/` changes — the app is untouched, so no a11y surface moves.

## Follow-up, not in scope

These harnesses cannot fail CI: they spawn a real Electron GUI and `test.yml` does not run them. That is why four could sit red on `staging`. Worth deciding separately whether they get a job.
