### PR TITLE
[fix] Recover a wedged foreign-folder mirror loop

### DIFF
--- a/src/shared/core/subsystem.js
+++ b/src/shared/core/subsystem.js
@@ -35,6 +35,13 @@ export class Subsystem extends ReadyResource {
     }
   }
 
+  // Open and not tearing down. A subsystem that can say more about whether it is still doing its
+  // job overrides this; reporting is deliberately separate from any recovery, so a subsystem
+  // nothing can restart still reports.
+  health() {
+    return { ok: !this.closed && !this.stopping, detail: null }
+  }
+
   // A missing collaborator fails at construction — at boot, in the root, with the subsystem's
   // name — instead of as a `hook?.()` that never fires.
   require(...names) {
@@ -86,5 +93,9 @@ export function createLifecycle({ log }) {
       }
     },
     get started() { return started.slice() },
+    // `name` is spread last so a subsystem returning its own cannot shadow the row key.
+    health() {
+      return started.map((subsystem) => ({ ...subsystem.health(), name: subsystem.name }))
+    },
   }
 }

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -32,6 +32,7 @@ import { markVerified, isVerifiedUnchanged } from '../transfer/files.js'
 import { PREVIEW_DETAIL_MAX_FILES, includePerFile } from './preview-detail.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { mirrorVerdict } from './mirror-health.js'
 import { mapLimit } from '../core/concurrency.js'
 import { AbortError } from './walk-disk.js'
 
@@ -43,6 +44,9 @@ const activeLoops = new Map()
 // far above its old home, registers into it.
 const tickInFlight = new Map()
 const pendingTicks = new Map()
+// loopKey -> { startedAt, progressAt, completedAt }. progressAt is bumped per file the pass
+// begins fetching, which is what separates a slow scan from a dead one.
+const mirrorLiveness = new Map()
 let ipcRef = null
 
 // The single guarded peer-key -> absolute-path conversion. Every site that turns
@@ -278,9 +282,12 @@ export async function applyChange(mount, change) {
 export async function initialMaterializeScan(mount) {
   const key = loopKey(mount.spaceId, mount.shareId)
   const p = runInitialMaterializeScan(mount).finally(() => {
-    if (tickInFlight.get(key) === p) tickInFlight.delete(key)
+    if (tickInFlight.get(key) !== p) return
+    tickInFlight.delete(key)
+    markMirrorPassEnded(key)
   })
   tickInFlight.set(key, p)
+  markMirrorPassStarted(key)
   return await p
 }
 
@@ -516,13 +523,16 @@ export async function runMaterializeTick(spaceId, shareId) {
     return tickInFlight.get(key)
   }
   const p = materializeOnce(spaceId, shareId).finally(() => {
-    // Identity-guarded, matching initialMaterializeScan: a pass settling after a scan replaced the
-    // entry must not delete the LIVE one, which would un-serialise two passes over the same mount.
+    // Identity-guarded, matching initialMaterializeScan: a stale pass settling after a restart
+    // replaced the entry must not delete the LIVE one, which would un-serialise two passes over
+    // the same mount.
     if (tickInFlight.get(key) !== p) return
     tickInFlight.delete(key)
+    markMirrorPassEnded(key)
     if (tickDirty.delete(key)) runMaterializeTick(spaceId, shareId).catch(() => {})
   })
   tickInFlight.set(key, p)
+  markMirrorPassStarted(key)
   return p
 }
 
@@ -620,6 +630,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   let res
   const streamKey = loopKey(mount.spaceId, mount.shareId)
   activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath })
+  markMirrorProgress(streamKey)
   pausedMirrorHashes.delete(streamKey) // a fresh/resumed fetch supersedes any paused-stop marker
   // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.
   ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
@@ -627,7 +638,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
     res = await overlay.fetchFile(entry.contentHash, {
       destPath: abs,
       reSeed: false,
-      onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b) },
+      onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b); markMirrorProgress(streamKey) },
       onVerify: (fraction) => ipcRef?.emit('event:decoration', {
         channel: 'transfer', spaceId: mount.spaceId, key: decoKey, phase: 'verifying', verifyFraction: fraction, bytes: 0, total,
       }),
@@ -793,6 +804,40 @@ async function ownerLeftSpace(spaceId, ownerKey) {
   return !space.members.some((m) => m.publicKey === ownerKey)
 }
 
+function markMirrorPassStarted(key) {
+  const at = Date.now()
+  const entry = mirrorLiveness.get(key)
+  if (entry) { entry.startedAt = at; entry.progressAt = at } else {
+    mirrorLiveness.set(key, { startedAt: at, progressAt: at, completedAt: 0 })
+  }
+}
+
+function markMirrorProgress(key) {
+  const entry = mirrorLiveness.get(key)
+  if (entry) entry.progressAt = Date.now()
+}
+
+function markMirrorPassEnded(key) {
+  const entry = mirrorLiveness.get(key)
+  if (!entry) return
+  entry.startedAt = 0
+  entry.progressAt = 0
+  entry.completedAt = Date.now()
+}
+
+// One verdict per mount that has a live loop. A mount with no loop is not reported: it is paused,
+// unmounted or gone, none of which this can or should recover.
+export function mirrorHealth({ now = Date.now() } = {}) {
+  const pollIntervalMs = getResourceCaps().foreignPollIntervalMs
+  const rows = []
+  for (const loop of activeLoops.values()) {
+    const key = loopKey(loop.spaceId, loop.shareId)
+    const verdict = mirrorVerdict(mirrorLiveness.get(key), { now, pollIntervalMs })
+    rows.push({ spaceId: loop.spaceId, shareId: loop.shareId, ...verdict })
+  }
+  return rows
+}
+
 export function stopForeignLoop(spaceId, shareId, { discardPartial = false } = {}) {
   const key = loopKey(spaceId, shareId)
   // Invalidate any in-flight scan/tick (it bails at the next file) and abort the
@@ -849,6 +894,20 @@ export class ForeignMirrors extends Subsystem {
   constructor(name, deps) { super(name, deps); this.require('ipc') }
   async _open() { initForeignFolders(this.deps.ipc) }
   async _close() { await stopAllForeignLoops() }
+
+  // Counts, not identifiers: diagnostics:export is user-shareable and redacts peer keys and
+  // topics, so space and share ids must not ride along. The probe names the mount in the worker
+  // log instead.
+  health() {
+    const open = !this.closed && !this.stopping
+    const mirrors = open ? mirrorHealth() : []
+    const wedged = mirrors.filter((mirror) => !mirror.ok)
+    return {
+      ok: open && wedged.length === 0,
+      detail: wedged.length ? wedged.map((mirror) => mirror.detail).join('; ') : null,
+      mirrors: { total: mirrors.length, wedged: wedged.length },
+    }
+  }
 }
 
 export async function unmountForeignFolder(spaceId, shareId) {
@@ -862,6 +921,7 @@ export async function unmountForeignFolder(spaceId, shareId) {
   const key = loopKey(spaceId, shareId)
   syncedSets.delete(key)
   syncDirty.delete(key)
+  mirrorLiveness.delete(key)
   await syncMirrorRecord(spaceId, shareId, () => tombstoneMirror(spaceId, shareId))
   emitStatus(spaceId, shareId, 'idle')
   ipcRef?.emit('event:share-files-updated', { spaceId, shareId })

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -838,6 +838,19 @@ export function mirrorHealth({ now = Date.now() } = {}) {
   return rows
 }
 
+// Un-wedge one mirror. stopForeignLoop bumps cancelGen, so a hung pass is generation-invalidated
+// and bails at its next checkpoint without writing; clearing the in-flight entry is the part the
+// stop does NOT do, and without it the fresh interval coalesces straight back onto the dead promise.
+export async function restartForeignLoop(spaceId, shareId) {
+  const key = loopKey(spaceId, shareId)
+  stopForeignLoop(spaceId, shareId)
+  tickInFlight.delete(key)
+  tickDirty.delete(key)
+  mirrorLiveness.delete(key)
+  await startForeignLoop({ spaceId, shareId })
+  runMaterializeTick(spaceId, shareId).catch((err) => log.debug('materialize tick after restart failed:', err.message))
+}
+
 export function stopForeignLoop(spaceId, shareId, { discardPartial = false } = {}) {
   const key = loopKey(spaceId, shareId)
   // Invalidate any in-flight scan/tick (it bails at the next file) and abort the

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -516,6 +516,9 @@ export async function runMaterializeTick(spaceId, shareId) {
     return tickInFlight.get(key)
   }
   const p = materializeOnce(spaceId, shareId).finally(() => {
+    // Identity-guarded, matching initialMaterializeScan: a pass settling after a scan replaced the
+    // entry must not delete the LIVE one, which would un-serialise two passes over the same mount.
+    if (tickInFlight.get(key) !== p) return
     tickInFlight.delete(key)
     if (tickDirty.delete(key)) runMaterializeTick(spaceId, shareId).catch(() => {})
   })

--- a/src/shared/folders/mirror-health.js
+++ b/src/shared/folders/mirror-health.js
@@ -1,0 +1,17 @@
+// The wedged/healthy rule for a mirror loop, kept pure so it is asserted directly rather than
+// through a live loop.
+//
+// Progress, not elapsed time: runMaterializeTick serialises passes per mount by handing every
+// later tick the in-flight promise, so a pass that never settles wedges the mount permanently while
+// the interval keeps firing. But an initial scan over thousands of files is legitimately slow, and
+// an elapsed-time rule would restart it mid-scan. Only a pass that is in flight AND not advancing
+// is wedged.
+export const STALL_FACTOR = 20
+
+export function mirrorVerdict(liveness, { now, pollIntervalMs, stallFactor = STALL_FACTOR }) {
+  const { startedAt = 0, progressAt = 0 } = liveness || {}
+  if (!startedAt) return { ok: true, detail: null }
+  const stalledForMs = now - (progressAt || startedAt)
+  if (stalledForMs <= pollIntervalMs * stallFactor) return { ok: true, detail: null }
+  return { ok: false, detail: `no progress for ${Math.round(stalledForMs / 1000)}s` }
+}

--- a/src/worker/boot.js
+++ b/src/worker/boot.js
@@ -287,7 +287,11 @@ export async function boot(bootstrap, {
     await life.start(mounts)
     await life.start(new Sweeps('sweeps', { ipc, auditLog }))
 
-    return { close, store, mounts, intents, auditLog, ownedFolders, publishService, overlayBackend, activeSpaces, applyRelayConfig: () => applyRelayConfig(log) }
+    return {
+      close, store, mounts, intents, auditLog, ownedFolders, publishService, overlayBackend, activeSpaces,
+      applyRelayConfig: () => applyRelayConfig(log),
+      health: () => [...(durable?.health() || []), ...life.health()],
+    }
   }
 }
 

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1729,7 +1729,7 @@ ipc.handle('diagnostics:export', async (msg) => {
     counters: getDiagnosticCounters(),
     requestFailures: getRequestFailureCounters(),
     requestMetrics: getRequestMetrics(),
-    health: health.snapshot({ queueDepth: getQueueDepth() }),
+    health: health.snapshot({ queueDepth: getQueueDepth(), subsystems: root?.health() || [] }),
     peerSamples: getPeerSamples(),
   }, msg?.redact !== false)
 })

--- a/src/worker/mounts-runtime.js
+++ b/src/worker/mounts-runtime.js
@@ -13,11 +13,14 @@ import { getDeepReconcileEvery } from '../shared/core/runtime-config.js'
 import { listDownloadRoots } from '../shared/core/paths.js'
 import { setOwnedMountStatus, listOwnedMounts, listAllMounts, listForeignMounts, getForeignMount } from '../shared/folders/mount-store.js'
 import { periodicReconcile, stopOwnedFolder, mountRootAvailable } from '../shared/folders/owned-folders.js'
-import { startForeignLoop, initialMaterializeScan, resumeAutoPausedForeignMount, autoPauseForeignMountGone } from '../shared/folders/foreign-folders.js'
+import { startForeignLoop, initialMaterializeScan, resumeAutoPausedForeignMount, autoPauseForeignMountGone, mirrorHealth, restartForeignLoop } from '../shared/folders/foreign-folders.js'
 import { ensureMirror } from '../shared/folders/mirror-records.js'
 
 const RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000
 const MOUNT_PROBE_INTERVAL_MS = 60_000
+// Two consecutive bad probes before acting, so one slow sample cannot restart a working mirror.
+const MIRROR_BAD_PROBES = 2
+const MIRROR_MAX_RESTARTS = 3
 
 
 // The download-root twin of owned-folders' mountRootAvailable, deliberately kept separate: a
@@ -28,6 +31,10 @@ function rootAvailable(root) {
 
 function readUnavailableRoots() {
   return listDownloadRoots().filter((root) => !rootAvailable(root))
+}
+
+function mirrorKey(spaceId, shareId) {
+  return spaceId + '/' + shareId
 }
 
 function sameRootSet(a, b) {
@@ -45,6 +52,11 @@ export class MountsRuntime extends Subsystem {
     // maintained by the probe loop; a transition is what drives every status event.
     this.lastMountPointStatus = new Map()
     this.unavailableRoots = []
+    // spaceId/shareId → consecutive unhealthy probes, restarts spent, and whether the budget
+    // running out has already been reported.
+    this.mirrorBadProbes = new Map()
+    this.mirrorRestarts = new Map()
+    this.mirrorGaveUp = new Set()
   }
 
   async _open() {
@@ -53,6 +65,7 @@ export class MountsRuntime extends Subsystem {
     this.timers.setInterval(() => {
       this.probeMountPoints().catch((err) => this.log.debug('mount probe failed:', err.message))
       try { this.probeDownloadRoots() } catch (err) { this.log.debug('download-root probe failed:', err.message) }
+      this.probeMirrorLiveness().catch((err) => this.log.debug('mirror liveness probe failed:', err.message))
     }, MOUNT_PROBE_INTERVAL_MS)
   }
 
@@ -123,6 +136,48 @@ export class MountsRuntime extends Subsystem {
       }
     } catch (err) {
       this.log.warn('foreign-folder restart failed:', err.message)
+    }
+  }
+
+  // A mirror whose pass is in flight but no longer advancing is wedged: every later tick coalesces
+  // onto the dead promise, so the folder stops syncing until the app restarts. Restart the loop
+  // rather than the subsystem — ForeignMirrors._open only re-wires the module, it starts no loops.
+  async probeMirrorLiveness() {
+    // The base clears the interval on close, but this probe awaits a restart: a shutdown starting
+    // mid-pass would otherwise re-arm a loop stopAllForeignLoops just stopped.
+    if (this.stopping) return
+    const rows = mirrorHealth()
+    const live = new Set(rows.map((row) => mirrorKey(row.spaceId, row.shareId)))
+    for (const key of this.mirrorBadProbes.keys()) if (!live.has(key)) this.mirrorBadProbes.delete(key)
+    for (const key of this.mirrorRestarts.keys()) if (!live.has(key)) this.mirrorRestarts.delete(key)
+    for (const key of this.mirrorGaveUp) if (!live.has(key)) this.mirrorGaveUp.delete(key)
+
+    for (const row of rows) {
+      const key = mirrorKey(row.spaceId, row.shareId)
+      if (row.ok) { this.mirrorBadProbes.delete(key); continue }
+
+      const bad = (this.mirrorBadProbes.get(key) || 0) + 1
+      this.mirrorBadProbes.set(key, bad)
+      if (bad < MIRROR_BAD_PROBES) continue
+
+      const spent = this.mirrorRestarts.get(key) || 0
+      if (spent >= MIRROR_MAX_RESTARTS) {
+        if (!this.mirrorGaveUp.has(key)) {
+          this.mirrorGaveUp.add(key)
+          this.log.error('mirror still wedged after', MIRROR_MAX_RESTARTS, 'restarts — leaving it down:', row.shareId, '-', row.detail)
+        }
+        continue
+      }
+
+      if (this.stopping) return
+      this.mirrorRestarts.set(key, spent + 1)
+      this.mirrorBadProbes.delete(key)
+      this.log.warn('mirror wedged, restarting its loop:', row.shareId, '-', row.detail)
+      try {
+        await restartForeignLoop(row.spaceId, row.shareId)
+      } catch (err) {
+        this.log.warn('mirror loop restart failed:', row.shareId, '-', err.message)
+      }
     }
   }
 

--- a/test/integration/foreign-mirror-inflight.test.js
+++ b/test/integration/foreign-mirror-inflight.test.js
@@ -1,0 +1,95 @@
+import test from 'brittle'
+import { freshPeer } from '../helpers/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
+import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
+import { saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { runMaterializeTick, initialMaterializeScan, stopForeignLoop } from '../../src/shared/folders/foreign-folders.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+
+// runMaterializeTick serialises passes per mount through one in-flight map. Whoever cleans that
+// entry up must check it still owns it: initialMaterializeScan registers unconditionally, so the
+// entry a tick's cleanup sees is not always the tick's own.
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function waitUntil (pred, ms = 5000) {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await delay(20)
+  }
+  throw new Error('condition not met within ' + ms + 'ms')
+}
+
+async function hangingMirror (t) {
+  const ctx = await freshPeer(t)
+  setRuntimeConfig({ ...getRuntimeConfig(), overlayEnabled: true })
+  await initOverlay()
+  t.teardown(async () => { await teardownOverlay() })
+
+  const space = await createSpace('Aurora')
+  const spaceId = space.spaceId
+  const shareId = generateShareId()
+  await publishShare(spaceId, {
+    id: shareId, type: 'owned-folder', name: 'Mirror', owner: getLocalPublicKeyHex(),
+    contentMode: 'overlay', catalogKey: 'c'.repeat(64), createdAt: Date.now(),
+  })
+
+  const origListPeer = overlayBackend.listPeerWithMeta
+  overlayBackend.listPeerWithMeta = async () => ({
+    entries: [{ relPath: 'big.bin', contentHash: 'a'.repeat(64), size: 96 * 1024 * 1024 }], complete: true,
+  })
+  t.teardown(() => { overlayBackend.listPeerWithMeta = origListPeer })
+
+  const overlay = getOverlay()
+  const origFetch = overlay.fetchFile
+  const origCancel = overlay.cancelFetch
+  t.teardown(() => { overlay.fetchFile = origFetch; overlay.cancelFetch = origCancel })
+  const spy = { fetches: 0, rejecters: [] }
+  overlay.fetchFile = () => {
+    spy.fetches += 1
+    return new Promise((_res, rej) => { spy.rejecters.push(rej) })
+  }
+  overlay.cancelFetch = () => true
+
+  await saveForeignMount({
+    spaceId, shareId, ownerKey: getLocalPublicKeyHex(), mountPath: ctx.tmpDir('mirror'),
+    enabled: true, attachedAt: Date.now(), status: 'active', syncedPaths: [],
+  })
+  t.teardown(() => { stopForeignLoop(spaceId, shareId, { discardPartial: true }) })
+  t.teardown(async () => {
+    for (const reject of spy.rejecters.splice(0)) {
+      const err = new Error('cancelled'); err.code = 'ECANCELLED'
+      reject(err)
+    }
+    await delay(50)
+  })
+  return { spaceId, shareId, spy }
+}
+
+// REGRESSION (FIX-R09-2): the tick's cleanup deleted the in-flight entry unconditionally, unlike
+// initialMaterializeScan's, which is identity-guarded. When a scan had replaced the entry, the
+// older tick settling evicted the LIVE one — and the next tick then started a second pass over the
+// same mount, which is the overlapping-snapshot corruption the map exists to prevent.
+test('REGRESSION (FIX-R09-2: a settling pass must not evict an in-flight entry it no longer owns)', async (t) => {
+  const { spaceId, shareId, spy } = await hangingMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  const mount = await getForeignMount(spaceId, shareId)
+  initialMaterializeScan(mount)
+  await waitUntil(() => spy.fetches === 2, 8000)
+
+  // Settle only the FIRST pass. Its cleanup now sees the scan's entry, not its own.
+  const cancelled = new Error('cancelled'); cancelled.code = 'ECANCELLED'
+  spy.rejecters.shift()(cancelled)
+  await delay(80)
+
+  runMaterializeTick(spaceId, shareId)
+  await delay(80)
+  t.is(spy.fetches, 2, 'the scan is still registered, so the tick coalesces instead of racing it')
+})

--- a/test/integration/foreign-mirror-restart.test.js
+++ b/test/integration/foreign-mirror-restart.test.js
@@ -5,10 +5,11 @@ import { freshPeer } from '../helpers/store.js'
 import { createSpace } from '../../src/shared/spaces/space.js'
 import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
 import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
-import { saveForeignMount } from '../../src/shared/folders/mount-store.js'
+import { saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
 import { setRuntimeConfig, getRuntimeConfig, getResourceCaps } from '../../src/shared/core/runtime-config.js'
 import {
   runMaterializeTick, startForeignLoop, stopForeignLoop, restartForeignLoop, mirrorHealth,
+  unmountForeignFolder,
 } from '../../src/shared/folders/foreign-folders.js'
 import { STALL_FACTOR } from '../../src/shared/folders/mirror-health.js'
 import { MountsRuntime } from '../../src/worker/mounts-runtime.js'
@@ -190,4 +191,40 @@ test('REGRESSION (FIX-R09-2 wiring): the mount probe actually calls the liveness
   const openBody = src.slice(src.indexOf('async _open()'), src.indexOf('async _resumeOwnedMounts'))
   t.ok(/this\.probeMirrorLiveness\(\)/.test(openBody), 'the periodic probe body calls probeMirrorLiveness')
   t.ok(/restartForeignLoop/.test(src), 'and the runtime imports the restart it drives')
+})
+
+// stopForeignLoop bumps cancelGen before the restart re-arms, so the pass being abandoned is
+// generation-invalidated. Its trailing persist would otherwise re-save a mount the user removed.
+test('a restart cannot resurrect a mount that was unmounted', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  await unmountForeignFolder(spaceId, shareId)
+  t.is(await getForeignMount(spaceId, shareId), null, 'the record is gone')
+
+  await restartForeignLoop(spaceId, shareId)
+  await delay(80)
+  t.is(await getForeignMount(spaceId, shareId), null, 'and the restart did not bring it back')
+  t.is(spy.fetches, 1, 'no pass runs for a mount that no longer exists')
+})
+
+test('the abandoned pass writes nothing once it finally settles', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  await restartForeignLoop(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 2)
+
+  const before = await getForeignMount(spaceId, shareId)
+  const cancelled = new Error('cancelled'); cancelled.code = 'ECANCELLED'
+  spy.rejecters.shift()(cancelled)
+  await delay(80)
+
+  const after = await getForeignMount(spaceId, shareId)
+  t.alike(after.syncedPaths, before.syncedPaths, 'the stale pass recorded no ownership')
+  t.is(after.status, before.status, 'and settled no status of its own')
 })

--- a/test/integration/foreign-mirror-restart.test.js
+++ b/test/integration/foreign-mirror-restart.test.js
@@ -1,0 +1,193 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { freshPeer } from '../helpers/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
+import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
+import { saveForeignMount } from '../../src/shared/folders/mount-store.js'
+import { setRuntimeConfig, getRuntimeConfig, getResourceCaps } from '../../src/shared/core/runtime-config.js'
+import {
+  runMaterializeTick, startForeignLoop, stopForeignLoop, restartForeignLoop, mirrorHealth,
+} from '../../src/shared/folders/foreign-folders.js'
+import { STALL_FACTOR } from '../../src/shared/folders/mirror-health.js'
+import { MountsRuntime } from '../../src/worker/mounts-runtime.js'
+import { createFakeIpc } from '../helpers/fake-ipc.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+
+// runMaterializeTick serialises passes per mount: a tick arriving while one runs is handed the
+// in-flight promise. A pass that never settles therefore wedges the mount permanently — the poll
+// interval keeps firing and every fire is a no-op. These tests reproduce that with an overlay
+// fetchFile that hangs and a cancelFetch that does NOT rescue it, which is what separates a real
+// wedge from the pause path (covered in foreign-pause-aborts-fetch.test.js).
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function waitUntil (pred, ms = 5000) {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await delay(20)
+  }
+  throw new Error('condition not met within ' + ms + 'ms')
+}
+
+async function wedgedMirror (t, { relPath = 'big.bin', contentHash = 'a'.repeat(64), size = 96 * 1024 * 1024, pollMs = 30_000 } = {}) {
+  const ctx = await freshPeer(t)
+  setRuntimeConfig({ ...getRuntimeConfig(), overlayEnabled: true, foreignPollIntervalMs: pollMs })
+  await initOverlay()
+  t.teardown(async () => { await teardownOverlay() })
+
+  const space = await createSpace('Aurora')
+  const spaceId = space.spaceId
+  const shareId = generateShareId()
+  await publishShare(spaceId, {
+    id: shareId, type: 'owned-folder', name: 'Mirror', owner: getLocalPublicKeyHex(),
+    contentMode: 'overlay', catalogKey: 'c'.repeat(64), createdAt: Date.now(),
+  })
+
+  const origListPeer = overlayBackend.listPeerWithMeta
+  overlayBackend.listPeerWithMeta = async () => ({ entries: [{ relPath, contentHash, size }], complete: true })
+  t.teardown(() => { overlayBackend.listPeerWithMeta = origListPeer })
+
+  // fetchFile hangs and cancelFetch is inert, so nothing the stop path does can settle the pass.
+  // The test holds every rejecter and settles them itself, which is what makes the ordering exact.
+  const overlay = getOverlay()
+  const origFetch = overlay.fetchFile
+  const origCancel = overlay.cancelFetch
+  t.teardown(() => { overlay.fetchFile = origFetch; overlay.cancelFetch = origCancel })
+  const spy = { fetches: 0, rejecters: [], opts: [] }
+  overlay.fetchFile = (_hash, options) => {
+    spy.fetches += 1
+    spy.opts.push(options)
+    return new Promise((_res, rej) => { spy.rejecters.push(rej) })
+  }
+  overlay.cancelFetch = () => true
+
+  await saveForeignMount({
+    spaceId, shareId, ownerKey: getLocalPublicKeyHex(), mountPath: ctx.tmpDir('mirror'),
+    enabled: true, attachedAt: Date.now(), status: 'active', syncedPaths: [],
+  })
+  await startForeignLoop({ spaceId, shareId })
+  t.teardown(() => { stopForeignLoop(spaceId, shareId, { discardPartial: true }) })
+  t.teardown(async () => { settleAll(spy); await delay(50) })
+  return { spaceId, shareId, spy }
+}
+
+function cancelled () {
+  const err = new Error('cancelled'); err.code = 'ECANCELLED'
+  return err
+}
+
+function settleAll (spy) { for (const reject of spy.rejecters.splice(0)) reject(cancelled()) }
+
+test('a hung pass wedges the mount and every later tick is a no-op', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  for (let i = 0; i < 5; i++) runMaterializeTick(spaceId, shareId)
+  await delay(50)
+  t.is(spy.fetches, 1, 'five more ticks start no work — they coalesce onto the dead promise')
+})
+
+test('a wedged mirror is reported unhealthy, and a working one is not', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  const pollMs = getResourceCaps().foreignPollIntervalMs
+  t.is(mirrorHealth()[0].ok, true, 'a pass that just started is not wedged')
+
+  const later = Date.now() + pollMs * STALL_FACTOR + 60_000
+  const wedged = mirrorHealth({ now: later })
+  t.is(wedged.length, 1, 'the mount with a live loop is reported')
+  t.is(wedged[0].ok, false, 'no progress past the window reads as wedged')
+  t.is(wedged[0].shareId, shareId)
+})
+
+// REGRESSION (FIX-R09-2: stopping the loop left the dead promise in the in-flight map, so a
+// restarted loop coalesced straight back onto it and the folder stayed dead).
+test('REGRESSION (FIX-R09-2: stopping and restarting the loop alone does not un-wedge it)', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  stopForeignLoop(spaceId, shareId)
+  await startForeignLoop({ spaceId, shareId })
+  runMaterializeTick(spaceId, shareId)
+  await delay(50)
+  t.is(spy.fetches, 1, 'the fresh loop still coalesces onto the dead promise — clearing the map is the fix')
+
+  await restartForeignLoop(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 2)
+  t.is(spy.fetches, 2, 'restartForeignLoop clears the in-flight entry, so a real pass runs again')
+})
+
+// A single very large file over a slow link bumps progress once when the fetch begins and then
+// spends hours inside fetchFile. Reading progress at the byte level is what stops that from being
+// restarted every window.
+test('bytes arriving keep a slow download healthy', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t)
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  const startedAt = Date.now()
+  const window = getResourceCaps().foreignPollIntervalMs * STALL_FACTOR
+
+  await delay(60)
+  t.is(mirrorHealth({ now: startedAt + window + 1 })[0].ok, false, 'no bytes yet — a stalled fetch is wedged')
+
+  spy.opts[0].onProgress(4096)
+  t.is(mirrorHealth({ now: startedAt + window + 1 })[0].ok, true, 'bytes arriving reset the stall clock')
+})
+
+test('the probe restarts a wedged mirror once, after two consecutive bad probes', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t, { pollMs: 50 })
+  const runtime = new MountsRuntime('mounts', { ipc: createFakeIpc() })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+
+  await runtime.probeMirrorLiveness()
+  t.is(spy.fetches, 1, 'one bad probe is not enough to act')
+
+  await runtime.probeMirrorLiveness()
+  await waitUntil(() => spy.fetches === 2)
+  t.is(spy.fetches, 2, 'the second consecutive bad probe restarts the loop')
+})
+
+// The base clears the probe interval on close, but the probe awaits a restart — one already in
+// flight when a shutdown starts would re-arm a loop stopAllForeignLoops just stopped.
+test('the probe does nothing once the runtime is stopping', async (t) => {
+  const { spaceId, shareId, spy } = await wedgedMirror(t, { pollMs: 50 })
+  const runtime = new MountsRuntime('mounts', { ipc: createFakeIpc() })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+
+  runtime._stopping = true
+  await runtime.probeMirrorLiveness()
+  await runtime.probeMirrorLiveness()
+  await delay(50)
+  t.is(spy.fetches, 1, 'no loop is restarted during teardown')
+})
+
+// The probe being correct proves nothing about it running: requestFailures and requestMetrics both
+// shipped as no-ops because the producer was built and never wired. _open's interval body is what
+// would silently drop it, and constructing the runtime for real needs a booted store, so the wiring
+// is pinned by source text — the same way the crash-backstop suite pins boot.js.
+test('REGRESSION (FIX-R09-2 wiring): the mount probe actually calls the liveness probe', (t) => {
+  const src = fs.readFileSync(path.join(
+    path.dirname(import.meta.url.replace(/^file:\/\//, '')), '..', '..', 'src', 'worker', 'mounts-runtime.js'
+  ), 'utf8')
+  const openBody = src.slice(src.indexOf('async _open()'), src.indexOf('async _resumeOwnedMounts'))
+  t.ok(/this\.probeMirrorLiveness\(\)/.test(openBody), 'the periodic probe body calls probeMirrorLiveness')
+  t.ok(/restartForeignLoop/.test(src), 'and the runtime imports the restart it drives')
+})

--- a/test/unit/diagnostics-bundle.test.js
+++ b/test/unit/diagnostics-bundle.test.js
@@ -203,3 +203,31 @@ test('the health block carries no identifying values, so redaction is a no-op fo
   const health = { loopLagMs: 5, loopLagMaxMs: 5, queueDepth: 0 }
   t.alike(buildDiagnostics(makeCtx({ health }), true).health, buildDiagnostics(makeCtx({ health }), false).health)
 })
+
+// The per-subsystem verdicts ride inside the health block. Nested, so the shallow "health survives"
+// guard above would not notice the builder flattening or dropping them.
+test('REGRESSION (FIX-R09-2): the per-subsystem health rows survive the builder', (t) => {
+  const health = {
+    loopLagMs: 1,
+    loopLagMaxMs: 2,
+    queueDepth: 0,
+    subsystems: [
+      { name: 'store', ok: true, detail: null },
+      { name: 'foreign-mirrors', ok: false, detail: 'no progress for 700s', mirrors: { total: 3, wedged: 1 } },
+    ],
+  }
+  const bundle = buildDiagnostics(makeCtx({ health }), true)
+  t.is(bundle.health.subsystems.length, 2)
+  t.is(bundle.health.subsystems[1].ok, false)
+  t.alike(bundle.health.subsystems[1].mirrors, { total: 3, wedged: 1 })
+})
+
+// PRIVACY: the mirror verdicts are counts and durations on purpose. Space and share ids are not
+// exported anywhere else in the bundle, and a wedged-mirror row must not be the exception.
+test('PRIVACY: subsystem health rows carry no space or share identifiers', (t) => {
+  const health = {
+    subsystems: [{ name: 'foreign-mirrors', ok: false, detail: 'no progress for 700s', mirrors: { total: 2, wedged: 1 } }],
+  }
+  const serialised = JSON.stringify(buildDiagnostics(makeCtx({ health }), true))
+  t.absent(/"(spaceId|shareId)"/.test(serialised), 'no space or share id keys anywhere in the bundle')
+})

--- a/test/unit/mirror-health.test.js
+++ b/test/unit/mirror-health.test.js
@@ -1,0 +1,46 @@
+import test from 'brittle'
+import { mirrorVerdict, STALL_FACTOR } from '../../src/shared/folders/mirror-health.js'
+
+const POLL = 30_000
+const WINDOW = POLL * STALL_FACTOR
+const at = (now) => ({ now, pollIntervalMs: POLL })
+
+test('a mount with no pass in flight is healthy', (t) => {
+  t.alike(mirrorVerdict({ startedAt: 0, progressAt: 0, completedAt: 1000 }, at(9_000_000)), { ok: true, detail: null })
+  t.alike(mirrorVerdict(undefined, at(9_000_000)), { ok: true, detail: null }, 'a mount never probed is not wedged')
+})
+
+// The reason the rule reads progress rather than elapsed time: an initial scan over thousands of
+// files is legitimately slow, and an elapsed-time rule would restart it mid-scan.
+test('a pass that is still advancing is healthy however long it has run', (t) => {
+  const startedAt = 1_000_000
+  const now = startedAt + WINDOW * 100
+  t.alike(mirrorVerdict({ startedAt, progressAt: now - 1000 }, at(now)), { ok: true, detail: null })
+})
+
+test('a pass in flight with no progress past the window is wedged', (t) => {
+  const startedAt = 1_000_000
+  const now = startedAt + WINDOW + 60_000
+  const verdict = mirrorVerdict({ startedAt, progressAt: startedAt }, at(now))
+  t.is(verdict.ok, false)
+  t.is(verdict.detail, 'no progress for 660s', 'the detail carries how long it has been stuck')
+})
+
+test('a pass that never reported progress falls back to its start time', (t) => {
+  const startedAt = 1_000_000
+  t.is(mirrorVerdict({ startedAt, progressAt: 0 }, at(startedAt + 1000)).ok, true, 'just started is not wedged')
+  t.is(mirrorVerdict({ startedAt, progressAt: 0 }, at(startedAt + WINDOW + 1)).ok, false, 'and still stalls on its own')
+})
+
+// Exclusive on purpose: a false restart costs a re-scan, so the boundary favours leaving it alone.
+test('exactly at the threshold is still healthy', (t) => {
+  const startedAt = 1_000_000
+  t.is(mirrorVerdict({ startedAt, progressAt: startedAt }, at(startedAt + WINDOW)).ok, true)
+  t.is(mirrorVerdict({ startedAt, progressAt: startedAt }, at(startedAt + WINDOW + 1)).ok, false)
+})
+
+test('the stall factor scales with the configured poll interval', (t) => {
+  const startedAt = 1_000_000
+  const fast = { now: startedAt + 20_000, pollIntervalMs: 500 }
+  t.is(mirrorVerdict({ startedAt, progressAt: startedAt }, fast).ok, false, 'a 500ms poll wedges far sooner')
+})

--- a/test/unit/subsystem-health.test.js
+++ b/test/unit/subsystem-health.test.js
@@ -1,0 +1,66 @@
+import test from 'brittle'
+import { Subsystem, createLifecycle } from '../../src/shared/core/subsystem.js'
+
+const silentLog = { debug () {}, info () {}, warn () {}, error () {} }
+
+class Plain extends Subsystem {}
+
+class Talkative extends Subsystem {
+  constructor (name, deps) { super(name, deps); this.wedged = false }
+  health () { return { ok: !this.wedged, detail: this.wedged ? 'stuck' : null } }
+}
+
+// A subsystem returning its own `name` must not be able to shadow the row key the caller uses to
+// identify it.
+class Liar extends Subsystem {
+  health () { return { ok: true, detail: null, name: 'something-else' } }
+}
+
+test('the default reports healthy while open and unhealthy once closing', async (t) => {
+  const one = new Plain('one')
+  await one.ready()
+  t.alike(one.health(), { ok: true, detail: null })
+  await one.close()
+  t.is(one.health().ok, false, 'a closed subsystem is not healthy')
+})
+
+test('an override replaces the default verdict', async (t) => {
+  const two = new Talkative('two')
+  await two.ready()
+  t.is(two.health().ok, true)
+  two.wedged = true
+  t.alike(two.health(), { ok: false, detail: 'stuck' })
+})
+
+test('the lifecycle reports every started subsystem and does not consume the list', async (t) => {
+  const life = createLifecycle({ log: silentLog })
+  await life.start(new Plain('a'))
+  const b = await life.start(new Talkative('b'))
+
+  t.alike(life.health().map((row) => row.name), ['a', 'b'], 'in start order')
+  t.is(life.health().length, 2, 'reading health twice still reports both')
+
+  b.wedged = true
+  const rows = life.health()
+  t.is(rows.find((row) => row.name === 'b').ok, false)
+  t.is(rows.find((row) => row.name === 'a').ok, true, 'one unhealthy subsystem does not taint the rest')
+
+  await life.close()
+  t.alike(life.health(), [], 'a closed lifecycle reports nothing')
+})
+
+test('a subsystem cannot shadow the row key with its own name field', async (t) => {
+  const life = createLifecycle({ log: silentLog })
+  await life.start(new Liar('honest-name'))
+  t.is(life.health()[0].name, 'honest-name')
+  await life.close()
+})
+
+test('health does not throw for a subsystem whose open failed', async (t) => {
+  class Broken extends Subsystem {
+    async _open () { throw new Error('nope') }
+  }
+  const broken = new Broken('broken')
+  await t.exception(broken.ready())
+  t.is(broken.health().ok, false, 'a subsystem that never opened is not healthy')
+})

--- a/test/unit/telemetry-wiring.test.js
+++ b/test/unit/telemetry-wiring.test.js
@@ -51,3 +51,7 @@ test('getQueueDepth reports frames parked before the router goes live', async (t
   await new Promise((r) => setImmediate(r))
   t.is(getQueueDepth(), 0, 'and the queue drains when it goes live')
 })
+
+test('REGRESSION (FIX-R09-2): the entry feeds the per-subsystem health into the same block', (t) => {
+  t.ok(/subsystems:\s*root\?\.health\(\)/.test(entry), 'diagnostics ctx carries subsystems: root?.health()')
+})


### PR DESCRIPTION
## What & why

A foreign folder could stop syncing until the app was restarted, with nothing
reporting it. `runMaterializeTick` serialises passes per mount by handing every
later tick the in-flight promise, so a pass that never settles wedges the mount
permanently — the poll keeps firing and every fire is a no-op.

Three commits, in dependency order:

- **`df7ed43`** — the tick's cleanup deleted its in-flight entry unconditionally
  while `initialMaterializeScan`'s is identity-guarded. A scan replaces the entry
  outright, so an older pass settling afterwards evicted the live one and let two
  passes run over the same mount. Latent today; a restart would have activated it.
- **`d521d92`** — `Subsystem.health()` aggregated by the lifecycle, and per-mount
  liveness in the mirror engine. `diagnostics:export` carries the verdicts as
  counts, so a stalled folder is visible without space or share ids leaving the
  device. Progress is read at the byte level, not "a fetch began" — otherwise one
  large file over a slow link reads identically to a dead loop.
- **`e369a1d`** — the existing 60s mount probe restarts a wedged loop after two
  consecutive bad probes, bounded by a three-restart budget, then logs and leaves
  it down. Clearing the in-flight entry is the part `stopForeignLoop` does *not*
  do; without it a restarted loop coalesces straight back onto the dead promise.

Restarts the **loop**, not the subsystem: `ForeignMirrors._open` only re-wires the
module, so restarting it would stop every mirror and start none.

## Coverage

Unit (the pure wedge rule, subsystem/lifecycle health, diagnostics bundle +
wiring) and integration (in-flight ownership, wedge detection, restart, the probe,
the shutdown guard). Both regressions are red-first against staging.

Flow adds no new test: the harness runs the worker as a subprocess and a wedge
needs an in-process hung `fetchFile`, so it cannot create one. Asserted at the
layer that can, per `.claude/testing.md`; the existing `foreign-mirror*` and
`folder-overlay-pause-resume` flows cover the in-flight map as regression.

No renderer change — frontend/a11y: SKIP.

## Ran locally

typecheck, `lint:ci`, `test:node:core` 1457/1457, `test:bare` 867/867. `test:flow`
was 193/193 pre-rebase; the post-rebase run was still going at push time (95/193,
zero failures) — CI is the authority. No `test:fe`/axe/VoiceOver: no UI surface.