### PR TITLE
[chore] Point the repository's own links at the new name

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -37,7 +37,7 @@ jobs:
           # PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_SIGNATURES_TOKEN }}
         with:
           path-to-signatures: 'signatures/cla.json'
-          path-to-document: 'https://github.com/ok/mirall-app/blob/main/CLA.md'
+          path-to-document: 'https://github.com/ok/mirall/blob/main/CLA.md'
           branch: 'cla-signatures'
           # `renovate-bot` is the identity our self-hosted Renovate actually
           # commits as: renovatebot/github-action signs commits as

--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@
   ·
   <a href="https://mirall.app/changelog">Changelog</a>
   ·
-  <a href="https://github.com/ok/mirall-app/issues">Report a bug</a>
+  <a href="https://github.com/ok/mirall/issues">Report a bug</a>
 </p>
 
 <p align="center">
-  <a href="https://github.com/ok/mirall-app/actions/workflows/test.yml"><img src="https://github.com/ok/mirall-app/actions/workflows/test.yml/badge.svg" alt="CI status"></a>
+  <a href="https://github.com/ok/mirall/actions/workflows/test.yml"><img src="https://github.com/ok/mirall/actions/workflows/test.yml/badge.svg" alt="CI status"></a>
   <a href="./LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue" alt="License: AGPL-3.0"></a>
   <img src="https://img.shields.io/badge/platform-macOS%20%7C%20Windows%20%7C%20Linux-555" alt="Platforms: macOS, Windows, Linux">
 </p>
@@ -138,7 +138,7 @@ Step-by-step guides live in the [documentation](https://mirall.app/docs).
 Prerequisites: [Node.js](https://nodejs.org) 22+.
 
 ```bash
-git clone https://github.com/ok/mirall-app.git
+git clone https://github.com/ok/mirall.git
 cd mirall-app
 npm ci
 npm start        # build + launch the app (updates disabled)


### PR DESCRIPTION
After the rename from `mirall-app` to `mirall`, four self-references still used the old path.

| File | Reference |
|---|---|
| `README.md` | "Report a bug" → issues |
| `README.md` | CI badge image **and** its link target |
| `README.md` | `git clone` URL |
| `.github/workflows/cla.yml` | `path-to-document` for CLA.md |

GitHub 301-redirects all of them, so nothing was broken — but the clone line gets copy-pasted by hand and the badge is fetched on every README view, and neither should be spending a redirect.

Verified the new paths resolve directly rather than assuming:

```
https://github.com/ok/mirall/issues                              200
https://github.com/ok/mirall/actions/workflows/test.yml/badge.svg 200
https://github.com/ok/mirall/blob/main/CLA.md                     200
```

No `ok/mirall-app` remains in the tree.