### PR TITLE
[perf] Batch the share:list-files per-row claim reads

### DIFF
--- a/src/shared/shares/share-listing.js
+++ b/src/shared/shares/share-listing.js
@@ -1,0 +1,128 @@
+// The display listing for one folder share: catalog entries in, renderable rows out. It lives
+// here rather than in the worker entrypoint so its read pattern is assertable — the property this
+// module holds is "reads do not scale with rows", and that cannot be tested through a closure in
+// an entrypoint no test can import.
+//
+// Data-layer calls arrive as an injected bundle with production defaults for the same reason: a
+// test counts calls by passing doubles, production passes nothing.
+import fs from 'bare-fs'
+import { createLogger } from '../core/logger.js'
+import { getListFilesCap } from '../core/runtime-config.js'
+import { pathFromMount } from '../transfer/path-guard.js'
+import { consumerRowStatusFor, unhashedStatusFor } from '../transfer/transfer-status.js'
+import { transferIdFor } from '../transfer/transfer-id.js'
+import { listingTruncated } from '../folders/share-limits.js'
+import { getOwnedMount, getForeignMount } from '../folders/mount-store.js'
+import { listPendingForSpace } from '../transfer/pending-transfers.js'
+import { isOwnerOnline } from '../transfer/swarm.js'
+import { getLocalPublicKeyHex } from '../spaces/profile.js'
+import { foreignFetchActive } from '../folders/foreign-folders.js'
+import { overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
+import {
+  claimedPathFor,
+  isDownloadedFile,
+  isVerifiedDownload,
+  getVerifiedHash,
+  getDownloadedPath,
+} from '../transfer/files.js'
+
+const log = createLogger('share-listing')
+
+// What production passes for `deps`; a test passes doubles instead.
+const productionDeps = {
+  getOwnedMount,
+  getForeignMount,
+  listPendingForSpace,
+  isOwnerOnline,
+  getLocalPublicKeyHex,
+  foreignFetchActive,
+  overlayHasTransfer,
+  claimedPathFor,
+  isDownloadedFile,
+  isVerifiedDownload,
+  getVerifiedHash,
+  getDownloadedPath,
+}
+
+function statSizeOrNull(absPath) {
+  try { return fs.statSync(absPath).size } catch { return null }
+}
+
+// Consumer-side status for a catalog-backed overlay share row. A null contentHash means the owner
+// is still hashing → `preparing` while the owner is online, else `unavailable` (entries are
+// advertised before hashing completes). Downloads land in the downloads folder and are recorded in
+// the downloaded registry (markDownloaded), so `downloaded` is detected via isDownloadedFile — a
+// file counts as downloaded iff the registry lists it.
+async function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending, deps }) {
+  if (foreignMount && foreignMount.enabled) {
+    const abs = pathFromMount(foreignMount.mountPath, entry.relPath)
+    if (statSizeOrNull(abs) === entry.size) {
+      const verified = !!entry.contentHash && (await deps.getVerifiedHash(spaceId, share.id + '|' + entry.relPath)) === entry.contentHash
+      return { status: 'synced', localPath: abs, verified }
+    }
+    // The mirror loop is pulling this row right now — 'downloading' so FolderView's
+    // bar/speed/verify lane (all gated on the status) render during materialization.
+    if (deps.foreignFetchActive(spaceId, share.id, entry.relPath)) {
+      return { status: 'downloading', localPath: null, pendingBytes: 0 }
+    }
+    if (!entry.contentHash) return { status: unhashedStatusFor(ownerOnline), localPath: null }
+    return { status: ownerOnline ? 'remote' : 'unavailable', localPath: null }
+  }
+  const drivePath = '/' + share.name + '/' + entry.relPath
+  if (await deps.isDownloadedFile(spaceId, drivePath, entry.contentHash)) {
+    const verified = await deps.isVerifiedDownload(spaceId, share.id + '|' + entry.relPath, entry.contentHash)
+    return { status: 'downloaded', localPath: (await deps.getDownloadedPath(spaceId, drivePath)) || deps.claimedPathFor(drivePath, null), verified }
+  }
+  // Status is one ordered rule set, mirroring the loose path's order (which hand-rolls the same
+  // null-hash-first check at its call site) — an in-flight fetch is 'downloading', a null hash is
+  // the owner's index, and only then does the durable pending row decide error/paused. Derived
+  // there, never overlaid by the renderer.
+  const transferId = transferIdFor(spaceId, share.id, entry.relPath)
+  const row = consumerRowStatusFor({
+    hashed: Boolean(entry.contentHash),
+    isActive: deps.overlayHasTransfer(transferId),
+    pendingRow: pending?.get(drivePath),
+    ownerOnline,
+  })
+  return { ...row, localPath: null }
+}
+
+export async function listOverlayShareFiles(spaceId, share, backend, deps = productionDeps) {
+  const isOwn = share.owner === deps.getLocalPublicKeyHex()
+  // One bounded pass returns the first `cap` catalog entries AND the true {total, totalBytes}
+  // for the whole share, so a huge folder never materialises a 150k-row array and the count is
+  // always consistent with the rows (total >= entries.length). The rich display rows below are
+  // built only for the capped entries.
+  const cap = getListFilesCap()
+  const { entries, total, totalBytes, complete = true } = isOwn
+    ? await backend.listOwn(spaceId, share.id, cap)
+    : await backend.listPeerWithMeta(spaceId, share, cap)
+  const ownerOnline = isOwn ? true : deps.isOwnerOnline(share.owner)
+  const ownedMount = isOwn ? await deps.getOwnedMount(spaceId, share.id) : null
+  const foreignMount = isOwn ? null : await deps.getForeignMount(spaceId, share.id)
+  const pending = isOwn ? null : new Map((await deps.listPendingForSpace(spaceId)).map((p) => [p.filePath, p]))
+  const out = []
+  for (const entry of entries) {
+    let row
+    try {
+      // pathFromMount throws on an unsafe peer-supplied relPath — skip that one
+      // entry rather than aborting the whole listing (a malicious owner catalog
+      // must not make the share un-browsable).
+      if (isOwn) {
+        row = { status: entry.contentHash ? 'synced' : 'publishing', localPath: ownedMount ? pathFromMount(ownedMount.mountPath, entry.relPath) : null }
+      } else {
+        row = await overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending, deps })
+      }
+    } catch (err) {
+      log.warn('skipping overlay file row with an unsafe path:', entry.relPath, '-', err.message)
+      continue
+    }
+    out.push({ relPath: entry.relPath, size: entry.size, hash: entry.contentHash || '', mtime: entry.mtime, status: row.status, localPath: row.localPath, verified: row.verified || false, pendingBytes: row.pendingBytes, errorCode: row.errorCode, transferId: isOwn ? undefined : transferIdFor(spaceId, share.id, entry.relPath) })
+  }
+  // Truncation is a FACT the worker reports, never something the renderer infers from
+  // (total > rows): on an incomplete read `total` is itself partial, so that inference collapses
+  // to false exactly when the rows were capped — and the truncation goes silent.
+  const truncated = listingTruncated({ rowCount: entries.length, total, cap, complete })
+  if (truncated) log.debug(`share:list-files showing ${out.length} of ${total} rows for share ${share.id} (capped at ${cap})`)
+  return { entries: out, complete, total, totalBytes, truncated, fileLimit: truncated ? cap : null }
+}

--- a/src/shared/shares/share-listing.js
+++ b/src/shared/shares/share-listing.js
@@ -20,10 +20,10 @@ import { foreignFetchActive } from '../folders/foreign-folders.js'
 import { overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
 import {
   claimedPathFor,
-  isDownloadedFile,
-  isVerifiedDownload,
-  getVerifiedHash,
-  getDownloadedPath,
+  verdictForClaim,
+  listVerifiedForShare,
+  listDownloadClaimsForShare,
+  pruneDownloadClaims,
 } from '../transfer/files.js'
 
 const log = createLogger('share-listing')
@@ -38,10 +38,10 @@ const productionDeps = {
   foreignFetchActive,
   overlayHasTransfer,
   claimedPathFor,
-  isDownloadedFile,
-  isVerifiedDownload,
-  getVerifiedHash,
-  getDownloadedPath,
+  verdictForClaim,
+  listVerifiedForShare,
+  listDownloadClaimsForShare,
+  pruneDownloadClaims,
 }
 
 function statSizeOrNull(absPath) {
@@ -50,16 +50,18 @@ function statSizeOrNull(absPath) {
 
 // Consumer-side status for a catalog-backed overlay share row. A null contentHash means the owner
 // is still hashing → `preparing` while the owner is online, else `unavailable` (entries are
-// advertised before hashing completes). Downloads land in the downloads folder and are recorded in
-// the downloaded registry (markDownloaded), so `downloaded` is detected via isDownloadedFile — a
-// file counts as downloaded iff the registry lists it.
-async function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending, deps }) {
+// advertised before hashing completes). A file counts as downloaded iff the downloaded registry
+// still claims it AND the disk agrees — and the claim comes from the listing's prefetched map, so
+// no row reads the bee.
+//
+// Synchronous by design: every fact it needs is in a prefetched map, an in-memory engine map, or a
+// stat. The row loop therefore never yields, which is what removes the worker-side stall.
+function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending, verified, claims, prune, deps }) {
+  const isVerified = Boolean(entry.contentHash) && verified.get(entry.relPath) === entry.contentHash
+
   if (foreignMount && foreignMount.enabled) {
     const abs = pathFromMount(foreignMount.mountPath, entry.relPath)
-    if (statSizeOrNull(abs) === entry.size) {
-      const verified = !!entry.contentHash && (await deps.getVerifiedHash(spaceId, share.id + '|' + entry.relPath)) === entry.contentHash
-      return { status: 'synced', localPath: abs, verified }
-    }
+    if (statSizeOrNull(abs) === entry.size) return { status: 'synced', localPath: abs, verified: isVerified }
     // The mirror loop is pulling this row right now — 'downloading' so FolderView's
     // bar/speed/verify lane (all gated on the status) render during materialization.
     if (deps.foreignFetchActive(spaceId, share.id, entry.relPath)) {
@@ -68,11 +70,17 @@ async function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignM
     if (!entry.contentHash) return { status: unhashedStatusFor(ownerOnline), localPath: null }
     return { status: ownerOnline ? 'remote' : 'unavailable', localPath: null }
   }
+
   const drivePath = '/' + share.name + '/' + entry.relPath
-  if (await deps.isDownloadedFile(spaceId, drivePath, entry.contentHash)) {
-    const verified = await deps.isVerifiedDownload(spaceId, share.id + '|' + entry.relPath, entry.contentHash)
-    return { status: 'downloaded', localPath: (await deps.getDownloadedPath(spaceId, drivePath)) || deps.claimedPathFor(drivePath, null), verified }
+  const rec = claims.get(drivePath) || null
+  const verdict = deps.verdictForClaim(spaceId, drivePath, rec, entry.contentHash)
+  // Collected, never acted on here: a del is a write, and taking a write turn per stale row is the
+  // cost this batching exists to remove. The listing flushes them once, after the rows.
+  if (verdict.prune) prune.push(drivePath)
+  if (verdict.downloaded) {
+    return { status: 'downloaded', localPath: deps.claimedPathFor(drivePath, rec), verified: isVerified }
   }
+
   // Status is one ordered rule set, mirroring the loose path's order (which hand-rolls the same
   // null-hash-first check at its call site) — an in-flight fetch is 'downloading', a null hash is
   // the owner's index, and only then does the durable pending row decide error/paused. Derived
@@ -85,6 +93,20 @@ async function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignM
     ownerOnline,
   })
   return { ...row, localPath: null }
+}
+
+// Two range scans replace up to three point reads PER ROW. Scoped to the rows this listing can
+// render, and to the branch it will take: an owner listing reads neither namespace (its rows are
+// pure path arithmetic), and a mounted mirror reads only the verified namespace (its rows never
+// consult a download claim). Every row then sees ONE consistent snapshot instead of its own
+// moment, so a listing can no longer render two of its rows against different states of the world.
+async function prefetchRowState(spaceId, share, entries, { isOwn, foreignMount, deps }) {
+  if (isOwn) return { verified: new Map(), claims: new Map() }
+  const relPaths = new Set(entries.map((entry) => entry.relPath))
+  const verified = await deps.listVerifiedForShare(spaceId, share.id, { keep: relPaths })
+  if (foreignMount && foreignMount.enabled) return { verified, claims: new Map() }
+  const keep = new Set([...relPaths].map((relPath) => '/' + share.name + '/' + relPath))
+  return { verified, claims: await deps.listDownloadClaimsForShare(spaceId, share.name, { keep }) }
 }
 
 export async function listOverlayShareFiles(spaceId, share, backend, deps = productionDeps) {
@@ -101,6 +123,10 @@ export async function listOverlayShareFiles(spaceId, share, backend, deps = prod
   const ownedMount = isOwn ? await deps.getOwnedMount(spaceId, share.id) : null
   const foreignMount = isOwn ? null : await deps.getForeignMount(spaceId, share.id)
   const pending = isOwn ? null : new Map((await deps.listPendingForSpace(spaceId)).map((p) => [p.filePath, p]))
+
+  const { verified, claims } = await prefetchRowState(spaceId, share, entries, { isOwn, foreignMount, deps })
+
+  const prune = []
   const out = []
   for (const entry of entries) {
     let row
@@ -111,7 +137,7 @@ export async function listOverlayShareFiles(spaceId, share, backend, deps = prod
       if (isOwn) {
         row = { status: entry.contentHash ? 'synced' : 'publishing', localPath: ownedMount ? pathFromMount(ownedMount.mountPath, entry.relPath) : null }
       } else {
-        row = await overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending, deps })
+        row = overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending, verified, claims, prune, deps })
       }
     } catch (err) {
       log.warn('skipping overlay file row with an unsafe path:', entry.relPath, '-', err.message)
@@ -119,6 +145,11 @@ export async function listOverlayShareFiles(spaceId, share, backend, deps = prod
     }
     out.push({ relPath: entry.relPath, size: entry.size, hash: entry.contentHash || '', mtime: entry.mtime, status: row.status, localPath: row.localPath, verified: row.verified || false, pendingBytes: row.pendingBytes, errorCode: row.errorCode, transferId: isOwn ? undefined : transferIdFor(spaceId, share.id, entry.relPath) })
   }
+
+  // Awaited so a caller can observe the flush, caught so a failed cache cleanup can never fail the
+  // listing the rows are already built for.
+  if (prune.length) await deps.pruneDownloadClaims(spaceId, prune).catch((err) => log.debug('claim prune failed:', err.message))
+
   // Truncation is a FACT the worker reports, never something the renderer infers from
   // (total > rows): on an incomplete read `total` is itself partial, so that inference collapses
   // to false exactly when the rows were capped — and the truncation goes silent.

--- a/src/shared/transfer/download-claim.js
+++ b/src/shared/transfer/download-claim.js
@@ -1,0 +1,32 @@
+// The claim → status decision for one downloaded-copy record, with every filesystem and config
+// fact passed in. Pure and dependency-free so the ORDER below is asserted directly rather than
+// through a bee and a real disk, and so the batched share listing can reach the same decision
+// from a pre-read record without re-reading it.
+//
+// The order is load-bearing:
+//   1. no record                 → not downloaded, nothing to prune
+//   2. file gone, folder gone    → the VOLUME is detached (ejected drive, dropped network share),
+//                                  not a deletion: report not-downloaded but KEEP the claim, so
+//                                  reattaching the disk restores the status instead of having
+//                                  destroyed the record and invited a duplicate re-download
+//   3. file gone, folder present → the user deleted the copy → PRUNE
+//   4. hash moved upstream       → the owner replaced the file → PRUNE
+//   5. outside the space's pinned download folder → not downloaded, KEEP. Non-destructive by
+//                                  design: pointing the space back at the old folder must restore
+//                                  the status. The check keys on the space's OVERRIDE, never on
+//                                  the effective root — following the global root is no promise
+//                                  about where a space's downloads live, so changing the global
+//                                  folder must not un-download every space that never opted in.
+//   6. otherwise                 → downloaded
+export function claimVerdict({ rec, exists, dirExists, currentHash = null, pinned = null, insidePinned = true }) {
+  if (!rec) return { downloaded: false, prune: false, reason: 'no-claim' }
+  if (!exists) {
+    if (!dirExists) return { downloaded: false, prune: false, reason: 'volume-unavailable' }
+    return { downloaded: false, prune: true, reason: 'local-file-gone' }
+  }
+  if (rec.hash && currentHash && rec.hash !== currentHash) {
+    return { downloaded: false, prune: true, reason: 'content-changed-upstream' }
+  }
+  if (pinned && !insidePinned) return { downloaded: false, prune: false, reason: 'outside-space-folder' }
+  return { downloaded: true, prune: false, reason: null }
+}

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -26,6 +26,7 @@ import { revealExitIsFailure } from './reveal-exit.js'
 import { looseShareFile, looseUnshareFile, looseHasOwn, looseListOwn, looseListPeer, looseTransferActive } from './loose-overlay.js'
 import { LOOSE_SHARE_ID, looseTransferIdFor } from './transfer-id.js'
 import { unhashedStatusFor } from './transfer-status.js'
+import { claimVerdict } from './download-claim.js'
 
 const log = createLogger('files')
 
@@ -76,13 +77,56 @@ export async function getVerifiedHash(spaceId, key) {
 // to sum a mirror's on-device bytes without stat'ing each file. The map is transient
 // and worker-only (never serialized over IPC); for a fully-mirrored huge share it
 // holds O(files) short strings — bounded, unlike retaining full row arrays.
-export async function listVerifiedForShare(spaceId, shareId) {
+export async function listVerifiedForShare(spaceId, shareId, { keep = null } = {}) {
   const prefix = 'verified:' + spaceId + ':' + shareId + '|'
   const map = new Map()
   for await (const node of downloadsBee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
-    if (node.value?.hash) map.set(node.key.slice(prefix.length), node.value.hash)
+    const relPath = node.key.slice(prefix.length)
+    if (keep && !keep.has(relPath)) continue
+    if (node.value?.hash) map.set(relPath, node.value.hash)
   }
   return map
+}
+
+// Bulk form of the downloaded-claim read for one share: drivePath -> claim record, in a single
+// range scan. The share listing needs the same record up to three times per row; one scan answers
+// every row.
+//
+// `keep` bounds RETENTION, not the scan. A listing renders at most listFilesCap rows, so holding a
+// claim for a row nobody will see is memory spent on nothing. It also settles the share-name prefix
+// question: a share named 'a' scans the claims of a share named 'a/b' too — their keys are
+// genuinely under that prefix — and those are dropped here, where a lookup by exact drivePath
+// could never have matched them anyway.
+export async function listDownloadClaimsForShare(spaceId, shareName, { keep = null } = {}) {
+  const prefix = spaceId + ':/' + shareName + '/'
+  const map = new Map()
+  for await (const node of downloadsBee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+    const drivePath = node.key.slice(spaceId.length + 1)
+    if (keep && !keep.has(drivePath)) continue
+    if (node.value) map.set(drivePath, node.value)
+  }
+  return map
+}
+
+// Prune the claims a listing found stale, in ONE batch after its rows are assembled. Deferred out
+// of the row loop because a del is a WRITE: inline, a read path took a write turn per stale row.
+//
+// Best-effort by design and never rethrown into the listing: a claim is a cache of a fact the disk
+// owns, so a failed prune costs one more re-check on the next listing, never correctness. A listing
+// that failed because its own cleanup failed would be the worse bug.
+export async function pruneDownloadClaims(spaceId, drivePaths) {
+  if (!drivePaths.length) return 0
+  const batch = downloadsBee.batch()
+  try {
+    for (const drivePath of drivePaths) await batch.del(spaceId + ':' + drivePath)
+    await batch.flush()
+  } catch (err) {
+    try { await batch.close() } catch {}
+    log.debug('claim prune failed:', err.message)
+    return 0
+  }
+  log.info('pruned', drivePaths.length, 'stale on-device claims')
+  return drivePaths.length
 }
 
 async function getVerifiedRecord(spaceId, key) {
@@ -117,48 +161,41 @@ export async function isVerifiedDownload(spaceId, key, contentHash) {
 // space that pins its own download folder — inside that folder. The downloads-meta record
 // is only a hint; the file is the truth.
 //
-// Ordering is load-bearing. Existence and upstream-hash currency are checked FIRST and
-// PRUNE the claim — a copy the user deleted, or one the owner replaced, is worthless. The
-// scope check comes LAST and is NON-DESTRUCTIVE: a file that still exists but sits outside
-// this space's pinned download folder reports not-downloaded while KEEPING the claim, so
-// pointing the space back at the old folder restores the status instead of having silently
-// destroyed the record.
-//
-// The scope check keys on the space's OVERRIDE, never on the effective root. An override is
-// a promise that this space's downloads live in one named folder; following the global root
-// is no such promise, so changing the global folder in Storage Settings must not un-download
-// every space that never opted into a folder of its own (the files are untouched on disk,
-// and re-fetching them would just duplicate them).
+// The filesystem + config half of that decision; download-claim.js holds the rule and the order.
+// Synchronous: every fact it needs is a stat or an in-memory config read, so a batched listing can
+// call it per row without the loop yielding. `dirExists` is resolved ONLY when the file is missing,
+// so the common case still costs one existsSync.
+export function verdictForClaim(spaceId, filePath, rec, currentHash = null) {
+  if (!rec) return claimVerdict({ rec: null })
+  const onDisk = claimedPathFor(filePath, rec)
+  const exists = fs.existsSync(onDisk)
+  const pinned = getSpaceDownloadOverride(spaceId)
+  return claimVerdict({
+    rec,
+    exists,
+    dirExists: exists ? true : fs.existsSync(path.dirname(onDisk)),
+    currentHash,
+    pinned,
+    insidePinned: pinned ? isInsideDownloadDir(onDisk, pinned) : true,
+  })
+}
+
+// The point-read form: one claim, read and acted on. Built on the same verdict as the batched
+// listing path so the two can never drift.
 async function verifyOnDevice(spaceId, filePath, currentHash = null) {
   const key = spaceId + ':' + filePath
   const node = await downloadsBee.get(key)
   if (!node) return false
-  const rec = node.value || {}
-  const onDisk = claimedPathFor(filePath, rec)
-  if (!fs.existsSync(onDisk)) {
-    // A missing file whose CONTAINING FOLDER is also missing means the volume is detached
-    // (ejected drive, dropped network share), not that the user deleted the copy. Pruning
-    // there would destroy the claim for a file that is still on that disk, and the re-download
-    // it invites lands a duplicate next to it. Report not-downloaded, keep the record.
-    if (!fs.existsSync(path.dirname(onDisk))) {
-      log.debug('claim folder unavailable, keeping claim:', filePath)
-      return false
-    }
+  const verdict = verdictForClaim(spaceId, filePath, node.value || {}, currentHash)
+  if (verdict.prune) {
     await downloadsBee.del(key)
-    log.info('reset on-device claim (local file gone):', filePath)
-    return false
-  }
-  if (rec.hash && currentHash && rec.hash !== currentHash) {
-    await downloadsBee.del(key)
-    log.info('reset on-device claim (content changed upstream):', filePath)
-    return false
-  }
-  const pinned = getSpaceDownloadOverride(spaceId)
-  if (pinned && !isInsideDownloadDir(onDisk, pinned)) {
+    log.info('reset on-device claim (' + verdict.reason + '):', filePath)
+  } else if (verdict.reason === 'volume-unavailable') {
+    log.debug('claim folder unavailable, keeping claim:', filePath)
+  } else if (verdict.reason === 'outside-space-folder') {
     log.debug('claim outside the space download folder:', filePath)
-    return false
   }
-  return true
+  return verdict.downloaded
 }
 
 export async function isDownloadedFile(spaceId, filePath, currentHash = null) {

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -10,7 +10,6 @@
 // in ./boot.js, whose returned `root.close()` is the whole stop sequence. ipc.start() is last, so
 // no frame is dispatched until every handler is registered.
 import os from 'bare-os'
-import fs from 'bare-fs'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
 import { createIPC, getBootstrapPromise, getRequestFailureCounters, getRequestMetrics, getQueueDepth } from '../shared/core/ipc.js'
@@ -25,7 +24,6 @@ import {
   isHandshakeIdentityBindingEnabled,
   isOverlayEnabled,
   isInPlaceFilesEnabled,
-  getListFilesCap,
   isRelayEnabled,
   setRelayConfig,
 } from '../shared/core/runtime-config.js'
@@ -74,7 +72,6 @@ import {
   leaveSpaceTopic,
   cleanupSpaceDrives,
   getConnectedPeers,
-  isOwnerOnline,
   broadcastProfileUpdate,
   getSwarmStatus,
   testRelayReachable,
@@ -118,11 +115,8 @@ import {
   removeFile,
   revealFile,
   addFile,
-  isDownloadedFile,
   getDownloadedPath,
   revealLocalPath,
-  getVerifiedHash,
-  isVerifiedDownload,
   claimedPathFor,
 } from '../shared/transfer/files.js'
 import {
@@ -133,13 +127,12 @@ import {
   looseCancelPublish,
   handleLooseFsEvent,
 } from '../shared/transfer/loose-overlay.js'
-import { overlayPause, overlayCancel, overlayCancelByKey, overlayHasTransfer } from '../shared/transfer/backends/overlay/overlay-backend.js'
+import { overlayPause, overlayCancel, overlayCancelByKey } from '../shared/transfer/backends/overlay/overlay-backend.js'
 import { subscribeServeDetail, unsubscribeServeDetail, listServeSummaries } from '../shared/transfer/serve-ledger.js'
 
-import { consumerRowStatusFor, unhashedStatusFor } from '../shared/transfer/transfer-status.js'
 import { transferIdFor, isLooseTransferId } from '../shared/transfer/transfer-id.js'
+import { pathFromMount } from '../shared/transfer/path-guard.js'
 import { makeKeyedCoalescer } from '../shared/state/coalesce.js'
-import { listPendingForSpace } from '../shared/transfer/pending-transfers.js'
 import { getStorageInfo, cleanupOrphanedData, freeSpace } from '../shared/storage/storage.js'
 import { spaceStorageSummary } from '../shared/storage/space-storage.js'
 import { classifyLeftovers, forgetUnreferencedPeerCores } from '../shared/storage/leftover.js'
@@ -161,13 +154,13 @@ import {
 } from '../shared/audit/audit-log.js'
 import { publishShare, tombstoneShare, readOwnShares, isValidShareName, generateShareId } from '../shared/shares/shares.js'
 import { listSharesForSpace } from '../shared/shares/share-registry.js'
+import { listOverlayShareFiles } from '../shared/shares/share-listing.js'
 import { publishMirror } from '../shared/folders/mirror-records.js'
 import { listMirrorsForShare, listMirrorsForSpace } from '../shared/folders/mirror-registry.js'
 import { boot } from './boot.js'
 import { AppError, ErrorCodes } from '../shared/core/errors.js'
 import { saveOwnedMount, getOwnedMount, deleteOwnedMount, listOwnedMounts, listAllMounts } from '../shared/folders/mount-store.js'
 import { validateMountPath, validateDownloadFolderAgainstMounts } from '../shared/folders/mount-validate.js'
-import { relKeyEscapes } from '../shared/folders/path-keys.js'
 import {
   handleFsEventFromMain,
   initialPublishScan,
@@ -180,14 +173,13 @@ import {
   cancelIndex,
 } from '../shared/folders/owned-folders.js'
 
-import { exceedsShareFileLimit, shareFileLimitMessage, listingTruncated } from '../shared/folders/share-limits.js'
+import { exceedsShareFileLimit, shareFileLimitMessage } from '../shared/folders/share-limits.js'
 import {
   initialMaterializeScan,
   previewMaterializeScan,
   startForeignLoop,
   setForeignEnabled,
   unmountForeignFolder,
-  foreignFetchActive,
 } from '../shared/folders/foreign-folders.js'
 import { saveForeignMount as persistForeignMount, getForeignMount, listForeignMounts } from '../shared/folders/mount-store.js'
 
@@ -762,106 +754,6 @@ ipc.handle('share:list-files', async (msg) => {
   if (backend === UNSUPPORTED) return { entries: [], complete: true, total: 0, totalBytes: 0 }
   return await listOverlayShareFiles(msg.spaceId, share, backend)
 })
-
-// Contain a renderer-supplied (share:reveal-file) or catalog relPath inside the mount, so
-// neither a compromised renderer nor a malicious owner catalog can reveal/open a file
-// outside the share folder. Same guard as the data layer (path-keys.relKeyEscapes); reject
-// before building the path.
-function pathFromMount(mountPath, relPath) {
-  if (relKeyEscapes(relPath)) {
-    throw new AppError(ErrorCodes.EPATH, `file path rejected — unsafe segment escapes the share folder: ${relPath}`)
-  }
-  const sep = mountPath.includes('\\') ? '\\' : '/'
-  const root = mountPath.replace(/[/\\]+$/, '')
-  const abs = root + sep + relPath.split('/').join(sep)
-  if (!(abs === root || abs.startsWith(root + sep))) {
-    throw new AppError(ErrorCodes.EPATH, `file path rejected — resolves outside the share folder: ${relPath}`)
-  }
-  return abs
-}
-
-function statSizeOrNull(absPath) {
-  try { return fs.statSync(absPath).size } catch { return null }
-}
-
-// Consumer-side status for a catalog-backed overlay share row. A null contentHash means
-// the owner is still hashing → `preparing` while the owner is online, else `unavailable`
-// (entries are advertised before hashing completes). Downloads land in the downloads folder and are recorded in the downloaded
-// registry (markDownloaded), so `downloaded` is detected via isDownloadedFile — a file
-// counts as downloaded iff the registry lists it.
-async function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending }) {
-  if (foreignMount && foreignMount.enabled) {
-    const abs = pathFromMount(foreignMount.mountPath, entry.relPath)
-    if (statSizeOrNull(abs) === entry.size) {
-      const verified = !!entry.contentHash && (await getVerifiedHash(spaceId, share.id + '|' + entry.relPath)) === entry.contentHash
-      return { status: 'synced', localPath: abs, verified }
-    }
-    // The mirror loop is pulling this row right now — 'downloading' so FolderView's
-    // bar/speed/verify lane (all gated on the status) render during materialization.
-    if (foreignFetchActive(spaceId, share.id, entry.relPath)) {
-      return { status: 'downloading', localPath: null, pendingBytes: 0 }
-    }
-    if (!entry.contentHash) return { status: unhashedStatusFor(ownerOnline), localPath: null }
-    return { status: ownerOnline ? 'remote' : 'unavailable', localPath: null }
-  }
-  const drivePath = '/' + share.name + '/' + entry.relPath
-  if (await isDownloadedFile(spaceId, drivePath, entry.contentHash)) {
-    const verified = await isVerifiedDownload(spaceId, share.id + '|' + entry.relPath, entry.contentHash)
-    return { status: 'downloaded', localPath: (await getDownloadedPath(spaceId, drivePath)) || claimedPathFor(drivePath, null), verified }
-  }
-  // Status is one ordered rule set, mirroring the loose path's order (which hand-rolls the same
-  // null-hash-first check at its call site) — an in-flight fetch is 'downloading', a null hash is
-  // the owner's index, and only then does the durable pending row decide error/paused. Derived
-  // there, never overlaid by the renderer.
-  const transferId = transferIdFor(spaceId, share.id, entry.relPath)
-  const row = consumerRowStatusFor({
-    hashed: Boolean(entry.contentHash),
-    isActive: overlayHasTransfer(transferId),
-    pendingRow: pending?.get(drivePath),
-    ownerOnline,
-  })
-  return { ...row, localPath: null }
-}
-
-async function listOverlayShareFiles(spaceId, share, backend) {
-  const isOwn = share.owner === getLocalPublicKeyHex()
-  // One bounded pass returns the first `cap` catalog entries AND the true {total, totalBytes}
-  // for the whole share, so a huge folder never materialises a 150k-row array and the count is
-  // always consistent with the rows (total >= entries.length). The rich display rows below are
-  // built only for the capped entries.
-  const cap = getListFilesCap()
-  const { entries, total, totalBytes, complete = true } = isOwn
-    ? await backend.listOwn(spaceId, share.id, cap)
-    : await backend.listPeerWithMeta(spaceId, share, cap)
-  const ownerOnline = isOwn ? true : isOwnerOnline(share.owner)
-  const ownedMount = isOwn ? await getOwnedMount(spaceId, share.id) : null
-  const foreignMount = isOwn ? null : await getForeignMount(spaceId, share.id)
-  const pending = isOwn ? null : new Map((await listPendingForSpace(spaceId)).map((p) => [p.filePath, p]))
-  const out = []
-  for (const entry of entries) {
-    let row
-    try {
-      // pathFromMount throws on an unsafe peer-supplied relPath — skip that one
-      // entry rather than aborting the whole listing (a malicious owner catalog
-      // must not make the share un-browsable).
-      if (isOwn) {
-        row = { status: entry.contentHash ? 'synced' : 'publishing', localPath: ownedMount ? pathFromMount(ownedMount.mountPath, entry.relPath) : null }
-      } else {
-        row = await overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, pending })
-      }
-    } catch (err) {
-      log.warn('skipping overlay file row with an unsafe path:', entry.relPath, '-', err.message)
-      continue
-    }
-    out.push({ relPath: entry.relPath, size: entry.size, hash: entry.contentHash || '', mtime: entry.mtime, status: row.status, localPath: row.localPath, verified: row.verified || false, pendingBytes: row.pendingBytes, errorCode: row.errorCode, transferId: isOwn ? undefined : transferIdFor(spaceId, share.id, entry.relPath) })
-  }
-  // Truncation is a FACT the worker reports, never something the renderer infers from
-  // (total > rows): on an incomplete read `total` is itself partial, so that inference collapses
-  // to false exactly when the rows were capped — and the truncation goes silent.
-  const truncated = listingTruncated({ rowCount: entries.length, total, cap, complete })
-  if (truncated) log.debug(`share:list-files showing ${out.length} of ${total} rows for share ${share.id} (capped at ${cap})`)
-  return { entries: out, complete, total, totalBytes, truncated, fileLimit: truncated ? cap : null }
-}
 
 ipc.handle('share:reveal-folder', async (msg) => {
   const share = await loadShareDescriptor(msg.spaceId, msg.ownerKey, msg.shareId)

--- a/test/integration/files-ops.test.js
+++ b/test/integration/files-ops.test.js
@@ -16,6 +16,10 @@ import {
   markVerified,
   getVerifiedHash,
   cleanupDownloadHistory,
+  listDownloadClaimsForShare,
+  listVerifiedForShare,
+  pruneDownloadClaims,
+  verdictForClaim,
 } from '../../src/shared/transfer/files.js'
 import { initPendingTransfers, recordPending, getPendingFor } from '../../src/shared/transfer/pending-transfers.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
@@ -190,4 +194,79 @@ test('verified marker round-trips and is cleared on space cleanup', async (t) =>
 
   await cleanupDownloadHistory(spaceId)
   t.is(await getVerifiedHash(spaceId, key), null, 'cleared with the space download history')
+})
+
+// The share listing reads every row's claim from one range scan instead of a point read per row,
+// so the scan must answer exactly what the point reads answered — no sibling share's keys, and
+// nothing retained for a row the listing will not render.
+test('listDownloadClaimsForShare scans one share and never a sibling', async (t) => {
+  const { spaceId, tmpDir } = await setup(t)
+  const dir = tmpDir('dl')
+  for (const drivePath of ['/Docs/a.txt', '/Docs/sub/b.txt', '/Docs2/c.txt', '/Doc/d.txt']) {
+    const landed = path.join(dir, drivePath.split('/').join('_'))
+    fs.writeFileSync(landed, 'bytes')
+    await markDownloaded(spaceId, drivePath, landed, { hash: 'h' })
+  }
+
+  const claims = await listDownloadClaimsForShare(spaceId, 'Docs')
+  t.alike([...claims.keys()].sort(), ['/Docs/a.txt', '/Docs/sub/b.txt'], 'only the named share, nested paths included')
+  t.is(claims.get('/Docs/a.txt').hash, 'h', 'the whole record comes back, not just the path')
+
+  const other = await listDownloadClaimsForShare('other-space', 'Docs')
+  t.is(other.size, 0, 'the scan is scoped to the space as well as the share')
+})
+
+test('the keep filter bounds retention without narrowing the scan', async (t) => {
+  const { spaceId, tmpDir } = await setup(t)
+  const landed = path.join(tmpDir('dl'), 'k.txt')
+  fs.writeFileSync(landed, 'bytes')
+  await markDownloaded(spaceId, '/Docs/keep.txt', landed, { hash: 'h1' })
+  await markDownloaded(spaceId, '/Docs/drop.txt', landed, { hash: 'h2' })
+  await markVerified(spaceId, 'sh1|keep.txt', 'h1')
+  await markVerified(spaceId, 'sh1|drop.txt', 'h2')
+
+  const claims = await listDownloadClaimsForShare(spaceId, 'Docs', { keep: new Set(['/Docs/keep.txt']) })
+  t.alike([...claims.keys()], ['/Docs/keep.txt'])
+
+  const verified = await listVerifiedForShare(spaceId, 'sh1', { keep: new Set(['keep.txt']) })
+  t.alike([...verified.keys()], ['keep.txt'])
+  t.is((await listVerifiedForShare(spaceId, 'sh1')).size, 2, 'no keep is the unfiltered scan the storage summary relies on')
+})
+
+test('pruneDownloadClaims removes exactly the listed keys in one batch', async (t) => {
+  const { spaceId, tmpDir } = await setup(t)
+  const landed = path.join(tmpDir('dl'), 'p.txt')
+  fs.writeFileSync(landed, 'bytes')
+  for (const drivePath of ['/Docs/one.txt', '/Docs/two.txt', '/Docs/three.txt']) {
+    await markDownloaded(spaceId, drivePath, landed, { hash: 'h' })
+  }
+
+  t.is(await pruneDownloadClaims(spaceId, []), 0, 'an empty batch is a no-op')
+  t.is(await pruneDownloadClaims(spaceId, ['/Docs/one.txt', '/Docs/three.txt']), 2)
+  t.alike([...(await listDownloadClaimsForShare(spaceId, 'Docs')).keys()], ['/Docs/two.txt'])
+})
+
+// FIX-21 again, now through the verdict the batched listing and the point read share: a file whose
+// CONTAINING FOLDER also vanished means the volume is detached, not that the user deleted the copy.
+// Pruning there would destroy the claim for a file still sitting on that disk.
+test('REGRESSION (FIX-21): a detached volume keeps the claim, a deleted file drops it', async (t) => {
+  const { spaceId, tmpDir } = await setup(t)
+  const volume = path.join(tmpDir('vol'), 'ExternalDisk')
+  fs.mkdirSync(volume, { recursive: true })
+  const landed = path.join(volume, 'v.txt')
+  fs.writeFileSync(landed, 'bytes')
+  await markDownloaded(spaceId, '/Docs/v.txt', landed, { hash: 'h1' })
+
+  const rec = (await listDownloadClaimsForShare(spaceId, 'Docs')).get('/Docs/v.txt')
+  t.is(verdictForClaim(spaceId, '/Docs/v.txt', rec, 'h1').downloaded, true, 'present on the mounted volume')
+
+  fs.rmSync(volume, { recursive: true, force: true })
+  const detached = verdictForClaim(spaceId, '/Docs/v.txt', rec, 'h1')
+  t.is(detached.prune, false, 'the volume is gone, so the claim is NOT pruned')
+  t.is(detached.downloaded, false, 'but the file is not reported as on this device')
+  t.absent(await isDownloadedFile(spaceId, '/Docs/v.txt', 'h1'), 'the point-read path agrees')
+  t.is(await getDownloadedPath(spaceId, '/Docs/v.txt'), landed, 'and the record survived the read')
+
+  fs.mkdirSync(volume, { recursive: true })
+  t.is(verdictForClaim(spaceId, '/Docs/v.txt', rec, 'h1').prune, true, 'the folder back without the file is a deletion')
 })

--- a/test/integration/share-listing-batch.test.js
+++ b/test/integration/share-listing-batch.test.js
@@ -1,0 +1,289 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import os from 'bare-os'
+import path from 'bare-path'
+import { listOverlayShareFiles } from '../../src/shared/shares/share-listing.js'
+import { claimVerdict } from '../../src/shared/transfer/download-claim.js'
+import { pathFromMount } from '../../src/shared/transfer/path-guard.js'
+import { consumerRowStatusFor, unhashedStatusFor } from '../../src/shared/transfer/transfer-status.js'
+import { transferIdFor } from '../../src/shared/transfer/transfer-id.js'
+
+const SPACE = 'sp1'
+const SHARE = { id: 'sh1', name: 'Docs', owner: 'peer' }
+
+// The listing takes its data-layer calls injected, so read COUNTS are assertable without
+// instrumenting a bee: production passes nothing, a test passes these.
+function countingDeps({ claims = new Map(), verified = new Map(), downloaded = () => false } = {}) {
+  const calls = { claimScans: 0, verifiedScans: 0, verdicts: 0, prunes: [] }
+  return {
+    calls,
+    getLocalPublicKeyHex: () => 'me',
+    isOwnerOnline: () => true,
+    getOwnedMount: async () => null,
+    getForeignMount: async () => null,
+    listPendingForSpace: async () => [],
+    foreignFetchActive: () => false,
+    overlayHasTransfer: () => false,
+    claimedPathFor: (drivePath, rec) => rec?.localPath || '/downloads/' + drivePath.split('/').pop(),
+    listDownloadClaimsForShare: async () => { calls.claimScans++; return claims },
+    listVerifiedForShare: async () => { calls.verifiedScans++; return verified },
+    verdictForClaim: (spaceId, drivePath, rec) => {
+      calls.verdicts++
+      return { downloaded: downloaded(drivePath, rec), prune: false, reason: null }
+    },
+    pruneDownloadClaims: async (spaceId, drivePaths) => { calls.prunes.push(...drivePaths); return drivePaths.length },
+  }
+}
+
+const rows = (n) => Array.from({ length: n }, (_, i) => ({ relPath: `f${i}.txt`, size: 10, contentHash: 'h' + i, mtime: 0 }))
+const backendFor = (entries) => ({
+  listOwn: async () => ({ entries, total: entries.length, totalBytes: 0, complete: true }),
+  listPeerWithMeta: async () => ({ entries, total: entries.length, totalBytes: 0, complete: true }),
+})
+
+test('reads do not scale with rows: two range scans regardless of listing size', async (t) => {
+  for (const n of [1, 200, 2000]) {
+    const deps = countingDeps()
+    const res = await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(n)), deps)
+    t.is(res.entries.length, n, `${n} rows rendered`)
+    t.is(deps.calls.claimScans, 1, `${n} rows: exactly ONE claim scan`)
+    t.is(deps.calls.verifiedScans, 1, `${n} rows: exactly ONE verified scan`)
+  }
+})
+
+test('a mounted mirror reads only the verified namespace', async (t) => {
+  const deps = countingDeps()
+  deps.getForeignMount = async () => ({ enabled: true, mountPath: '/mnt/Docs' })
+  await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(50)), deps)
+  t.is(deps.calls.verifiedScans, 1)
+  t.is(deps.calls.claimScans, 0, 'a mirror row never consults a download claim, so the scan is not issued')
+})
+
+test('an owner listing reads neither namespace', async (t) => {
+  const deps = countingDeps()
+  deps.getLocalPublicKeyHex = () => SHARE.owner
+  deps.getOwnedMount = async () => ({ mountPath: '/src/Docs' })
+  const res = await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(50)), deps)
+  t.is(deps.calls.claimScans + deps.calls.verifiedScans, 0)
+  t.is(res.entries[0].status, 'synced')
+  t.is(res.entries[0].localPath, pathFromMount('/src/Docs', 'f0.txt'))
+})
+
+test('the scans are asked to retain only the rows this listing renders', async (t) => {
+  const deps = countingDeps()
+  const seen = {}
+  deps.listVerifiedForShare = async (spaceId, shareId, opts) => { seen.verified = opts.keep; return new Map() }
+  deps.listDownloadClaimsForShare = async (spaceId, shareName, opts) => { seen.claims = opts.keep; return new Map() }
+  await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(3)), deps)
+  t.alike([...seen.verified].sort(), ['f0.txt', 'f1.txt', 'f2.txt'], 'verified records are kept by relPath')
+  t.alike([...seen.claims].sort(), ['/Docs/f0.txt', '/Docs/f1.txt', '/Docs/f2.txt'], 'claims are kept by drive path')
+})
+
+test('stale claims are collected during the pass and pruned ONCE after it', async (t) => {
+  const deps = countingDeps()
+  deps.verdictForClaim = (spaceId, drivePath) => ({
+    downloaded: false, prune: drivePath.endsWith('f1.txt'), reason: 'local-file-gone',
+  })
+  const batches = []
+  const inner = deps.pruneDownloadClaims
+  deps.pruneDownloadClaims = async (spaceId, drivePaths) => { batches.push(drivePaths.length); return inner(spaceId, drivePaths) }
+  await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(10)), deps)
+  t.alike(batches, [1], 'exactly one prune call, carrying the one stale key — not one call per row')
+  t.alike(deps.calls.prunes, ['/Docs/f1.txt'])
+})
+
+test('a listing with nothing stale issues no prune at all', async (t) => {
+  const deps = countingDeps()
+  let called = 0
+  deps.pruneDownloadClaims = async () => { called++; return 0 }
+  await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(10)), deps)
+  t.is(called, 0)
+})
+
+test('a prune failure never fails the listing', async (t) => {
+  const deps = countingDeps()
+  deps.verdictForClaim = () => ({ downloaded: false, prune: true, reason: 'local-file-gone' })
+  deps.pruneDownloadClaims = async () => { throw new Error('bee closed') }
+  const res = await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(3)), deps)
+  t.is(res.entries.length, 3, 'the rows are returned even though the cleanup threw')
+})
+
+test('an unsafe relPath skips its row without aborting the listing', async (t) => {
+  const deps = countingDeps()
+  deps.getForeignMount = async () => ({ enabled: true, mountPath: '/mnt/Docs' })
+  const entries = [
+    { relPath: 'ok.txt', size: 1, contentHash: 'h', mtime: 0 },
+    { relPath: '../escape.txt', size: 1, contentHash: 'h', mtime: 0 },
+  ]
+  const res = await listOverlayShareFiles(SPACE, SHARE, backendFor(entries), deps)
+  t.is(res.entries.length, 1)
+  t.is(res.entries[0].relPath, 'ok.txt')
+  t.is(res.total, 2, 'the count still reports what the catalog holds')
+})
+
+// ---------------------------------------------------------------------------
+// Row parity across the whole decision space.
+//
+// `baselineRow` below is the pre-batching row rule transcribed verbatim from the point-read
+// implementation: an await per claim read, a second read for the verified marker, a third for the
+// landed path, and the claim pruned inline. It is an INDEPENDENT implementation of the same rule,
+// so agreement across the matrix is what makes "no behaviour change" a property the suite holds
+// rather than a claim the change asserts.
+// ---------------------------------------------------------------------------
+
+const CLAIMS = {
+  none: null,
+  current: { rec: { localPath: '/dl/f.txt', hash: 'h1' }, exists: true, dirExists: true, pinned: null, insidePinned: true },
+  hashless: { rec: { localPath: '/dl/f.txt' }, exists: true, dirExists: true, pinned: null, insidePinned: true },
+  'stale-hash': { rec: { localPath: '/dl/f.txt', hash: 'hOLD' }, exists: true, dirExists: true, pinned: null, insidePinned: true },
+  gone: { rec: { localPath: '/dl/f.txt', hash: 'h1' }, exists: false, dirExists: true, pinned: null, insidePinned: true },
+  detached: { rec: { localPath: '/vol/f.txt', hash: 'h1' }, exists: false, dirExists: false, pinned: null, insidePinned: true },
+  outside: { rec: { localPath: '/other/f.txt', hash: 'h1' }, exists: true, dirExists: true, pinned: '/dl', insidePinned: false },
+}
+const VERIFIED = { match: 'h1', mismatch: 'hZ', absent: null }
+const PENDING = { none: undefined, partial: { bytesTransferred: 5 }, error: { errorCode: 'EBAD', bytesTransferred: 0 } }
+
+const entryOf = (w) => ({ relPath: 'f.txt', size: 10, contentHash: w.hashed ? 'h1' : null, mtime: 7 })
+const claimedPathFor = (drivePath, rec) => rec?.localPath || '/downloads/' + path.basename(drivePath)
+
+function baselineRow(w, mountPath) {
+  const entry = entryOf(w)
+  const out = { pruned: false }
+  if (w.mirrored) {
+    const abs = pathFromMount(mountPath, entry.relPath)
+    if (statSizeOrNull(abs) === entry.size) {
+      const verified = !!entry.contentHash && VERIFIED[w.verified] === entry.contentHash
+      return { ...out, row: { status: 'synced', localPath: abs, verified } }
+    }
+    if (w.fetchActive) return { ...out, row: { status: 'downloading', localPath: null, pendingBytes: 0 } }
+    if (!entry.contentHash) return { ...out, row: { status: unhashedStatusFor(w.ownerOnline), localPath: null } }
+    return { ...out, row: { status: w.ownerOnline ? 'remote' : 'unavailable', localPath: null } }
+  }
+  const drivePath = '/' + SHARE.name + '/' + entry.relPath
+  const world = CLAIMS[w.claim]
+  let downloaded = false
+  if (world) {
+    if (!world.exists) out.pruned = world.dirExists
+    else if (world.rec.hash && entry.contentHash && world.rec.hash !== entry.contentHash) out.pruned = true
+    else if (world.pinned && !world.insidePinned) downloaded = false
+    else downloaded = true
+  }
+  if (downloaded) {
+    const verified = entry.contentHash ? VERIFIED[w.verified] === entry.contentHash : false
+    return { ...out, row: { status: 'downloaded', localPath: claimedPathFor(drivePath, world.rec), verified } }
+  }
+  const row = consumerRowStatusFor({
+    hashed: Boolean(entry.contentHash),
+    isActive: w.active,
+    pendingRow: PENDING[w.pending],
+    ownerOnline: w.ownerOnline,
+  })
+  return { ...out, row: { ...row, localPath: null } }
+}
+
+function statSizeOrNull(absPath) {
+  try { return fs.statSync(absPath).size } catch { return null }
+}
+
+// The shape listOverlayShareFiles pushes, with absent optional fields normalised so the two sides
+// compare on value rather than on which of undefined/null the branch happened to produce.
+function shaped(w, row) {
+  const entry = entryOf(w)
+  return {
+    relPath: entry.relPath,
+    size: entry.size,
+    hash: entry.contentHash || '',
+    mtime: entry.mtime,
+    status: row.status,
+    localPath: row.localPath ?? null,
+    verified: row.verified || false,
+    pendingBytes: row.pendingBytes ?? null,
+    errorCode: row.errorCode ?? null,
+    transferId: transferIdFor(SPACE, SHARE.id, entry.relPath),
+  }
+}
+
+function worldDeps(w, mountPath) {
+  const world = CLAIMS[w.claim]
+  const drivePath = '/' + SHARE.name + '/f.txt'
+  const pruned = []
+  return {
+    pruned,
+    getLocalPublicKeyHex: () => 'me',
+    isOwnerOnline: () => w.ownerOnline,
+    getOwnedMount: async () => null,
+    getForeignMount: async () => (w.mirrored ? { enabled: true, mountPath } : null),
+    listPendingForSpace: async () => (PENDING[w.pending] ? [{ ...PENDING[w.pending], filePath: drivePath }] : []),
+    foreignFetchActive: () => w.fetchActive,
+    overlayHasTransfer: () => w.active,
+    claimedPathFor,
+    listDownloadClaimsForShare: async () => (world ? new Map([[drivePath, world.rec]]) : new Map()),
+    listVerifiedForShare: async () => (VERIFIED[w.verified] ? new Map([['f.txt', VERIFIED[w.verified]]]) : new Map()),
+    verdictForClaim: (spaceId, filePath, rec, currentHash) => (rec
+      ? claimVerdict({ rec, currentHash, exists: world.exists, dirExists: world.dirExists, pinned: world.pinned, insidePinned: world.insidePinned })
+      : claimVerdict({ rec: null })),
+    pruneDownloadClaims: async (spaceId, drivePaths) => { pruned.push(...drivePaths); return drivePaths.length },
+  }
+}
+
+function matrix() {
+  const cells = []
+  for (const mirrored of [true, false]) {
+    for (const sizeMatch of mirrored ? [true, false] : [false]) {
+      for (const fetchActive of mirrored ? [true, false] : [false]) {
+        for (const claim of mirrored ? ['none'] : Object.keys(CLAIMS)) {
+          for (const verified of Object.keys(VERIFIED)) {
+            for (const hashed of [true, false]) {
+              for (const ownerOnline of [true, false]) {
+                for (const pending of mirrored ? ['none'] : Object.keys(PENDING)) {
+                  for (const active of mirrored ? [false] : [true, false]) {
+                    cells.push({ mirrored, sizeMatch, fetchActive, claim, verified, hashed, ownerOnline, pending, active })
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  return cells
+}
+
+const describe = (w) => Object.entries(w).map(([k, v]) => k + '=' + v).join(' ')
+
+test('every row of the decision space matches the pre-batching rule', async (t) => {
+  const root = path.join(os.tmpdir(), 'mirall-listing-parity-' + Date.now().toString(36))
+  const present = path.join(root, 'present')
+  const empty = path.join(root, 'empty')
+  fs.mkdirSync(present, { recursive: true })
+  fs.mkdirSync(empty, { recursive: true })
+  fs.writeFileSync(path.join(present, 'f.txt'), '0123456789')
+  t.teardown(() => { try { fs.rmSync(root, { recursive: true, force: true }) } catch {} })
+
+  const cells = matrix()
+  t.ok(cells.length > 500, `${cells.length} combinations covered`)
+  let mismatches = 0
+  let prunesChecked = 0
+  for (const w of cells) {
+    const mountPath = w.sizeMatch ? present : empty
+    const expected = baselineRow(w, mountPath)
+    const deps = worldDeps(w, mountPath)
+    const res = await listOverlayShareFiles(SPACE, SHARE, backendFor([entryOf(w)]), deps)
+    const gotRow = res.entries[0]
+    const wantRow = shaped(w, expected.row)
+    const got = { ...gotRow, localPath: gotRow.localPath ?? null, pendingBytes: gotRow.pendingBytes ?? null, errorCode: gotRow.errorCode ?? null }
+    if (JSON.stringify(got) !== JSON.stringify(wantRow)) {
+      mismatches++
+      t.alike(got, wantRow, describe(w))
+    }
+    const wantPruned = expected.pruned ? ['/' + SHARE.name + '/f.txt'] : []
+    if (JSON.stringify(deps.pruned) !== JSON.stringify(wantPruned)) {
+      mismatches++
+      t.alike(deps.pruned, wantPruned, 'prune: ' + describe(w))
+    }
+    if (expected.pruned) prunesChecked++
+  }
+  t.is(mismatches, 0, 'every combination renders the same row and prunes the same claims')
+  t.ok(prunesChecked > 0, 'the matrix actually exercises the pruning branches')
+})

--- a/test/unit/download-claim.test.js
+++ b/test/unit/download-claim.test.js
@@ -1,0 +1,51 @@
+import test from 'brittle'
+import { claimVerdict } from '../../src/shared/transfer/download-claim.js'
+
+const REC = { localPath: '/dl/a.txt', hash: 'h1', downloadedAt: 1 }
+
+test('claimVerdict resolves every branch of the on-device decision', (t) => {
+  t.alike(claimVerdict({ rec: null }), { downloaded: false, prune: false, reason: 'no-claim' })
+  t.alike(
+    claimVerdict({ rec: REC, exists: true, dirExists: true, currentHash: 'h1' }),
+    { downloaded: true, prune: false, reason: null },
+    'present and current',
+  )
+  t.is(
+    claimVerdict({ rec: REC, exists: true, dirExists: true, currentHash: null }).downloaded, true,
+    'no upstream hash to compare against does not invalidate a claim',
+  )
+  t.is(
+    claimVerdict({ rec: { localPath: '/dl/a.txt' }, exists: true, dirExists: true, currentHash: 'h9' }).downloaded, true,
+    'a hashless claim is not pruned by an upstream hash — the comparison needs a hash on BOTH sides',
+  )
+})
+
+// The ordering is the whole reason this decision is a function of its own: a rewrite that checked
+// the pinned folder first would destroy the claim of a file that is merely in the wrong place, and
+// re-pointing the space at the old folder would then no longer restore it.
+test('REGRESSION (FIX-CLAIM-ORDER): a detached volume keeps the claim, a deletion prunes it', (t) => {
+  t.alike(
+    claimVerdict({ rec: REC, exists: false, dirExists: false }),
+    { downloaded: false, prune: false, reason: 'volume-unavailable' },
+    'file gone AND folder gone = ejected drive: not downloaded, but the claim SURVIVES',
+  )
+  t.alike(
+    claimVerdict({ rec: REC, exists: false, dirExists: true }),
+    { downloaded: false, prune: true, reason: 'local-file-gone' },
+    'file gone, folder present = the user deleted it: prune',
+  )
+  t.alike(
+    claimVerdict({ rec: REC, exists: true, dirExists: true, currentHash: 'h2' }),
+    { downloaded: false, prune: true, reason: 'content-changed-upstream' },
+    'the owner replaced the file: prune',
+  )
+  t.alike(
+    claimVerdict({ rec: REC, exists: true, dirExists: true, currentHash: 'h1', pinned: '/other', insidePinned: false }),
+    { downloaded: false, prune: false, reason: 'outside-space-folder' },
+    'outside the pinned folder is NON-destructive: reports not-downloaded, keeps the record',
+  )
+  t.is(
+    claimVerdict({ rec: REC, exists: false, dirExists: true, pinned: '/other', insidePinned: false }).prune, true,
+    'prune wins over scope — a deleted file is pruned even when it was out of scope',
+  )
+})


### PR DESCRIPTION
## What & why

A consumer folder listing read the downloads bee up to **three times per row** — the claim, the
verified marker, then the same claim key a third time for the landed path. At the 5000-row cap that
is 15000 sequential point reads, each an `await`, so the row loop yielded the worker's event loop
tens of thousands of times while transfers and every other IPC request queued behind it.

Two range scans over the claim and verified namespaces now answer every row. The row builder is
synchronous, so the loop no longer yields at all.

Measured against a real Hyperbee, 5000 fully-downloaded rows: **~343ms → ~35ms** (~22ms of that the
two scans, the rest the per-row `existsSync` that stays). Batching the stats is a further win and is
deliberately out of scope — it changes the disk-truth semantics the claim check rests on.

Two commits: the pure move first (no behaviour change, no test changes), then the batching.

### Behaviour changes

1. **One consistent snapshot per listing.** Every row sees claim/verified state as of the two scans,
   where each row previously saw its own moment. A file that finishes downloading mid-assembly now
   appears on the next refresh — which is level-triggered and already fires.
2. **Stale claims are pruned in one batch after the rows, best-effort.** Same keys, same rule; a
   prune failure is swallowed rather than failing a listing whose rows are already built.
3. `worker/main.js` loses its **duplicate `pathFromMount`** — both call sites now use the canonical
   guard in `transfer/path-guard.js`.

## Coverage

- **Unit** — `download-claim.js` is pure, so the prune-before-scope ordering is asserted directly
  instead of through a bee and a real disk.
- **Integration** — read counts through injected doubles (two scans regardless of row count; a
  mirror reads only the verified namespace; an owner listing reads neither), prune batching, prune
  failure isolation, and the new bulk/prune primitives through a real bee.
- **Row parity** — a 552-cell matrix over
  `(mirrored, sizeMatch, fetchActive, claim, verified, hashed, ownerOnline, pending, active)`
  asserted against an independent transcription of the pre-batching rule, so "no behaviour change"
  is a property the suite holds. Verified load-bearing: mutating the prune rule fails it.
- **Frontend** — no scenario added; `src/renderer/**` is untouched and the response shape is
  byte-identical.

## Ran locally

`test:fe` s4 s5 s6 s10 s36 s41 — 6/6 (transfer/downloaded, owned folder, mirror, file actions,
browse-download-subfolder, owner-offline) as a regression guard on the row statuses.

a11y: n/a — no UI surface changed, no new controls.