### PR TITLE
[fix] Contain the space list pane's sr-only spans

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -199,6 +199,13 @@ plain Tailwind sizes + `font-headline`:
   is `scrollbar-width: auto` (not thin, despite the name) and sets `scrollbar-color`, which opts
   Chromium out of overlay scrollbars — so the bar always takes real layout width, and a controls row
   *outside* the pane runs wider than the rows inside it.
+- **Every scroll pane is `relative`.** `sr-only` is `position: absolute`, and an absolutely
+  positioned box is clipped only from its *containing block* upwards — not by a scroll pane it
+  merely sits inside in the DOM. An unpositioned pane therefore lets the `sr-only` spans of rows
+  below the fold resolve against whatever is positioned above it (or the `<html>` block) and grow
+  the **document**, which paints an OS scrollbar down the side of the window over a shell that is
+  exactly `100vh`. Both `FolderView` and `SpaceView` carry it on their list pane;
+  `npm run test:layout` and `npm run test:layout:spaceoverflow` measure it.
 - **Dominant spacing increments:** `gap-4` and `gap-6` (flex/grid),
   `space-y-6`, `space-y-10` (between settings sections), `p-5` (card rows),
   `p-6` (toggles, section cards), `p-8` (large cards).

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:layout:mirrorers": "node test/frontend-layout/run-mirrorers.mjs",
     "test:layout:indexing": "node test/frontend-layout/run-indexing.mjs",
     "test:layout:memo": "node test/frontend-layout/run-memo.mjs",
+    "test:layout:spaceoverflow": "node test/frontend-layout/run-spaceoverflow.mjs",
     "test:layout:focusring": "node test/frontend-layout/run-focusring.mjs",
     "test:layout:truncation": "node test/frontend-layout/run-truncation.mjs"
   },

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -389,9 +389,14 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
       >
         <div
           ref={filesRef}
-          /* 4px of interior room for a focused card's ring, cancelled by an equal negative margin
-             so no card moves; `pr-4` is the shared scrollbar gutter. Same shape as FolderView. */
-          className={`overflow-y-auto scrollbar-thin min-h-0 -mx-1 -mt-1 pl-1 pt-1 pb-4 space-y-8${filesOverflow ? ' pr-4' : ' pr-1'}`}
+          /* `relative` makes this pane the containing block for the `sr-only` spans inside the
+             rows (a file's full name, via FileName). They are `position: absolute`, so without it
+             they resolve against the grid above — which no longer clips anything — and a row
+             below the fold drops its 1px span past the viewport bottom, growing the DOCUMENT into
+             an OS scrollbar down the whole window. FolderView's pane carries it for the same
+             reason. The 4px of interior room is for a focused card's ring, cancelled by an equal
+             negative margin so no card moves; `pr-4` is the shared scrollbar gutter. */
+          className={`relative overflow-y-auto scrollbar-thin min-h-0 -mx-1 -mt-1 pl-1 pt-1 pb-4 space-y-8${filesOverflow ? ' pr-4' : ' pr-1'}`}
         >
           {showSpaceEmptyState(pane) ? (
             <div className="flex flex-col min-h-[24rem] mt-12">

--- a/test/frontend-layout/README.md
+++ b/test/frontend-layout/README.md
@@ -76,6 +76,22 @@ The failed row rendered the error as an extra `<p>` under the meta line, growing
 the card from 88px to 100px; and the toast capped at 480px, wrapping long
 disk-full messages (which embed file names) to three cramped lines.
 
+## Space-screen document overflow (`npm run test:layout:spaceoverflow`)
+
+The twin of the FolderView scenario above, for `<SpaceView>`. Mounts the **real**
+screen with five folder shares and two loose files — more rows than the pane is
+tall — and asserts the **document** never becomes scrollable, at rest and with the
+list scrolled to its end.
+
+### What it caught
+
+The same bug class as the FolderView scenario, one screen over: the space list
+pane was not `relative`, so the `position:absolute` `sr-only` name spans inside
+rows below the fold resolved against the **grid** instead. Removing that grid's
+`overflow-hidden` (to stop it shaving focus rings off the cards) left nothing to
+clip them, and two 1px spans grew the document by 171px — an OS scrollbar down
+the side of the window. Fix: `relative` on the pane, as FolderView already does.
+
 ## Run
 
 ```
@@ -83,6 +99,7 @@ npm run test:layout              # FolderView document-overflow scenario
 npm run test:layout:members      # SpaceView Members-panel sizing scenario
 npm run test:layout:peerdownload # Peer-download serve-UI (meta clip + % fallback)
 npm run test:layout:filecard     # FileCard error-state height + toast width cap
+npm run test:layout:spaceoverflow # SpaceView document-overflow scenario
 node test/frontend-layout/run.mjs --no-build          # reuse the existing bundle
 node test/frontend-layout/run-members.mjs --no-build   # reuse the existing bundle
 ```

--- a/test/frontend-layout/build.mjs
+++ b/test/frontend-layout/build.mjs
@@ -95,4 +95,9 @@ await build({
   entryPoints: [path.join(HERE, 'harness-truncation-entry.tsx')],
   outfile: path.join(HERE, 'dist/harness-truncation.js'),
 })
+await build({
+  ...common,
+  entryPoints: [path.join(HERE, 'harness-spaceoverflow-entry.tsx')],
+  outfile: path.join(HERE, 'dist/harness-spaceoverflow.js'),
+})
 console.error('[build] harness bundled')

--- a/test/frontend-layout/document-overflow.ts
+++ b/test/frontend-layout/document-overflow.ts
@@ -1,0 +1,158 @@
+// Shared document-overflow probe for the layout harnesses.
+//
+// The app shell is a fixed-viewport surface: the root `min-h-screen`, the `<main>` top padding
+// and the screen's own `h-[calc(100vh-5rem-var(--banner-h))]` sum to exactly 100vh. So the
+// DOCUMENT must never become scrollable — an OS-level scrollbar over the whole window (outside
+// every pane that legitimately scrolls) is the user-visible symptom of a box that escaped its
+// clipping ancestor.
+//
+// The helpers below are the diagnosis kit: which elements poke below the viewport, whether an
+// ancestor clips them (so they cannot contribute to the document scroll height), and what the
+// shell containers measure at that moment.
+
+export interface Offender {
+  tag: string
+  cls: string
+  top: number
+  bottom: number
+  height: number
+  clipped: boolean
+  pos: string
+}
+
+// Does an ancestor establish a containing block for an absolutely-positioned descendant?
+function isContainingBlock(s: CSSStyleDeclaration): boolean {
+  return s.position !== 'static' || s.transform !== 'none' || s.filter !== 'none' || s.contain.includes('paint')
+}
+
+// Is anything between `el` and <html> clipping it (so it can't contribute to the DOCUMENT scroll
+// height)? Rows inside a list's `overflow-y-auto` pane are clipped — unless they are positioned
+// against an ancestor OUTSIDE that pane, which is exactly the bug class this catches: an
+// absolutely-positioned box is clipped only from its containing block upwards, so a scroll pane
+// it merely sits inside in the DOM does not contain it. Walking parents alone would call such a
+// box clipped and hide the one element that is growing the document.
+function clippedByAncestor(el: Element): boolean {
+  let seekingContainingBlock = getComputedStyle(el).position === 'absolute'
+  let p = el.parentElement
+  while (p && p !== document.documentElement) {
+    const s = getComputedStyle(p)
+    if (seekingContainingBlock) {
+      if (!isContainingBlock(s)) { p = p.parentElement; continue }
+      seekingContainingBlock = false
+    }
+    if (s.overflowY !== 'visible' || s.overflowX !== 'visible') return true
+    p = p.parentElement
+  }
+  return false
+}
+
+// Every element whose bottom escapes the viewport, annotated with whether it's clipped and its
+// position — so the real (non-clipped, non-fixed) contributor sorts to the top.
+export function offenders(ih: number): Offender[] {
+  const out: Offender[] = []
+  for (const el of Array.from(document.querySelectorAll('body *'))) {
+    const r = el.getBoundingClientRect()
+    if (r.height > 0 && r.bottom > ih + 1) {
+      const pos = getComputedStyle(el).position
+      out.push({
+        tag: el.tagName.toLowerCase(),
+        cls: String((el as HTMLElement).className || '').slice(0, 70),
+        top: Math.round(r.top),
+        bottom: Math.round(r.bottom),
+        height: Math.round(r.height),
+        clipped: clippedByAncestor(el),
+        pos,
+      })
+    }
+  }
+  out.sort((a, b) => {
+    const aReal = !a.clipped && a.pos !== 'fixed'
+    const bReal = !b.clipped && b.pos !== 'fixed'
+    if (aReal !== bReal) return aReal ? -1 : 1
+    return b.bottom - a.bottom
+  })
+  return out.slice(0, 16)
+}
+
+// Every positioned (absolute/fixed/sticky) element — to catch an overlay whose containing block
+// sits outside the pane that was supposed to clip it.
+export function positioned(): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = []
+  for (const el of Array.from(document.querySelectorAll('body, body *'))) {
+    const s = getComputedStyle(el)
+    if (s.position === 'absolute' || s.position === 'fixed' || s.position === 'sticky') {
+      const r = el.getBoundingClientRect()
+      out.push({
+        tag: el.tagName.toLowerCase(), pos: s.position,
+        cls: String((el as HTMLElement).className || '').slice(0, 70),
+        top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height),
+        cssTop: s.top, cssBottom: s.bottom, cssHeight: s.height,
+        parent: el.parentElement?.tagName.toLowerCase() ?? '',
+      })
+    }
+  }
+  return out
+}
+
+export function bodyChildren(): Array<Record<string, unknown>> {
+  return Array.from(document.body.children).map((el) => {
+    const r = el.getBoundingClientRect()
+    return {
+      tag: el.tagName.toLowerCase(),
+      cls: String((el as HTMLElement).className || '').slice(0, 70),
+      top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height),
+    }
+  })
+}
+
+export function containerMetrics(): Record<string, unknown> {
+  const pick = (sel: string) => {
+    const el = document.querySelector(sel) as HTMLElement | null
+    if (!el) return null
+    const r = el.getBoundingClientRect()
+    const s = getComputedStyle(el)
+    return {
+      sel, top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height),
+      scrollH: el.scrollHeight, clientH: el.clientHeight, overflowY: s.overflowY, pt: s.paddingTop,
+    }
+  }
+  return {
+    html: { scrollH: document.documentElement.scrollHeight, clientH: document.documentElement.clientHeight },
+    body: pick('body'),
+    root: pick('#root > div'),
+    main: pick('main'),
+    screen: pick('main > div > div'),
+  }
+}
+
+// The user-visible symptom: can the whole document be scrolled (revealing empty space below)?
+// Unlike raw scrollHeight this reflects the actual OS scrollbar.
+export function documentScrollable(): boolean {
+  const el = document.scrollingElement || document.documentElement
+  const before = el.scrollTop
+  el.scrollTop = 100000
+  const can = el.scrollTop > 0
+  el.scrollTop = before
+  return can
+}
+
+// The clipping chain above an element: where a box that pokes below the viewport stops being
+// somebody's problem. Reads the rect, the scroll geometry and the overflow of every ancestor up
+// to <body>, so a failure names the box that grew rather than the row that noticed.
+export function ancestorChain(el: Element | null): Array<Record<string, unknown>> {
+  const out: Array<Record<string, unknown>> = []
+  let cur: Element | null = el
+  while (cur && cur !== document.documentElement) {
+    const r = cur.getBoundingClientRect()
+    const s = getComputedStyle(cur)
+    out.push({
+      tag: cur.tagName.toLowerCase(),
+      cls: String((cur as HTMLElement).className || '').slice(0, 70),
+      top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height),
+      scrollH: (cur as HTMLElement).scrollHeight, clientH: (cur as HTMLElement).clientHeight,
+      overflowY: s.overflowY, position: s.position,
+    })
+    cur = cur.parentElement
+  }
+  return out
+}

--- a/test/frontend-layout/fake-bridge.js
+++ b/test/frontend-layout/fake-bridge.js
@@ -36,9 +36,11 @@
     { publicKey: OWNER_PK, driveKey: 'd'.repeat(64), displayName: 'Vhinz', online: true, avatar: null },
     { publicKey: SELF_PK, driveKey: 'e'.repeat(64), displayName: 'You', online: true, avatar: null },
   ]
+  // schemaVersion 2 is what every shipped space carries; without it SpaceView renders the
+  // legacy banner and hides the drop zone, i.e. not the screen users see.
   const space = {
     spaceId: SPACE_ID, name: 'Aurora', icon: 'folder', topic: 't'.repeat(64),
-    created: '2026-01-01', members, favorite: false,
+    created: '2026-01-01', members, favorite: false, schemaVersion: 2,
   }
   const foreignMount = {
     spaceId: SPACE_ID, shareId: SHARE_ID, mountPath: '/tmp/mirror', enabled: true,
@@ -65,8 +67,10 @@
       case 'features:get': return { overlay: false }
       // Routes the full SpaceView mount (members layout harness) needs; the
       // FolderView scenario never calls these, so the empties are inert there.
-      case 'files:list': return []
-      case 'share:list': return []
+      // A harness that wants a populated space screen seeds these two through __HARNESS_CFG;
+      // the scenarios that only need the shell keep the empty listings.
+      case 'files:list': return (window.__HARNESS_CFG && window.__HARNESS_CFG.files) || []
+      case 'share:list': return (window.__HARNESS_CFG && window.__HARNESS_CFG.shares) || []
       case 'space:storage-summary': return { totalBytes: folderInfo().totalBytes, onDeviceBytes: 0 }
       case 'space:pending-requests': return (window.__HARNESS_CFG && window.__HARNESS_CFG.pendingRequests) || []
       case 'foreign-folder:list-all': return []
@@ -82,7 +86,7 @@
   }
 
   // Expose a driver surface to the harness entry.
-  window.__fake = { SPACE_ID, SHARE_ID, OWNER_PK, files, members }
+  window.__fake = { SPACE_ID, SHARE_ID, OWNER_PK, SELF_PK, files, members }
   window.__fakeEmit = (eventObj) => reply(eventObj)
 
   const noop = () => {}

--- a/test/frontend-layout/harness-entry.tsx
+++ b/test/frontend-layout/harness-entry.tsx
@@ -11,6 +11,7 @@ import { createRoot } from 'react-dom/client'
 import './../../src/renderer/i18n.js'
 import { ToastProvider } from './../../src/renderer/components/toast/ToastProvider.js'
 import FolderView from './../../src/renderer/screens/FolderView.js'
+import { offenders, positioned, bodyChildren, containerMetrics, documentScrollable } from './document-overflow.js'
 
 const f = (window as unknown as { __fake: { SPACE_ID: string; SHARE_ID: string; OWNER_PK: string; files: Array<{ relPath: string; size: number }> } }).__fake
 const emit = (window as unknown as { __fakeEmit: (o: Record<string, unknown>) => void }).__fakeEmit
@@ -38,110 +39,8 @@ createRoot(container).render(
 
 // --- measurement -----------------------------------------------------------
 
-interface Offender { tag: string; cls: string; top: number; bottom: number; height: number; clipped: boolean; pos: string }
-
-// Is anything between `el` and <html> clipping it (so it can't contribute to the
-// DOCUMENT scroll height)? Rows in the list's `overflow-y-auto` pane are clipped.
-function clippedByAncestor(el: Element): boolean {
-  let p = el.parentElement
-  while (p && p !== document.documentElement) {
-    const s = getComputedStyle(p)
-    if (s.overflowY !== 'visible' || s.overflowX !== 'visible') return true
-    p = p.parentElement
-  }
-  return false
-}
-
-// Capture every element whose bottom escapes the viewport, annotated with
-// whether it's clipped and its position — so the real (non-clipped, non-fixed)
-// contributor stands out.
-function offenders(ih: number): Offender[] {
-  const out: Offender[] = []
-  for (const el of Array.from(document.querySelectorAll('body *'))) {
-    const r = el.getBoundingClientRect()
-    if (r.height > 0 && r.bottom > ih + 1) {
-      const pos = getComputedStyle(el).position
-      out.push({
-        tag: el.tagName.toLowerCase(),
-        cls: String((el as HTMLElement).className || '').slice(0, 70),
-        top: Math.round(r.top),
-        bottom: Math.round(r.bottom),
-        height: Math.round(r.height),
-        clipped: clippedByAncestor(el),
-        pos,
-      })
-    }
-  }
-  // The real document-overflow contributors: not clipped, not fixed. Surface
-  // those first, then any others for context.
-  out.sort((a, b) => {
-    const aReal = !a.clipped && a.pos !== 'fixed'
-    const bReal = !b.clipped && b.pos !== 'fixed'
-    if (aReal !== bReal) return aReal ? -1 : 1
-    return b.bottom - a.bottom
-  })
-  return out.slice(0, 16)
-}
-
-// Every positioned (absolute/fixed/sticky) element, plus body's direct children
-// — to catch a portal/overlay whose containing block is the ICB (<html>) and so
-// inflates documentElement.scrollHeight without showing up in body.scrollHeight.
-function positioned() {
-  const out: Array<Record<string, unknown>> = []
-  for (const el of Array.from(document.querySelectorAll('body, body *'))) {
-    const s = getComputedStyle(el)
-    if (s.position === 'absolute' || s.position === 'fixed' || s.position === 'sticky') {
-      const r = el.getBoundingClientRect()
-      out.push({
-        tag: el.tagName.toLowerCase(), pos: s.position,
-        cls: String((el as HTMLElement).className || '').slice(0, 70),
-        top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height),
-        cssTop: s.top, cssBottom: s.bottom, cssHeight: s.height,
-        parent: el.parentElement?.tagName.toLowerCase() ?? '',
-      })
-    }
-  }
-  return out
-}
-
-function bodyChildren() {
-  return Array.from(document.body.children).map((el) => {
-    const r = el.getBoundingClientRect()
-    return { tag: el.tagName.toLowerCase(), cls: String((el as HTMLElement).className || '').slice(0, 70), top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height) }
-  })
-}
-
-function containerMetrics() {
-  const pick = (sel: string) => {
-    const el = document.querySelector(sel) as HTMLElement | null
-    if (!el) return null
-    const r = el.getBoundingClientRect()
-    const s = getComputedStyle(el)
-    return { sel, top: Math.round(r.top), bottom: Math.round(r.bottom), height: Math.round(r.height), scrollH: el.scrollHeight, clientH: el.clientHeight, overflowY: s.overflowY, pt: s.paddingTop }
-  }
-  return {
-    html: { scrollH: document.documentElement.scrollHeight, clientH: document.documentElement.clientHeight },
-    body: pick('body'),
-    root: pick('#root > div'),
-    main: pick('main'),
-    screen: pick('main > div > div'),
-  }
-}
-
 function fileRowCount(): number {
   return document.querySelectorAll('p.truncate').length
-}
-
-// The user-visible symptom: can the whole document be scrolled (revealing the
-// empty space below)? This is what `overflow:hidden` OR a containing-context fix
-// both resolve — and unlike raw scrollHeight it reflects the actual OS scrollbar.
-function documentScrollable(): boolean {
-  const el = document.scrollingElement || document.documentElement
-  const before = el.scrollTop
-  el.scrollTop = 100000
-  const can = el.scrollTop > 0
-  el.scrollTop = before
-  return can
 }
 
 const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms))

--- a/test/frontend-layout/harness-spaceoverflow-entry.tsx
+++ b/test/frontend-layout/harness-spaceoverflow-entry.tsx
@@ -1,0 +1,163 @@
+// Real-Chromium document-overflow harness for the SPACE screen (the FolderView scenario in
+// harness-entry.tsx is its twin). Mounts the REAL <SpaceView> inside the REAL app-shell wrappers
+// (root `min-h-screen` + `<main>` top-padding that, with the screen's
+// `h-[calc(100vh-5rem-var(--banner-h))]`, sum to exactly 100vh) with enough folder shares and
+// loose files to overflow the list, and asserts the DOCUMENT never becomes scrollable — the list
+// pane scrolls, the window does not.
+//
+// `window.bridge` is installed by fake-bridge.js (a classic script loaded first in
+// harness-spaceoverflow.html), so `ipc.ts` and every hook/component run unmodified.
+import './harness-bootstrap.js'
+import { createRoot } from 'react-dom/client'
+import './../../src/renderer/i18n.js'
+import { ToastProvider } from './../../src/renderer/components/toast/ToastProvider.js'
+import { KeyboardProvider } from './../../src/renderer/keyboard/KeyboardProvider.js'
+import SpaceView from './../../src/renderer/screens/SpaceView.js'
+import { offenders, positioned, bodyChildren, containerMetrics, documentScrollable, ancestorChain } from './document-overflow.js'
+import type { FileEntry, Share } from './../../src/renderer/types.js'
+
+interface Phase {
+  overflow: number
+  scrollable: boolean
+  paneScrollTop: number
+}
+
+interface HarnessResults {
+  innerHeight: number
+  shareCards: number
+  paneScrolls: boolean
+  rest: Phase | null
+  scrolled: Phase | null
+  worstOffenders: unknown
+  chain: unknown
+  worstMetrics: unknown
+  worstPositioned: unknown
+  worstBodyChildren: unknown
+  pass: boolean
+  error: string | null
+}
+
+declare global {
+  interface Window {
+    __fake: { SPACE_ID: string; OWNER_PK: string; SELF_PK: string }
+    __HARNESS_CFG?: { shares?: Share[]; files?: FileEntry[] }
+    __results: HarnessResults
+  }
+}
+
+const { SPACE_ID, OWNER_PK, SELF_PK } = window.__fake
+
+// The shape of the reported screen: several folder shares of my own, one owned by a peer, and a
+// couple of loose files below them — more rows than the pane is tall.
+const SHARE_NAMES = ['anon-avatars', 'Boiler Room Carl Cox in Ibiza', 'Boiler Room DJ Rush in Rotterdam', 'Boiler Room Monika Kruse in Berlin', 'empty folder']
+const shares: Share[] = SHARE_NAMES.map((name, i) => ({
+  id: `share-${i}`,
+  type: 'owned-folder',
+  name,
+  owner: i === SHARE_NAMES.length - 1 ? OWNER_PK : SELF_PK,
+  spaceId: SPACE_ID,
+  createdAt: 0,
+}))
+const files: FileEntry[] = ['Bios-Ren7000.zip', 'Rack-Layout.pdf'].map((name, i) => ({
+  path: '/' + name,
+  size: 8_200_000 + i,
+  hash: String(i).repeat(64),
+  owner: { displayName: 'You', publicKey: SELF_PK },
+  driveKey: 'e'.repeat(64),
+  localBytes: 8_200_000 + i,
+  isAvailable: true,
+  status: 'mine',
+}))
+window.__HARNESS_CFG = { shares, files }
+
+createRoot(document.getElementById('root') as HTMLElement).render(
+  <div className="min-h-screen bg-surface">
+    <main className="pt-[calc(5rem+var(--banner-h,0px))]">
+      <ToastProvider>
+        <KeyboardProvider currentScreen="space-view" selectedSpaceId={SPACE_ID}>
+          <SpaceView spaceId={SPACE_ID} onBack={() => {}} onManageStorage={() => {}} />
+        </KeyboardProvider>
+      </ToastProvider>
+    </main>
+  </div>,
+)
+
+// --- measurement -----------------------------------------------------------
+
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+// ShareCard's root — the only `group isolate` box on the screen.
+function shareCardCount(): number {
+  return document.querySelectorAll('div.group.isolate').length
+}
+
+// The list pane: the screen's own scroller, found by what it does rather than by a class chain.
+// It is the first `overflow-y: auto` box in document order — the list sits ahead of the sidebar.
+function listPane(): HTMLElement | null {
+  const main = document.querySelector('main')
+  if (!main) return null
+  for (const el of Array.from(main.querySelectorAll<HTMLElement>('div'))) {
+    if (getComputedStyle(el).overflowY === 'auto') return el
+  }
+  return null
+}
+
+function phase(pane: HTMLElement): Phase {
+  return {
+    overflow: document.documentElement.scrollHeight - window.innerHeight,
+    scrollable: documentScrollable(),
+    paneScrollTop: Math.round(pane.scrollTop),
+  }
+}
+
+function publish(results: Partial<HarnessResults> & { pass: boolean; error: string | null }): void {
+  window.__results = {
+    innerHeight: window.innerHeight,
+    shareCards: shareCardCount(),
+    paneScrolls: false,
+    rest: null,
+    scrolled: null,
+    worstOffenders: offenders(window.innerHeight),
+    chain: ancestorChain(listPane()),
+    worstMetrics: containerMetrics(),
+    worstPositioned: positioned(),
+    worstBodyChildren: bodyChildren(),
+    ...results,
+  }
+}
+
+async function run() {
+  const deadline = Date.now() + 8000
+  while (shareCardCount() < shares.length && Date.now() < deadline) await sleep(50)
+  if (shareCardCount() < shares.length) return publish({ pass: false, error: 'share cards never rendered' })
+  await sleep(200)
+
+  const pane = listPane()
+  if (!pane) return publish({ pass: false, error: 'list scroll pane not found' })
+
+  const rest = phase(pane)
+
+  // Scroll the list to its end: the rows that were below the fold are the ones whose escaping
+  // boxes (an overlay positioned against an ancestor outside the pane, say) land past the
+  // viewport bottom and grow the document.
+  const paneScrolls = pane.scrollHeight > pane.clientHeight + 1
+  pane.scrollTop = pane.scrollHeight
+  await sleep(200)
+  const scrolled = phase(pane)
+
+  const worstAt = rest.overflow >= scrolled.overflow ? rest : scrolled
+  if (worstAt === rest) pane.scrollTop = 0
+  await sleep(50)
+
+  publish({
+    paneScrolls,
+    rest,
+    scrolled,
+    // The list must overflow for the scrolled measurement to mean anything, and neither phase
+    // may leave the document scrollable.
+    pass: paneScrolls && !rest.scrollable && !scrolled.scrollable,
+    error: null,
+  })
+}
+
+run()

--- a/test/frontend-layout/harness-spaceoverflow.html
+++ b/test/frontend-layout/harness-spaceoverflow.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mirall space document-overflow harness</title>
+  <!-- The REAL built stylesheet, so the harness uses the app's actual CSS. -->
+  <link rel="stylesheet" href="../../assets/dist/app.css" />
+  <!-- Classic script: installs window.bridge BEFORE the ESM bundle imports ipc.ts. -->
+  <script src="./fake-bridge.js"></script>
+</head>
+<body style="background: var(--color-background);">
+  <div id="root"></div>
+  <script type="module" src="./dist/harness-spaceoverflow.js"></script>
+</body>
+</html>

--- a/test/frontend-layout/run-spaceoverflow.mjs
+++ b/test/frontend-layout/run-spaceoverflow.mjs
@@ -1,0 +1,54 @@
+// Space-screen document-overflow test (LOCAL/dev-machine only — spawns a real Electron GUI
+// process, like the agent-desktop frontend suite). Mounts the real <SpaceView> with a list long
+// enough to scroll and asserts the DOCUMENT never becomes scrollable — an OS scrollbar over the
+// whole window means a box escaped the pane that was supposed to clip it. Prints the offending
+// elements so a failure is self-diagnosing.
+//
+//   node test/frontend-layout/run-spaceoverflow.mjs            (builds, then runs)
+//   node test/frontend-layout/run-spaceoverflow.mjs --no-build (reuse existing bundle)
+import { runHarness } from './run-harness.mjs'
+
+const out = await runHarness({ html: 'harness-spaceoverflow.html' })
+
+const fmt = (list) => (list || []).map((o) => {
+  const flag = o.pos === 'fixed' ? '[fixed]' : o.clipped ? '[clipped]' : '[FLOW] '
+  return `      ${flag} <${o.tag} class="${o.cls}">  top=${o.top} bottom=${o.bottom} h=${o.height}`
+}).join('\n')
+
+const fmtPhase = (label, p) => p
+  ? `      ${label}: documentOverflow=${p.overflow}px scrollable=${p.scrollable} (pane scrollTop=${p.paneScrollTop})`
+  : `      ${label}: (not measured)`
+
+console.log('\n──────── SpaceView document-overflow harness ────────')
+console.log(`innerHeight            : ${out.innerHeight}px`)
+console.log(`share cards rendered   : ${out.shareCards}`)
+console.log(`list pane scrolls      : ${out.paneScrolls}`)
+console.log('measurements:')
+console.log(fmtPhase('at rest ', out.rest))
+console.log(fmtPhase('scrolled', out.scrolled))
+if (out.error) console.log(`error                  : ${out.error}`)
+
+if (!out.pass) {
+  const m = out.worstMetrics || {}
+  console.log('container metrics:')
+  console.log(`      html      scrollH=${m.html?.scrollH} clientH=${m.html?.clientH}`)
+  for (const key of ['body', 'root', 'main', 'screen']) {
+    const c = m[key]
+    if (c) console.log(`      ${key.padEnd(9)} top=${c.top} bottom=${c.bottom} h=${c.height} scrollH=${c.scrollH} clientH=${c.clientH} overflowY=${c.overflowY} pt=${c.pt}`)
+  }
+  console.log('body direct children:')
+  for (const c of out.worstBodyChildren || []) console.log(`      <${c.tag} class="${c.cls}"> top=${c.top} bottom=${c.bottom} h=${c.height}`)
+  console.log('positioned (absolute/fixed/sticky) elements below the fold:')
+  for (const q of (out.worstPositioned || []).filter((x) => x.bottom > out.innerHeight)) {
+    console.log(`      [${q.pos}] <${q.tag} class="${q.cls}"> (in ${q.parent}) top=${q.top} bottom=${q.bottom} h=${q.height}`)
+  }
+  console.log('list pane, and every ancestor above it:')
+  for (const c of out.chain || []) console.log(`      <${c.tag} class="${c.cls}"> top=${c.top} bottom=${c.bottom} h=${c.height} scrollH=${c.scrollH} clientH=${c.clientH} overflowY=${c.overflowY} pos=${c.position}`)
+  console.log('elements escaping the viewport ([FLOW]=real document-overflow contributor):')
+  console.log(fmt(out.worstOffenders) || '      (none captured)')
+}
+
+const pass = out.pass === true
+console.log(`\n${pass ? 'ok  ' : 'FAIL'} the space screen keeps its scrolling inside the list pane` +
+  (pass ? '' : '  — the document itself scrolls, so an OS scrollbar appears over the window'))
+process.exit(pass ? 0 : 1)


### PR DESCRIPTION
The space screen showed an OS scrollbar down the whole window: its list pane was not `relative`, so the absolutely positioned `sr-only` name spans (`FileName`) in rows below the fold resolved against the grid above it. #157 removed that grid's `overflow-hidden` to stop it shaving focus rings off the cards, which left nothing to clip them — two 1px spans grew the document by 171px. `FolderView`'s pane already carries `relative` for the same reason.

**Coverage** — new `npm run test:layout:spaceoverflow`, the twin of the existing FolderView document-overflow scenario. Measured 171px / scrollable before the fix, 0px / not scrollable after. The shared probe moved to `document-overflow.ts` and now resolves an absolute box's containing block instead of walking DOM parents, which had labelled the offender "clipped" and hidden it.

Local: `test:layout:spaceoverflow`, `test:layout`, `:members`, `:approval`, `:dropoverlay`, `:focusring` all ok; `lint:ci` + `typecheck` clean.