### PR TITLE
[perf] Skip the mirror walk while the owner's catalog head is unchanged

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -697,6 +697,8 @@ function getWorker(specifier) {
     // the runtime-config default). Lets the frontend suite exercise the truncation banner
     // with a handful of files; a bad value is caught by getListFilesCap's fail-safe.
     listFilesCap: process.env.MIRALL_LIST_FILES_CAP ? Number(process.env.MIRALL_LIST_FILES_CAP) : undefined,
+    // The mirror-walk skip's rollback lever: 1 restores the pre-skip cadence without a release.
+    foreignFullWalkEvery: process.env.MIRALL_FOREIGN_FULL_WALK_EVERY ? Number(process.env.MIRALL_FOREIGN_FULL_WALK_EVERY) : undefined,
     // Same idea for the add-folder admission gate, so the frontend suite can trip it with a
     // handful of files; a bad value is caught by getMaxFilesPerShare's fail-safe.
     maxFilesPerShare: process.env.MIRALL_MAX_FILES_PER_SHARE ? Number(process.env.MIRALL_MAX_FILES_PER_SHARE) : undefined,

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -140,6 +140,12 @@ const DEFAULTED = {
   // Foreign-mirror materialize poll cadence. Tests shrink it to assert orphan-mount teardown
   // (owner left → unmount) promptly; production uses the 30s default.
   foreignPollIntervalMs: 30_000,
+  // How many mirror ticks may skip the walk before one runs in full regardless. The owner's catalog
+  // version cannot see a LOCAL change (a user deleting a mirrored file) and a foreign mount has no
+  // filesystem watcher, so this backstop is what repairs it — within 5 min at the 30s poll.
+  // 1 disables the skip entirely: the rollback, settable in a shipped build via
+  // MIRALL_FOREIGN_FULL_WALK_EVERY, which the host forwards on the bootstrap frame.
+  foreignFullWalkEvery: 10,
   // Per-requester rate limit on the overlay serve gate (inbound content-requests),
   // keyed on the asker's authenticated profile key. More
   // generous than the handshake limiter — a legit consumer issues one request
@@ -418,5 +424,6 @@ export function getResourceCaps() {
     avatarMaxBytes: c.maxAvatarBytes,
     deriveDebounceMs: c.deriveDebounceMs,
     foreignPollIntervalMs: c.foreignPollIntervalMs,
+    foreignFullWalkEvery: c.foreignFullWalkEvery,
   }
 }

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -33,6 +33,7 @@ import { PREVIEW_DETAIL_MAX_FILES, includePerFile } from './preview-detail.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { mirrorVerdict } from './mirror-health.js'
+import { shouldWalk } from './mirror-walk.js'
 import { mapLimit } from '../core/concurrency.js'
 import { AbortError } from './walk-disk.js'
 
@@ -281,6 +282,7 @@ export async function applyChange(mount, change) {
 // the bulk stop can only WAIT for what it can see, hence the same in-flight map the poll tick uses.
 export async function initialMaterializeScan(mount) {
   const key = loopKey(mount.spaceId, mount.shareId)
+  forgetConverged(key)
   const p = runInitialMaterializeScan(mount).finally(() => {
     if (tickInFlight.get(key) !== p) return
     tickInFlight.delete(key)
@@ -461,6 +463,15 @@ const pausedMirrorHashes = new Map()
 // outlives pause/resume (a stopped pass has already written files it must keep owning) and is
 // dropped only on unmount, with the record.
 const syncedSets = new Map() // loopKey -> Set<ownerKey>
+// loopKey -> the owner-catalog version the last CONVERGED pass walked, and how many ticks have
+// skipped since. A converged mirror re-walks only when that version moves or the backstop is due.
+const convergedHeads = new Map()
+const skippedTicks = new Map()
+
+function forgetConverged (key) {
+  convergedHeads.delete(key)
+  skippedTicks.delete(key)
+}
 const syncDirty = new Set()  // loopKeys whose Set / renamedPaths differ from the persisted record
 
 function syncedSetFor (mount) {
@@ -728,6 +739,31 @@ async function initialMaterializeScanCatalog(mount, share) {
 async function materializeOnceCatalog(mount, share) {
   const key = loopKey(mount.spaceId, mount.shareId)
   const gen = mirrorGen(key)
+
+  // Read BEFORE the listing: an append landing mid-walk leaves the head past the version this pass
+  // records, so the next tick walks. A pass only ever converges against the snapshot it walked.
+  const version = await getContentBackend(share).catalogVersion?.(mount.spaceId, share) ?? null
+  const skipped = skippedTicks.get(key) || 0
+  const decision = shouldWalk({
+    // Only a non-null version is ever stored, so a miss and an unknown both read as null.
+    watermark: convergedHeads.get(key) ?? null,
+    version,
+    skipped,
+    fullWalkEvery: getResourceCaps().foreignFullWalkEvery,
+  })
+  if (!decision.walk) {
+    skippedTicks.set(key, skipped + 1)
+    // No settle: the pass that converged already wrote the terminal state, and by definition
+    // nothing has happened since.
+    return
+  }
+  if (skipped > 0) log.debug('mirror walking after', skipped, 'skipped tick(s):', decision.reason, mount.shareId)
+  // A walk invalidates the watermark up front. Only a pass that reaches the convergence test below
+  // may re-establish one, so a pass that throws midway — an unlink the OS refuses, a bee put that
+  // fails — cannot leave a stale watermark standing over a zeroed skip counter, which would retry
+  // the failed work at the backstop's cadence instead of the poll's.
+  forgetConverged(key)
+
   const synced = syncedSetFor(mount)
   const fresh = new Set()
   const { entries: raw, complete } = await getContentBackend(share).listPeerWithMeta(mount.spaceId, share)
@@ -768,6 +804,18 @@ async function materializeOnceCatalog(mount, share) {
   // Once per pass and only when something changed — the old code wrote the whole record on every
   // tick of an owner-online mirror, whether or not anything moved.
   await persistSyncState(mount, key, gen)
+  // Nothing left to do: every file present, the listing a full read, and no path still owned that the
+  // catalog no longer lists. Every entry in the listing was recorded into `synced` above, so the
+  // listing is a subset of the Set and equal sizes prove the two agree — an O(1) test for
+  // "no deletions pending".
+  //
+  // Deliberately NOT gated on `honorDeletions`: that gate says whether this pass was ALLOWED to act
+  // on deletions, not whether any exist. An offline owner cannot append, so it is exactly when
+  // skipping is safest — and if deletions really are outstanding the size check catches them and the
+  // mirror keeps walking. A cancelled pass proves nothing, and a version we could not read cannot
+  // authorise a later skip.
+  const converged = allPresent && complete && synced.size === onDrive.size
+  if (converged && version !== null && !mirrorStopped(key, gen)) convergedHeads.set(key, version)
   // Re-check the generation adjacent to the enqueue (no await between) so a pause/unmount that
   // landed during the deletion-reconcile await above can't be overwritten by this terminal write.
   if (!mirrorStopped(key, gen)) await settleMirrorSyncState(mount, allPresent)
@@ -847,6 +895,7 @@ export async function restartForeignLoop(spaceId, shareId) {
   tickInFlight.delete(key)
   tickDirty.delete(key)
   mirrorLiveness.delete(key)
+  forgetConverged(key)
   await startForeignLoop({ spaceId, shareId })
   runMaterializeTick(spaceId, shareId).catch((err) => log.debug('materialize tick after restart failed:', err.message))
 }
@@ -875,6 +924,7 @@ export function stopForeignLoop(spaceId, shareId, { discardPartial = false } = {
     pausedMirrorHashes.delete(key)
   }
   tickDirty.delete(key)
+  forgetConverged(key)
   const handle = activeLoops.get(key)
   if (handle) {
     clearInterval(handle.timer)
@@ -935,6 +985,7 @@ export async function unmountForeignFolder(spaceId, shareId) {
   syncedSets.delete(key)
   syncDirty.delete(key)
   mirrorLiveness.delete(key)
+  forgetConverged(key)
   await syncMirrorRecord(spaceId, shareId, () => tombstoneMirror(spaceId, shareId))
   emitStatus(spaceId, shareId, 'idle')
   ipcRef?.emit('event:share-files-updated', { spaceId, shareId })

--- a/src/shared/folders/mirror-walk.js
+++ b/src/shared/folders/mirror-walk.js
@@ -1,0 +1,15 @@
+// Whether a mirror tick must walk, kept pure so the rule is asserted directly rather than through a
+// live loop and a real catalog.
+//
+// The order is the safety argument: every branch that cannot prove nothing changed costs a walk.
+// A skip is only ever authorised by a known version that matches a watermark a converged pass set.
+export const DEFAULT_FULL_WALK_EVERY = 10
+
+export function shouldWalk({ watermark = null, version = null, skipped = 0, fullWalkEvery = DEFAULT_FULL_WALK_EVERY } = {}) {
+  if (watermark === null) return { walk: true, reason: 'no-watermark' }
+  if (version === null) return { walk: true, reason: 'version-unknown' }
+  if (version !== watermark) return { walk: true, reason: 'catalog-appended' }
+  if (!(fullWalkEvery > 1)) return { walk: true, reason: 'backstop-disabled' }
+  if (skipped + 1 >= fullWalkEvery) return { walk: true, reason: 'backstop' }
+  return { walk: false, reason: null }
+}

--- a/src/shared/shares/share-catalog.js
+++ b/src/shared/shares/share-catalog.js
@@ -331,6 +331,40 @@ export async function collectPeerShare(catalogKeyHex, shareId, { sck = null, lim
   }
 }
 
+// The version of a peer catalog we already hold, WITHOUT a network wait: `bee.version` is
+// Math.max(1, _checkout || core.length), and a connected reader's core.length follows the writer on
+// its own because hypercore defaults eagerUpgrade on — the same mechanism that makes the peer-catalog
+// 'append' hook fire. So this answers "has the owner appended since we last converged?" for the price
+// of a property read, where core.update({ wait: true }) would cost up to peerReadTimeoutMs per call
+// against an offline owner.
+//
+// null means UNKNOWN — no key, no SCK, or a core never opened. Callers must read null as "walk",
+// never as "unchanged": the fail-safe direction is more work, never less.
+export async function peerCatalogVersion(spaceId, rec, { space } = {}) {
+  try {
+    const { keyHex, sck, readable } = await resolvePeerCatalog(spaceId, rec, { space })
+    if (!readable) return null
+    const bee = openPeerCatalog(keyHex, sck)
+    if (!bee) return null
+    // Pinned across the await for the same reason collectPeerShare pins: inserting into the LRU can
+    // evict — and close — an unpinned entry, including this one, and the pending ready() would then
+    // reject underneath us.
+    peerCatalogs.acquire(keyHex)
+    try {
+      await bee.ready()
+      return bee.version
+    } finally {
+      peerCatalogs.release(keyHex)
+    }
+  } catch (err) {
+    // Never throws. A caller reads null as "walk", and the whole contract of this probe is that
+    // failing to answer costs work rather than correctness — a rejection escaping here would abort
+    // the mirror pass before it did anything, and the tick's callers only log at debug.
+    log.debug('peer catalog version unavailable:', err.message)
+    return null
+  }
+}
+
 export async function listPeerShareMeta(catalogKeyHex, shareId, { sck = null } = {}) {
   const { entries, complete } = await collectPeerShare(catalogKeyHex, shareId, { sck })
   return { entries, complete }

--- a/src/shared/transfer/backends/overlay/index.js
+++ b/src/shared/transfer/backends/overlay/index.js
@@ -13,6 +13,11 @@ export const overlayBackend = {
   publishDelete: A.overlayPublishDelete,
   listOwn: A.overlayListOwn,
   listPeerWithMeta: A.overlayListPeerWithMeta,
+  // OPTIONAL member. A backend without it makes its mirrors walk every tick, which is the behaviour
+  // before it existed. Optional deliberately: promoting a member of an injected contract to required
+  // breaks every hand-written double at once, and such a break surfaces as a TypeError that kills
+  // the test runner without printing an assertion — expensive to diagnose, trivial to avoid.
+  catalogVersion: A.overlayCatalogVersion,
   requestDownload: A.overlayRequestDownload,
   ensureRemote: A.overlayEnsureRemote,
   releaseRemote: A.overlayReleaseRemote,

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -27,6 +27,7 @@ import {
   watchPeerCatalog,
   setOwnCatalogAppendHook,
   resolvePeerCatalog,
+  peerCatalogVersion,
   catalogKeyField,
 } from '../../../shares/share-catalog.js'
 import { getOwnedMount } from '../../../folders/mount-store.js'
@@ -477,6 +478,12 @@ export async function overlayListPeerWithMeta(spaceId, share, limit = Infinity, 
   if (!readable) return { entries: [], complete: true, total: 0, totalBytes: 0 }
   ensurePeerCatalogWatch(spaceId, share, keyHex, sck)
   return await collectPeerShare(keyHex, share.id, { sck, limit, onEach })
+}
+
+// The mirror loop's cheap "has anything changed?" probe. Optional in the backend contract: a backend
+// that cannot answer simply has no member, and its mirrors walk every tick exactly as before.
+export async function overlayCatalogVersion(spaceId, share) {
+  return await peerCatalogVersion(spaceId, share)
 }
 
 // On an owner-catalog append, re-resolve every active overlay-folder transfer from THIS

--- a/test/flow/foreign-mirror-head-tracking.test.js
+++ b/test/flow/foreign-mirror-head-tracking.test.js
@@ -1,0 +1,75 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { mkTmpDir } from '../helpers/fixtures.js'
+
+// The safety premise of the mirror-walk skip, and the ONE property no single-peer test can reach.
+//
+// A converged mirror stops listing the owner's catalog and instead compares a locally-read
+// `bee.version` against the version its last converged pass walked. That is only sound if a REMOTE
+// owner's append advances that number on OUR reader with no core.update({ wait: true }) — i.e. if
+// hypercore's eagerUpgrade really does keep a connected reader's core.length current. Every
+// integration test stubs the probe with a hand-driven counter, so none of them can see this: if the
+// premise were false, they would all still pass while every real mirror silently froze.
+//
+// The backstop is disabled here (foreignFullWalkEvery far beyond any tick this test will run) so it
+// cannot mask a failure. With a working probe the new file lands in seconds; with a broken one it
+// would wait for tick 5000 and this test would time out — which is exactly the signal wanted.
+test('a remote owner append advances the mirror\'s local catalog version', { timeout: 120000 }, async (t) => {
+  const bootstrap = await localTestnet(t)
+  const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
+  const B = await launchPeer(t, {
+    bootstrap,
+    displayName: 'Bob',
+    flags: { foreignFullWalkEvery: 5000, foreignPollIntervalMs: 1000 },
+  })
+  const spaceId = await connectInSpace(t, A, B)
+  const aKey = (await A.request('profile:get')).publicKey
+
+  const share = await A.request('share:create', { spaceId, name: 'Photos' })
+  const folder = mkTmpDir(t)
+  fs.writeFileSync(path.join(folder, 'first.txt'), 'one')
+  const scanDone = A.waitFor('event:owned-folder-scan-completed', (m) => m.shareId === share.id)
+  await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })
+  await scanDone
+
+  await B.until('share:list', { spaceId }, (list) => list.some((s) => s.id === share.id))
+  const mirrorDir = mkTmpDir(t)
+  const active = B.waitFor('event:foreign-folder-mount-status',
+    (m) => m.shareId === share.id && m.status === 'active')
+  await B.request('foreign-folder:mount', { spaceId, shareId: share.id, ownerKey: aKey, mountPath: mirrorDir })
+  await active
+  t.ok(fs.existsSync(path.join(mirrorDir, 'first.txt')), 'the mirror converged on the initial file')
+
+  // Let several poll ticks run against an unchanged catalog. By the end of this the mirror is in the
+  // skipping state the rest of the test depends on — with the backstop 5000 ticks away, nothing but
+  // a version change can bring it back.
+  await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+    (res) => res.entries.length === 1)
+  await new Promise((r) => setTimeout(r, 4000))
+
+  // A publishes a second file. This is the only thing that moves A's catalog head.
+  const late = path.join(folder, 'second.txt')
+  fs.writeFileSync(late, 'two')
+  await A.request('event:owned-folder-fs-event', { shareId: share.id, action: 'add', relPath: 'second.txt', absPath: late })
+  await A.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+    (res) => res.entries.length === 2)
+
+  // B's LISTING seeing the row proves only that the catalog replicated — share:list-files reads the
+  // catalog directly and does not go through the mirror tick at all. Verified against a deliberately
+  // frozen probe: this wait still passed while the file was never mirrored.
+  await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+    (res) => res.entries.length === 2)
+
+  // THIS is the discriminating assertion. Materializing requires a tick that chose to walk, which
+  // requires B's locally-read version to have moved. With the probe frozen the same listing reports
+  // second.txt as status 'remote' with localPath null — visible, and never mirrored — and this wait
+  // is what goes red.
+  const landed = path.join(mirrorDir, 'second.txt')
+  await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+    () => fs.existsSync(landed))
+  t.ok(fs.existsSync(landed), 'the appended file materialized on the mirror without a backstop walk')
+  t.is(fs.readFileSync(landed, 'utf8'), 'two', 'and its bytes are the owner\'s')
+})

--- a/test/integration/content-backend-conformance.test.js
+++ b/test/integration/content-backend-conformance.test.js
@@ -15,6 +15,13 @@ const CONTRACT = [
   'requestDownload', 'ensureRemote', 'releaseRemote',
 ]
 
+// Members a backend MAY implement. A caller must reach every one of these through `?.` and behave
+// correctly when it is absent — `catalogVersion` missing means a mirror walks every tick, which is
+// simply the behaviour before it existed. Kept separate from CONTRACT deliberately: promoting one of
+// these to required breaks every hand-written double at once, and that is a decision to take on
+// purpose rather than by adding a line to the wrong list.
+const OPTIONAL = ['catalogVersion', 'init', 'attach', 'teardown', 'sweepPresence']
+
 test('absent / legacy / unknown content modes are UNSUPPORTED', (t) => {
   for (const share of [{ contentMode: 'eager' }, {}, null, { contentMode: 'deferred' }, { contentMode: 'future-mode' }]) {
     t.is(getContentBackend(share), UNSUPPORTED)
@@ -40,4 +47,19 @@ test('overlay resolves to a backend when the flag is on (UNSUPPORTED when off)',
   }
   t.ok(hasContentBackend({ contentMode: 'overlay' }), 'hasContentBackend true when usable')
   t.absent(isUnsupportedShare({ contentMode: 'overlay' }), 'isUnsupportedShare false when the flag is on')
+})
+
+test('optional backend members are optional, and absent ones are never called unguarded', (t) => {
+  setRuntimeConfig({ overlayEnabled: true })
+  t.teardown(() => setRuntimeConfig({ overlayEnabled: false }))
+  const backend = getContentBackend({ contentMode: 'overlay' })
+  for (const name of OPTIONAL) {
+    t.is(typeof backend[name], 'function', `overlay implements the optional ${name}`)
+    t.absent(CONTRACT.includes(name), `${name} is NOT in the required contract`)
+  }
+  // The behaviour that matters — a backend missing an optional member still works — is asserted
+  // against the real call site in foreign-mirror-head-skip.test.js ('a backend with no
+  // catalogVersion walks every tick'). Asserting `absent?.()` here would only prove optional
+  // chaining works, which is true of every JS runtime and would stay green if a caller dropped
+  // the `?.`.
 })

--- a/test/integration/foreign-mirror-head-skip.test.js
+++ b/test/integration/foreign-mirror-head-skip.test.js
@@ -1,0 +1,157 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { setupSelfMirror } from '../helpers/owned.js'
+import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import {
+  initialMaterializeScan, runMaterializeTick, restartForeignLoop, mirrorHealth,
+  startForeignLoop, stopForeignLoop,
+} from '../../src/shared/folders/foreign-folders.js'
+
+// A converged mirror re-listed the owner's whole catalog and re-stat'd every file every 30s forever.
+// The listing COUNT is the assertion: a wall-time or CPU measure could not go red, and the property
+// under test is "no work was issued", not "the work was fast".
+function instrument (t, { version = 1 } = {}) {
+  const state = { listings: 0, version }
+  const origList = overlayBackend.listPeerWithMeta
+  const origVersion = overlayBackend.catalogVersion
+  overlayBackend.listPeerWithMeta = async (...a) => { state.listings++; return await origList(...a) }
+  overlayBackend.catalogVersion = async () => state.version
+  t.teardown(() => {
+    overlayBackend.listPeerWithMeta = origList
+    overlayBackend.catalogVersion = origVersion
+  })
+  return state
+}
+
+async function converge (ctx) {
+  await initialMaterializeScan(ctx.mount)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+}
+
+test('a converged mirror issues no listing while the catalog head is unchanged', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x', 'b.txt': 'y' } })
+  const state = instrument(t)
+  await converge(ctx)
+  const settled = state.listings
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled, 'two further ticks did no work at all')
+})
+
+test('an owner append makes the very next tick walk', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const state = instrument(t)
+  await converge(ctx)
+  const settled = state.listings
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled, 'skipping while the head is still')
+  state.version += 1
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled + 1, 'a moved head walks immediately — no backstop wait')
+})
+
+test('the backstop walks on the Nth consecutive tick', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  // After setupSelfMirror, never before: booting the peer rebuilds the runtime config from the
+  // bootstrap frame and would drop a cap set earlier.
+  const cfg = getRuntimeConfig()
+  setRuntimeConfig({ ...cfg, foreignFullWalkEvery: 3 })
+  t.teardown(() => setRuntimeConfig(cfg))
+  const state = instrument(t)
+  await converge(ctx)
+  const settled = state.listings
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled, 'two skips')
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled + 1, 'the third tick walks regardless')
+})
+
+// The backstop's whole purpose. The catalog version cannot see a LOCAL deletion, and a foreign mount
+// has no filesystem watcher, so without it nothing would ever notice the file was gone.
+test('a locally deleted mirror file is repaired by the backstop', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const cfg = getRuntimeConfig()
+  setRuntimeConfig({ ...cfg, foreignFullWalkEvery: 2 })
+  t.teardown(() => setRuntimeConfig(cfg))
+  instrument(t)
+  await converge(ctx)
+  const mirrored = path.join(ctx.mirrorPath, 'a.txt')
+  t.ok(fs.existsSync(mirrored), 'materialized')
+  fs.unlinkSync(mirrored)
+  // fullWalkEvery 2 means one skip then a walk: the deletion is invisible to the catalog version, so
+  // only the backstop tick can see it.
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.absent(fs.existsSync(mirrored), 'the skipping tick cannot see a local deletion — by design')
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.ok(fs.existsSync(mirrored), 're-materialized by the backstop, with no catalog change at all')
+})
+
+// The liveness watchdog restarts a mirror whose pass has been in flight without progress, so a skip
+// that left a pass open would tear down a perfectly converged mirror every stall window, forever.
+//
+// This is a GUARD, not a red-first regression test, and the distinction is worth stating: the
+// start/end bracket lives in runMaterializeTick, outside the function the skip was added to, so the
+// skip cannot bypass it today and this assertion passes with or without the change. It earns its
+// place only against a future refactor that moves the skip up into the interval — which is the
+// shape a reader would naturally reach for, and the reason the skip is where it is.
+test('a skipping tick completes a pass, so the liveness watchdog sees a healthy mirror', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  instrument(t)
+  // mirrorHealth only reports mounts with a live loop, so the loop is the subject here. A long poll
+  // keeps its own interval out of the assertion.
+  const cfg = getRuntimeConfig()
+  setRuntimeConfig({ ...cfg, foreignPollIntervalMs: 600_000 })
+  t.teardown(() => setRuntimeConfig(cfg))
+  await startForeignLoop({ spaceId: ctx.spaceId, shareId: ctx.share.id })
+  t.teardown(() => stopForeignLoop(ctx.spaceId, ctx.share.id))
+
+  await converge(ctx)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  const rows = mirrorHealth({ now: Date.now() + 60 * 60 * 1000 })
+  t.ok(rows.length > 0, 'the mount has a live loop to report on')
+  for (const row of rows) t.ok(row.ok, `mirror ${row.shareId} healthy an hour after its last walk`)
+})
+
+test('an incomplete listing never sets the watermark', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x', 'b.txt': 'y' } })
+  const state = instrument(t)
+  // Incomplete from the first pass on: a drain that timed out mid-catalog cannot prove the mirror
+  // holds everything, so no pass may converge and every tick must keep walking.
+  ctx.listing.complete = false
+  await converge(ctx)
+  const afterFirst = state.listings
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, afterFirst + 2, 'both further ticks walked')
+})
+
+test('a restart clears the watermark', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const state = instrument(t)
+  await converge(ctx)
+  const settled = state.listings
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled, 'skipping before the restart')
+  await restartForeignLoop(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.ok(state.listings > settled, 'the first tick after a restart walks')
+})
+
+// The optional-member contract: a backend that cannot answer costs work, never correctness.
+test('a backend with no catalogVersion walks every tick, exactly as before', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const state = { listings: 0 }
+  const origList = overlayBackend.listPeerWithMeta
+  const origVersion = overlayBackend.catalogVersion
+  overlayBackend.listPeerWithMeta = async (...a) => { state.listings++; return await origList(...a) }
+  delete overlayBackend.catalogVersion
+  t.teardown(() => { overlayBackend.listPeerWithMeta = origList; overlayBackend.catalogVersion = origVersion })
+  await converge(ctx)
+  const settled = state.listings
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.listings, settled + 2, 'no probe means no skip')
+})

--- a/test/unit/mirror-walk-decision.test.js
+++ b/test/unit/mirror-walk-decision.test.js
@@ -1,0 +1,69 @@
+import test from 'brittle'
+import { shouldWalk, DEFAULT_FULL_WALK_EVERY } from '../../src/shared/folders/mirror-walk.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+test('a mirror with no watermark always walks', (t) => {
+  t.is(shouldWalk({ watermark: null, version: 7 }).walk, true)
+  t.is(shouldWalk({ watermark: null, version: 7 }).reason, 'no-watermark')
+  t.is(shouldWalk().walk, true, 'and so does a call with nothing known at all')
+})
+
+// The fail-safe direction: a probe that cannot answer must cost work, never authorise a skip.
+test('an unknown version always walks, even against a matching watermark', (t) => {
+  t.is(shouldWalk({ watermark: 7, version: null }).walk, true)
+  t.is(shouldWalk({ watermark: 7, version: null }).reason, 'version-unknown')
+  t.is(shouldWalk({ watermark: null, version: null }).walk, true)
+})
+
+test('a moved head walks; an unchanged head skips', (t) => {
+  t.is(shouldWalk({ watermark: 7, version: 8 }).reason, 'catalog-appended')
+  t.is(shouldWalk({ watermark: 8, version: 7 }).reason, 'catalog-appended',
+    'a version that went BACKWARDS is still a change, never a skip')
+  const skip = shouldWalk({ watermark: 7, version: 7 })
+  t.is(skip.walk, false, 'the whole point of the change')
+  t.is(skip.reason, null)
+})
+
+test('version 0 and version 1 are distinguished from unknown', (t) => {
+  // A brand-new catalog reads version 1, and 0 is falsy — neither may collapse into "unknown".
+  t.is(shouldWalk({ watermark: 1, version: 1 }).walk, false, 'a fresh catalog can converge')
+  t.is(shouldWalk({ watermark: 0, version: 0 }).walk, false)
+  t.is(shouldWalk({ watermark: 0, version: 1 }).reason, 'catalog-appended')
+})
+
+test('the backstop forces a walk on the Nth consecutive tick', (t) => {
+  const at = (skipped) => shouldWalk({ watermark: 7, version: 7, skipped, fullWalkEvery: 10 })
+  for (let s = 0; s < 9; s++) t.is(at(s).walk, false, `skip ${s + 1} of 9 is still a skip`)
+  t.is(at(9).walk, true, 'the 10th tick walks')
+  t.is(at(9).reason, 'backstop')
+  t.is(at(99).walk, true, 'and anything past it keeps walking until the counter resets')
+})
+
+// The rollback contract: one config value restores today's behaviour exactly.
+test('foreignFullWalkEvery of 1 or less disables the skip entirely', (t) => {
+  for (const every of [1, 0, -1]) {
+    const d = shouldWalk({ watermark: 7, version: 7, skipped: 0, fullWalkEvery: every })
+    t.is(d.walk, true, `fullWalkEvery ${every} always walks`)
+    t.is(d.reason, 'backstop-disabled')
+  }
+})
+
+test('the default is the 10-tick backstop', (t) => {
+  t.is(DEFAULT_FULL_WALK_EVERY, 10)
+  t.is(shouldWalk({ watermark: 7, version: 7, skipped: 8 }).walk, false)
+  t.is(shouldWalk({ watermark: 7, version: 7, skipped: 9 }).walk, true)
+})
+
+// The default is declared twice across a layer boundary — core/ must not import from folders/, the
+// same constraint that makes PUBLISH_ORDERS a hand-kept twin with its own parity assertion. Without
+// this, changing one leaves the other stale and nothing fails: production always reads the
+// runtime-config value, so the module default is only ever exercised here.
+test('DEFAULT_FULL_WALK_EVERY matches the runtime-config default', (t) => {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const src = readFileSync(path.join(here, '..', '..', 'src', 'shared', 'core', 'runtime-config.js'), 'utf8')
+  const m = src.match(/^\s*foreignFullWalkEvery:\s*(\d+),/m)
+  t.ok(m, 'runtime-config declares foreignFullWalkEvery')
+  t.is(Number(m[1]), DEFAULT_FULL_WALK_EVERY, 'the two declarations agree')
+})


### PR DESCRIPTION
## What & why

Closes **r02-F2**, the last unimplemented plan from the architecture review
(`plan-fix-mirror-tick-synced-paths.md` Phase 2, written 2026-08-28 and never built — verified:
`foreignFullWalkEvery` had 0 occurrences).

A converged mirror — every file present, nothing to delete — ran a full pass every 30 s and changed
nothing. Per tick: one `syncPeerHead` (a `core.update({ wait: true })` raced to the 8 s peer-read
budget) plus a full catalog drain; then **per file** an `fs.existsSync`, an async `stat`, and an
`isVerifiedUnchanged` → **a Hyperbee point read**. On a 5 000-file mirror that is 5 000 bee reads and
10 000 filesystem calls every 30 seconds, in perpetuity, to discover nothing had changed. #113 fixed
the write amplification on this path; it did not remove the pass.

A pass that finds nothing to do now records the catalog version it walked. Later ticks compare a
**locally read** `bee.version` against it and skip the whole pass while it holds.

Three details worth review attention:

- **Convergence is `allPresent && complete && synced.size === onDrive.size`,** deliberately *not*
  gated on `honorDeletions`. That gate asks whether a pass was *allowed* to act on deletions, not
  whether any exist — and an offline owner cannot append, so it is exactly when skipping is safest.
  Every listed entry is recorded into `synced`, so equal sizes are an O(1) proof that no deletions
  are pending.
- **A walk clears the watermark up front.** Only a pass reaching the convergence test re-establishes
  one, so a pass that throws midway (an unlink the OS refuses, a failed bee put) cannot leave a stale
  watermark over a zeroed skip counter — which would have retried the failed work at the backstop's
  cadence instead of the poll's.
- **The probe never throws and returns `null` when it cannot answer**, which callers read as "walk".
  It also pins the bee across its `await`, because inserting into the catalog LRU can evict — and
  close — an unpinned entry, including the one just inserted.

**Backstop:** every 10th tick walks regardless. A catalog version cannot see a *local* change (a user
deleting a mirrored file) and a foreign mount has no filesystem watcher, so nothing else would notice.
`MIRALL_FOREIGN_FULL_WALK_EVERY=1` restores the previous cadence exactly, without a release.

**One new invariant to be aware of:** `overlayListPeerWithMeta` is the sole caller of
`ensurePeerCatalogWatch`, so the listing this change skips was also what re-armed the peer-catalog
append watch. Not reachable today (the watch is armed during the converging walk and `dropCatalog` is
never called with a peer key), but it is now load-bearing.

## Coverage

- **Unit** — `mirror-walk-decision.test.js`: every branch of the rule, the fail-safe direction
  (unknown version always walks), version 0/1 not collapsing into unknown, the backstop arithmetic,
  the rollback, and a parity assertion for the default declared on both sides of the core/folders
  boundary.
- **Integration** — `foreign-mirror-head-skip.test.js`: listing *counts* prove no work is issued;
  an append walks the very next tick; the backstop repairs a locally deleted file; an incomplete
  listing never sets the watermark; a restart clears it; a backend with no probe walks every tick.
- **Flow (two-peer)** — `foreign-mirror-head-tracking.test.js`: the safety premise no single-peer
  test can reach — that a *remote* owner's append advances `bee.version` on our reader with no
  `core.update`. The backstop is set 5 000 ticks away so it cannot mask a failure. **Verified
  red-capable:** with the probe frozen at a constant the test fails in 20 s, and the listing then
  shows the new file as `status: 'remote', localPath: null` — visible, never mirrored.

## Ran locally

`test:fe` not run — no renderer surface changes. The mirror status the UI renders is written by
`settleMirrorSyncState`, which a skipped tick deliberately does not call because the converging pass
already did. No a11y-affecting change.