### PR TITLE
[fix] Stop counting deletions as files being added

### DIFF
--- a/src/renderer/hooks/useIndexProgress.ts
+++ b/src/renderer/hooks/useIndexProgress.ts
@@ -15,17 +15,27 @@ interface IndexProgressEvent extends IndexStatus {
 
 export function useIndexProgress(spaceId: string, shareId: string): IndexStatus | null {
   const [status, setStatus] = useState<IndexStatus | null>(null)
+  // Cleared DURING RENDER, not in the effect: FolderView is reused rather than keyed per share, so
+  // an effect-time reset runs after the render that already carries the new share — one frame of
+  // the previous folder's count under this folder's header. The same reason useShareFiles resets
+  // its fold here. Empty ids take this path too, so leaving an owned folder drops its status
+  // instead of latching it behind the caller's render guard.
+  const [watched, setWatched] = useState(spaceId + '|' + shareId)
+  const current = spaceId + '|' + shareId
+  if (watched !== current) {
+    setWatched(current)
+    setStatus(null)
+  }
 
   useEffect(() => {
     if (!spaceId || !shareId) return
     let alive = true
-    setStatus(null)
     request('owned-folder:index-status', { spaceId, shareId })
       .then((s) => { if (alive) setStatus(s as IndexStatus) })
       .catch(() => {})
     const unsub = subscribe<IndexProgressEvent>('event:owned-folder-index-progress', (msg) => {
       if (msg.spaceId !== spaceId || msg.shareId !== shareId) return
-      setStatus({ queued: msg.queued, running: msg.running, done: msg.done, failed: msg.failed, totalOnDisk: msg.totalOnDisk, bytesQueued: msg.bytesQueued })
+      setStatus({ adding: msg.adding, queued: msg.queued, running: msg.running, done: msg.done, failed: msg.failed, totalOnDisk: msg.totalOnDisk, bytesQueued: msg.bytesQueued })
     })
     return () => { alive = false; unsub() }
   }, [spaceId, shareId])

--- a/src/renderer/indexSummary.d.ts
+++ b/src/renderer/indexSummary.d.ts
@@ -1,4 +1,6 @@
 export interface IndexStatus {
+  /** Publish work only — the queue also carries retires, which are not additions. */
+  adding?: number
   queued?: number
   running?: number
   done?: number
@@ -10,8 +12,6 @@ export interface IndexStatus {
 export interface IndexSummary {
   active: boolean
   files: number
-  running: number
-  queued: number
   bytesQueued: number
 }
 

--- a/src/renderer/indexSummary.js
+++ b/src/renderer/indexSummary.js
@@ -6,22 +6,19 @@
 // disagree: a queued file has no catalog entry yet, so it has no row to count. That gap is the whole
 // reason this notice exists, so the numbers must never be presented as the same measurement.
 //
-// `bytesQueued` covers the files still WAITING (publish-scheduler's bytesForShare drops an item from
-// the queue when it starts), so it is reported as what is left to read, never as a total.
+// `adding` and `bytesQueued` are PUBLISH work only. The queue carries retires too — a delete is
+// enqueued with the departing file's size — and counting those made removing a folder read as
+// "Adding 300 files to this folder", the same class of mislabelling the indexing pills just fixed.
 
 const count = (n) => (Number.isFinite(n) && n > 0 ? n : 0)
 
 export function deriveIndexSummary (status) {
-  const running = count(status?.running)
-  const queued = count(status?.queued)
-  const files = running + queued
+  const files = count(status?.adding)
   return {
     active: files > 0,
     files,
-    running,
-    queued,
-    // Only shown when there is something still waiting; the running file's own bytes ride the
-    // per-row progress bar, so adding them here would double-count what the rows already show.
-    bytesQueued: queued > 0 ? count(status?.bytesQueued) : 0,
+    // Already publish-only and already dropped when an item starts, so this is what is still
+    // WAITING to be read; the running file's own bytes are on its row's bar.
+    bytesQueued: files > 0 ? count(status?.bytesQueued) : 0,
   }
 }

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -190,6 +190,7 @@
     "addingCount_other": "{{count}} werden geteilt",
     "indexingSummary_one": "{{count}} Datei wird diesem Ordner hinzugefügt",
     "indexingSummary_other": "{{count}} Dateien werden diesem Ordner hinzugefügt",
+    "indexingAnnounce": "Dateien werden diesem Ordner hinzugefügt",
     "indexingQueuedSize": "{{size}} zu lesen",
     "subfolderCount_one": "enthält {{count}} Unterordner",
     "subfolderCount_other": "enthält {{count}} Unterordner",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -214,6 +214,7 @@
     "addingCount_other": "{{count}} adding",
     "indexingSummary_one": "Adding {{count}} file to this folder",
     "indexingSummary_other": "Adding {{count}} files to this folder",
+    "indexingAnnounce": "Adding files to this folder",
     "indexingQueuedSize": "{{size}} to read",
     "subfolderCount_one": "contains {{count}} subfolder",
     "subfolderCount_other": "contains {{count}} subfolders",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -190,6 +190,7 @@
     "addingCount_other": "{{count}} añadiendo",
     "indexingSummary_one": "Añadiendo {{count}} archivo a esta carpeta",
     "indexingSummary_other": "Añadiendo {{count}} archivos a esta carpeta",
+    "indexingAnnounce": "Añadiendo archivos a esta carpeta",
     "indexingQueuedSize": "{{size}} por leer",
     "subfolderCount_one": "contiene {{count}} subcarpeta",
     "subfolderCount_other": "contiene {{count}} subcarpetas",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -190,6 +190,7 @@
     "addingCount_other": "{{count}} en cours d’ajout",
     "indexingSummary_one": "Ajout de {{count}} fichier à ce dossier",
     "indexingSummary_other": "Ajout de {{count}} fichiers à ce dossier",
+    "indexingAnnounce": "Ajout de fichiers à ce dossier",
     "indexingQueuedSize": "{{size}} à lire",
     "subfolderCount_one": "contient {{count}} sous-dossier",
     "subfolderCount_other": "contient {{count}} sous-dossiers",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -190,6 +190,7 @@
     "addingCount_other": "{{count}} in aggiunta",
     "indexingSummary_one": "Aggiunta di {{count}} file a questa cartella",
     "indexingSummary_other": "Aggiunta di {{count}} file a questa cartella",
+    "indexingAnnounce": "Aggiunta di file a questa cartella",
     "indexingQueuedSize": "{{size}} da leggere",
     "subfolderCount_one": "contiene {{count}} sottocartella",
     "subfolderCount_other": "contiene {{count}} sottocartelle",

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -286,21 +286,22 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
                 reason as the over-limit region below. Counts the SCAN (scheduler queue depth), not
                 the rows on screen: FolderTree's "N adding" badge counts rows, and a file that is
                 only queued has no row yet, which is exactly the gap this closes. */}
+            {isYou && indexing.active && (
+              <div className="flex items-center gap-2 mb-4 px-4 py-2 rounded-lg bg-info/20 text-on-surface text-sm">
+                <Icon name="update" size={16} className="text-on-info shrink-0 animate-pulse" />
+                <span>
+                  {t('folder.indexingSummary', { count: indexing.files })}
+                  {indexing.bytesQueued > 0 ? ' · ' + t('folder.indexingQueuedSize', { size: formatSize(indexing.bytesQueued) }) : ''}
+                </span>
+              </div>
+            )}
+            {/* The counts above change about twice a second for the length of the scan, so they are
+                deliberately NOT in a live region — ProgressBar makes the same call for the same
+                reason. This one carries a count-free sentence, so it is announced once when the
+                scan starts and once when it ends, while the numbers stay browsable as text. */}
             {isYou && (
-              <div
-                role="status"
-                aria-live="polite"
-                className={indexing.active ? 'flex items-center gap-2 mb-4 px-4 py-2 rounded-lg bg-info/20 text-on-surface text-sm' : 'sr-only'}
-              >
-                {indexing.active ? (
-                  <>
-                    <Icon name="update" size={16} className="text-on-info shrink-0 animate-pulse" />
-                    <span>
-                      {t('folder.indexingSummary', { count: indexing.files })}
-                      {indexing.bytesQueued > 0 ? ' · ' + t('folder.indexingQueuedSize', { size: formatSize(indexing.bytesQueued) }) : ''}
-                    </span>
-                  </>
-                ) : null}
+              <div role="status" aria-live="polite" className="sr-only">
+                {indexing.active ? t('folder.indexingAnnounce') : ''}
               </div>
             )}
             {/* Always-present live region so the "first N of M" notice is ANNOUNCED when it

--- a/src/shared/folders/publish-queue.js
+++ b/src/shared/folders/publish-queue.js
@@ -42,6 +42,11 @@ function createHeap(cmp) {
   }
 }
 
+// The per-share bytes and `adds` counters are PUBLISH work only: a retire carries the departing
+// file's size purely as a sort key and reads nothing, so summing those in made deleting a folder
+// report the same shape as adding one.
+const isAdd = (item) => item.op !== OP.RETIRE
+
 const sameFacts = (a, b) => a.op === b.op && a.size === b.size && a.mtime === b.mtime && a.deep === b.deep
 
 // `settled` and `exited` are read lazily off the run's shared deferreds (see work-item.js).
@@ -61,13 +66,13 @@ export function createPublishQueue({ order = 'fifo' } = {}) {
 
   const bucket = (shareId) => {
     let b = perShare.get(shareId)
-    if (!b) perShare.set(shareId, (b = { queued: 0, running: 0, queuedBytes: 0 }))
+    if (!b) perShare.set(shareId, (b = { queued: 0, running: 0, queuedBytes: 0, adds: 0, runningAdds: 0 }))
     return b
   }
   const live = (entry) => byKey.get(entry.item.key) === entry.item && entry.item.state === STATE.QUEUED && entry.gen === entry.item.gen
   const push = (item) => heap.push({ item, gen: item.gen, priority: item.priority, op: item.op, size: item.size, seq: item.seq })
-  const admit = (item) => { queued += 1; queuedBytes += item.size; const b = bucket(item.shareId); b.queued += 1; b.queuedBytes += item.size }
-  const release = (item) => { queued -= 1; queuedBytes -= item.size; const b = bucket(item.shareId); b.queued -= 1; b.queuedBytes -= item.size }
+  const admit = (item) => { queued += 1; queuedBytes += item.size; const b = bucket(item.shareId); b.queued += 1; if (isAdd(item)) { b.adds += 1; b.queuedBytes += item.size } }
+  const release = (item) => { queued -= 1; queuedBytes -= item.size; const b = bucket(item.shareId); b.queued -= 1; if (isAdd(item)) { b.adds -= 1; b.queuedBytes -= item.size } }
 
   function enqueue(spec) {
     const key = itemKey(spec.shareId, spec.relPath)
@@ -119,7 +124,7 @@ export function createPublishQueue({ order = 'fifo' } = {}) {
       item.state = STATE.RUNNING
       release(item)
       running += 1
-      bucket(item.shareId).running += 1
+      const b = bucket(item.shareId); b.running += 1; if (isAdd(item)) b.runningAdds += 1
       return item
     }
   }
@@ -129,7 +134,9 @@ export function createPublishQueue({ order = 'fifo' } = {}) {
   function settle(item, settlement) {
     if (item.state !== STATE.RUNNING) return item.state
     running -= 1
-    bucket(item.shareId).running -= 1
+    // isAdd is read before the requeue arm below reassigns item.op, or a publish superseded by a
+    // retire (a file deleted mid-hash) would decrement the wrong lane.
+    const b = bucket(item.shareId); b.running -= 1; if (isAdd(item)) b.runningAdds -= 1
     const run = item.run
     const exit = item.exit
     if (item.dirty) {
@@ -207,7 +214,9 @@ export function createPublishQueue({ order = 'fifo' } = {}) {
       const b = perShare.get(shareId)
       return b ? b.queued + b.running : 0
     },
+    // Publish-only, both of them: what the share still has to READ, and how many files that is.
     bytesForShare(shareId) { return perShare.get(shareId)?.queuedBytes ?? 0 },
+    addingForShare(shareId) { const b = perShare.get(shareId); return b ? b.adds + b.runningAdds : 0 },
     stats() { return { queued, running, queuedBytes } },
   }
 }

--- a/src/shared/folders/publish-scheduler.js
+++ b/src/shared/folders/publish-scheduler.js
@@ -124,6 +124,8 @@ function describeShare(queues, running, tallies, spaceId, shareId, order, concur
     failed: t?.failed ?? 0,
     totalOnDisk: t?.totalOnDisk ?? null,
     bytesQueued: q?.bytesForShare(shareId) ?? 0,
+    // Publish work only — `queued`/`running` above count retires too, and a delete is not an add.
+    adding: q?.addingForShare(shareId) ?? 0,
     order,
     concurrency,
   }
@@ -274,6 +276,10 @@ export function createPublishScheduler({
       tallies.cancel(key)
       releaseWaiters(key)
       if (!q || isIdle(q)) onSpaceIdle?.(spaceId)
+      // Emptying the queue is a shape change like any other, and the one nothing else covers: with
+      // no item of this share holding a slot there is no settle to follow, so without this the last
+      // report anyone saw is the pre-cancel depth.
+      onProgress?.(spaceId, shareId)
       return n
     },
     // One path's item, no pass semantics. `exited` resolves once its executor has returned (at

--- a/test/frontend/scenarios/s120-folder-index-summary.mjs
+++ b/test/frontend/scenarios/s120-folder-index-summary.mjs
@@ -55,7 +55,9 @@ export default async function s120 ({ runDir, bootstrap }) {
     await r.ok('the notice clears once the scan drains', async () => {
       await waitFor(async () => {
         const text = allText(await A.snap())
-        return /shared by you/i.test(text) && !/adding \d+ files to this folder/i.test(text)
+        // `files?` — the singular renders at exactly one file left, and a plural-only regex
+        // would call the notice gone while it is still on screen.
+        return /shared by you/i.test(text) && !/adding \d+ files? to this folder/i.test(text)
       }, 180000, 'the scan notice goes away when there is nothing left to add')
       await A.shot('s120-A-settled', runDir)
     })

--- a/test/unit/index-summary.test.js
+++ b/test/unit/index-summary.test.js
@@ -5,33 +5,37 @@ test('no status yet is not an active scan', (t) => {
   t.absent(deriveIndexSummary(null).active, 'null (before the first read) shows nothing')
   t.absent(deriveIndexSummary(undefined).active)
   t.absent(deriveIndexSummary({}).active, 'an empty status shows nothing')
-  t.absent(deriveIndexSummary({ queued: 0, running: 0, bytesQueued: 0 }).active, 'a drained scan shows nothing')
+  t.absent(deriveIndexSummary({ adding: 0, bytesQueued: 0 }).active, 'a drained scan shows nothing')
 })
 
-test('the file count is the work still outstanding — running plus queued', (t) => {
-  const s = deriveIndexSummary({ running: 2, queued: 40, done: 8, bytesQueued: 1024 })
+test('the file count is the publish work still outstanding', (t) => {
+  const s = deriveIndexSummary({ adding: 42, queued: 40, running: 2, done: 8, bytesQueued: 1024 })
   t.ok(s.active)
-  t.is(s.files, 42, 'both lanes count: a queued file is exactly the one with no row to show it')
-  t.is(s.running, 2)
-  t.is(s.queued, 40)
+  t.is(s.files, 42, 'running and queued both count: a queued file is the one with no row to show it')
   t.is(s.bytesQueued, 1024)
 })
 
-test('a running-only scan reports no queued bytes', (t) => {
-  // bytesForShare drops an item when it starts, so with nothing queued the number is 0 anyway —
-  // but it must not be shown even if the worker sent a stale one: the running file's bytes are
-  // already on its own row's bar, and repeating them here would double-count.
-  const s = deriveIndexSummary({ running: 1, queued: 0, bytesQueued: 999 })
-  t.ok(s.active, 'still an active scan')
-  t.is(s.files, 1)
-  t.is(s.bytesQueued, 0, 'nothing waiting, so nothing is reported as left to read')
+// REGRESSION (FIX-INDEX-RETIRE): the queue carries retires too, each enqueued with the departing
+// file's size. Counting them made deleting a folder read as "Adding 300 files to this folder ·
+// 2.0 GB to read" — the same mislabelling as calling indexing a download, in the other direction.
+test('REGRESSION (FIX-INDEX-RETIRE): a queue of deletions is not an addition', (t) => {
+  // What the worker reports while a bulk delete drains: work is pending, but none of it is a publish.
+  const s = deriveIndexSummary({ adding: 0, queued: 300, running: 2, bytesQueued: 0 })
+  t.absent(s.active, 'a delete-only pass announces no additions')
+  t.is(s.files, 0)
+  t.is(s.bytesQueued, 0, 'and nothing to read — a retire reads no bytes')
+})
+
+test('bytes are only reported alongside files still to add', (t) => {
+  const s = deriveIndexSummary({ adding: 0, bytesQueued: 999 })
+  t.absent(s.active)
+  t.is(s.bytesQueued, 0, 'a stale byte count cannot outlive the work it described')
 })
 
 test('wire numbers are clamped', (t) => {
   // The status crosses IPC; a malformed frame must not reach the view as NaN or a negative count.
-  const s = deriveIndexSummary({ running: NaN, queued: -3, bytesQueued: Infinity })
-  t.absent(s.active)
-  t.is(s.files, 0)
-  t.is(s.bytesQueued, 0)
-  t.is(deriveIndexSummary({ running: 1, queued: 2, bytesQueued: -5 }).bytesQueued, 0, 'a negative size is dropped')
+  t.is(deriveIndexSummary({ adding: NaN }).files, 0)
+  t.is(deriveIndexSummary({ adding: -3 }).files, 0)
+  t.is(deriveIndexSummary({ adding: 2, bytesQueued: Infinity }).bytesQueued, 0, 'a non-finite size is dropped')
+  t.is(deriveIndexSummary({ adding: 2, bytesQueued: -5 }).bytesQueued, 0, 'a negative size is dropped')
 })

--- a/test/unit/publish-scheduler.test.js
+++ b/test/unit/publish-scheduler.test.js
@@ -507,3 +507,55 @@ test('REGRESSION (FIX-INDEX-START): an item that STARTS is reported, not only on
   t.is(reports[reports.length - 1].running, 0, 'a drained lane reports nothing running')
   t.is(reports[reports.length - 1].queued, 0)
 })
+
+// REGRESSION (FIX-INDEX-RETIRE): the per-share counters had no notion of op, so a retire — enqueued
+// with the departing file's size as its sort key — was reported as work to add, with bytes to read.
+test('REGRESSION (FIX-INDEX-RETIRE): retires are not counted as additions', async (t) => {
+  const g = gate()
+  const s = createPublishScheduler({ execute: g.execute, concurrency: () => 1 })
+  s.beginShare('s1', 'sh1', 0)
+  s.enqueueMany([
+    { spaceId: 's1', shareId: 'sh1', relPath: 'gone-a.bin', op: OP.RETIRE, size: 1024 * 1024, priority: PRIORITY.BULK },
+    { spaceId: 's1', shareId: 'sh1', relPath: 'gone-b.bin', op: OP.RETIRE, size: 2048 * 1024, priority: PRIORITY.BULK },
+  ])
+  await sleep(0)
+
+  const deleting = s.statusFor('s1', 'sh1')
+  t.is(deleting.queued + deleting.running, 2, 'the lane still reports the work it holds')
+  t.is(deleting.adding, 0, 'but none of it is an addition')
+  t.is(deleting.bytesQueued, 0, 'and a retire reads no bytes')
+
+  s.enqueue({ spaceId: 's1', shareId: 'sh1', relPath: 'new.bin', op: OP.PUBLISH, size: 4096, priority: PRIORITY.BULK })
+  const mixed = s.statusFor('s1', 'sh1')
+  t.is(mixed.adding, 1, 'a publish alongside them counts exactly once')
+  t.is(mixed.bytesQueued, 4096, 'and contributes only its own bytes')
+  await g.releaseAll()
+})
+
+// REGRESSION (FIX-INDEX-CANCEL): cancelShare empties the queue, but with no item of that share
+// holding a slot there is no settle behind it — so the last report anyone saw was the pre-cancel
+// depth, and a view driven by it stayed latched on work that no longer exists.
+test('REGRESSION (FIX-INDEX-CANCEL): cancelling a share reports the emptied lane', async (t) => {
+  const g = gate()
+  const reports = []
+  const s = createPublishScheduler({
+    execute: g.execute,
+    concurrency: () => 1,
+    onProgress: (spaceId, shareId) => reports.push(s.statusFor(spaceId, shareId)),
+  })
+  // Another space holds the only slot, so nothing of sh1's ever runs — the case with no settle.
+  s.enqueue({ spaceId: 'other', shareId: 'sh0', relPath: 'hog.bin', op: OP.PUBLISH, size: 1, priority: PRIORITY.BULK })
+  await sleep(0)
+  s.enqueueMany([
+    { spaceId: 's1', shareId: 'sh1', relPath: 'a.bin', op: OP.PUBLISH, size: 10, priority: PRIORITY.BULK },
+    { spaceId: 's1', shareId: 'sh1', relPath: 'b.bin', op: OP.PUBLISH, size: 20, priority: PRIORITY.BULK },
+  ])
+  await sleep(0)
+  t.is(s.statusFor('s1', 'sh1').adding, 2, 'precondition: two files queued behind another space')
+
+  const before = reports.length
+  s.cancelShare('s1', 'sh1')
+  t.ok(reports.length > before, 'the cancel reported')
+  t.is(reports[reports.length - 1].adding, 0, 'and reported the lane as empty')
+  await g.releaseAll()
+})


### PR DESCRIPTION
Review follow-up to #139 — five findings, none of which made it into that PR before it merged.

## The one that matters

The publish lane's per-share counters had no notion of `op`. A retire is enqueued carrying the departing file's real size (`owned-folders.js` pushes `OP.RETIRE` with `size: entry.size`), so the new scan notice counted deletions as additions:

- delete one file → "Adding 1 file to this folder"
- delete a 2 GB subtree → "Adding 300 files to this folder · 2.0 GB to read"
- a rename (unlink + add) → double-counted

Same class of mislabelling #131 fixed for the indexing pills, in the opposite direction. `bytesForShare` and a new `addingForShare` are now publish-only, and `describeShare` reports `adding` alongside the existing all-op `queued`/`running`. `isAdd` is read before the requeue arm reassigns `item.op`, so a publish superseded by a retire mid-hash decrements the lane it was actually counted in.

## The other four

- **a11y — the live region announced the whole sentence twice a second** for the length of the scan. `ProgressBar.tsx` already ruled on exactly this ("rather than an aria-live region, which at the 250ms progress cadence would spam VoiceOver"). The counts moved out of the live region; it now carries a count-free sentence, announced once on start and once on finish, while the numbers stay browsable as ordinary text.
- **`cancelShare` was the one queue-shape change left unreported.** With no item of that share holding a slot there is no settle behind it, so the notice stayed latched at the pre-cancel depth. Reachable via `stopOwnedFolder`.
- **`useIndexProgress` reset in the effect, not in render**, so opening folder B while A was scanning painted one frame of A's count under B's header; the empty-args path never reset at all, latching a stale status behind the caller's render guard. Same render-time key reset `useShareFiles` uses.
- **`s120`'s "notice clears" assertion used a plural-only regex**, so at exactly one file left it would have gone green over a still-visible banner.

## Coverage

Two new `REGRESSION` tests in `publish-scheduler.test.js` (`FIX-INDEX-RETIRE`, `FIX-INDEX-CANCEL`) and a rewritten `index-summary.test.js` including the delete-only case.

## Ran locally

typecheck, lint (0 errors, back to the 18-warning baseline after the counters pushed `createPublishQueue` over the 150-line guardrail), comment-hygiene, test-timing, and the affected unit files. `test:bare` 859/859 + `test:node` 193/193 + `test:fe s120` 3/3 were run on identical content in the #139 worktree before this was split out.
