### PR TITLE
[fix] Refresh the owner's folder view when its catalog write lands

### DIFF
--- a/src/shared/shares/share-catalog.js
+++ b/src/shared/shares/share-catalog.js
@@ -25,6 +25,14 @@ const log = createLogger('share-catalog')
 export const FILE_PREFIX = 'file/'
 
 const ownCatalogs = new Map()   // spaceId -> Hyperbee (writable)
+// Notified with (spaceId) whenever OUR OWN catalog core appends. Every other party learns of a
+// catalog change from its `append`; the owner alone was refreshed by the publish call sites, which
+// fire BEFORE a batched write reaches the bee (catalog-writer buffers for catalogFlushMs). Through a
+// long hash nothing else fires, so the owner's own listing sat on a pre-flush snapshot while every
+// member watched the indexing row it could not see. Installed by the overlay backend rather than
+// imported, so this module keeps no dependency on the IPC layer (as setOverlayCatalogChangeHook).
+let ownAppendHook = null
+export function setOwnCatalogAppendHook(fn) { ownAppendHook = fn }
 // Bounded: one Hyperbee + Hypercore session per (peer, space), each with an append listener, and
 // every open core replicates to every socket. Unbounded it grew to peers x spaces and was reclaimed
 // only on leave. A watched catalog is PINNED — evicting one would silently stop the mirror loop its
@@ -81,6 +89,12 @@ export async function ownCatalog(spaceId) {
   const bee = createBee(catalogNameForSpace(space, spaceId), sck ? { encryptionKey: sck } : {})
   await bee.ready()
   ownCatalogs.set(spaceId, bee)
+  // Attached at creation, so no writer or reader can forget it, and read through `ownAppendHook`
+  // at fire time, so a bee opened before the backend installed the hook still reports. The guard
+  // silences a session that is no longer this space's catalog: `ownCatalog` awaits before it sets,
+  // so two concurrent misses build two sessions of one core and both would otherwise report every
+  // append, and a dropped catalog would keep reporting for a space that no longer has one.
+  bee.core.on('append', () => { if (ownCatalogs.get(spaceId) === bee) ownAppendHook?.(spaceId) })
   return bee
 }
 
@@ -484,8 +498,8 @@ export class Catalogs extends Subsystem {
     }
   }
 
-  // The watchers hold the same bees peerCatalogs does, and their 'append' listeners sit on the
-  // core session, so closing the bee drops them too.
+  // The watchers hold the same bees peerCatalogs does, and their 'append' listeners — the peer
+  // watchers' and the own catalogs' — sit on the core session, so closing the bee drops them too.
   async _closeAll() {
     const open = [...ownCatalogs.values(), ...peerCatalogs.values()]
     ownCatalogs.clear()

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -25,6 +25,7 @@ import {
   getPeerEntry,
   getPeerEntryState,
   watchPeerCatalog,
+  setOwnCatalogAppendHook,
   resolvePeerCatalog,
   catalogKeyField,
 } from '../../../shares/share-catalog.js'
@@ -118,8 +119,15 @@ let publishesAborting = false
 const sharesRefresh = makeSharesRefresh(
   (spaceId, shareId) => ipcRef?.emit('event:share-files-updated', { spaceId, shareId }),
 )
-export function initContentBackendOverlay(ipc) { ipcRef = ipc }
-export function resetContentBackendState() { ipcRef = null; sharesRefresh.reset(); peerPrepareBroadcast = null; pendingPublishProbe = null; presenceGone.clear(); publishesAborting = false }
+export function initContentBackendOverlay(ipc) {
+  ipcRef = ipc
+  // The owner's level trigger. A catalog append is the one owner-side signal that cannot fire ahead
+  // of the write it announces, which is exactly what publishOne's advertise-time touch cannot
+  // promise for a batched publish. Wildcarded on the share axis (no shareId): ONE catalog backs
+  // every share in the space plus the loose channel, so an append names no single share.
+  setOwnCatalogAppendHook((spaceId) => sharesRefresh.touch(spaceId, undefined))
+}
+export function resetContentBackendState() { ipcRef = null; setOwnCatalogAppendHook(null); sharesRefresh.reset(); peerPrepareBroadcast = null; pendingPublishProbe = null; presenceGone.clear(); publishesAborting = false }
 export function abortInFlightPublishes() { publishesAborting = true }
 export function setSharePrepareBroadcast(fn) { peerPrepareBroadcast = fn }
 // Installed by owned-folders: (spaceId, shareId, relPath) → true while a publish for that path is
@@ -288,7 +296,7 @@ async function publishOne(spaceId, share, relPath, absPath, { catalog = directCa
       catalog,
       signal,
       force,
-      // Refresh the owner's view NOW (the `preparing` row) + start the hashing-progress
+      // Refresh the owner's view NOW (the `publishing` row) + start the hashing-progress
       // ticker — the same instant the consumer's peer-catalog append surfaces it.
       onAdvertised: (size) => {
         sharesRefresh.touch(spaceId, share.id)

--- a/test/integration/overlay-backend.test.js
+++ b/test/integration/overlay-backend.test.js
@@ -7,7 +7,9 @@ import { publishShare, generateShareId } from '../../src/shared/shares/shares.js
 import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
 import { saveOwnedMount } from '../../src/shared/folders/mount-store.js'
 import { initialPublishScan } from '../../src/shared/folders/owned-folders.js'
-import { getOwnEntry } from '../../src/shared/shares/share-catalog.js'
+import { getOwnEntry, ownCatalog } from '../../src/shared/shares/share-catalog.js'
+import { createCatalogBatch } from '../../src/shared/shares/catalog-writer.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 import { serveIndex } from '../../src/shared/transfer/backends/overlay/overlay-serve-index.js'
 import { getOverlay, teardownOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
 import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
@@ -19,6 +21,15 @@ import {
 // consumer fetch (two-peer) is validated in the flow tier (A6). The defining
 // property asserted here: publishing copies NO bytes into a core — the overlay
 // serves straight from the user's source file on disk.
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+// Bounded settle for an in-process event. No scaled(): test/helpers/timing.js reads process.env,
+// which Bare does not provide. The assertion that follows is what fails, never this wait.
+async function until (pred, ms = 5000) {
+  const deadline = Date.now() + ms
+  while (!pred() && Date.now() < deadline) await sleep(10)
+  return pred()
+}
+
 async function setup (t, { files = {} } = {}) {
   const ctx = await freshPeer(t)
   const space = await createSpace('Aurora')
@@ -284,6 +295,59 @@ test('owner refresh fires at advertise-time, before its own publishing progress'
   t.absent(decorations.some((e) => e.payload.phase === 'preparing'),
     "the owner never paints itself the consumer's waiting phase")
   t.ok(decorations.at(-1)?.payload.done === true, 'the bar is terminated when the hash lands')
+})
+
+// REGRESSION (FIX-OWN-APPEND): the same promise, for the BULK path. A bulk publish stages its
+// advertise in the space's catalog batch, so the advertise-time refresh above announces a row that
+// is not readable yet — and nothing fires again until the item settles, which for a multi-GB hash
+// is minutes. So the owner's own folder sat on a pre-flush snapshot while every member, level-
+// triggered by that same catalog's append, already showed the indexing row. The owner now watches
+// its own catalog too: the write that lands announces itself, share-axis wildcard (no shareId,
+// since one catalog backs every share in the space).
+test('REGRESSION (FIX-OWN-APPEND): a batched publish refreshes the owner once its write lands', async (t) => {
+  const ctx = await setup(t, { files: { 'a.txt': 'staged, not yet flushed' } })
+  // Hold the flush window open: this test is about the gap between staging and landing, and a
+  // background flush firing mid-assertion would close it for the wrong reason.
+  const cfg = getRuntimeConfig()
+  setRuntimeConfig({ ...cfg, catalogFlushMs: 60000, catalogFlushMaxOps: 1000 })
+  t.teardown(() => setRuntimeConfig(cfg))
+
+  const bee = await ownCatalog(ctx.spaceId)
+  // The share-pinned refreshes are the publish call sites; only the catalog watcher emits without a
+  // shareId, so the wildcard is what tells the new signal apart from the ones that already fired.
+  // Scoped to THIS space: the module-global sharesRefresh coalescer outlives a test, and its
+  // trailing fire resolves ipcRef when it fires — so a neighbouring test's pending fire can land in
+  // this one's events. The spaceId is what tells them apart.
+  const mine = (e) => e.type === 'event:share-files-updated' && e.payload.shareId === undefined && e.payload.spaceId === ctx.spaceId
+  const landed = () => ctx.fake.events.filter(mine)
+  const lengthAtLanded = []
+  const emit = ctx.fake.ipc.emit
+  ctx.fake.ipc.emit = (type, payload) => {
+    if (mine({ type, payload })) lengthAtLanded.push(bee.core.length)
+    emit(type, payload)
+  }
+  t.teardown(() => { ctx.fake.ipc.emit = emit })
+
+  const catalog = createCatalogBatch(ctx.spaceId)
+  await overlayBackend.publishAdd(ctx.spaceId, ctx.share, 'a.txt', path.join(ctx.mountPath, 'a.txt'), { catalog })
+
+  t.ok(ctx.fake.emitted('event:share-files-updated').length > 0, 'the publish announced itself at advertise-time')
+  t.absent(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'),
+    'but the row it announced is not readable yet — the write is still staged in the batch')
+  t.is(landed().length, 0, 'and nothing has announced a landed write')
+
+  await catalog.flush()
+  await until(() => landed().length > 0)
+  t.ok(landed().length > 0, 'the landed write announces itself')
+  t.ok(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'), 'and by then the row is readable')
+  // The level-trigger property, stated as the thing that cannot happen: an announcement rides an
+  // append, so it can never run ahead of the write the way the advertise-time touch does.
+  t.ok(lengthAtLanded[0] > 0, 'the announcement could not precede the write that caused it')
+  // A first flush appends the bee header AND the data block, and the 250 ms coalescer answers the
+  // first with its leading edge; the trailing edge is what carries the rest. Settled, the owner has
+  // been told about every landed write.
+  await until(() => lengthAtLanded[lengthAtLanded.length - 1] === bee.core.length)
+  t.is(lengthAtLanded[lengthAtLanded.length - 1], bee.core.length, 'settled, the owner saw every write landed')
 })
 
 // The whole-file integrity verify (now STREAMED so a multi-GB file is checked


### PR DESCRIPTION
## What & why

While the owner indexes files it just added to an owned folder, its own folder view shows less than every member's. Measured with a two-peer probe (two 1.2 GB files, mount scan): the owner's list sat empty for the whole 5.4 s hash while the member showed both files "Preparing…" with a live bar from 2.9 s. At the measured ~230 MB/s that is ~90 s of wrong state for a 20 GB file, minutes for 60 GB.

The owner is the only party with no watcher on the log it writes. A member is level-triggered by the owner's catalog `append`; the owner was told only by the publish call sites. A bulk publish stages its advertise in the space's catalog batch, so `onAdvertised`'s refresh announces a row that is not readable for another `catalogFlushMs` (2500 ms) — and nothing fires again until the item settles, which for a multi-GB hash is minutes. Interactive publishes write direct, which is why one file could look right while its neighbour did not.

`ownCatalog()` now attaches one `append` listener per own catalog, dispatched through a hook the overlay backend installs. The poke reuses `event:share-files-updated` with no `shareId`: one catalog backs every share in the space plus the loose channel, so an append names no single share, and `POKE_SCOPE` already documents that wildcard. Deliberately not `Scope.files` — that would invalidate `files:list`, whose peer fan-out does a network head-sync per member on every append.

The advertise-time touch stays: it is what makes the direct path instant, and the test beside this one pins that ordering.

## Coverage

`REGRESSION (FIX-OWN-APPEND)` in `test/integration/overlay-backend.test.js` — the batched twin of the direct-path test above it, which only ever called `publishAdd` without a catalog. Verified red with the listener neutralized: "the landed write announces itself" fails while the three assertions describing the pre-fix state still pass.

## Ran locally

`test:bare` 859/859, `test:flow` 193/193, typecheck, lint (0 errors), comment-hygiene and test-timing gates clean. Probe re-run: the owner's list flips to `publishing` at ~2.8 s against the member's ~2.9 s, instead of trailing by the whole hash. No renderer change and no new a11y surface — #131 covered the indexing labels and bar.
