### PR TITLE
[refactor] Decompose swarm.js: leave protocol, convergence tick, registries, presence

### DIFF
--- a/src/shared/transfer/convergence-tick.js
+++ b/src/shared/transfer/convergence-tick.js
@@ -1,0 +1,232 @@
+// The slow level-triggered re-drive: one global pass that re-sends identity frames whose implicit
+// ack never arrived, re-folds rosters whose considered records haven't replicated, re-pokes listings
+// that gave up on a peer catalog, and rescues transfers whose owner the swarm has quietly stopped
+// dialing. It is the standing answer to "restart the app and it fixes itself" — every arm here
+// exists because some state used to need a restart to converge.
+//
+// A converged, quiet swarm does no work in this module at all: each arm is gated on an observable
+// deficit, and the escalation to a discovery refresh is throttled and budgeted per space on top.
+import { getSpace } from '../spaces/space.js'
+import { getConvergenceConfig } from '../core/runtime-config.js'
+import { escalationDue, announceStatus } from './announce-ledger.js'
+import { refreshContentDiscoveries, contentPlaneHasPeer, getContentPlaneStatus } from './content-swarm.js'
+import { takeIncompleteListSpaces } from './list-deficits.js'
+import { rosterDeficits, recomputeMemberView, scheduleCapture, captureDeficits } from '../spaces/member-registry.js'
+import { isSpaceLeaving } from './leave-protocol.js'
+import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, announceLedger } from './swarm-registries.js'
+
+let log = null
+let sendSingleHandshake = null
+// The stalled-owner probe stays a swarm.js slot filled from the Swarm subsystem's constructor deps;
+// this reads it at call time. LIFECYCLE-3d retired the set*Hook seam — a nullable slot with a
+// setter is a silent no-op when nobody sets it — and hook-deps.test.js holds that line by name.
+let getStalledOwners = () => null
+// Read at call time, not captured: initSwarm and destroySwarm reassign both handles.
+let getSwarm = () => null
+let getIpc = () => null
+
+export function initConvergenceTick(deps) {
+  log = deps.log
+  sendSingleHandshake = deps.sendSingleHandshake
+  getStalledOwners = deps.getStalledOwners
+  getSwarm = deps.getSwarm
+  getIpc = deps.getIpc
+}
+
+let convergenceTimer = null
+let convergenceTicking = false          // re-entrancy guard: the tick is async, setInterval isn't
+const deficitTicks = new Map()          // spaceId → consecutive ticks with a roster deficit
+const lastRefreshAt = new Map()         // spaceId → last escalation (discovery.refresh) time
+const escalationsSpent = new Map()      // spaceId → discovery.refreshes spent on the current deficit
+
+// Re-send identity frames whose implicit ack never arrived. Settled means: for a member
+// space, some identity on that socket is admitted to it (their reciprocal proved the round
+// trip); for a pending space, the grant/deny flipped the status. A space that is leaving,
+// left, or only held as a pending-leave replay topic (no record) has nothing to announce.
+async function drainAnnounceLedger() {
+  if (socketMsgHandlers.size === 0) return
+  // Resolve per-space status only for the spaces actually in the ledger — a converged client
+  // with an empty ledger does no bee reads at all.
+  const pending = announceLedger.spaceIds()
+  if (pending.size === 0) return
+  const cfg = getConvergenceConfig()
+  const status = new Map()
+  for (const spaceId of pending) {
+    if (!spaceTopics.has(spaceId) || isSpaceLeaving(spaceId)) continue
+    // announceStatus distinguishes "present but statusless" (owner-created / v1 → 'active',
+    // a real member space) from "gone" (null → settled). Conflating them killed the owner's heal.
+    status.set(spaceId, announceStatus(await getSpace(spaceId)))
+  }
+  const isSettled = (socket, spaceId, kind) => {
+    const st = status.get(spaceId)
+    if (!st) return true
+    if (kind === 'request') return st !== 'pending'
+    for (const k of socketToPeers.get(socket) || []) {
+      if (connectedPeers.get(k)?.spaces.has(spaceId)) return true
+    }
+    return false
+  }
+  const due = announceLedger.due({
+    now: Date.now(),
+    baseMs: cfg.announceBaseMs,
+    capMs: cfg.announceCapMs,
+    maxAttempts: cfg.announceMaxAttempts,
+    isSettled,
+  })
+  for (const { socketId: socket, spaceId } of due) {
+    const handler = socketMsgHandlers.get(socket)
+    const topic = spaceTopics.get(spaceId)
+    // A dead socket (disconnected during a prior await) leaves zombie ledger entries the pure
+    // due() can't see socketMsgHandlers to prune — forget it here so its bucket evaporates.
+    if (!handler) { announceLedger.forgetSocket(socket); continue }
+    if (!topic) continue
+    log.debug('re-announcing space', spaceId)
+    await sendSingleHandshake(socket, handler, spaceId, topic)
+  }
+}
+
+// One slow, global, deficit-gated pass — the level-triggered re-drive an app restart used
+// to be: re-send unacked identity frames, re-fold rosters whose considered records haven't
+// replicated (escalating a persistent deficit to a throttled discovery refresh — fresh
+// connections mean fresh replication streams), and re-poke listings that gave up on a peer
+// catalog under the read budget. A converged, quiet swarm does nothing here.
+async function runConvergenceTick() {
+  await drainAnnounceLedger()
+  const cfg = getConvergenceConfig()
+  const deficits = rosterDeficits()
+  for (const spaceId of spaceTopics.keys()) {
+    if (!deficits.has(spaceId) || isSpaceLeaving(spaceId)) {
+      // Deficit cleared: reset all per-space escalation state so a LATER deficit (a new member
+      // not yet replicated) gets a fresh escalation budget.
+      forgetSpaceConvergence(spaceId)
+      continue
+    }
+    const ticks = (deficitTicks.get(spaceId) || 0) + 1
+    deficitTicks.set(spaceId, ticks)
+    recomputeMemberView(spaceId)
+    const spent = escalationsSpent.get(spaceId) || 0
+    const due = spent < cfg.convergenceMaxEscalations && escalationDue({
+      ticks,
+      escalateTicks: cfg.convergenceEscalateTicks,
+      lastRefreshAt: lastRefreshAt.get(spaceId) || 0,
+      minMs: cfg.convergenceRefreshMinMs,
+      now: Date.now(),
+    })
+    if (due) {
+      lastRefreshAt.set(spaceId, Date.now())
+      escalationsSpent.set(spaceId, spent + 1)
+      log.info('convergence refresh — roster deficit persisted', ticks, 'ticks for', spaceId)
+      const discovery = spaceDiscoveries.get(spaceId)
+      if (discovery) {
+        try {
+          discovery.refresh({ client: true, server: true }).catch((err) => log.debug('convergence refresh failed:', spaceId, err.message))
+        } catch (err) {
+          log.debug('convergence refresh failed:', spaceId, err.message)
+        }
+      }
+    }
+  }
+  for (const spaceId of takeIncompleteListSpaces()) {
+    if (spaceTopics.has(spaceId) && !isSpaceLeaving(spaceId)) getIpc()?.emit('event:files-updated', { spaceId })
+  }
+  // Re-attempt incomplete peer-bee captures: a capture that raced a starved or
+  // short-lived session heals here on a later one. Throttled per key inside the
+  // scheduler; retired keys (complete or past the sweep cap) never come back.
+  for (const key of await captureDeficits()) scheduleCapture(key)
+  try { await rescueStalledTransfers() } catch (err) { log.debug('stalled-transfer rescue failed:', err.message) }
+}
+
+// The tick's cleanup only visits current spaceTopics, so a space we just left would dangle here
+// (and mistime escalation on a same-space rejoin) — leaveSpaceTopic calls this on the way out.
+export function forgetSpaceConvergence(spaceId) {
+  deficitTicks.delete(spaceId)
+  lastRefreshAt.delete(spaceId)
+  escalationsSpent.delete(spaceId)
+}
+
+// Hyperswarm stops re-dialing a peer whose connections keep dying young: a link that drops inside
+// its prove-yourself window never resets the peer's attempt counter, and after the fourth such
+// close the peer loses its retry timer altogether — the next automatic dial is a topic re-lookup
+// ten minutes out. The escalation above cannot save us: it is gated on a ROSTER deficit, and a
+// two-peer space whose roster is fully replicated never has one, so a download can sit dead while
+// the swarm believes it is converged.
+//
+// A pending download whose owner we hold no socket for is exactly that state, and a discovery
+// refresh is the one lever that clears it (rediscovering a peer resets its attempts). Both planes
+// need it: the bulk plane carries the bytes, but the control plane carries the presence lease the
+// download's resume gate reads — rescuing only one leaves the transfer gated behind the other.
+// Refresh eagerly at first — a flapping link brings the peer back within a second or two, and every
+// cycle we sit out is a cycle the transfer makes no progress. But an owner who is simply offline
+// would then have us re-announce forever, so each fruitless attempt backs the next one off, up to a
+// quiet ceiling. Any attempt that finds every owner reachable resets it.
+const STALL_RESCUE_MIN_MS = 10_000
+const STALL_RESCUE_MAX_MS = 300_000
+let lastStallRescueAt = 0
+let stallRescueBackoffMs = STALL_RESCUE_MIN_MS
+let stallRescueInFlight = false
+
+export async function rescueStalledTransfers() {
+  const stalledOwners = getStalledOwners()
+  if (!getSwarm() || !stalledOwners || stallRescueInFlight) return false
+
+  stallRescueInFlight = true
+  try {
+    const contentActive = getContentPlaneStatus().active
+    let controlDown = false
+    let contentDown = false
+    for (const ownerKey of await stalledOwners()) {
+      if (!connectedPeers.has(ownerKey)) controlDown = true
+      if (contentActive && !contentPlaneHasPeer(ownerKey)) contentDown = true
+    }
+    if (!controlDown && !contentDown) {
+      stallRescueBackoffMs = STALL_RESCUE_MIN_MS // everyone we are waiting on is reachable
+      return false
+    }
+    if (Date.now() - lastStallRescueAt < stallRescueBackoffMs) return false
+
+    lastStallRescueAt = Date.now()
+    stallRescueBackoffMs = Math.min(stallRescueBackoffMs * 2, STALL_RESCUE_MAX_MS)
+    log.info('stalled transfer — refreshing discovery:', controlDown ? 'control' : '', contentDown ? 'content' : '')
+    if (controlDown) {
+      for (const [spaceId, discovery] of spaceDiscoveries) {
+        try { await discovery.refresh({ client: true, server: true }) } catch (err) { log.debug('stall refresh failed for', spaceId, err.message) }
+      }
+    }
+    if (contentDown) await refreshContentDiscoveries()
+    return true
+  } finally {
+    stallRescueInFlight = false
+  }
+}
+
+export function startConvergenceTick() {
+  if (convergenceTimer) return
+  const { convergenceTickMs } = getConvergenceConfig()
+  if (!convergenceTickMs) return
+  convergenceTimer = setInterval(() => {
+    // The tick is async and setInterval doesn't await it — skip a fire that lands while the
+    // previous run is still in flight, so overlapping runs can't double-send or double-count.
+    if (convergenceTicking) return
+    convergenceTicking = true
+    runConvergenceTick()
+      .catch((err) => log.debug('convergence tick failed:', err.message))
+      .finally(() => { convergenceTicking = false })
+  }, convergenceTickMs)
+  convergenceTimer.unref?.()
+}
+
+// What destroySwarm calls: stop the timer and drop every counter, so a restarted swarm escalates
+// from a clean budget rather than inheriting the previous session's spent attempts.
+export function resetConvergenceTick() {
+  if (convergenceTimer) {
+    clearInterval(convergenceTimer)
+    convergenceTimer = null
+  }
+  convergenceTicking = false
+  deficitTicks.clear()
+  lastRefreshAt.clear()
+  escalationsSpent.clear()
+  lastStallRescueAt = 0
+  stallRescueBackoffMs = STALL_RESCUE_MIN_MS
+  stallRescueInFlight = false
+}

--- a/src/shared/transfer/deferred-admission.js
+++ b/src/shared/transfer/deferred-admission.js
@@ -1,0 +1,151 @@
+// Deferred admission: a joiner who connected before anyone approved them. The handshake cannot admit
+// them yet, so their socket is parked in pendingRequesters and this reconciles it later — when an
+// approval record replicates in, or when a space is re-entered.
+//
+// Kept out of swarm.js because it is a retry loop over the registries, not connection handling, and
+// because its two in-flight sets are its own: nothing else reads them.
+import { getSpace, listSpaces, listJoinRequests, getJoinRequestDriveKey } from '../spaces/space.js'
+import { connectedPeers, spaceTopics, socketMsgHandlers, pendingRequesters } from './swarm-registries.js'
+
+// 'spaceId:joinerKey' currently being admitted via reconcile. Exists only to keep a concurrent
+// trigger from starting a second identical pass. readmitInflight is declared with its own function
+// further down, where the block already had it.
+const pendingAdmitInflight = new Set()
+
+let getGates = () => null
+let log = null
+let handleHandshake = null
+let sendSingleHandshake = null
+// Read at call time: initSwarm and destroySwarm reassign the handle.
+let getIpc = () => null
+
+export function initDeferredAdmission(deps) {
+  getGates = deps.getGates
+  log = deps.log
+  handleHandshake = deps.handleHandshake
+  sendSingleHandshake = deps.sendSingleHandshake
+  getIpc = deps.getIpc
+}
+
+export function resetDeferredAdmission() {
+  pendingAdmitInflight.clear()
+  readmitInflight.clear()
+}
+
+// A peer we recorded as a pending join request may since have been approved by a
+// co-member. Re-run the gate; if it now passes, admit them. If we hold their driveKey
+// (captured from a post-grant re-handshake) we replay their handshake directly — opening
+// their drive, listing them as a member, sending the reciprocal, and clearing the stale
+// request via the shared admit path. If we only ever saw their membership:request (no
+// drive), we prompt a fresh handshake over the live socket so they re-send with a driveKey
+// the gate can then admit for content — rather than bailing and leaving them unadmitted.
+export async function reconcilePendingRequester(spaceId, joinerKey) {
+  const key = spaceId + ':admit:' + joinerKey
+  if (pendingAdmitInflight.has(key)) return
+  pendingAdmitInflight.add(key)
+  try {
+    const space = await getSpace(spaceId)
+    if (!space || space.status === 'pending') return
+    if ((space.members || []).some((m) => m.publicKey === joinerKey)) return
+    if (!(await getGates().isApprovedByPeers(space, joinerKey))) return
+    const sock = connectedPeers.get(joinerKey)?.socket || pendingRequesters.get(joinerKey)
+    const topic = spaceTopics.get(spaceId)
+    if (!sock || !topic) return
+    const driveKey = getJoinRequestDriveKey(spaceId, joinerKey)
+    if (!driveKey) {
+      const handler = socketMsgHandlers.get(sock)
+      if (handler) await sendSingleHandshake(sock, handler, spaceId, topic)
+      return
+    }
+    const req = listJoinRequests(spaceId).find((r) => r.publicKey === joinerKey)
+    await handleHandshake(sock, null, {
+      type: 'handshake',
+      profileKey: joinerKey,
+      driveKey,
+      displayName: req?.displayName || 'Unknown',
+      spaceTopic: topic,
+    })
+  } finally {
+    pendingAdmitInflight.delete(key)
+  }
+}
+
+async function reconcilePendingRequestersForSpace(spaceId) {
+  for (const req of listJoinRequests(spaceId)) {
+    reconcilePendingRequester(spaceId, req.publicKey).catch((err) => {
+      log.warn('pending requester reconcile failed:', err.message)
+    })
+  }
+}
+
+export async function reconcilePendingRequestersForApprover(approverKey) {
+  const spaces = await listSpaces()
+  for (const space of spaces) {
+    if (!(space.members || []).some((m) => m.publicKey === approverKey)) continue
+    await reconcilePendingRequestersForSpace(space.spaceId)
+  }
+}
+
+const readmitInflight = new Set()
+
+// The derived member set just vouched for joinerKey; admit it if we have a live socket but no
+// admitted handshake for this space (its handshake raced ahead of the record that admits it, so we
+// bounced it to a join request and never sent the reciprocal — leaving a connected member showing as
+// Unknown/Offline). Replaying handleHandshake opens its drive, lists it, marks presence, and sends
+// the reciprocal. If we never captured its driveKey, send our handshake instead to prompt a fresh
+// one. Unlike reconcilePendingRequester this trusts the fold (no isApprovedByPeers re-check), so it
+// also admits the creator, who is approved by nobody.
+async function admitDerivedMember(spaceId, joinerKey) {
+  const sock = connectedPeers.get(joinerKey)?.socket || pendingRequesters.get(joinerKey)
+  const topic = spaceTopics.get(spaceId)
+  if (!sock || !topic) return
+  const driveKey = getJoinRequestDriveKey(spaceId, joinerKey)
+  if (!driveKey) {
+    const handler = socketMsgHandlers.get(sock)
+    if (handler) await sendSingleHandshake(sock, handler, spaceId, topic)
+    return
+  }
+  const req = listJoinRequests(spaceId).find((r) => r.publicKey === joinerKey)
+  await handleHandshake(sock, null, {
+    type: 'handshake',
+    profileKey: joinerKey,
+    driveKey,
+    displayName: req?.displayName || 'Unknown',
+    spaceTopic: topic,
+  })
+}
+
+export function readmitConnectedMembers(spaceId, keys) {
+  for (const key of keys) {
+    if (!pendingRequesters.has(key) && !connectedPeers.has(key)) continue
+    const guard = spaceId + ':' + key
+    if (readmitInflight.has(guard)) continue
+    readmitInflight.add(guard)
+    admitDerivedMember(spaceId, key)
+      .catch((err) => log.warn('readmit on derive failed:', err.message))
+      .finally(() => readmitInflight.delete(guard))
+  }
+}
+
+export function emitSharesUpdated(spaceId) {
+  if (getIpc()) getIpc().emit('event:shares-updated', { spaceId })
+}
+
+// A peer's profile bee appended (it holds their `share/<space>/*` records), so refresh the
+// share list for every space we share with them. Coarse by design — any bee change pokes
+// the list — but cheap, and it's the renderer's only signal that a peer added/removed a share.
+// We poke the FILE list too: files:list hides a peer's folder-share contents using prefixes read
+// from this same profile bee, but the renderer's useFiles refreshes only on event:files-updated
+// (the profile-bee append fires shares-updated, not files-updated). Without this a peer's
+// newly-shared — or slow-to-replicate — folder would leak its files into the flat loose-file list
+// until some unrelated files-updated happened to fire.
+export async function emitPeerSharesUpdated(profileKeyHex) {
+  if (!getIpc()) return
+  for (const space of await listSpaces()) {
+    if ((space.members || []).some((m) => m.publicKey === profileKeyHex)) {
+      getIpc().emit('event:shares-updated', { spaceId: space.spaceId })
+      getIpc().emit('event:files-updated', { spaceId: space.spaceId })
+      getIpc().emit('event:mirrors-updated', { spaceId: space.spaceId })
+    }
+  }
+}

--- a/src/shared/transfer/leave-protocol.js
+++ b/src/shared/transfer/leave-protocol.js
@@ -1,0 +1,386 @@
+// Leaving a space, and the two replay lanes that make a leave stick when nobody was listening.
+//
+// Three concerns, one lifecycle: applying an inbound `leave` frame (adopt the leaver's vouchees,
+// tombstone, revoke, ack), replaying our own outbound leave until a co-member acks it durably, and
+// replaying a withdrawn join request until a member writes the converging denial. They share the
+// leaving-space marker, the purged-topic join/leave helpers and the ack-eligibility bookkeeping,
+// and nothing outside them touches those — which is what makes this a module rather than a section.
+//
+// Takes its collaborators through init() rather than importing swarm.js: the swarm handle and the
+// IPC channel are both reassigned across a restart, and getLocalBinding caches per-drive-key
+// signatures that only the connection layer can mint.
+import b4a from 'b4a'
+import { getProfileKey, revokeApproval, adoptVouchees } from '../spaces/profile.js'
+import { getSpace, removeMember, persistLeftTombstone } from '../spaces/space.js'
+import { leaveFrameBound } from './handshake-guard.js'
+import { destroyContentPeerSockets } from './content-swarm.js'
+import { record } from '../audit/audit-log.js'
+import { peerLeft } from '../audit/network-watch.js'
+import { markLeft } from '../spaces/member-registry.js'
+import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers } from './swarm-registries.js'
+
+let presence = null
+let log = null
+let getLocalBinding = () => null
+let getRevokeServesHook = () => null
+// Read at call time, not captured: initSwarm and destroySwarm reassign both handles.
+let getSwarm = () => null
+let getIpc = () => null
+
+export function initLeaveProtocol(deps) {
+  presence = deps.presence
+  log = deps.log
+  getLocalBinding = deps.getLocalBinding
+  getRevokeServesHook = deps.getRevokeServesHook
+  getSwarm = deps.getSwarm
+  getIpc = deps.getIpc
+}
+
+// spaceIds whose teardown is in flight. Read all over the worker (files:list and size reads
+// short-circuit on it so they never race a drive being closed), which is why it is exported
+// through three accessors rather than as the Set.
+const leavingSpaces = new Set()
+export function markSpaceLeaving(spaceId) { leavingSpaces.add(spaceId) }
+export function unmarkSpaceLeaving(spaceId) { leavingSpaces.delete(spaceId) }
+export function isSpaceLeaving(spaceId) { return leavingSpaces.has(spaceId) }
+
+// spaceId (we are leaving) → Set<profileKeyHex> of co-members that applied our leave
+const leaveAcks = new Map()
+
+function memberSnapshot (space, publicKey) {
+  return {
+    spaceName: space?.name ?? null,
+    memberName: (space?.members || []).find((m) => m.publicKey === publicKey)?.displayName ?? null,
+  }
+}
+
+function recordMemberLeft (spaceId, profileKey, snapshot) {
+  record('member.left', {
+    actor: { type: 'peer', key: profileKey, name: snapshot.memberName },
+    space: { id: spaceId, name: snapshot.spaceName },
+    target: { kind: 'member', id: profileKey, name: snapshot.memberName },
+  })
+}
+
+export async function handleLeaveFrame(socket, peerInfo, msg) {
+  const { spaceId, profileKey } = msg
+  if (!spaceId || !profileKey) return
+
+  // Our own teardown destroys the sockets that clear the auth index, so an inbound
+  // frame for a space we're leaving races into the rejection below — drop it quietly.
+  if (leavingSpaces.has(spaceId)) return
+
+  // Accept iff the sender proves it controls profileKey on THIS connection: the fast path is the
+  // per-socket auth index; the robust path is the frame's identity binding, which survives the
+  // teardown/reconnect race that clears or has-not-yet-populated that index. Additive — the binding
+  // proof is strictly stronger than the index, so a third party still cannot evict a member.
+  const onSocket = socketToPeers.get(socket)?.has(profileKey) || false
+  if (!onSocket && !leaveFrameBound(peerInfo, msg)) {
+    log.warn('leave frame rejected — sender not authenticated on socket and no valid binding')
+    return
+  }
+
+  const space = await getSpace(spaceId)
+  if (!space?.members) return
+
+  // Take over the leaver's vouchees before touching anything else. The revoke below unroots the
+  // leaver, and from then on the fold stops walking its bee, so the subtree it alone vouched for
+  // could never be recovered. The leaver is connected right now, which is the best window there is
+  // to read that record. When it is unreadable, apply NOTHING: the replication-driven path retries
+  // once the departure record lands, which is strictly better than tombstoning here while our vouch
+  // still stands (a tombstone would suppress every retry).
+  if (!(await adoptVouchees(spaceId, profileKey))) {
+    log.warn('leave frame deferred — leaver record unreadable, cannot adopt:', profileKey.slice(0, 12))
+    return
+  }
+
+  // After the deferral above, so a leave we did not apply records nothing.
+  const leftSnapshot = memberSnapshot(space, profileKey)
+
+  // Tombstone the leaver FIRST so the member-view fold can't re-add them from their stale
+  // still-active record (their del-record may not replicate before they disconnect). Set
+  // before removeMember so any in-flight re-derive already subtracts them. Persist it so the
+  // subtraction survives a restart, incl. the creator/root where revokeApproval is a no-op.
+  // msg.ts is untrusted wire data used as the durable self-clear stamp — reject a non-finite /
+  // non-positive value (a negative would make tombstoneActive false and re-add the leaver). It is
+  // the leaver's own clock, same as the member/<S>.ts a rejoin writes, so the comparison stays
+  // single-clock in the common path.
+  const leaveTs = (typeof msg.ts === 'number' && Number.isFinite(msg.ts) && msg.ts > 0) ? msg.ts : Date.now()
+  markLeft(spaceId, profileKey, leaveTs)
+  let durablyApplied = true
+  try { await persistLeftTombstone(spaceId, profileKey, leaveTs) } catch (err) {
+    durablyApplied = false
+    log.warn('persist leave tombstone failed:', err.message)
+  }
+
+  // Revoke our own approval so a later rejoin needs fresh approval, not a silent re-admit off the
+  // surviving grow-only record. Unconditional + idempotent: a leaver already pruned by the fold (or a
+  // duplicate frame) must still lose our vouch. No-op for the creator (we hold no approval for the
+  // root). Safe to unroot the leaver here — its vouchees were adopted above.
+  try { await revokeApproval(spaceId, profileKey) } catch (err) {
+    durablyApplied = false
+    log.warn('approval revoke on leave failed:', err.message)
+  }
+
+  // Ack the leaver over its own socket so it can stop waiting (awaitLeaveAcks) — but ONLY once the
+  // durable tombstone + revoke actually landed, since that is exactly what the ack attests. A
+  // swallowed durable failure must not resolve the wait early; the leaver falls back to the cap.
+  const selfKey = getProfileKey()
+  if (durablyApplied && selfKey) {
+    try { socketMsgHandlers.get(socket)?.send(JSON.stringify({ type: 'leave-ack', spaceId, profileKey: b4a.toString(selfKey, 'hex') })) } catch {}
+  }
+
+  const removed = await removeMember(spaceId, profileKey)
+  if (!removed) return
+  log.info('peer left space (leave frame):', profileKey.slice(0, 12) + '...', '→', spaceId)
+
+  presence.clear(profileKey, spaceId)   // the leaver is offline in this space immediately
+  peerLeft(profileKey, spaceId)         // ...but that is a LEAVE; member.left carries it
+
+  const peer = connectedPeers.get(profileKey)
+  if (peer) {
+    peer.spaces.delete(spaceId)
+    peer.looseCatalogKeys?.delete(spaceId)
+    if (peer.spaces.size === 0) {
+      connectedPeers.delete(profileKey)
+      const set = socketToPeers.get(peer.socket)
+      if (set) {
+        set.delete(profileKey)
+        if (set.size === 0) socketToPeers.delete(peer.socket)
+      }
+      // The overlay content channel rides the CONTENT socket, not this one: a peer we no longer
+      // share any space with must lose that socket too, or we keep serving it bulk bytes.
+      try { destroyContentPeerSockets(profileKey) } catch {}
+    }
+  }
+  // Their leave revokes our serve grants for this space: the grant is cached per (peer, path) at
+  // request time and re-checked against that cache only, so a membership change has to invalidate
+  // it actively — otherwise an in-flight transfer keeps streaming to a peer no longer entitled.
+  getRevokeServesHook()?.(spaceId, profileKey)
+
+  recordMemberLeft(spaceId, profileKey, leftSnapshot)
+
+  getIpc().emit('event:member-left', { spaceId, publicKey: profileKey })
+  getIpc().emit('event:files-updated', { spaceId })
+}
+
+// ── pending outbound leaves (leave-while-alone recovery) ────────────────────────
+// spaceId → { topic, ts }. A leave that provably reached no member is re-announced on
+// every new connection until a co-member acks its durable apply. Seeded from the
+// pendingleave/ markers at boot (the space record itself is already purged); the worker
+// injects onApplied to clear the marker + leave the topic. ts is the ORIGINAL leave
+// stamp so a genuine later rejoin (strictly newer member/<S> ts) always outranks the
+// replayed tombstone on co-members.
+const pendingLeaves = new Map()
+const pendingLeaveFramesSent = new WeakMap()   // socket → Set<spaceId> (ack eligibility for the record-less space)
+let onPendingLeaveApplied = null
+
+export function configurePendingLeaves(onApplied) { onPendingLeaveApplied = onApplied }
+
+export function registerPendingLeave(spaceId, topicHex, ts) {
+  pendingLeaves.set(spaceId, { topic: topicHex, ts })
+}
+
+export function unregisterPendingLeave(spaceId) { pendingLeaves.delete(spaceId) }
+
+export function hasPendingLeave(spaceId) { return pendingLeaves.has(spaceId) }
+
+// Join/leave the topic of a PURGED space (both leave-replay and cancel-replay need this — the
+// space record is gone, so joinSpaceTopic can't read it). Return whether they acted, for logging.
+function joinPurgedSpaceTopic(spaceId, topicHex) {
+  const swarm = getSwarm()
+  if (!swarm || spaceDiscoveries.has(spaceId)) return false
+  spaceTopics.set(spaceId, topicHex)
+  spaceDiscoveries.set(spaceId, swarm.join(b4a.from(topicHex, 'hex'), { server: true, client: true }))
+  return true
+}
+
+async function leavePurgedSpaceTopic(spaceId) {
+  const topicHex = spaceTopics.get(spaceId)
+  if (!topicHex) return false
+  try { await getSwarm().leave(b4a.from(topicHex, 'hex')) } catch {}
+  spaceTopics.delete(spaceId)
+  spaceDiscoveries.delete(spaceId)
+  return true
+}
+
+export function joinPendingLeaveTopic(spaceId, topicHex) {
+  if (joinPurgedSpaceTopic(spaceId, topicHex)) log.info('joined topic for pending-leave replay:', spaceId)
+}
+
+export async function leavePendingLeaveTopic(spaceId) {
+  if (await leavePurgedSpaceTopic(spaceId)) log.info('left pending-leave topic:', spaceId)
+}
+
+export function sendPendingLeaveFrames(socket, msgHandler) {
+  if (pendingLeaves.size === 0) return
+  const profileKey = getProfileKey()
+  if (!profileKey) return
+  const profileKeyHex = b4a.toString(profileKey, 'hex')
+  let sent = pendingLeaveFramesSent.get(socket)
+  if (!sent) pendingLeaveFramesSent.set(socket, (sent = new Set()))
+  for (const [spaceId, { ts }] of pendingLeaves) {
+    sent.add(spaceId)
+    try {
+      msgHandler.send(JSON.stringify({ type: 'leave', spaceId, profileKey: profileKeyHex, ts, ...(getLocalBinding() || {}) }))
+    } catch (err) {
+      log.debug('pending-leave frame send failed:', err.message)
+    }
+  }
+}
+
+export function sendLeaveFrameToConnectedPeers(spaceId) {
+  if (socketMsgHandlers.size === 0) return
+  const profileKey = getProfileKey()
+  if (!profileKey) return
+  const profileKeyHex = b4a.toString(profileKey, 'hex')
+  leaveAcks.set(spaceId, new Set())   // collect co-member acks BEFORE the frames go out (no missed-ack race)
+  const payload = JSON.stringify({
+    type: 'leave',
+    spaceId,
+    profileKey: profileKeyHex,
+    ts: Date.now(),
+    ...(getLocalBinding() || {}),
+  })
+  for (const [, handler] of socketMsgHandlers) {
+    try { handler.send(payload) } catch (err) {
+      log.warn('leave frame send failed:', err.message)
+    }
+  }
+}
+
+export function leaveAcksSatisfied(expectedKeys, receivedSet) {
+  for (const k of expectedKeys) if (!receivedSet.has(k)) return false
+  return true
+}
+
+// Wait (bounded) for the connected members of a space to confirm they applied our leave — an
+// observed signal that the load-bearing revokeApproval ran on our approvers before we tear
+// down. Resolves early on full coverage; falls back to the cap for peers on older releases
+// (which never ack) or a straggler. No connected members ⇒ nothing to wait for.
+export async function awaitLeaveAcks(spaceId, { capMs = 2000, pollMs = 50, floorMs = 0 } = {}) {
+  const received = leaveAcks.get(spaceId)
+  const expected = new Set(presence.onlineIn(spaceId))
+  try {
+    if (!received || expected.size === 0) return true
+    const start = Date.now()
+    for (;;) {
+      const elapsed = Date.now() - start
+      // Hold at least floorMs even once every ack lands: an ack proves the co-member ran its
+      // revoke, but NOT that it pulled our `del member/<S>` block (authored just before the frame)
+      // so it can re-host the departure to members offline at leave time. The floor preserves a
+      // replication window for that block.
+      if (elapsed >= floorMs && leaveAcksSatisfied(expected, received)) return true
+      if (elapsed >= capMs) return false
+      await new Promise((r) => setTimeout(r, pollMs))
+    }
+  } finally {
+    // Snapshot the acked keys before dropping the ledger, so the pending-leave arm decision can
+    // ask "which members provably applied the leave" — the boolean return conflates that with
+    // "nobody was connected" (vacuous true), which would skip the marker exactly when a member
+    // dropped mid-leave.
+    if (received) lastLeaveAckedKeys.set(spaceId, new Set(received))
+    leaveAcks.delete(spaceId)
+  }
+}
+
+// spaceId → Set<keyHex> of members that acked our most recent leave (populated by awaitLeaveAcks).
+const lastLeaveAckedKeys = new Map()
+export function takeLeaveAckedKeys(spaceId) {
+  const set = lastLeaveAckedKeys.get(spaceId)
+  lastLeaveAckedKeys.delete(spaceId)
+  return set || new Set()
+}
+
+export function handleLeaveAckFrame(socket, msg) {
+  const { spaceId, profileKey } = msg
+  if (!spaceId || !profileKey) return
+  // A pending-leave replay ack arrives on a socket with no live handshake for the purged
+  // space (we no longer handshake it), so the strict rule below would drop it. Accept it
+  // from a socket this pending frame went out on: the Noise session pins the counterparty,
+  // and the worst a false ack does is stop the re-announce — the pre-marker behavior.
+  if (pendingLeaves.has(spaceId) && pendingLeaveFramesSent.get(socket)?.has(spaceId)) {
+    pendingLeaves.delete(spaceId)
+    log.info('pending leave acked — clearing marker:', spaceId)
+    Promise.resolve(onPendingLeaveApplied?.(spaceId)).catch((err) => log.debug('pending-leave clear failed:', err.message))
+  }
+  // Only count an ack from a peer that authenticated as this profileKey on this socket, so a peer
+  // can't forge acks for other members and collapse the leaver's flush wait early.
+  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  leaveAcks.get(spaceId)?.add(profileKey)
+}
+
+// ── pending outbound cancels (withdraw-a-request delivery) ──────────────────────
+// A withdrawing pending joiner must reach at least one member showing its request; that member
+// writes a durable denied tombstone which replicates to the rest. Re-announced on every new
+// connection until an applied ack lands. In-memory: cleared on restart.
+const pendingCancels = new Map()   // spaceId → { topic, joinerKey, attempts }
+const pendingCancelFramesSent = new WeakMap()   // socket → Set<spaceId> (ack eligibility)
+// Bound the replay so an abandoned withdrawal to an always-offline space can't hold the topic for
+// the whole session; a member reached before the cap converges it, past it we give up (a member
+// offline the entire time keeps the stale request — the documented in-memory-only residual).
+const MAX_CANCEL_ATTEMPTS = 30
+let onPendingCancelApplied = null
+
+export function configurePendingCancels(onApplied) { onPendingCancelApplied = onApplied }
+
+export function registerPendingCancel(spaceId, topicHex, joinerKey) {
+  pendingCancels.set(spaceId, { topic: topicHex, joinerKey, attempts: 0 })
+}
+
+export function hasPendingCancel(spaceId) { return pendingCancels.has(spaceId) }
+
+export function joinPendingCancelTopic(spaceId, topicHex) { joinPurgedSpaceTopic(spaceId, topicHex) }
+export async function leavePendingCancelTopic(spaceId) { await leavePurgedSpaceTopic(spaceId) }
+
+export function sendPendingCancelFrames(socket, msgHandler) {
+  if (pendingCancels.size === 0) return
+  let sent = pendingCancelFramesSent.get(socket)
+  if (!sent) pendingCancelFramesSent.set(socket, (sent = new Set()))
+  for (const [spaceId, pc] of pendingCancels) {
+    try { msgHandler.send(JSON.stringify({ type: 'membership:cancel', spaceTopic: pc.topic, joinerKey: pc.joinerKey })) } catch { continue }
+    sent.add(spaceId)
+    if (++pc.attempts >= MAX_CANCEL_ATTEMPTS) {
+      pendingCancels.delete(spaceId)
+      leavePurgedSpaceTopic(spaceId).catch((err) => log.debug('pending-cancel give-up leave failed:', err.message))
+    }
+  }
+}
+
+// Initial send of a freshly-registered cancel on every current connection. Goes through
+// sendPendingCancelFrames (not broadcastMembershipCancel) so ack eligibility is recorded per socket
+// — otherwise a member acking over the existing connection would be rejected by handleMembershipCancelAck.
+export function sendPendingCancelToConnected() {
+  for (const [socket, handler] of socketMsgHandlers) sendPendingCancelFrames(socket, handler)
+}
+
+// A member acked our cancel with applied:true (it wrote the converging tombstone) on a socket we
+// actually sent the cancel on — stop replaying and drop the topic. The socket + frame-sent check
+// mirrors handleLeaveAckFrame: a peer that never received our cancel can't clear it.
+export function handleMembershipCancelAck(socket, msg) {
+  if (!msg.applied || typeof msg.spaceTopic !== 'string') return
+  for (const [spaceId, pc] of pendingCancels) {
+    if (pc.topic !== msg.spaceTopic) continue
+    if (!pendingCancelFramesSent.get(socket)?.has(spaceId)) return
+    pendingCancels.delete(spaceId)
+    Promise.resolve(onPendingCancelApplied?.(spaceId)).catch((err) => log.debug('pending-cancel clear failed:', err.message))
+    return
+  }
+}
+
+// What destroySwarm calls instead of clearing six containers by hand. The two onApplied hooks are
+// injected by the worker per boot, so they drop with everything else.
+export function resetLeaveProtocol() {
+  leavingSpaces.clear()
+  leaveAcks.clear()
+  pendingLeaves.clear()
+  lastLeaveAckedKeys.clear()
+  pendingCancels.clear()
+  onPendingLeaveApplied = null
+  onPendingCancelApplied = null
+}
+
+// Membership removal is the member-set fold's job (member-registry): a peer drops from the
+// set when their replicated `del member/S` (leave) lands, and stays an offline member
+// otherwise. This layer deliberately never prunes membership on disconnect — admission is
+// separate from membership display, and a dead socket says nothing about membership.

--- a/src/shared/transfer/presence-broadcast.js
+++ b/src/shared/transfer/presence-broadcast.js
@@ -16,6 +16,7 @@ import { connectedPeers, socketToPeers, spaceTopics, socketMsgHandlers } from '.
 
 let presence = null
 let membersPoke = null
+let log = null
 let presenceTimer = null
 let getSwarm = () => null
 let getIpc = () => null
@@ -25,8 +26,23 @@ let getIpc = () => null
 export function initPresenceBroadcast(deps) {
   presence = deps.presence
   membersPoke = deps.membersPoke
+  log = deps.log
   getSwarm = deps.getSwarm
   getIpc = deps.getIpc
+}
+
+const PRESENCE_HEARTBEAT_MS = 5000
+
+// The interval lives with the timer variable, not with initSwarm: broadcastDeparture has to stop
+// the heartbeat before it sends (a beat landing after the departure re-marks us online on the
+// receiver and undoes it), and it can only stop a timer this module actually holds.
+export function startPresenceHeartbeat() {
+  if (presenceTimer) return
+  presenceTimer = setInterval(() => {
+    try { broadcastPresence() } catch (err) { log.debug('presence heartbeat failed:', err.message) }
+    presence.prune()
+  }, PRESENCE_HEARTBEAT_MS)
+  presenceTimer.unref?.()
 }
 
 export function stopPresenceHeartbeat() {

--- a/src/shared/transfer/presence-broadcast.js
+++ b/src/shared/transfer/presence-broadcast.js
@@ -1,0 +1,184 @@
+// Presence and the ephemeral broadcasts that ride the same lane: the liveness heartbeat, the
+// departure notice, and the share prepare/index progress frames. All of it is fire-and-forget — no
+// durable state, no acknowledgement — which is why it separates from the swarm's connection handling
+// so cleanly.
+//
+// Reads the shared registries directly and takes its three genuine collaborators through init(),
+// following the module-state pattern serve-ledger.js and loose-overlay.js already use here. That
+// keeps swarm.js's public surface intact: it re-exports these names rather than wrapping them.
+import b4a from 'b4a'
+import { getProfileKey } from '../spaces/profile.js'
+import { LOOSE_SHARE_ID } from './transfer-id.js'
+import { shareDecoKey } from './decoration-key.js'
+import { peerSeen } from '../audit/network-watch.js'
+import { presenceFrameKind } from '../state/presence.js'
+import { connectedPeers, socketToPeers, spaceTopics, socketMsgHandlers } from './swarm-registries.js'
+
+let presence = null
+let membersPoke = null
+let presenceTimer = null
+let getSwarm = () => null
+let getIpc = () => null
+
+// getSwarm and getIpc are read at call time, not captured: initSwarm and destroySwarm reassign both,
+// so a value taken at init would go stale on the first reconnect.
+export function initPresenceBroadcast(deps) {
+  presence = deps.presence
+  membersPoke = deps.membersPoke
+  getSwarm = deps.getSwarm
+  getIpc = deps.getIpc
+}
+
+export function stopPresenceHeartbeat() {
+  if (presenceTimer) { clearInterval(presenceTimer); presenceTimer = null }
+}
+
+// Heartbeat: advertise our own liveness per space to the peers in it. The recipient leases
+// us for PRESENCE_TTL_MS from when it receives this — we can't extend our own lease.
+function broadcastPresence() {
+  if (socketMsgHandlers.size === 0) return
+  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
+  for (const [spaceId, topicHex] of spaceTopics) {
+    for (const [, peer] of connectedPeers) {
+      if (!peer.spaces.has(spaceId)) continue
+      const handler = socketMsgHandlers.get(peer.socket)
+      if (handler) { try { handler.send(JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex })) } catch {} }
+    }
+  }
+}
+
+// Graceful-quit departure: tell every connected peer we're going offline NOW so they flip us
+// offline immediately instead of waiting out the socket close / 15s presence TTL. Reuses the
+// presence frame with offline:true (NOT the leave frame — that mints membership tombstones we must
+// not trigger on a mere quit). Best-effort; socket close + TTL remain the backstops.
+export function broadcastDeparture() {
+  // Stop our own heartbeat first: a heartbeat firing later in the shutdown teardown window would
+  // re-mark us online on a receiver (mark after clear) and undo this departure.
+  if (presenceTimer) { clearInterval(presenceTimer); presenceTimer = null }
+  if (!getSwarm() || socketMsgHandlers.size === 0) return
+  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
+  for (const [spaceId, topicHex] of spaceTopics) {
+    for (const [, peer] of connectedPeers) {
+      if (!peer.spaces.has(spaceId)) continue
+      const handler = socketMsgHandlers.get(peer.socket)
+      if (handler) { try { handler.send(JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex, offline: true })) } catch {} }
+    }
+  }
+}
+
+// Owner→members: live indexing/hashing progress for a file still advertised with contentHash:null
+// (consumer status 'preparing'). Ephemeral, scoped to peers connected on this space.
+export function broadcastSharePrepareProgress(spaceId, payload) {
+  if (socketMsgHandlers.size === 0) return
+  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
+  const frame = JSON.stringify({ type: 'share-prepare-progress', profileKey: profileKeyHex, spaceId, ...payload })
+  for (const [, peer] of connectedPeers) {
+    if (!peer.spaces.has(spaceId)) continue
+    const handler = socketMsgHandlers.get(peer.socket)
+    if (handler) { try { handler.send(frame) } catch {} }
+  }
+}
+
+// A share is admission-gated at 5k files and a folder that grows past it keeps publishing, so this
+// is a display bound, not a limit — it only stops a peer-supplied count from rendering as nonsense.
+const MAX_WIRE_COUNT = 1_000_000
+
+// Owner→members: how much of a share is still waiting to be indexed. Ephemeral like the per-file
+// frame above, and for the same reason — the queue is not durable state, so it is re-announced
+// rather than replicated. It carries what the catalog cannot: files that have no entry yet because
+// their publish has not started.
+export function broadcastShareIndexProgress(spaceId, payload) {
+  if (socketMsgHandlers.size === 0) return
+  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
+  const frame = JSON.stringify({ type: 'share-index-progress', profileKey: profileKeyHex, spaceId, ...payload })
+  for (const [, peer] of connectedPeers) {
+    if (!peer.spaces.has(spaceId)) continue
+    const handler = socketMsgHandlers.get(peer.socket)
+    if (handler) { try { handler.send(frame) } catch {} }
+  }
+}
+
+// Re-surface an owner's queue depth to our renderer. Same anti-spoof guard as the prepare frame:
+// accept only from an identity authenticated on this socket. Non-authoritative and count-only —
+// it names no file and gates no content, so the worst a bad frame can do is a wrong number in a
+// notice. Its own validator: the prepare frame's requires total > 0 and bytes within it, which a
+// queue summary does not satisfy.
+function handleShareIndexProgressFrame(socket, msg) {
+  const { profileKey, spaceId, shareId, adding, bytesQueued } = msg
+  if (typeof profileKey !== 'string' || typeof spaceId !== 'string' || typeof shareId !== 'string') return
+  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  // The sender is carried through as `ownerKey` so the consumer can require it to be the share's
+  // actual owner. Authentication proves only WHO is speaking: without this any approved co-member
+  // could describe someone else's share, and the notice names that someone by display name.
+  // Wire numbers are peer-controlled: whole counts only, bounded, so a bad frame cannot reach the
+  // renderer as a fractional or astronomically pluralized sentence.
+  const safeCount = (n) => (Number.isSafeInteger(n) && n > 0 ? Math.min(n, MAX_WIRE_COUNT) : 0)
+  const safeBytes = (n) => (Number.isFinite(n) && n > 0 ? Math.min(n, Number.MAX_SAFE_INTEGER) : 0)
+  getIpc().emit('event:share-index-progress', {
+    spaceId, shareId, ownerKey: profileKey, adding: safeCount(adding), bytesQueued: safeBytes(bytesQueued),
+  })
+}
+
+// Receive a peer's heartbeat: refresh its lease, but only for an identity already
+// authenticated on this socket (same guard as the leave frame) — so presence can't be
+// spoofed for a peer we never handshaked. The TTL is ours; any sender-claimed expiry is
+// ignored.
+function handlePresenceFrame(socket, msg) {
+  const kind = presenceFrameKind(msg)
+  if (kind === 'ignore') return
+  const { profileKey, spaceTopic } = msg
+  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  const spaceId = resolveSpaceIdForTopic(spaceTopic)
+  if (!spaceId) return
+  if (kind === 'clear') {
+    // Explicit graceful-quit departure (offline:true): flip the peer offline now, don't wait for
+    // the socket close or the TTL. Gate the emit on a real online→offline transition (like the mark
+    // path) so repeated departure frames can't amplify reconcile hints. Idempotent with the
+    // socket-close handleDisconnect that follows.
+    if (presence.clear(profileKey, spaceId)) {
+      membersPoke.poke(spaceId)
+      getIpc()?.emit('event:files-updated', { spaceId })
+    }
+    return
+  }
+  if (presence.mark(profileKey, spaceId)) {
+    // Same-socket lease restore: the peer went silent past the TTL and is back without
+    // a re-handshake — the arrival mirror of the onExpire departure emit.
+    peerSeen(profileKey, spaceId)
+    membersPoke.poke(spaceId)
+    getIpc()?.emit('event:files-updated', { spaceId })
+  }
+}
+
+// Re-surface a peer's indexing progress to our renderer. Same anti-spoof guard as presence/leave:
+// accept only from an identity authenticated on this socket. Non-authoritative — the row shows it
+// only while genuinely 'preparing', and contentHash still gates the content itself.
+function handleSharePrepareProgressFrame(socket, msg) {
+  const { profileKey, spaceId, shareId, relPath, bytes, total, eta } = msg
+  if (typeof profileKey !== 'string' || typeof spaceId !== 'string') return
+  if (typeof shareId !== 'string' || typeof relPath !== 'string') return
+  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  const key = shareId === LOOSE_SHARE_ID ? '/' + relPath : shareDecoKey(shareId, relPath)
+  // The owner finished (or abandoned) the hash. Decorations are cleared only by this frame, so
+  // without it the bar sits at ~100% and repaints stale on the next re-hash of the same path. It
+  // carries no numbers to validate, and clears at most a cosmetic bar a progress frame repaints.
+  if (msg.done === true) {
+    // Phase-scoped: this key is SHARED with our own download of the same file, and a re-publish
+    // restarts that download the moment the materialized hash replicates — a `done` landing just
+    // after it must not take down a live download bar.
+    getIpc().emit('event:decoration', { channel: 'transfer', spaceId, key, phase: 'preparing', done: true })
+    return
+  }
+  // Wire numbers are peer-controlled: drop anything non-finite / out of range so a bad frame
+  // can't reach the renderer as a NaN bar (width:'NaN%' / aria-valuenow=NaN).
+  if (!Number.isFinite(bytes) || !Number.isFinite(total) || total <= 0 || bytes < 0 || bytes > total) return
+  // null/absent = the owner is still warming up its estimate ("Estimating…"); preserve it. Any
+  // other value is a peer-controlled number, so clamp non-finite/non-positive to 0.
+  const safeEta = eta == null ? null : (Number.isFinite(eta) && eta > 0 ? eta : 0)
+  getIpc().emit('event:decoration', { channel: 'transfer', spaceId, key, phase: 'preparing', bytes, total, speed: 0, eta: safeEta })
+}
+
+function resolveSpaceIdForTopic(topicHex) {
+  for (const [spaceId, topic] of spaceTopics) if (topic === topicHex) return spaceId
+  return null
+}

--- a/src/shared/transfer/presence-broadcast.js
+++ b/src/shared/transfer/presence-broadcast.js
@@ -35,7 +35,7 @@ export function stopPresenceHeartbeat() {
 
 // Heartbeat: advertise our own liveness per space to the peers in it. The recipient leases
 // us for PRESENCE_TTL_MS from when it receives this — we can't extend our own lease.
-function broadcastPresence() {
+export function broadcastPresence() {
   if (socketMsgHandlers.size === 0) return
   const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
   for (const [spaceId, topicHex] of spaceTopics) {
@@ -103,7 +103,7 @@ export function broadcastShareIndexProgress(spaceId, payload) {
 // it names no file and gates no content, so the worst a bad frame can do is a wrong number in a
 // notice. Its own validator: the prepare frame's requires total > 0 and bytes within it, which a
 // queue summary does not satisfy.
-function handleShareIndexProgressFrame(socket, msg) {
+export function handleShareIndexProgressFrame(socket, msg) {
   const { profileKey, spaceId, shareId, adding, bytesQueued } = msg
   if (typeof profileKey !== 'string' || typeof spaceId !== 'string' || typeof shareId !== 'string') return
   if (!socketToPeers.get(socket)?.has(profileKey)) return
@@ -123,7 +123,7 @@ function handleShareIndexProgressFrame(socket, msg) {
 // authenticated on this socket (same guard as the leave frame) — so presence can't be
 // spoofed for a peer we never handshaked. The TTL is ours; any sender-claimed expiry is
 // ignored.
-function handlePresenceFrame(socket, msg) {
+export function handlePresenceFrame(socket, msg) {
   const kind = presenceFrameKind(msg)
   if (kind === 'ignore') return
   const { profileKey, spaceTopic } = msg
@@ -153,7 +153,7 @@ function handlePresenceFrame(socket, msg) {
 // Re-surface a peer's indexing progress to our renderer. Same anti-spoof guard as presence/leave:
 // accept only from an identity authenticated on this socket. Non-authoritative — the row shows it
 // only while genuinely 'preparing', and contentHash still gates the content itself.
-function handleSharePrepareProgressFrame(socket, msg) {
+export function handleSharePrepareProgressFrame(socket, msg) {
   const { profileKey, spaceId, shareId, relPath, bytes, total, eta } = msg
   if (typeof profileKey !== 'string' || typeof spaceId !== 'string') return
   if (typeof shareId !== 'string' || typeof relPath !== 'string') return
@@ -178,7 +178,7 @@ function handleSharePrepareProgressFrame(socket, msg) {
   getIpc().emit('event:decoration', { channel: 'transfer', spaceId, key, phase: 'preparing', bytes, total, speed: 0, eta: safeEta })
 }
 
-function resolveSpaceIdForTopic(topicHex) {
+export function resolveSpaceIdForTopic(topicHex) {
   for (const [spaceId, topic] of spaceTopics) if (topic === topicHex) return spaceId
   return null
 }

--- a/src/shared/transfer/swarm-registries.js
+++ b/src/shared/transfer/swarm-registries.js
@@ -1,0 +1,36 @@
+// The swarm's shared indexes: who is connected, over which socket, on which topics. Every section of
+// swarm.js reads them, which is exactly why they belong to none of it.
+//
+// Extracted first, before the sections that use them. Measured, the shared registries were the bulk
+// of every remaining section's dependency list — presence needed 11 identifiers from the core and
+// deferred admission 10, of which four each were these Maps. Giving them a home is what makes those
+// sections cheap to move; doing it the other way round means threading Maps through injected
+// dependency objects and calling the result a decomposition.
+//
+// Exported bindings, not accessors: a Map's identity never changes, so importers mutate contents
+// through a stable reference. resetRegistries() is what a teardown calls instead of clearing each
+// one by hand — the reason destroySwarm knew about all of them.
+
+// profileKey → { socket, profileKey, displayName, avatar, spaces: Map<spaceId, driveKey> }
+export const connectedPeers = new Map()
+// socket → Set<profileKey>  (reverse index for disconnect lookup)
+export const socketToPeers = new Map()
+export const spaceTopics = new Map()
+// spaceId → PeerDiscovery (kept so reconnectAll can refresh)
+export const spaceDiscoveries = new Map()
+// socket → Protomux msgHandler (for sending handshakes to existing connections)
+export const socketMsgHandlers = new Map()
+// profileKey → socket. A pending joiner has no drive or handshake yet, so its socket is tracked here
+// to grant against later.
+export const pendingRequesters = new Map()
+// profileKey → signerKey hex. Every identity frame a peer sends carries its bound ed25519 signer
+// key; remembering it per profileKey is what lets a membership:grant be sealed to a
+// CURRENTLY-CONNECTED joiner, independent of the join-request record's lifecycle (which loses it
+// across leave/rejoin churn). A grant only ever reaches a connected joiner, so its key is always here.
+export const boundSignerKeys = new Map()
+
+const ALL = [connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys]
+
+export function resetRegistries() {
+  for (const m of ALL) m.clear()
+}

--- a/src/shared/transfer/swarm-registries.js
+++ b/src/shared/transfer/swarm-registries.js
@@ -10,6 +10,7 @@
 // Exported bindings, not accessors: a Map's identity never changes, so importers mutate contents
 // through a stable reference. resetRegistries() is what a teardown calls instead of clearing each
 // one by hand — the reason destroySwarm knew about all of them.
+import { createAnnounceLedger } from './announce-ledger.js'
 
 // profileKey → { socket, profileKey, displayName, avatar, spaces: Map<spaceId, driveKey> }
 export const connectedPeers = new Map()
@@ -29,7 +30,12 @@ export const pendingRequesters = new Map()
 // across leave/rejoin churn). A grant only ever reaches a connected joiner, so its key is always here.
 export const boundSignerKeys = new Map()
 
-const ALL = [connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys]
+// Which identity frames went out on which socket and still await their implicit ack. Same test as
+// the Maps above — the handshake records into it, disconnect prunes it, the outbound handshake
+// stamps it and the convergence tick drains it — so it is nobody's private state either.
+export const announceLedger = createAnnounceLedger()
+
+const ALL = [connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, announceLedger]
 
 export function resetRegistries() {
   for (const m of ALL) m.clear()

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -51,6 +51,7 @@ import { Subsystem } from '../core/subsystem.js'
 import { classify, stabilise, routableAddressKind, CANARY, BLOCKED_DWELL_MS, NAT_SETTLE_MS, LIVENESS_FAILURES_FOR_OFFLINE } from '../core/reachability.js'
 import { createSwarmDiagnostics } from './swarm-diagnostics.js'
 import { createAdmissionGates } from './admission-gates.js'
+import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, resetRegistries } from './swarm-registries.js'
 
 const log = createLogger('swarm')
 
@@ -101,10 +102,6 @@ let presenceTimer = null
 
 let swarm
 let ipcRef
-const connectedPeers = new Map()  // profileKey → { socket, profileKey, displayName, avatar, spaces: Map<spaceId, driveKey> }
-const socketToPeers = new Map()   // socket → Set<profileKey>  (reverse index for disconnect lookup)
-const spaceTopics = new Map()
-const spaceDiscoveries = new Map() // spaceId → PeerDiscovery (kept so reconnectAll can refresh)
 const leavingSpaces = new Set()         // spaceIds whose teardown is in flight
 const leaveAcks = new Map()             // spaceId (we are leaving) → Set<profileKeyHex> of co-members that applied our leave
 
@@ -116,13 +113,6 @@ let membershipControlHandler = null     // membership:* frames (join request / g
 let connectionAttachHook = null         // per-connection (mux, socket) hook so content backends bind extra protocol channels (overlay)
 let revokeServesForSpaceHook = null     // membership changed → drop the serve grants cached for that space (overlay owns them; swarm must not import it)
 const profileBeeAppendListeners = new Map()  // profileKey hex → { bee, listener } — the ONE held bee per peer
-const socketMsgHandlers = new Map()     // socket → Protomux msgHandler (for sending handshakes to existing connections)
-const pendingRequesters = new Map()     // profileKey → socket (a pending joiner has no drive/handshake yet, so track its socket to grant later)
-// Every identity frame a peer sends carries its bound ed25519 signer key; remember it per
-// profileKey so a membership:grant can always be sealed to a CURRENTLY-CONNECTED joiner —
-// independent of the fragile join-request-record lifecycle (which loses it across leave/rejoin
-// churn). A grant only reaches a connected joiner, so its signer key is always here.
-const boundSignerKeys = new Map()       // profileKey → signerKey hex
 const pendingAdmitInflight = new Set()  // 'spaceId:joinerKey' currently being admitted via reconcile
 const bannedNoiseKeys = new Set()       // Noise keys evicted for identity-frame flooding; the firewall rejects their reconnects
 let rateLimiter = null                  // dual-lane per-socket identity-frame token bucket, created in initSwarm
@@ -1879,6 +1869,7 @@ async function destroySwarm() {
     convergenceTimer = null
   }
   convergenceTicking = false
+  resetRegistries()
   announceLedger.clear()
   deficitTicks.clear()
   lastRefreshAt.clear()
@@ -1904,11 +1895,6 @@ async function destroySwarm() {
   canaryInFlight = null
   browserOnlineHint = true
   localBindings.clear()
-  boundSignerKeys.clear()
-  spaceTopics.clear()
-  spaceDiscoveries.clear()
-  connectedPeers.clear()
-  socketToPeers.clear()
   leaveAcks.clear()
   // Close the one held bee per peer, not just the map: each carries a live session and an
   // append listener.
@@ -1917,8 +1903,6 @@ async function destroySwarm() {
     held.bee.close().catch(() => {})
   }
   profileBeeAppendListeners.clear()
-  socketMsgHandlers.clear()
-  pendingRequesters.clear()
   pendingAdmitInflight.clear()
   bannedNoiseKeys.clear()
   rateLimiter?.clear()

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -52,6 +52,18 @@ import { classify, stabilise, routableAddressKind, CANARY, BLOCKED_DWELL_MS, NAT
 import { createSwarmDiagnostics } from './swarm-diagnostics.js'
 import { createAdmissionGates } from './admission-gates.js'
 import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, resetRegistries } from './swarm-registries.js'
+import {
+  initPresenceBroadcast, stopPresenceHeartbeat, broadcastPresence, resolveSpaceIdForTopic,
+  handlePresenceFrame, handleShareIndexProgressFrame, handleSharePrepareProgressFrame,
+} from './presence-broadcast.js'
+// Re-exported so swarm.js stays the public address for these: worker/main.js and the overlay
+// backend import them from here.
+export { broadcastDeparture, broadcastSharePrepareProgress, broadcastShareIndexProgress } from './presence-broadcast.js'
+import {
+  initDeferredAdmission, resetDeferredAdmission, reconcilePendingRequester,
+  reconcilePendingRequestersForApprover, emitPeerSharesUpdated,
+} from './deferred-admission.js'
+export { readmitConnectedMembers, emitSharesUpdated } from './deferred-admission.js'
 
 const log = createLogger('swarm')
 
@@ -168,6 +180,16 @@ const diag = createSwarmDiagnostics({
   getDhtVersion: () => DHT_VERSION,
 })
 // The join gates. connectedPeers is passed rather than imported: it is this module's registry.
+initDeferredAdmission({
+  getGates: () => gates,
+  log,
+  handleHandshake: (...a) => handleHandshake(...a),
+  sendSingleHandshake: (...a) => sendSingleHandshake(...a),
+  getIpc: () => ipcRef,
+})
+
+initPresenceBroadcast({ presence, membersPoke, getSwarm: () => swarm, getIpc: () => ipcRef })
+
 const gates = createAdmissionGates({ connectedPeers, log, getIpc: () => ipcRef })
 
 // Re-exported, not relocated: worker/main.js imports BOTH (isApprovedMember for the join-request
@@ -1081,126 +1103,6 @@ function handleMembershipCancelAck(socket, msg) {
 // otherwise. This layer deliberately never prunes membership on disconnect — admission is
 // separate from membership display, and a dead socket says nothing about membership.
 
-// === Deferred admission of pending joiners ===
-
-// A peer we recorded as a pending join request may since have been approved by a
-// co-member. Re-run the gate; if it now passes, admit them. If we hold their driveKey
-// (captured from a post-grant re-handshake) we replay their handshake directly — opening
-// their drive, listing them as a member, sending the reciprocal, and clearing the stale
-// request via the shared admit path. If we only ever saw their membership:request (no
-// drive), we prompt a fresh handshake over the live socket so they re-send with a driveKey
-// the gate can then admit for content — rather than bailing and leaving them unadmitted.
-export async function reconcilePendingRequester(spaceId, joinerKey) {
-  const key = spaceId + ':admit:' + joinerKey
-  if (pendingAdmitInflight.has(key)) return
-  pendingAdmitInflight.add(key)
-  try {
-    const space = await getSpace(spaceId)
-    if (!space || space.status === 'pending') return
-    if ((space.members || []).some((m) => m.publicKey === joinerKey)) return
-    if (!(await gates.isApprovedByPeers(space, joinerKey))) return
-    const sock = connectedPeers.get(joinerKey)?.socket || pendingRequesters.get(joinerKey)
-    const topic = spaceTopics.get(spaceId)
-    if (!sock || !topic) return
-    const driveKey = getJoinRequestDriveKey(spaceId, joinerKey)
-    if (!driveKey) {
-      const handler = socketMsgHandlers.get(sock)
-      if (handler) await sendSingleHandshake(sock, handler, spaceId, topic)
-      return
-    }
-    const req = listJoinRequests(spaceId).find((r) => r.publicKey === joinerKey)
-    await handleHandshake(sock, null, {
-      type: 'handshake',
-      profileKey: joinerKey,
-      driveKey,
-      displayName: req?.displayName || 'Unknown',
-      spaceTopic: topic,
-    })
-  } finally {
-    pendingAdmitInflight.delete(key)
-  }
-}
-
-async function reconcilePendingRequestersForSpace(spaceId) {
-  for (const req of listJoinRequests(spaceId)) {
-    reconcilePendingRequester(spaceId, req.publicKey).catch((err) => {
-      log.warn('pending requester reconcile failed:', err.message)
-    })
-  }
-}
-
-async function reconcilePendingRequestersForApprover(approverKey) {
-  const spaces = await listSpaces()
-  for (const space of spaces) {
-    if (!(space.members || []).some((m) => m.publicKey === approverKey)) continue
-    await reconcilePendingRequestersForSpace(space.spaceId)
-  }
-}
-
-const readmitInflight = new Set()
-
-// The derived member set just vouched for joinerKey; admit it if we have a live socket but no
-// admitted handshake for this space (its handshake raced ahead of the record that admits it, so we
-// bounced it to a join request and never sent the reciprocal — leaving a connected member showing as
-// Unknown/Offline). Replaying handleHandshake opens its drive, lists it, marks presence, and sends
-// the reciprocal. If we never captured its driveKey, send our handshake instead to prompt a fresh
-// one. Unlike reconcilePendingRequester this trusts the fold (no isApprovedByPeers re-check), so it
-// also admits the creator, who is approved by nobody.
-async function admitDerivedMember(spaceId, joinerKey) {
-  const sock = connectedPeers.get(joinerKey)?.socket || pendingRequesters.get(joinerKey)
-  const topic = spaceTopics.get(spaceId)
-  if (!sock || !topic) return
-  const driveKey = getJoinRequestDriveKey(spaceId, joinerKey)
-  if (!driveKey) {
-    const handler = socketMsgHandlers.get(sock)
-    if (handler) await sendSingleHandshake(sock, handler, spaceId, topic)
-    return
-  }
-  const req = listJoinRequests(spaceId).find((r) => r.publicKey === joinerKey)
-  await handleHandshake(sock, null, {
-    type: 'handshake',
-    profileKey: joinerKey,
-    driveKey,
-    displayName: req?.displayName || 'Unknown',
-    spaceTopic: topic,
-  })
-}
-
-export function readmitConnectedMembers(spaceId, keys) {
-  for (const key of keys) {
-    if (!pendingRequesters.has(key) && !connectedPeers.has(key)) continue
-    const guard = spaceId + ':' + key
-    if (readmitInflight.has(guard)) continue
-    readmitInflight.add(guard)
-    admitDerivedMember(spaceId, key)
-      .catch((err) => log.warn('readmit on derive failed:', err.message))
-      .finally(() => readmitInflight.delete(guard))
-  }
-}
-
-export function emitSharesUpdated(spaceId) {
-  if (ipcRef) ipcRef.emit('event:shares-updated', { spaceId })
-}
-
-// A peer's profile bee appended (it holds their `share/<space>/*` records), so refresh the
-// share list for every space we share with them. Coarse by design — any bee change pokes
-// the list — but cheap, and it's the renderer's only signal that a peer added/removed a share.
-// We poke the FILE list too: files:list hides a peer's folder-share contents using prefixes read
-// from this same profile bee, but the renderer's useFiles refreshes only on event:files-updated
-// (the profile-bee append fires shares-updated, not files-updated). Without this a peer's
-// newly-shared — or slow-to-replicate — folder would leak its files into the flat loose-file list
-// until some unrelated files-updated happened to fire.
-async function emitPeerSharesUpdated(profileKeyHex) {
-  if (!ipcRef) return
-  for (const space of await listSpaces()) {
-    if ((space.members || []).some((m) => m.publicKey === profileKeyHex)) {
-      ipcRef.emit('event:shares-updated', { spaceId: space.spaceId })
-      ipcRef.emit('event:files-updated', { spaceId: space.spaceId })
-      ipcRef.emit('event:mirrors-updated', { spaceId: space.spaceId })
-    }
-  }
-}
-
 // === Topics, outbound handshakes & space cleanup ===
 
 export async function joinSpaceTopic(spaceId) {
@@ -1578,158 +1480,6 @@ export function compactStore() {
   }, 'forced full-range')
 }
 
-// === Presence & ephemeral broadcasts ===
-
-// Heartbeat: advertise our own liveness per space to the peers in it. The recipient leases
-// us for PRESENCE_TTL_MS from when it receives this — we can't extend our own lease.
-function broadcastPresence() {
-  if (socketMsgHandlers.size === 0) return
-  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
-  for (const [spaceId, topicHex] of spaceTopics) {
-    for (const [, peer] of connectedPeers) {
-      if (!peer.spaces.has(spaceId)) continue
-      const handler = socketMsgHandlers.get(peer.socket)
-      if (handler) { try { handler.send(JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex })) } catch {} }
-    }
-  }
-}
-
-// Graceful-quit departure: tell every connected peer we're going offline NOW so they flip us
-// offline immediately instead of waiting out the socket close / 15s presence TTL. Reuses the
-// presence frame with offline:true (NOT the leave frame — that mints membership tombstones we must
-// not trigger on a mere quit). Best-effort; socket close + TTL remain the backstops.
-export function broadcastDeparture() {
-  // Stop our own heartbeat first: a heartbeat firing later in the shutdown teardown window would
-  // re-mark us online on a receiver (mark after clear) and undo this departure.
-  if (presenceTimer) { clearInterval(presenceTimer); presenceTimer = null }
-  if (!swarm || socketMsgHandlers.size === 0) return
-  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
-  for (const [spaceId, topicHex] of spaceTopics) {
-    for (const [, peer] of connectedPeers) {
-      if (!peer.spaces.has(spaceId)) continue
-      const handler = socketMsgHandlers.get(peer.socket)
-      if (handler) { try { handler.send(JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex, offline: true })) } catch {} }
-    }
-  }
-}
-
-// Owner→members: live indexing/hashing progress for a file still advertised with contentHash:null
-// (consumer status 'preparing'). Ephemeral, scoped to peers connected on this space.
-export function broadcastSharePrepareProgress(spaceId, payload) {
-  if (socketMsgHandlers.size === 0) return
-  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
-  const frame = JSON.stringify({ type: 'share-prepare-progress', profileKey: profileKeyHex, spaceId, ...payload })
-  for (const [, peer] of connectedPeers) {
-    if (!peer.spaces.has(spaceId)) continue
-    const handler = socketMsgHandlers.get(peer.socket)
-    if (handler) { try { handler.send(frame) } catch {} }
-  }
-}
-
-// A share is admission-gated at 5k files and a folder that grows past it keeps publishing, so this
-// is a display bound, not a limit — it only stops a peer-supplied count from rendering as nonsense.
-const MAX_WIRE_COUNT = 1_000_000
-
-// Owner→members: how much of a share is still waiting to be indexed. Ephemeral like the per-file
-// frame above, and for the same reason — the queue is not durable state, so it is re-announced
-// rather than replicated. It carries what the catalog cannot: files that have no entry yet because
-// their publish has not started.
-export function broadcastShareIndexProgress(spaceId, payload) {
-  if (socketMsgHandlers.size === 0) return
-  const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
-  const frame = JSON.stringify({ type: 'share-index-progress', profileKey: profileKeyHex, spaceId, ...payload })
-  for (const [, peer] of connectedPeers) {
-    if (!peer.spaces.has(spaceId)) continue
-    const handler = socketMsgHandlers.get(peer.socket)
-    if (handler) { try { handler.send(frame) } catch {} }
-  }
-}
-
-// Re-surface an owner's queue depth to our renderer. Same anti-spoof guard as the prepare frame:
-// accept only from an identity authenticated on this socket. Non-authoritative and count-only —
-// it names no file and gates no content, so the worst a bad frame can do is a wrong number in a
-// notice. Its own validator: the prepare frame's requires total > 0 and bytes within it, which a
-// queue summary does not satisfy.
-function handleShareIndexProgressFrame(socket, msg) {
-  const { profileKey, spaceId, shareId, adding, bytesQueued } = msg
-  if (typeof profileKey !== 'string' || typeof spaceId !== 'string' || typeof shareId !== 'string') return
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
-  // The sender is carried through as `ownerKey` so the consumer can require it to be the share's
-  // actual owner. Authentication proves only WHO is speaking: without this any approved co-member
-  // could describe someone else's share, and the notice names that someone by display name.
-  // Wire numbers are peer-controlled: whole counts only, bounded, so a bad frame cannot reach the
-  // renderer as a fractional or astronomically pluralized sentence.
-  const safeCount = (n) => (Number.isSafeInteger(n) && n > 0 ? Math.min(n, MAX_WIRE_COUNT) : 0)
-  const safeBytes = (n) => (Number.isFinite(n) && n > 0 ? Math.min(n, Number.MAX_SAFE_INTEGER) : 0)
-  ipcRef.emit('event:share-index-progress', {
-    spaceId, shareId, ownerKey: profileKey, adding: safeCount(adding), bytesQueued: safeBytes(bytesQueued),
-  })
-}
-
-// Receive a peer's heartbeat: refresh its lease, but only for an identity already
-// authenticated on this socket (same guard as the leave frame) — so presence can't be
-// spoofed for a peer we never handshaked. The TTL is ours; any sender-claimed expiry is
-// ignored.
-function handlePresenceFrame(socket, msg) {
-  const kind = presenceFrameKind(msg)
-  if (kind === 'ignore') return
-  const { profileKey, spaceTopic } = msg
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
-  const spaceId = resolveSpaceIdForTopic(spaceTopic)
-  if (!spaceId) return
-  if (kind === 'clear') {
-    // Explicit graceful-quit departure (offline:true): flip the peer offline now, don't wait for
-    // the socket close or the TTL. Gate the emit on a real online→offline transition (like the mark
-    // path) so repeated departure frames can't amplify reconcile hints. Idempotent with the
-    // socket-close handleDisconnect that follows.
-    if (presence.clear(profileKey, spaceId)) {
-      membersPoke.poke(spaceId)
-      ipcRef?.emit('event:files-updated', { spaceId })
-    }
-    return
-  }
-  if (presence.mark(profileKey, spaceId)) {
-    // Same-socket lease restore: the peer went silent past the TTL and is back without
-    // a re-handshake — the arrival mirror of the onExpire departure emit.
-    peerSeen(profileKey, spaceId)
-    membersPoke.poke(spaceId)
-    ipcRef?.emit('event:files-updated', { spaceId })
-  }
-}
-
-// Re-surface a peer's indexing progress to our renderer. Same anti-spoof guard as presence/leave:
-// accept only from an identity authenticated on this socket. Non-authoritative — the row shows it
-// only while genuinely 'preparing', and contentHash still gates the content itself.
-function handleSharePrepareProgressFrame(socket, msg) {
-  const { profileKey, spaceId, shareId, relPath, bytes, total, eta } = msg
-  if (typeof profileKey !== 'string' || typeof spaceId !== 'string') return
-  if (typeof shareId !== 'string' || typeof relPath !== 'string') return
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
-  const key = shareId === LOOSE_SHARE_ID ? '/' + relPath : shareDecoKey(shareId, relPath)
-  // The owner finished (or abandoned) the hash. Decorations are cleared only by this frame, so
-  // without it the bar sits at ~100% and repaints stale on the next re-hash of the same path. It
-  // carries no numbers to validate, and clears at most a cosmetic bar a progress frame repaints.
-  if (msg.done === true) {
-    // Phase-scoped: this key is SHARED with our own download of the same file, and a re-publish
-    // restarts that download the moment the materialized hash replicates — a `done` landing just
-    // after it must not take down a live download bar.
-    ipcRef.emit('event:decoration', { channel: 'transfer', spaceId, key, phase: 'preparing', done: true })
-    return
-  }
-  // Wire numbers are peer-controlled: drop anything non-finite / out of range so a bad frame
-  // can't reach the renderer as a NaN bar (width:'NaN%' / aria-valuenow=NaN).
-  if (!Number.isFinite(bytes) || !Number.isFinite(total) || total <= 0 || bytes < 0 || bytes > total) return
-  // null/absent = the owner is still warming up its estimate ("Estimating…"); preserve it. Any
-  // other value is a peer-controlled number, so clamp non-finite/non-positive to 0.
-  const safeEta = eta == null ? null : (Number.isFinite(eta) && eta > 0 ? eta : 0)
-  ipcRef.emit('event:decoration', { channel: 'transfer', spaceId, key, phase: 'preparing', bytes, total, speed: 0, eta: safeEta })
-}
-
-function resolveSpaceIdForTopic(topicHex) {
-  for (const [spaceId, topic] of spaceTopics) if (topic === topicHex) return spaceId
-  return null
-}
-
 // === Liveness queries, membership frames & network status ===
 
 // Online peers in a space (presence lease, not socket liveness) — the display liveness that
@@ -1903,7 +1653,6 @@ async function destroySwarm() {
     held.bee.close().catch(() => {})
   }
   profileBeeAppendListeners.clear()
-  pendingAdmitInflight.clear()
   bannedNoiseKeys.clear()
   rateLimiter?.clear()
   rateLimiter = null
@@ -1921,7 +1670,7 @@ async function destroySwarm() {
   pendingLeaves.clear()
   lastLeaveAckedKeys.clear()
   pendingCancels.clear()
-  readmitInflight.clear()
+  resetDeferredAdmission()
   lastReconnectAt = 0
   bootedAt = 0
   corruptionDiagnosed = false

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -53,7 +53,7 @@ import { createSwarmDiagnostics } from './swarm-diagnostics.js'
 import { createAdmissionGates } from './admission-gates.js'
 import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, resetRegistries } from './swarm-registries.js'
 import {
-  initPresenceBroadcast, stopPresenceHeartbeat, broadcastPresence, resolveSpaceIdForTopic,
+  initPresenceBroadcast, startPresenceHeartbeat, stopPresenceHeartbeat, resolveSpaceIdForTopic,
   handlePresenceFrame, handleShareIndexProgressFrame, handleSharePrepareProgressFrame,
 } from './presence-broadcast.js'
 // Re-exported so swarm.js stays the public address for these: worker/main.js and the overlay
@@ -79,7 +79,6 @@ const membersPoke = makeKeyedCoalescer(
 // (where to send); presence is the liveness display source. Marked on handshake, refreshed
 // by heartbeats, cleared on disconnect, expired by TTL (catches a silently-dead socket).
 const PRESENCE_TTL_MS = 15000
-const PRESENCE_HEARTBEAT_MS = 5000
 // On silent-death lease expiry, re-emit so the roster + file availability re-derive (a peer that
 // goes quiet without a clean disconnect would otherwise stay "online" until an unrelated refresh).
 // files-updated is already coalesced downstream into event:reconcile by the hint bus.
@@ -110,7 +109,6 @@ function auditPeerLost(peerKey, spaceId, displayName = null) {
 function peerName(space, peerKey) {
   return (space?.members || []).find((m) => m.publicKey === peerKey)?.displayName || null
 }
-let presenceTimer = null
 
 let swarm
 let ipcRef
@@ -188,7 +186,7 @@ initDeferredAdmission({
   getIpc: () => ipcRef,
 })
 
-initPresenceBroadcast({ presence, membersPoke, getSwarm: () => swarm, getIpc: () => ipcRef })
+initPresenceBroadcast({ presence, membersPoke, log, getSwarm: () => swarm, getIpc: () => ipcRef })
 
 const gates = createAdmissionGates({ connectedPeers, log, getIpc: () => ipcRef })
 
@@ -237,11 +235,7 @@ function initSwarm(_ipc) {
   bootedAt = Date.now()
   log.info('initialized')
 
-  presenceTimer = setInterval(() => {
-    try { broadcastPresence() } catch (err) { log.debug('presence heartbeat failed:', err.message) }
-    presence.prune()
-  }, PRESENCE_HEARTBEAT_MS)
-  presenceTimer.unref?.()
+  startPresenceHeartbeat()
   startConvergenceTick()
 
   swarm.on('update', scheduleStatusEmit)
@@ -1610,10 +1604,7 @@ async function destroySwarm() {
     statusEmitTimer = null
   }
   resetNetworkWatch()
-  if (presenceTimer) {
-    clearInterval(presenceTimer)
-    presenceTimer = null
-  }
+  stopPresenceHeartbeat()
   if (convergenceTimer) {
     clearInterval(convergenceTimer)
     convergenceTimer = null

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -18,11 +18,9 @@ import b4a from 'b4a'
 import os from 'bare-os'
 import { getStore, diagnoseStoreCores, isStorageInconsistency } from '../core/store.js'
 import {
-  getProfileKey, getProfile, openProfileBee, revokeApproval, adoptVouchees, getIdentitySigner, } from '../spaces/profile.js'
+  getProfileKey, getProfile, openProfileBee, getIdentitySigner, } from '../spaces/profile.js'
 import {
-  getDrive, getSpace, upsertMember, removeMember, listSpaces,
-  listJoinRequests, getJoinRequestDriveKey, clearJoinRequest,
-  ownLooseCatalogPublish, persistLeftTombstone,
+  getDrive, getSpace, upsertMember, clearJoinRequest, ownLooseCatalogPublish,
 } from '../spaces/space.js'
 import { getRuntimeConfig, getUpgradeKey, isHandshakeIdentityBindingEnabled, getResourceCaps, getHandshakeRateLimit, getConvergenceConfig, getIdentityFrameDropWindow, isRelayEnabled, isSeparateContentPlaneEnabled, getPeerFrameMaxBytes, getPeerFrameLimits } from '../core/runtime-config.js'
 import { enabledRelayKeys, relayFunctionFor, decodeRelayKey } from './relay.js'
@@ -31,27 +29,22 @@ import crypto from 'hypercore-crypto'
 import idEncoding from 'hypercore-id-encoding'
 import { catalogKeyField } from '../shares/share-catalog.js'
 import { HEX64 } from '../invite-envelope.js'
-import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, createRateLimiter, validFrameShape, leaveFrameBound } from './handshake-guard.js'
-import { createAnnounceLedger, escalationDue, announceStatus } from './announce-ledger.js'
-import { joinContentTopic, leaveContentTopic, refreshContentDiscoveries, destroyContentPeerSockets, contentPlaneHasPeer, getContentPlaneStatus, getContentSwarm } from './content-swarm.js'
+import { checkInboundSender, clampDisplayName, signNoiseBinding, createDualRateLimiter, createRateLimiter, validFrameShape } from './handshake-guard.js'
+import { joinContentTopic, leaveContentTopic, refreshContentDiscoveries, destroyContentPeerSockets, getContentPlaneStatus, getContentSwarm } from './content-swarm.js'
 import { applyNetImpairment } from './net-impair.js'
-import { takeIncompleteListSpaces, clearListDeficits } from './list-deficits.js'
-import { LOOSE_SHARE_ID } from './transfer-id.js'
-import { shareDecoKey } from './decoration-key.js'
-import { record } from '../audit/audit-log.js'
+import { clearListDeficits } from './list-deficits.js'
 import { observePeerProfile } from '../audit/peer-watch.js'
-import { observeReachability, peerLost, peerLostMeta, peerSeen, peerLeft, resetNetworkWatch } from '../audit/network-watch.js'
+import { observeReachability, peerLost, peerLostMeta, peerSeen, resetNetworkWatch } from '../audit/network-watch.js'
 import { sealSck } from './sck-seal.js'
 import { sanitizeAvatar } from '../identity-limits.js'
-import { markLeft, rosterDeficits, recomputeMemberView, scheduleCapture, captureDeficits } from '../spaces/member-registry.js'
-import { createPresence, presenceFrameKind } from '../state/presence.js'
+import { createPresence } from '../state/presence.js'
 import { makeKeyedCoalescer } from '../state/coalesce.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { classify, stabilise, routableAddressKind, CANARY, BLOCKED_DWELL_MS, NAT_SETTLE_MS, LIVENESS_FAILURES_FOR_OFFLINE } from '../core/reachability.js'
 import { createSwarmDiagnostics } from './swarm-diagnostics.js'
 import { createAdmissionGates } from './admission-gates.js'
-import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, resetRegistries } from './swarm-registries.js'
+import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, announceLedger, resetRegistries } from './swarm-registries.js'
 import {
   initPresenceBroadcast, startPresenceHeartbeat, stopPresenceHeartbeat, resolveSpaceIdForTopic,
   handlePresenceFrame, handleShareIndexProgressFrame, handleSharePrepareProgressFrame,
@@ -60,10 +53,29 @@ import {
 // backend import them from here.
 export { broadcastDeparture, broadcastSharePrepareProgress, broadcastShareIndexProgress } from './presence-broadcast.js'
 import {
-  initDeferredAdmission, resetDeferredAdmission, reconcilePendingRequester,
+  initDeferredAdmission, resetDeferredAdmission,
   reconcilePendingRequestersForApprover, emitPeerSharesUpdated,
 } from './deferred-admission.js'
-export { readmitConnectedMembers, emitSharesUpdated } from './deferred-admission.js'
+export { readmitConnectedMembers, emitSharesUpdated, reconcilePendingRequester } from './deferred-admission.js'
+import {
+  initLeaveProtocol, resetLeaveProtocol,
+  handleLeaveFrame, handleLeaveAckFrame, handleMembershipCancelAck,
+  sendPendingLeaveFrames, sendPendingCancelFrames,
+} from './leave-protocol.js'
+// Every one of these has callers in worker/main.js or worker/ipc/space-leave.js, so swarm.js stays
+// their public address.
+export {
+  markSpaceLeaving, unmarkSpaceLeaving, isSpaceLeaving,
+  configurePendingLeaves, registerPendingLeave, unregisterPendingLeave, hasPendingLeave,
+  joinPendingLeaveTopic, leavePendingLeaveTopic, sendLeaveFrameToConnectedPeers,
+  leaveAcksSatisfied, awaitLeaveAcks, takeLeaveAckedKeys,
+  configurePendingCancels, registerPendingCancel, hasPendingCancel,
+  joinPendingCancelTopic, leavePendingCancelTopic, sendPendingCancelToConnected,
+} from './leave-protocol.js'
+import {
+  initConvergenceTick, resetConvergenceTick, startConvergenceTick, forgetSpaceConvergence,
+} from './convergence-tick.js'
+export { rescueStalledTransfers } from './convergence-tick.js'
 
 const log = createLogger('swarm')
 
@@ -112,18 +124,12 @@ function peerName(space, peerKey) {
 
 let swarm
 let ipcRef
-const leavingSpaces = new Set()         // spaceIds whose teardown is in flight
-const leaveAcks = new Map()             // spaceId (we are leaving) → Set<profileKeyHex> of co-members that applied our leave
-
-export function markSpaceLeaving(spaceId) { leavingSpaces.add(spaceId) }
-export function unmarkSpaceLeaving(spaceId) { leavingSpaces.delete(spaceId) }
-export function isSpaceLeaving(spaceId) { return leavingSpaces.has(spaceId) }
 let overlayReconnectHook = null         // notified when an overlay-content owner (re)connects, so paused/interrupted overlay downloads (loose + folder) resume
 let membershipControlHandler = null     // membership:* frames (join request / grant / deny) routed to the worker
 let connectionAttachHook = null         // per-connection (mux, socket) hook so content backends bind extra protocol channels (overlay)
+let stalledOwnersHook = null            // worker-supplied probe: which owners are we waiting on?
 let revokeServesForSpaceHook = null     // membership changed → drop the serve grants cached for that space (overlay owns them; swarm must not import it)
 const profileBeeAppendListeners = new Map()  // profileKey hex → { bee, listener } — the ONE held bee per peer
-const pendingAdmitInflight = new Set()  // 'spaceId:joinerKey' currently being admitted via reconcile
 const bannedNoiseKeys = new Set()       // Noise keys evicted for identity-frame flooding; the firewall rejects their reconnects
 let rateLimiter = null                  // dual-lane per-socket identity-frame token bucket, created in initSwarm
 let frameLimiter = null                 // general per-socket budget charged for EVERY frame type
@@ -133,12 +139,6 @@ function countDroppedFrame(reason) { droppedFrames[reason] += 1 }
 export function getDroppedFrameCounters() { return { ...droppedFrames } }
 // Unsettled identity-frame announcements per (socket, space), drained by the convergence
 // tick — the level-triggered resend that heals a dropped handshake/membership:request.
-const announceLedger = createAnnounceLedger()
-let convergenceTimer = null
-let convergenceTicking = false          // re-entrancy guard: the tick is async, setInterval isn't
-const deficitTicks = new Map()          // spaceId → consecutive ticks with a roster deficit
-const lastRefreshAt = new Map()         // spaceId → last escalation (discovery.refresh) time
-const escalationsSpent = new Map()      // spaceId → discovery.refreshes spent on the current deficit
 let testDrop = null                     // test-only inbound identity-frame drop window
 
 let dhtReady = false
@@ -187,6 +187,21 @@ initDeferredAdmission({
 })
 
 initPresenceBroadcast({ presence, membersPoke, log, getSwarm: () => swarm, getIpc: () => ipcRef })
+initLeaveProtocol({
+  presence,
+  log,
+  getLocalBinding: (...a) => getLocalBinding(...a),
+  getRevokeServesHook: () => revokeServesForSpaceHook,
+  getSwarm: () => swarm,
+  getIpc: () => ipcRef,
+})
+initConvergenceTick({
+  log,
+  sendSingleHandshake: (...a) => sendSingleHandshake(...a),
+  getStalledOwners: () => stalledOwnersHook,
+  getSwarm: () => swarm,
+  getIpc: () => ipcRef,
+})
 
 const gates = createAdmissionGates({ connectedPeers, log, getIpc: () => ipcRef })
 
@@ -770,332 +785,6 @@ function handleDisconnect(socket) {
 
 // Captured before the teardown drops the member from the roster: the audit row has to stay
 // readable once the record is gone.
-function memberSnapshot (space, publicKey) {
-  return {
-    spaceName: space?.name ?? null,
-    memberName: (space?.members || []).find((m) => m.publicKey === publicKey)?.displayName ?? null,
-  }
-}
-
-function recordMemberLeft (spaceId, profileKey, snapshot) {
-  record('member.left', {
-    actor: { type: 'peer', key: profileKey, name: snapshot.memberName },
-    space: { id: spaceId, name: snapshot.spaceName },
-    target: { kind: 'member', id: profileKey, name: snapshot.memberName },
-  })
-}
-
-// === Leave protocol ===
-
-async function handleLeaveFrame(socket, peerInfo, msg) {
-  const { spaceId, profileKey } = msg
-  if (!spaceId || !profileKey) return
-
-  // Our own teardown destroys the sockets that clear the auth index, so an inbound
-  // frame for a space we're leaving races into the rejection below — drop it quietly.
-  if (leavingSpaces.has(spaceId)) return
-
-  // Accept iff the sender proves it controls profileKey on THIS connection: the fast path is the
-  // per-socket auth index; the robust path is the frame's identity binding, which survives the
-  // teardown/reconnect race that clears or has-not-yet-populated that index. Additive — the binding
-  // proof is strictly stronger than the index, so a third party still cannot evict a member.
-  const onSocket = socketToPeers.get(socket)?.has(profileKey) || false
-  if (!onSocket && !leaveFrameBound(peerInfo, msg)) {
-    log.warn('leave frame rejected — sender not authenticated on socket and no valid binding')
-    return
-  }
-
-  const space = await getSpace(spaceId)
-  if (!space?.members) return
-
-  // Take over the leaver's vouchees before touching anything else. The revoke below unroots the
-  // leaver, and from then on the fold stops walking its bee, so the subtree it alone vouched for
-  // could never be recovered. The leaver is connected right now, which is the best window there is
-  // to read that record. When it is unreadable, apply NOTHING: the replication-driven path retries
-  // once the departure record lands, which is strictly better than tombstoning here while our vouch
-  // still stands (a tombstone would suppress every retry).
-  if (!(await adoptVouchees(spaceId, profileKey))) {
-    log.warn('leave frame deferred — leaver record unreadable, cannot adopt:', profileKey.slice(0, 12))
-    return
-  }
-
-  // After the deferral above, so a leave we did not apply records nothing.
-  const leftSnapshot = memberSnapshot(space, profileKey)
-
-  // Tombstone the leaver FIRST so the member-view fold can't re-add them from their stale
-  // still-active record (their del-record may not replicate before they disconnect). Set
-  // before removeMember so any in-flight re-derive already subtracts them. Persist it so the
-  // subtraction survives a restart, incl. the creator/root where revokeApproval is a no-op.
-  // msg.ts is untrusted wire data used as the durable self-clear stamp — reject a non-finite /
-  // non-positive value (a negative would make tombstoneActive false and re-add the leaver). It is
-  // the leaver's own clock, same as the member/<S>.ts a rejoin writes, so the comparison stays
-  // single-clock in the common path.
-  const leaveTs = (typeof msg.ts === 'number' && Number.isFinite(msg.ts) && msg.ts > 0) ? msg.ts : Date.now()
-  markLeft(spaceId, profileKey, leaveTs)
-  let durablyApplied = true
-  try { await persistLeftTombstone(spaceId, profileKey, leaveTs) } catch (err) {
-    durablyApplied = false
-    log.warn('persist leave tombstone failed:', err.message)
-  }
-
-  // Revoke our own approval so a later rejoin needs fresh approval, not a silent re-admit off the
-  // surviving grow-only record. Unconditional + idempotent: a leaver already pruned by the fold (or a
-  // duplicate frame) must still lose our vouch. No-op for the creator (we hold no approval for the
-  // root). Safe to unroot the leaver here — its vouchees were adopted above.
-  try { await revokeApproval(spaceId, profileKey) } catch (err) {
-    durablyApplied = false
-    log.warn('approval revoke on leave failed:', err.message)
-  }
-
-  // Ack the leaver over its own socket so it can stop waiting (awaitLeaveAcks) — but ONLY once the
-  // durable tombstone + revoke actually landed, since that is exactly what the ack attests. A
-  // swallowed durable failure must not resolve the wait early; the leaver falls back to the cap.
-  const selfKey = getProfileKey()
-  if (durablyApplied && selfKey) {
-    try { socketMsgHandlers.get(socket)?.send(JSON.stringify({ type: 'leave-ack', spaceId, profileKey: b4a.toString(selfKey, 'hex') })) } catch {}
-  }
-
-  const removed = await removeMember(spaceId, profileKey)
-  if (!removed) return
-  log.info('peer left space (leave frame):', profileKey.slice(0, 12) + '...', '→', spaceId)
-
-  presence.clear(profileKey, spaceId)   // the leaver is offline in this space immediately
-  peerLeft(profileKey, spaceId)         // ...but that is a LEAVE; member.left carries it
-
-  const peer = connectedPeers.get(profileKey)
-  if (peer) {
-    peer.spaces.delete(spaceId)
-    peer.looseCatalogKeys?.delete(spaceId)
-    if (peer.spaces.size === 0) {
-      connectedPeers.delete(profileKey)
-      const set = socketToPeers.get(peer.socket)
-      if (set) {
-        set.delete(profileKey)
-        if (set.size === 0) socketToPeers.delete(peer.socket)
-      }
-      // The overlay content channel rides the CONTENT socket, not this one: a peer we no longer
-      // share any space with must lose that socket too, or we keep serving it bulk bytes.
-      try { destroyContentPeerSockets(profileKey) } catch {}
-    }
-  }
-  // Their leave revokes our serve grants for this space: the grant is cached per (peer, path) at
-  // request time and re-checked against that cache only, so a membership change has to invalidate
-  // it actively — otherwise an in-flight transfer keeps streaming to a peer no longer entitled.
-  revokeServesForSpaceHook?.(spaceId, profileKey)
-
-  recordMemberLeft(spaceId, profileKey, leftSnapshot)
-
-  ipcRef.emit('event:member-left', { spaceId, publicKey: profileKey })
-  ipcRef.emit('event:files-updated', { spaceId })
-}
-
-// ── pending outbound leaves (leave-while-alone recovery) ────────────────────────
-// spaceId → { topic, ts }. A leave that provably reached no member is re-announced on
-// every new connection until a co-member acks its durable apply. Seeded from the
-// pendingleave/ markers at boot (the space record itself is already purged); the worker
-// injects onApplied to clear the marker + leave the topic. ts is the ORIGINAL leave
-// stamp so a genuine later rejoin (strictly newer member/<S> ts) always outranks the
-// replayed tombstone on co-members.
-const pendingLeaves = new Map()
-const pendingLeaveFramesSent = new WeakMap()   // socket → Set<spaceId> (ack eligibility for the record-less space)
-let onPendingLeaveApplied = null
-
-export function configurePendingLeaves(onApplied) { onPendingLeaveApplied = onApplied }
-
-export function registerPendingLeave(spaceId, topicHex, ts) {
-  pendingLeaves.set(spaceId, { topic: topicHex, ts })
-}
-
-export function unregisterPendingLeave(spaceId) { pendingLeaves.delete(spaceId) }
-
-export function hasPendingLeave(spaceId) { return pendingLeaves.has(spaceId) }
-
-// Join/leave the topic of a PURGED space (both leave-replay and cancel-replay need this — the
-// space record is gone, so joinSpaceTopic can't read it). Return whether they acted, for logging.
-function joinPurgedSpaceTopic(spaceId, topicHex) {
-  if (!swarm || spaceDiscoveries.has(spaceId)) return false
-  spaceTopics.set(spaceId, topicHex)
-  spaceDiscoveries.set(spaceId, swarm.join(b4a.from(topicHex, 'hex'), { server: true, client: true }))
-  return true
-}
-
-async function leavePurgedSpaceTopic(spaceId) {
-  const topicHex = spaceTopics.get(spaceId)
-  if (!topicHex) return false
-  try { await swarm.leave(b4a.from(topicHex, 'hex')) } catch {}
-  spaceTopics.delete(spaceId)
-  spaceDiscoveries.delete(spaceId)
-  return true
-}
-
-export function joinPendingLeaveTopic(spaceId, topicHex) {
-  if (joinPurgedSpaceTopic(spaceId, topicHex)) log.info('joined topic for pending-leave replay:', spaceId)
-}
-
-export async function leavePendingLeaveTopic(spaceId) {
-  if (await leavePurgedSpaceTopic(spaceId)) log.info('left pending-leave topic:', spaceId)
-}
-
-function sendPendingLeaveFrames(socket, msgHandler) {
-  if (pendingLeaves.size === 0) return
-  const profileKey = getProfileKey()
-  if (!profileKey) return
-  const profileKeyHex = b4a.toString(profileKey, 'hex')
-  let sent = pendingLeaveFramesSent.get(socket)
-  if (!sent) pendingLeaveFramesSent.set(socket, (sent = new Set()))
-  for (const [spaceId, { ts }] of pendingLeaves) {
-    sent.add(spaceId)
-    try {
-      msgHandler.send(JSON.stringify({ type: 'leave', spaceId, profileKey: profileKeyHex, ts, ...(getLocalBinding() || {}) }))
-    } catch (err) {
-      log.debug('pending-leave frame send failed:', err.message)
-    }
-  }
-}
-
-export function sendLeaveFrameToConnectedPeers(spaceId) {
-  if (socketMsgHandlers.size === 0) return
-  const profileKey = getProfileKey()
-  if (!profileKey) return
-  const profileKeyHex = b4a.toString(profileKey, 'hex')
-  leaveAcks.set(spaceId, new Set())   // collect co-member acks BEFORE the frames go out (no missed-ack race)
-  const payload = JSON.stringify({
-    type: 'leave',
-    spaceId,
-    profileKey: profileKeyHex,
-    ts: Date.now(),
-    ...(getLocalBinding() || {}),
-  })
-  for (const [, handler] of socketMsgHandlers) {
-    try { handler.send(payload) } catch (err) {
-      log.warn('leave frame send failed:', err.message)
-    }
-  }
-}
-
-export function leaveAcksSatisfied(expectedKeys, receivedSet) {
-  for (const k of expectedKeys) if (!receivedSet.has(k)) return false
-  return true
-}
-
-// Wait (bounded) for the connected members of a space to confirm they applied our leave — an
-// observed signal that the load-bearing revokeApproval ran on our approvers before we tear
-// down. Resolves early on full coverage; falls back to the cap for peers on older releases
-// (which never ack) or a straggler. No connected members ⇒ nothing to wait for.
-export async function awaitLeaveAcks(spaceId, { capMs = 2000, pollMs = 50, floorMs = 0 } = {}) {
-  const received = leaveAcks.get(spaceId)
-  const expected = new Set(getConnectedPeers(spaceId))
-  try {
-    if (!received || expected.size === 0) return true
-    const start = Date.now()
-    for (;;) {
-      const elapsed = Date.now() - start
-      // Hold at least floorMs even once every ack lands: an ack proves the co-member ran its
-      // revoke, but NOT that it pulled our `del member/<S>` block (authored just before the frame)
-      // so it can re-host the departure to members offline at leave time. The floor preserves a
-      // replication window for that block.
-      if (elapsed >= floorMs && leaveAcksSatisfied(expected, received)) return true
-      if (elapsed >= capMs) return false
-      await new Promise((r) => setTimeout(r, pollMs))
-    }
-  } finally {
-    // Snapshot the acked keys before dropping the ledger, so the pending-leave arm decision can
-    // ask "which members provably applied the leave" — the boolean return conflates that with
-    // "nobody was connected" (vacuous true), which would skip the marker exactly when a member
-    // dropped mid-leave.
-    if (received) lastLeaveAckedKeys.set(spaceId, new Set(received))
-    leaveAcks.delete(spaceId)
-  }
-}
-
-// spaceId → Set<keyHex> of members that acked our most recent leave (populated by awaitLeaveAcks).
-const lastLeaveAckedKeys = new Map()
-export function takeLeaveAckedKeys(spaceId) {
-  const set = lastLeaveAckedKeys.get(spaceId)
-  lastLeaveAckedKeys.delete(spaceId)
-  return set || new Set()
-}
-
-function handleLeaveAckFrame(socket, msg) {
-  const { spaceId, profileKey } = msg
-  if (!spaceId || !profileKey) return
-  // A pending-leave replay ack arrives on a socket with no live handshake for the purged
-  // space (we no longer handshake it), so the strict rule below would drop it. Accept it
-  // from a socket this pending frame went out on: the Noise session pins the counterparty,
-  // and the worst a false ack does is stop the re-announce — the pre-marker behavior.
-  if (pendingLeaves.has(spaceId) && pendingLeaveFramesSent.get(socket)?.has(spaceId)) {
-    pendingLeaves.delete(spaceId)
-    log.info('pending leave acked — clearing marker:', spaceId)
-    Promise.resolve(onPendingLeaveApplied?.(spaceId)).catch((err) => log.debug('pending-leave clear failed:', err.message))
-  }
-  // Only count an ack from a peer that authenticated as this profileKey on this socket, so a peer
-  // can't forge acks for other members and collapse the leaver's flush wait early.
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
-  leaveAcks.get(spaceId)?.add(profileKey)
-}
-
-// ── pending outbound cancels (withdraw-a-request delivery) ──────────────────────
-// A withdrawing pending joiner must reach at least one member showing its request; that member
-// writes a durable denied tombstone which replicates to the rest. Re-announced on every new
-// connection until an applied ack lands. In-memory: cleared on restart.
-const pendingCancels = new Map()   // spaceId → { topic, joinerKey, attempts }
-const pendingCancelFramesSent = new WeakMap()   // socket → Set<spaceId> (ack eligibility)
-// Bound the replay so an abandoned withdrawal to an always-offline space can't hold the topic for
-// the whole session; a member reached before the cap converges it, past it we give up (a member
-// offline the entire time keeps the stale request — the documented in-memory-only residual).
-const MAX_CANCEL_ATTEMPTS = 30
-let onPendingCancelApplied = null
-
-export function configurePendingCancels(onApplied) { onPendingCancelApplied = onApplied }
-
-export function registerPendingCancel(spaceId, topicHex, joinerKey) {
-  pendingCancels.set(spaceId, { topic: topicHex, joinerKey, attempts: 0 })
-}
-
-export function hasPendingCancel(spaceId) { return pendingCancels.has(spaceId) }
-
-export function joinPendingCancelTopic(spaceId, topicHex) { joinPurgedSpaceTopic(spaceId, topicHex) }
-export async function leavePendingCancelTopic(spaceId) { await leavePurgedSpaceTopic(spaceId) }
-
-function sendPendingCancelFrames(socket, msgHandler) {
-  if (pendingCancels.size === 0) return
-  let sent = pendingCancelFramesSent.get(socket)
-  if (!sent) pendingCancelFramesSent.set(socket, (sent = new Set()))
-  for (const [spaceId, pc] of pendingCancels) {
-    try { msgHandler.send(JSON.stringify({ type: 'membership:cancel', spaceTopic: pc.topic, joinerKey: pc.joinerKey })) } catch { continue }
-    sent.add(spaceId)
-    if (++pc.attempts >= MAX_CANCEL_ATTEMPTS) {
-      pendingCancels.delete(spaceId)
-      leavePurgedSpaceTopic(spaceId).catch((err) => log.debug('pending-cancel give-up leave failed:', err.message))
-    }
-  }
-}
-
-// Initial send of a freshly-registered cancel on every current connection. Goes through
-// sendPendingCancelFrames (not broadcastMembershipCancel) so ack eligibility is recorded per socket
-// — otherwise a member acking over the existing connection would be rejected by handleMembershipCancelAck.
-export function sendPendingCancelToConnected() {
-  for (const [socket, handler] of socketMsgHandlers) sendPendingCancelFrames(socket, handler)
-}
-
-// A member acked our cancel with applied:true (it wrote the converging tombstone) on a socket we
-// actually sent the cancel on — stop replaying and drop the topic. The socket + frame-sent check
-// mirrors handleLeaveAckFrame: a peer that never received our cancel can't clear it.
-function handleMembershipCancelAck(socket, msg) {
-  if (!msg.applied || typeof msg.spaceTopic !== 'string') return
-  for (const [spaceId, pc] of pendingCancels) {
-    if (pc.topic !== msg.spaceTopic) continue
-    if (!pendingCancelFramesSent.get(socket)?.has(spaceId)) return
-    pendingCancels.delete(spaceId)
-    Promise.resolve(onPendingCancelApplied?.(spaceId)).catch((err) => log.debug('pending-cancel clear failed:', err.message))
-    return
-  }
-}
-
-// Membership removal is the member-set fold's job (member-registry): a peer drops from the
-// set when their replicated `del member/S` (leave) lands, and stays an offline member
-// otherwise. This layer deliberately never prunes membership on disconnect — admission is
-// separate from membership display, and a dead socket says nothing about membership.
 
 // === Topics, outbound handshakes & space cleanup ===
 
@@ -1205,179 +894,6 @@ export async function broadcastProfileUpdate() {
   }
 }
 
-// === Convergence tick ===
-
-// Re-send identity frames whose implicit ack never arrived. Settled means: for a member
-// space, some identity on that socket is admitted to it (their reciprocal proved the round
-// trip); for a pending space, the grant/deny flipped the status. A space that is leaving,
-// left, or only held as a pending-leave replay topic (no record) has nothing to announce.
-async function drainAnnounceLedger() {
-  if (socketMsgHandlers.size === 0) return
-  // Resolve per-space status only for the spaces actually in the ledger — a converged client
-  // with an empty ledger does no bee reads at all.
-  const pending = announceLedger.spaceIds()
-  if (pending.size === 0) return
-  const cfg = getConvergenceConfig()
-  const status = new Map()
-  for (const spaceId of pending) {
-    if (!spaceTopics.has(spaceId) || isSpaceLeaving(spaceId)) continue
-    // announceStatus distinguishes "present but statusless" (owner-created / v1 → 'active',
-    // a real member space) from "gone" (null → settled). Conflating them killed the owner's heal.
-    status.set(spaceId, announceStatus(await getSpace(spaceId)))
-  }
-  const isSettled = (socket, spaceId, kind) => {
-    const st = status.get(spaceId)
-    if (!st) return true
-    if (kind === 'request') return st !== 'pending'
-    for (const k of socketToPeers.get(socket) || []) {
-      if (connectedPeers.get(k)?.spaces.has(spaceId)) return true
-    }
-    return false
-  }
-  const due = announceLedger.due({
-    now: Date.now(),
-    baseMs: cfg.announceBaseMs,
-    capMs: cfg.announceCapMs,
-    maxAttempts: cfg.announceMaxAttempts,
-    isSettled,
-  })
-  for (const { socketId: socket, spaceId } of due) {
-    const handler = socketMsgHandlers.get(socket)
-    const topic = spaceTopics.get(spaceId)
-    // A dead socket (disconnected during a prior await) leaves zombie ledger entries the pure
-    // due() can't see socketMsgHandlers to prune — forget it here so its bucket evaporates.
-    if (!handler) { announceLedger.forgetSocket(socket); continue }
-    if (!topic) continue
-    log.debug('re-announcing space', spaceId)
-    await sendSingleHandshake(socket, handler, spaceId, topic)
-  }
-}
-
-// One slow, global, deficit-gated pass — the level-triggered re-drive an app restart used
-// to be: re-send unacked identity frames, re-fold rosters whose considered records haven't
-// replicated (escalating a persistent deficit to a throttled discovery refresh — fresh
-// connections mean fresh replication streams), and re-poke listings that gave up on a peer
-// catalog under the read budget. A converged, quiet swarm does nothing here.
-async function runConvergenceTick() {
-  await drainAnnounceLedger()
-  const cfg = getConvergenceConfig()
-  const deficits = rosterDeficits()
-  for (const spaceId of spaceTopics.keys()) {
-    if (!deficits.has(spaceId) || isSpaceLeaving(spaceId)) {
-      // Deficit cleared: reset all per-space escalation state so a LATER deficit (a new member
-      // not yet replicated) gets a fresh escalation budget.
-      deficitTicks.delete(spaceId)
-      lastRefreshAt.delete(spaceId)
-      escalationsSpent.delete(spaceId)
-      continue
-    }
-    const ticks = (deficitTicks.get(spaceId) || 0) + 1
-    deficitTicks.set(spaceId, ticks)
-    recomputeMemberView(spaceId)
-    const spent = escalationsSpent.get(spaceId) || 0
-    const due = spent < cfg.convergenceMaxEscalations && escalationDue({
-      ticks,
-      escalateTicks: cfg.convergenceEscalateTicks,
-      lastRefreshAt: lastRefreshAt.get(spaceId) || 0,
-      minMs: cfg.convergenceRefreshMinMs,
-      now: Date.now(),
-    })
-    if (due) {
-      lastRefreshAt.set(spaceId, Date.now())
-      escalationsSpent.set(spaceId, spent + 1)
-      log.info('convergence refresh — roster deficit persisted', ticks, 'ticks for', spaceId)
-      const discovery = spaceDiscoveries.get(spaceId)
-      if (discovery) {
-        try {
-          discovery.refresh({ client: true, server: true }).catch((err) => log.debug('convergence refresh failed:', spaceId, err.message))
-        } catch (err) {
-          log.debug('convergence refresh failed:', spaceId, err.message)
-        }
-      }
-    }
-  }
-  for (const spaceId of takeIncompleteListSpaces()) {
-    if (spaceTopics.has(spaceId) && !isSpaceLeaving(spaceId)) ipcRef?.emit('event:files-updated', { spaceId })
-  }
-  // Re-attempt incomplete peer-bee captures: a capture that raced a starved or
-  // short-lived session heals here on a later one. Throttled per key inside the
-  // scheduler; retired keys (complete or past the sweep cap) never come back.
-  for (const key of await captureDeficits()) scheduleCapture(key)
-  try { await rescueStalledTransfers() } catch (err) { log.debug('stalled-transfer rescue failed:', err.message) }
-}
-
-// Hyperswarm stops re-dialing a peer whose connections keep dying young: a link that drops inside
-// its prove-yourself window never resets the peer's attempt counter, and after the fourth such
-// close the peer loses its retry timer altogether — the next automatic dial is a topic re-lookup
-// ten minutes out. The escalation above cannot save us: it is gated on a ROSTER deficit, and a
-// two-peer space whose roster is fully replicated never has one, so a download can sit dead while
-// the swarm believes it is converged.
-//
-// A pending download whose owner we hold no socket for is exactly that state, and a discovery
-// refresh is the one lever that clears it (rediscovering a peer resets its attempts). Both planes
-// need it: the bulk plane carries the bytes, but the control plane carries the presence lease the
-// download's resume gate reads — rescuing only one leaves the transfer gated behind the other.
-// Refresh eagerly at first — a flapping link brings the peer back within a second or two, and every
-// cycle we sit out is a cycle the transfer makes no progress. But an owner who is simply offline
-// would then have us re-announce forever, so each fruitless attempt backs the next one off, up to a
-// quiet ceiling. Any attempt that finds every owner reachable resets it.
-const STALL_RESCUE_MIN_MS = 10_000
-const STALL_RESCUE_MAX_MS = 300_000
-let stalledOwnersHook = null
-let lastStallRescueAt = 0
-let stallRescueBackoffMs = STALL_RESCUE_MIN_MS
-let stallRescueInFlight = false
-
-
-export async function rescueStalledTransfers() {
-  if (!swarm || !stalledOwnersHook || stallRescueInFlight) return false
-
-  stallRescueInFlight = true
-  try {
-    const contentActive = getContentPlaneStatus().active
-    let controlDown = false
-    let contentDown = false
-    for (const ownerKey of await stalledOwnersHook()) {
-      if (!connectedPeers.has(ownerKey)) controlDown = true
-      if (contentActive && !contentPlaneHasPeer(ownerKey)) contentDown = true
-    }
-    if (!controlDown && !contentDown) {
-      stallRescueBackoffMs = STALL_RESCUE_MIN_MS // everyone we are waiting on is reachable
-      return false
-    }
-    if (Date.now() - lastStallRescueAt < stallRescueBackoffMs) return false
-
-    lastStallRescueAt = Date.now()
-    stallRescueBackoffMs = Math.min(stallRescueBackoffMs * 2, STALL_RESCUE_MAX_MS)
-    log.info('stalled transfer — refreshing discovery:', controlDown ? 'control' : '', contentDown ? 'content' : '')
-    if (controlDown) {
-      for (const [spaceId, discovery] of spaceDiscoveries) {
-        try { await discovery.refresh({ client: true, server: true }) } catch (err) { log.debug('stall refresh failed for', spaceId, err.message) }
-      }
-    }
-    if (contentDown) await refreshContentDiscoveries()
-    return true
-  } finally {
-    stallRescueInFlight = false
-  }
-}
-
-function startConvergenceTick() {
-  if (convergenceTimer) return
-  const { convergenceTickMs } = getConvergenceConfig()
-  if (!convergenceTickMs) return
-  convergenceTimer = setInterval(() => {
-    // The tick is async and setInterval doesn't await it — skip a fire that lands while the
-    // previous run is still in flight, so overlapping runs can't double-send or double-count.
-    if (convergenceTicking) return
-    convergenceTicking = true
-    runConvergenceTick()
-      .catch((err) => log.debug('convergence tick failed:', err.message))
-      .finally(() => { convergenceTicking = false })
-  }, convergenceTickMs)
-  convergenceTimer.unref?.()
-}
-
 export async function leaveSpaceTopic(spaceId) {
   const space = await getSpace(spaceId)
   if (!space) return
@@ -1386,12 +902,9 @@ export async function leaveSpaceTopic(spaceId) {
   spaceTopics.delete(spaceId)
   spaceDiscoveries.delete(spaceId)
   try { await leaveContentTopic(spaceId) } catch {} // no-op unless the content plane is active
-  // The tick's cleanup only visits current spaceTopics, so a left space's escalation state
-  // would dangle (and mistime escalation on a same-space rejoin) — drop it here. The announce
-  // ledger self-prunes the left space on its next drain (status resolves null → settled).
-  deficitTicks.delete(spaceId)
-  lastRefreshAt.delete(spaceId)
-  escalationsSpent.delete(spaceId)
+  // The announce ledger self-prunes the left space on its next drain (status resolves null →
+  // settled); the tick's per-space escalation state has to be dropped explicitly.
+  forgetSpaceConvergence(spaceId)
   log.info('left topic for space', spaceId)
   scheduleStatusEmit()
 }
@@ -1605,16 +1118,8 @@ async function destroySwarm() {
   }
   resetNetworkWatch()
   stopPresenceHeartbeat()
-  if (convergenceTimer) {
-    clearInterval(convergenceTimer)
-    convergenceTimer = null
-  }
-  convergenceTicking = false
+  resetConvergenceTick()
   resetRegistries()
-  announceLedger.clear()
-  deficitTicks.clear()
-  lastRefreshAt.clear()
-  escalationsSpent.clear()
   clearListDeficits()
   testDrop = null
   presence.clearAll()
@@ -1636,7 +1141,6 @@ async function destroySwarm() {
   canaryInFlight = null
   browserOnlineHint = true
   localBindings.clear()
-  leaveAcks.clear()
   // Close the one held bee per peer, not just the map: each carries a live session and an
   // append listener.
   for (const held of profileBeeAppendListeners.values()) {
@@ -1650,24 +1154,16 @@ async function destroySwarm() {
   frameLimiter = null
   membersPoke.reset()
   ipcRef = null
-  leavingSpaces.clear()
   overlayReconnectHook = null
   membershipControlHandler = null
   connectionAttachHook = null
   revokeServesForSpaceHook = null
   stalledOwnersHook = null
-  onPendingLeaveApplied = null
-  onPendingCancelApplied = null
-  pendingLeaves.clear()
-  lastLeaveAckedKeys.clear()
-  pendingCancels.clear()
+  resetLeaveProtocol()
   resetDeferredAdmission()
   lastReconnectAt = 0
   bootedAt = 0
   corruptionDiagnosed = false
-  lastStallRescueAt = 0
-  stallRescueBackoffMs = STALL_RESCUE_MIN_MS
-  stallRescueInFlight = false
   relaySelections = 0
   try {
     await swarm.destroy()

--- a/test/unit/module-export-resolution.test.js
+++ b/test/unit/module-export-resolution.test.js
@@ -1,0 +1,83 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const roots = ['shared', 'worker', 'main', 'preload'].map((d) => path.join(here, '..', '..', 'src', d))
+
+function walk (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) { if (name !== 'vendor') walk(p, out) } else if (name.endsWith('.js')) out.push(p)
+  }
+  return out
+}
+
+// The names a module actually provides. `export *` is a wildcard we cannot resolve without
+// following the chain, so a module carrying one opts out rather than reporting false misses.
+export function exportedNames (source) {
+  const names = new Set()
+  for (const m of source.matchAll(/(?:^|\n)export\s+(?:async\s+)?function\s*\*?\s*(\w+)/g)) names.add(m[1])
+  for (const m of source.matchAll(/(?:^|\n)export\s+(?:const|let|var|class)\s+(\w+)/g)) names.add(m[1])
+  for (const m of source.matchAll(/export\s*\{([^}]*)\}/g)) {
+    for (const part of m[1].split(',')) {
+      const p = part.trim()
+      if (p) names.add(p.split(/\s+as\s+/).pop().trim())
+    }
+  }
+  if (/(?:^|\n)export\s+default/.test(source)) names.add('default')
+  if (/(?:^|\n)export\s*\*/.test(source)) names.add('*')
+  return names
+}
+
+// Named imports from a relative specifier, which are the only ones we can resolve on disk.
+export function relativeNamedImports (source) {
+  const out = []
+  for (const m of source.matchAll(/import\s*\{([^}]*)\}\s*from\s*'(\.[^']+)'/g)) {
+    const names = m[1].split(',').map((p) => p.trim()).filter(Boolean)
+      .map((p) => p.split(/\s+as\s+/)[0].trim())
+    out.push({ spec: m[2], names })
+  }
+  return out
+}
+
+// REGRESSION (SWARM-DECOMP-2: a name moved out of swarm.js while an importer still asked swarm.js
+// for it. no-undef cannot see this — the identifier IS bound in the importer, to an import that
+// resolves to nothing — and neither typecheck nor the unit suite loads the data layer, so it
+// surfaced only as `does not provide an export named 'broadcastPresence'` when the Bare loader
+// refused the worker bundle, minutes into a flow run. Twice.)
+test('REGRESSION (SWARM-DECOMP-2): every named import resolves to a real export', (t) => {
+  // The grammar, on fixtures: what must be caught, and what must stay legal.
+  t.ok(exportedNames('export async function* listOwnShare (a) {}\n').has('listOwnShare'),
+    'an async generator counts as exported')
+  t.ok(exportedNames("export { a as b } from './x.js'\n").has('b'), 'a re-export under a new name counts')
+  t.ok(exportedNames('export const x = 1\nexport let y = 2\n').has('y'), 'a mutable binding counts')
+  t.absent(exportedNames('const notExported = 1\n').has('notExported'), 'a plain declaration does not')
+  t.ok(exportedNames("export * from './x.js'\n").has('*'), 'a wildcard is reported so callers can opt out')
+  t.alike(relativeNamedImports("import { a, b as c } from './m.js'\n"), [{ spec: './m.js', names: ['a', 'b'] }],
+    'named imports are read under their source name')
+  t.alike(relativeNamedImports("import x from 'hyperswarm'\n"), [], 'bare specifiers are out of scope')
+
+  const cache = new Map()
+  const missing = []
+  for (const root of roots) {
+    for (const file of walk(root)) {
+      const source = readFileSync(file, 'utf8')
+      for (const { spec, names } of relativeNamedImports(source)) {
+        const target = path.resolve(path.dirname(file), spec)
+        if (!cache.has(target)) {
+          let provided = null
+          try { provided = exportedNames(readFileSync(target, 'utf8')) } catch { provided = null }
+          cache.set(target, provided)
+        }
+        const provided = cache.get(target)
+        if (!provided || provided.has('*')) continue
+        for (const name of names) {
+          if (!provided.has(name)) missing.push(`${path.relative(here, file)} imports "${name}" from ${spec}`)
+        }
+      }
+    }
+  }
+  t.alike(missing, [], 'no module asks a sibling for a name it does not export')
+})

--- a/test/unit/presence-heartbeat-ownership.test.js
+++ b/test/unit/presence-heartbeat-ownership.test.js
@@ -1,0 +1,55 @@
+import test from 'brittle'
+import {
+  initPresenceBroadcast, startPresenceHeartbeat, stopPresenceHeartbeat, broadcastDeparture,
+} from '../../src/shared/transfer/presence-broadcast.js'
+
+// REGRESSION (SWARM-DECOMP-1: moving broadcastDeparture out of swarm.js left the heartbeat
+// interval behind. presence-broadcast declared its own presenceTimer, which nothing ever assigned,
+// so the departure's first line — clear the heartbeat before announcing offline — cleared null. A
+// beat landing in the shutdown teardown window then re-marked us online on the receiver and undid
+// the departure, which is the whole reason that line exists. Nothing went red: the flow test still
+// passed on the socket close, and no-undef cannot see two modules each holding their own null.)
+test('REGRESSION (SWARM-DECOMP-1): the departure stops the heartbeat it races', (t) => {
+  const realSet = globalThis.setInterval
+  const realClear = globalThis.clearInterval
+  const started = []
+  const cleared = []
+  globalThis.setInterval = (fn, ms) => { const h = realSet(fn, ms); started.push(h); return h }
+  globalThis.clearInterval = (h) => { cleared.push(h); return realClear(h) }
+  t.teardown(() => {
+    globalThis.setInterval = realSet
+    globalThis.clearInterval = realClear
+    stopPresenceHeartbeat()
+  })
+
+  initPresenceBroadcast({
+    presence: { prune () {} },
+    membersPoke: null,
+    log: { debug () {} },
+    getSwarm: () => null,     // departure returns right after the clear — no frames needed here
+    getIpc: () => null,
+  })
+
+  startPresenceHeartbeat()
+  t.is(started.length, 1, 'the heartbeat is armed by the module that holds the timer')
+
+  broadcastDeparture()
+  t.ok(cleared.includes(started[0]), 'and the departure clears that exact timer')
+
+  // Not just the OS timer: the module's own handle has to be dropped too, or the next start is a
+  // silent no-op and the peer never hears another heartbeat.
+  startPresenceHeartbeat()
+  t.is(started.length, 2, 'and a later start arms a fresh one')
+})
+
+test('starting the heartbeat twice arms one timer', (t) => {
+  const realSet = globalThis.setInterval
+  const started = []
+  globalThis.setInterval = (fn, ms) => { const h = realSet(fn, ms); started.push(h); return h }
+  t.teardown(() => { globalThis.setInterval = realSet; stopPresenceHeartbeat() })
+
+  initPresenceBroadcast({ presence: { prune () {} }, membersPoke: null, log: { debug () {} }, getSwarm: () => null, getIpc: () => null })
+  startPresenceHeartbeat()
+  startPresenceHeartbeat()
+  t.is(started.length, 1, 'a second start is a no-op, so a reconnect cannot double the beat rate')
+})


### PR DESCRIPTION
Continues the `swarm.js` decomposition. Five modules out; `swarm.js` **2537 → 1757 (−31%)**, `destroySwarm` **62 reset statements → 41**.

| module | lines | owns |
|---|---|---|
| `swarm-registries.js` | 42 | the shared indexes + the announce ledger |
| `presence-broadcast.js` | 200 | heartbeat, departure, progress frames |
| `deferred-admission.js` | 151 | the pending-joiner retry loop |
| `leave-protocol.js` | 386 | inbound leave + both replay lanes |
| `convergence-tick.js` | 232 | announce drain, roster escalation, stall rescue |

Each takes its collaborators through `init(deps)`, with lazy accessors for the two handles `initSwarm`/`destroySwarm` reassign. `swarm.js` re-exports every name the worker imports, so no call site moves.

Ordering note: the registries came out **first**, before the sections using them. Measured, they were the bulk of every remaining section's dependency list (presence needed 11 identifiers from the core, deferred admission 10 — four each were these Maps). Doing it the other way means threading Maps through dependency objects and calling that a decomposition.

### One behaviour fix rides along (a313238)

Moving `broadcastDeparture` out in `7dcc7d1` left the heartbeat interval in `swarm.js`, so the timer the departure cleared was a `null` its own module never set. Its first line exists to stop the heartbeat before announcing offline — a beat landing in the teardown window re-marks us online on the receiver and undoes the departure. The interval now lives with the timer that owns it.

Nothing went red: the flow test passes on the socket close, and `no-undef` cannot see two modules each holding their own `null`. Found by pruning orphaned imports — `stopPresenceHeartbeat` was imported and never called. Regression test verified red on the defect, green on the fix.

### Two new guards

- `module-export-resolution.test.js` — every named import resolves to a real export. A name that moves out while an importer still asks the old module for it is invisible to `no-undef` (the identifier *is* bound, to an import resolving to nothing) and surfaces only when the Bare loader refuses the worker bundle, minutes into a flow run. That happened twice in this campaign.
- `presence-heartbeat-ownership.test.js` — the regression above.

### Gates

unit 1524/1524 · flow 191/191 · bare 922/923 — the bare failure is the known one-random-test-per-run flakiness (a different test failed the previous run, one run was fully clean, and `invite-record-capture.test.js` passes 11/11 five times isolated).
