### PR TITLE
[refactor] Move the swarm's reporting surface into its own module

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1057,6 +1057,7 @@ Since the #199 reorg, split into domain subfolders. `invite-envelope.js` stays a
 | `transfer/transfer-status.js` | `pausedStatusFor` — derives a row's paused sub-status |
 | `transfer/pending-transfers.js` | Pending-transfers bee CRUD (resume across restarts) |
 | `transfer/swarm.js` | Hyperswarm + Protomux handshakes, per-space identity binding (§16), overlay channel attach, presence/membership gossip |
+| `transfer/swarm-diagnostics.js` | The swarm's read-only reporting surface: address, routing-table size, peer reach, peer samples, DHT health, connect/relay stats, and the offline status shape. `swarm.js` builds one instance over accessors and assembles the results into the status object. Imports no `bare-*`, so it is unit-tested. |
 | `transfer/handshake-guard.js` | Verifies the identity binding on every identity-asserting frame (§16) |
 | `transfer/sck-seal.js` | Seals the SCK to a joiner's bound signer key at approval (§16) |
 | `transfer/progress-ticker.js` | `makeProgressTicker(total, emit)` — 250 ms-throttled `{bytes,total,speed,eta}`; shared by single-file transfers and folder mirroring |

--- a/src/shared/transfer/swarm-diagnostics.js
+++ b/src/shared/transfer/swarm-diagnostics.js
@@ -1,0 +1,164 @@
+// The swarm's read-only reporting surface: the snapshot builders that describe the live Hyperswarm
+// without changing it. Its only importer is swarm.js, which assembles them into the status object
+// the worker ships over IPC.
+//
+// A factory over accessors rather than plain functions: `swarm` is reassigned by initSwarm and
+// destroySwarm, so a value captured at import time goes stale, and threading the handle through
+// fourteen call sites would put it back in every caller's face.
+//
+// Imports nothing from bare-*, deliberately: that is what lets this load under node and be unit
+// tested. The one impure value it reports — the hyperdht version — is read by swarm.js and passed in.
+import b4a from 'b4a'
+import { CANARY } from '../core/reachability.js'
+
+const DEFAULT_BOOTSTRAP = ['node1.hyperdht.org:49737', 'node2.hyperdht.org:49737', 'node3.hyperdht.org:49737']
+
+
+export function createSwarmDiagnostics({ getSwarm, getRelaySelections, getDhtVersion }) {
+  function getBootstrapList() {
+    try {
+      const list = global.Pear?.config?.dht?.bootstrap
+      if (Array.isArray(list)) return list.map(String)
+    } catch {}
+      // A copy: this array is handed to every status reader, and the fallback must not be mutable
+    // through one of them.
+    return DEFAULT_BOOTSTRAP.slice()
+  }
+
+  function safeAddress() {
+    try {
+      const addr = getSwarm()?.dht?.address?.()
+      if (addr && typeof addr.port === 'number') {
+        return { host: typeof addr.host === 'string' ? addr.host : null, port: addr.port }
+      }
+    } catch {}
+    return { host: null, port: 0 }
+  }
+
+  function safeRoutingTableSize() {
+    try {
+      const arr = getSwarm()?.dht?.toArray?.({ limit: 50 })
+      return Array.isArray(arr) ? arr.length : 0
+    } catch { return 0 }
+  }
+
+  // The gap between peers we DISCOVERED on our topics and peers we actually connected to
+  // is the strongest connectivity signal available: the DHT told us where they are and we
+  // could not open a socket to any of them.
+  function snapshotPeerReach() {
+    const peers = getSwarm()?.peers
+    if (!peers) return { discovered: 0, connected: 0, exhausted: 0 }
+    let exhausted = 0
+    for (const info of peers.values()) {
+      // attempts > 3 is where hyperswarm's _shouldRequeue gives up and the peer leaves the
+      // retry queue until a fresh lookup rediscovers it.
+      if (!info.proven && info.attempts > 3) exhausted++
+    }
+    return { discovered: peers.size, connected: getSwarm().connections?.size || 0, exhausted }
+  }
+
+  const PEER_SAMPLE_CAP = 32
+
+  // PeerInfo.topics carries an upstream "remove on next major" marker, so never assume it.
+  function topicHexOf(info) {
+    const topic = Array.isArray(info?.topics) ? info.topics[0] : null
+    if (!topic) return null
+    try { return b4a.toString(topic, 'hex') } catch { return null }
+  }
+
+  function snapshotPeerSamples() {
+    const peers = getSwarm()?.peers
+    if (!peers) return []
+    const out = []
+    for (const [key, info] of peers) {
+      if (out.length >= PEER_SAMPLE_CAP) break
+      out.push({
+        publicKey: key,
+        topic: topicHexOf(info),
+        attempts: info.attempts || 0,
+        proven: !!info.proven,
+      })
+    }
+    return out
+  }
+
+  function snapshotDhtHealth() {
+    const health = getSwarm()?.dht?.health
+    if (!health) return { online: true, degraded: false, cold: true, idle: true, timeoutsRate: 0 }
+    const s = health.stats || {}
+    return {
+      online: s.online !== false,
+      degraded: !!s.degraded,
+      cold: !!s.cold,
+      idle: !!s.idle,
+      timeoutsRate: typeof s.timeoutsRate === 'number' ? s.timeoutsRate : 0,
+    }
+  }
+
+  function snapshotStats() {
+    const s = getSwarm()?.stats || {}
+    const c = s.connects || {}
+    const cl = c.client || {}
+    const sv = c.server || {}
+    return {
+      updates: s.updates || 0,
+      connects: {
+        client: { opened: cl.opened || 0, closed: cl.closed || 0, attempted: cl.attempted || 0 },
+        server: { opened: sv.opened || 0, closed: sv.closed || 0, attempted: sv.attempted || 0 },
+      },
+      bannedPeers: s.bannedPeers || 0,
+      relaying: snapshotRelayingStats(),
+    }
+  }
+
+  // hyperdht counts relayed connection attempts on the DHT node, not the swarm, so this
+  // reads through to the shared node rather than swarm.stats.
+  function snapshotRelayingStats() {
+    const r = getSwarm()?.dht?.stats?.relaying || {}
+    return { selected: getRelaySelections(), attempts: r.attempts || 0, successes: r.successes || 0, aborts: r.aborts || 0 }
+  }
+
+  function offlineStatusSnapshot() {
+    return {
+      state: 'offline',
+      dhtReady: false,
+      announced: false,
+      peerCount: 0,
+      connecting: 0,
+      suspended: false,
+      lastConnectionAt: null,
+      bootedAt: 0,
+      identity: { publicKey: '', nodeId: null },
+      address: { publicHost: null, publicPort: 0, localPort: 0 },
+      nat: { firewalled: null, randomized: null, ephemeral: true },
+      routing: { bootstrap: getBootstrapList(), tableSize: 0 },
+      topics: 0,
+      stats: {
+        updates: 0,
+        connects: {
+          client: { opened: 0, closed: 0, attempted: 0 },
+          server: { opened: 0, closed: 0, attempted: 0 },
+        },
+        bannedPeers: 0,
+        relaying: { selected: 0, attempts: 0, successes: 0, aborts: 0 },
+      },
+      peerReach: { discovered: 0, connected: 0, exhausted: 0 },
+      dhtHealth: { online: false, degraded: false, cold: true, idle: true, timeoutsRate: 0 },
+      canary: { state: CANARY.UNAVAILABLE, at: 0 },
+      liveness: { failures: 0, checkedAt: 0, interfaceKind: 'physical' },
+      reachability: { verdict: 'unknown', cause: null, confidence: 'predicted', evidence: null, since: 0, pending: null },
+      versions: { dht: getDhtVersion() },
+    }
+  }
+
+  return {
+    getBootstrapList,
+    safeAddress,
+    safeRoutingTableSize,
+    snapshotPeerReach,
+    snapshotPeerSamples,
+    snapshotDhtHealth,
+    snapshotStats,
+    offlineStatusSnapshot,
+  }
+}

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -13,8 +13,8 @@
 import Hyperswarm from 'hyperswarm'
 import Protomux from 'protomux'
 import c from 'compact-encoding'
-import b4a from 'b4a'
 import fs from 'bare-fs'
+import b4a from 'b4a'
 import os from 'bare-os'
 import { getStore, diagnoseStoreCores, isStorageInconsistency } from '../core/store.js'
 import {
@@ -53,6 +53,7 @@ import { makeKeyedCoalescer } from '../state/coalesce.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { classify, stabilise, routableAddressKind, CANARY, BLOCKED_DWELL_MS, NAT_SETTLE_MS, LIVENESS_FAILURES_FOR_OFFLINE } from '../core/reachability.js'
+import { createSwarmDiagnostics } from './swarm-diagnostics.js'
 
 const log = createLogger('swarm')
 
@@ -159,8 +160,6 @@ let lastReconnectAt = 0
 let bootedAt = 0
 const STATUS_EMIT_DEBOUNCE_MS = 300
 const RECONNECT_THROTTLE_MS = 5000
-const DEFAULT_BOOTSTRAP = ['node1.hyperdht.org:49737', 'node2.hyperdht.org:49737', 'node3.hyperdht.org:49737']
-
 const DHT_VERSION = (() => {
   try {
     const url = new URL('../../node_modules/hyperdht/package.json', import.meta.url)
@@ -171,6 +170,14 @@ const DHT_VERSION = (() => {
     return 'unknown'
   }
 })()
+
+// Read-only reporting over the live swarm. Accessors, not the handle: initSwarm/destroySwarm
+// reassign `swarm`, and relaySelections is a counter this module keeps.
+const diag = createSwarmDiagnostics({
+  getSwarm: () => swarm,
+  getRelaySelections: () => relaySelections,
+  getDhtVersion: () => DHT_VERSION,
+})
 
 const BENIGN_SOCKET_ERRORS = ['timed out', 'reset by peer', 'Duplicate connection']
 function isBenignSocketError (err) {
@@ -2063,140 +2070,6 @@ async function destroySwarm() {
   log.info('swarm destroyed')
 }
 
-function getBootstrapList() {
-  try {
-    const list = global.Pear?.config?.dht?.bootstrap
-    if (Array.isArray(list)) return list.map(String)
-  } catch {}
-  return DEFAULT_BOOTSTRAP
-}
-
-function safeAddress() {
-  try {
-    const addr = swarm?.dht?.address?.()
-    if (addr && typeof addr.port === 'number') {
-      return { host: typeof addr.host === 'string' ? addr.host : null, port: addr.port }
-    }
-  } catch {}
-  return { host: null, port: 0 }
-}
-
-function safeRoutingTableSize() {
-  try {
-    const arr = swarm?.dht?.toArray?.({ limit: 50 })
-    return Array.isArray(arr) ? arr.length : 0
-  } catch { return 0 }
-}
-
-// The gap between peers we DISCOVERED on our topics and peers we actually connected to
-// is the strongest connectivity signal available: the DHT told us where they are and we
-// could not open a socket to any of them.
-function snapshotPeerReach() {
-  const peers = swarm?.peers
-  if (!peers) return { discovered: 0, connected: 0, exhausted: 0 }
-  let exhausted = 0
-  for (const info of peers.values()) {
-    // attempts > 3 is where hyperswarm's _shouldRequeue gives up and the peer leaves the
-    // retry queue until a fresh lookup rediscovers it.
-    if (!info.proven && info.attempts > 3) exhausted++
-  }
-  return { discovered: peers.size, connected: swarm.connections?.size || 0, exhausted }
-}
-
-const PEER_SAMPLE_CAP = 32
-
-// PeerInfo.topics carries an upstream "remove on next major" marker, so never assume it.
-function topicHexOf(info) {
-  const topic = Array.isArray(info?.topics) ? info.topics[0] : null
-  if (!topic) return null
-  try { return b4a.toString(topic, 'hex') } catch { return null }
-}
-
-function snapshotPeerSamples() {
-  const peers = swarm?.peers
-  if (!peers) return []
-  const out = []
-  for (const [key, info] of peers) {
-    if (out.length >= PEER_SAMPLE_CAP) break
-    out.push({
-      publicKey: key,
-      topic: topicHexOf(info),
-      attempts: info.attempts || 0,
-      proven: !!info.proven,
-    })
-  }
-  return out
-}
-
-function snapshotDhtHealth() {
-  const health = swarm?.dht?.health
-  if (!health) return { online: true, degraded: false, cold: true, idle: true, timeoutsRate: 0 }
-  const s = health.stats || {}
-  return {
-    online: s.online !== false,
-    degraded: !!s.degraded,
-    cold: !!s.cold,
-    idle: !!s.idle,
-    timeoutsRate: typeof s.timeoutsRate === 'number' ? s.timeoutsRate : 0,
-  }
-}
-
-function snapshotStats() {
-  const s = swarm?.stats || {}
-  const c = s.connects || {}
-  const cl = c.client || {}
-  const sv = c.server || {}
-  return {
-    updates: s.updates || 0,
-    connects: {
-      client: { opened: cl.opened || 0, closed: cl.closed || 0, attempted: cl.attempted || 0 },
-      server: { opened: sv.opened || 0, closed: sv.closed || 0, attempted: sv.attempted || 0 },
-    },
-    bannedPeers: s.bannedPeers || 0,
-    relaying: snapshotRelayingStats(),
-  }
-}
-
-// hyperdht counts relayed connection attempts on the DHT node, not the swarm, so this
-// reads through to the shared node rather than swarm.stats.
-function snapshotRelayingStats() {
-  const r = swarm?.dht?.stats?.relaying || {}
-  return { selected: relaySelections, attempts: r.attempts || 0, successes: r.successes || 0, aborts: r.aborts || 0 }
-}
-
-function offlineStatusSnapshot() {
-  return {
-    state: 'offline',
-    dhtReady: false,
-    announced: false,
-    peerCount: 0,
-    connecting: 0,
-    suspended: false,
-    lastConnectionAt: null,
-    bootedAt: 0,
-    identity: { publicKey: '', nodeId: null },
-    address: { publicHost: null, publicPort: 0, localPort: 0 },
-    nat: { firewalled: null, randomized: null, ephemeral: true },
-    routing: { bootstrap: getBootstrapList(), tableSize: 0 },
-    topics: 0,
-    stats: {
-      updates: 0,
-      connects: {
-        client: { opened: 0, closed: 0, attempted: 0 },
-        server: { opened: 0, closed: 0, attempted: 0 },
-      },
-      bannedPeers: 0,
-      relaying: { selected: 0, attempts: 0, successes: 0, aborts: 0 },
-    },
-    peerReach: { discovered: 0, connected: 0, exhausted: 0 },
-    dhtHealth: { online: false, degraded: false, cold: true, idle: true, timeoutsRate: 0 },
-    canary: { state: CANARY.UNAVAILABLE, at: 0 },
-    liveness: { failures: 0, checkedAt: 0, interfaceKind: 'physical' },
-    reachability: { verdict: 'unknown', cause: null, confidence: 'predicted', evidence: null, since: 0, pending: null },
-    versions: { dht: DHT_VERSION },
-  }
-}
-
 // === Blind relay ===
 
 const RELAY_PROBE_TIMEOUT_MS = 10000
@@ -2272,7 +2145,7 @@ function recordVerdictTransition(next) {
 
 function recomputeReachability() {
   const dht = swarm?.dht || {}
-  const stats = snapshotStats()
+  const stats = diag.snapshotStats()
   const now = Date.now()
   const raw = classify({
     now,
@@ -2287,9 +2160,9 @@ function recomputeReachability() {
       publicHost: typeof dht.host === 'string' ? dht.host : null,
       publicPort: typeof dht.port === 'number' ? dht.port : 0,
     },
-    routing: { tableSize: safeRoutingTableSize() },
-    dhtHealth: snapshotDhtHealth(),
-    peerReach: snapshotPeerReach(),
+    routing: { tableSize: diag.safeRoutingTableSize() },
+    dhtHealth: diag.snapshotDhtHealth(),
+    peerReach: diag.snapshotPeerReach(),
     dials: { attempted: stats.connects.client.attempted, opened: stats.connects.client.opened },
     canary: lastCanaryResult,
     liveness: { failures: livenessFailures, checkedAt: livenessCheckedAt },
@@ -2315,13 +2188,13 @@ export function getDiagnosticCounters() {
     readyAt,
     bootedAt,
     hostChangeCount,
-    localPortStable: safeAddress().port > 0,
+    localPortStable: diag.safeAddress().port > 0,
     droppedFrames: getDroppedFrameCounters(),
   }
 }
 
 export function getPeerSamples() {
-  return snapshotPeerSamples()
+  return diag.snapshotPeerSamples()
 }
 
 const CANARY_TIMEOUT_MS = 10000
@@ -2560,7 +2433,7 @@ export async function probeCanary(upgradeKey, { force = false } = {}) {
 }
 
 export function getSwarmStatus() {
-  if (!swarm) return offlineStatusSnapshot()
+  if (!swarm) return diag.offlineStatusSnapshot()
 
   const reachability = recomputeReachability()
 
@@ -2573,7 +2446,7 @@ export function getSwarmStatus() {
     : peerCount > 0 ? 'online' : 'connecting'
 
   const dht = swarm.dht || {}
-  const addr = safeAddress()
+  const addr = diag.safeAddress()
   const pubKey = swarm.keyPair?.publicKey
     ? b4a.toString(swarm.keyPair.publicKey, 'hex')
     : ''
@@ -2600,14 +2473,14 @@ export function getSwarmStatus() {
       ephemeral: !!dht.ephemeral,
     },
     routing: {
-      bootstrap: getBootstrapList(),
-      tableSize: safeRoutingTableSize(),
+      bootstrap: diag.getBootstrapList(),
+      tableSize: diag.safeRoutingTableSize(),
     },
     topics: spaceTopics.size,
     contentPlane: getContentPlaneStatus(),
-    stats: snapshotStats(),
-    peerReach: snapshotPeerReach(),
-    dhtHealth: snapshotDhtHealth(),
+    stats: diag.snapshotStats(),
+    peerReach: diag.snapshotPeerReach(),
+    dhtHealth: diag.snapshotDhtHealth(),
     canary: lastCanaryResult,
     liveness: { failures: livenessFailures, checkedAt: livenessCheckedAt, interfaceKind },
     reachability,

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -162,7 +162,9 @@ const STATUS_EMIT_DEBOUNCE_MS = 300
 const RECONNECT_THROTTLE_MS = 5000
 const DHT_VERSION = (() => {
   try {
-    const url = new URL('../../node_modules/hyperdht/package.json', import.meta.url)
+    // Three levels: this file is src/shared/transfer/, so ../../ lands on src/, where there is no
+    // node_modules. That typo made the reported version a permanent 'unknown'.
+    const url = new URL('../../../node_modules/hyperdht/package.json', import.meta.url)
     const text = fs.readFileSync(url, 'utf8')
     const pkg = JSON.parse(text)
     return typeof pkg.version === 'string' ? pkg.version : 'unknown'

--- a/test/integration/swarm-dht-version.test.js
+++ b/test/integration/swarm-dht-version.test.js
@@ -1,0 +1,16 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import { getSwarmStatus } from '../../src/shared/transfer/swarm.js'
+
+// REGRESSION (FIX-DHT-VERSION): the version lookup resolved '../../node_modules/hyperdht' from
+// src/shared/transfer/, i.e. src/node_modules — which does not exist. Every read threw ENOENT and
+// the status reported 'unknown', so the Network Status panel's DHT version field was permanently
+// blank-ish. Nothing pinned the value, in either direction.
+//
+// Integration, not unit: swarm.js pulls bare-* and will not load under node.
+test('REGRESSION (FIX-DHT-VERSION): the reported DHT version is the real one', async (t) => {
+  const status = getSwarmStatus()
+  const real = JSON.parse(fs.readFileSync(new URL('../../node_modules/hyperdht/package.json', import.meta.url), 'utf8')).version
+  t.ok(real && real !== 'unknown', 'the package is readable from the test, so the app can read it too')
+  t.is(status.versions.dht, real, 'and the status reports it rather than the ENOENT fallback')
+})

--- a/test/unit/swarm-diagnostics.test.js
+++ b/test/unit/swarm-diagnostics.test.js
@@ -1,0 +1,63 @@
+import test from 'brittle'
+import { createSwarmDiagnostics } from '../../src/shared/transfer/swarm-diagnostics.js'
+
+// The module imports nothing from bare-*, which is what lets it be tested here rather than in the
+// slow integration tier. A future edit that pulls in a bare module breaks this file loudly.
+const make = (swarm, { relaySelections = 0, dhtVersion = '1.2.3' } = {}) =>
+  createSwarmDiagnostics({ getSwarm: () => swarm, getRelaySelections: () => relaySelections, getDhtVersion: () => dhtVersion })
+
+test('every snapshot degrades to a zero shape with no swarm', (t) => {
+  const d = make(null)
+  t.alike(d.safeAddress(), { host: null, port: 0 })
+  t.is(d.safeRoutingTableSize(), 0)
+  t.alike(d.snapshotPeerReach(), { discovered: 0, connected: 0, exhausted: 0 })
+  t.alike(d.snapshotPeerSamples(), [])
+  t.is(d.snapshotStats().updates, 0)
+})
+
+// A torn-down DHT is the condition these two exist to absorb: getSwarmStatus deliberately runs them
+// against a swarm it has already established may be destroyed.
+test('safeAddress and safeRoutingTableSize absorb a throwing DHT', (t) => {
+  const boom = { get dht() { throw new Error('destroyed') } }
+  t.alike(make(boom).safeAddress(), { host: null, port: 0 }, 'no throw escapes')
+  t.is(make(boom).safeRoutingTableSize(), 0)
+})
+
+test('peer reach counts the discovered/connected gap and the exhausted retries', (t) => {
+  // attempts > 3 is where hyperswarm stops requeueing, so that is what "exhausted" means.
+  const peers = new Map([
+    ['a', { proven: true, attempts: 1 }],
+    ['b', { proven: false, attempts: 9 }],
+    ['c', { proven: false, attempts: 2 }],
+  ])
+  const d = make({ peers, connections: { size: 1 } })
+  t.alike(d.snapshotPeerReach(), { discovered: 3, connected: 1, exhausted: 1 })
+})
+
+test('peer samples are capped and tolerate the removable topics field', (t) => {
+  // PeerInfo.topics carries an upstream "remove on next major" marker, so a missing one must not throw.
+  const peers = new Map(Array.from({ length: 40 }, (_, i) => [String(i), { attempts: i, proven: false }]))
+  const out = make({ peers }).snapshotPeerSamples()
+  t.is(out.length, 32, 'capped')
+  t.is(out[0].topic, null, 'a peer with no topics reports null, not a crash')
+})
+
+test('relay selections come from the accessor, not the swarm', (t) => {
+  const d = make({ dht: { stats: { relaying: { attempts: 4, successes: 2, aborts: 1 } } } }, { relaySelections: 7 })
+  t.alike(d.snapshotStats().relaying, { selected: 7, attempts: 4, successes: 2, aborts: 1 })
+})
+
+// REGRESSION (FIX-BOOTSTRAP-REF): getBootstrapList used to hand out the module's own fallback array.
+// Every status read shares one array, so a caller sorting or pushing to status.routing.bootstrap
+// corrupted the fallback for the rest of the process.
+test('REGRESSION (FIX-BOOTSTRAP-REF): the bootstrap fallback is copied, not shared', (t) => {
+  const d = make(null)
+  const first = d.getBootstrapList()
+  first.push('evil.example:1')
+  t.absent(d.getBootstrapList().includes('evil.example:1'), 'a mutating caller cannot poison the default')
+  t.not(d.getBootstrapList(), first, 'a fresh array each read')
+})
+
+test('the offline snapshot reports the injected dht version', (t) => {
+  t.is(make(null, { dhtVersion: '9.9.9' }).offlineStatusSnapshot().versions.dht, '9.9.9')
+})


### PR DESCRIPTION
First step of the `swarm.js` decomposition (`plan-swarm-decomposition.md`). **2774 → 2632 lines.**

## What & why

`swarm.js` is the largest file in `src/` and the only god file that never came down across the whole
architecture-review campaign, while `worker/main.js` fell 2411 → 1692 and `overlay-backend.js`
1090 → 716.

Measuring showed why it *looked* immovable: `destroySwarm()` calls `.clear()` on 22 containers, so
the section holding those calls appears to touch almost every piece of state in the file. Mask that
one teardown and **17 of 23 containers have exactly one writing section.**

This step takes the easiest slice: the nine snapshot builders that describe the live Hyperswarm
without changing it. They own no state, so `destroySwarm` is untouched — deliberately. The plan's
acceptance test is that it shrinks on the steps that move *ownership*; this one moves *reporting*.

The module takes accessors rather than the swarm handle, because `initSwarm`/`destroySwarm` reassign
it and a captured value goes stale. It imports nothing from `bare-*`, which is what lets it load
under node and be unit-tested there rather than in the slow integration tier.

## Second commit: a real bug the extraction surfaced

`DHT_VERSION` resolved `../../node_modules/hyperdht` from `src/shared/transfer/` — i.e.
`src/node_modules`, which does not exist. Verified under `bare`:

```
../../    -> ENOENT        (so the status reported "unknown", always)
../../../ -> 6.32.0
```

The Network Status panel's DHT version field has been permanently blank-ish. Nothing pinned the value
in either direction, which is why the typo survived. Fixed in its own commit with a regression test,
deliberately **not** folded into the refactor.

## Coverage

- **Unit** (new, possible because the module is node-loadable): zero-shape degradation with no swarm,
  a throwing/torn-down DHT absorbed by the two `safe*` helpers, peer-reach discovered/connected/
  exhausted maths, the 32-sample cap, the removable `topics` field, relay counters via the accessor.
- **`REGRESSION (FIX-BOOTSTRAP-REF)`**: `getBootstrapList()` returned the module's own fallback array
  by reference, so a caller mutating `status.routing.bootstrap` corrupted the process-wide default.
  Now copies.
- **`REGRESSION (FIX-DHT-VERSION)`** (integration — `swarm.js` needs `bare-*`): the status reports
  the real version.
- Existing suites unchanged: the refactor commit needed no test edits, which is the property that
  makes it a move.

## Follow-ups this review surfaced, deliberately not fixed here

All pre-existing, none introduced by this change:

- Every status read runs the snapshot suite **twice** — once in `recomputeReachability`, once in
  `getSwarmStatus`. Hoisting into locals halves it.
- The offline and live status shapes have **already diverged**: the live object has `contentPlane`,
  the offline one has no such key; `snapshotDhtHealth`'s no-swarm branch says `online: true` while
  `offlineStatusSnapshot` says `false`. Nothing enforces parity between the two producers.
- `snapshotDhtHealth` **fails open to `online: true`** when `dht.health` is absent, and that feeds
  `classify()`. For a verdict engine whose job is telling a blocked user they are blocked, the safe
  default for an unobservable signal is "unknown". This belongs with step 1b (connectivity), which
  owns the verdict.

## Ran locally

typecheck, `lint:ci`, `test:unit` 1503/1503, `test:bare` 923/923, `test:flow` 190/191 — the single
failure is `FIX-HANDSHAKE-BURST`, which passes in isolation (verified) and is a load flake of the
concurrent full-suite run; CI shards flow 6 ways. `test:fe` not run: no renderer surface changes.