### PR TITLE
[feat] Reach a folder's acts from the command palette

### DIFF
--- a/src/renderer/folderCommands.d.ts
+++ b/src/renderer/folderCommands.d.ts
@@ -1,0 +1,25 @@
+import type { ShareRole } from './types.js'
+
+export interface FolderCommandsInput {
+  role: ShareRole
+  // Syncing is currently held: the owner's paused index, or a mirror switched off.
+  paused: boolean
+  sourceMissing: boolean
+  // The screen can hand the mirror act somewhere; without it the entry has nowhere to go.
+  canMirror: boolean
+}
+
+export interface FolderCommandSpec {
+  labelKey: string
+  available: boolean
+}
+
+export interface FolderCommands {
+  open: FolderCommandSpec
+  locate: FolderCommandSpec
+  toggleSync: FolderCommandSpec
+  mirror: FolderCommandSpec
+  edit: FolderCommandSpec
+}
+
+export function deriveFolderCommands(input: FolderCommandsInput): FolderCommands

--- a/src/renderer/folderCommands.js
+++ b/src/renderer/folderCommands.js
@@ -1,0 +1,28 @@
+// Which folder acts the command palette offers, and under what label. Unavailability splits three
+// ways here, and none of the three wants a greyed-out row:
+//   wrong role     — absent. "Mirror" on a folder you already own is not an act that is
+//                    temporarily blocked, it is meaningless, and listing it teaches nothing.
+//   toggle state   — never gated; the LABEL swings instead. A folder that is not syncing offers
+//                    Resume, which is the act the user opened the palette for.
+//   work in flight — not modelled at all. The acts it blocks (Delete, Unmount) are deliberately
+//                    kept out of the palette, so no entry here ever needs a disabled state.
+//
+// The palette renders one flat ranked list with no group headings, so every label carries the
+// folder name: it is the only thing marking these rows as scoped to the folder on screen rather
+// than to the space beside it, and it is what makes the name itself a useful search term.
+
+export function deriveFolderCommands (input) {
+  const { role, paused, sourceMissing, canMirror } = input
+  const isOwn = role === 'mine'
+  const isBrowse = role === 'browse'
+  return {
+    open: { labelKey: 'shortcuts.folderOpen', available: !isBrowse && !sourceMissing },
+    locate: { labelKey: 'shortcuts.folderLocate', available: isOwn && sourceMissing },
+    toggleSync: {
+      labelKey: paused ? 'shortcuts.folderResume' : 'shortcuts.folderPause',
+      available: !isBrowse,
+    },
+    mirror: { labelKey: 'shortcuts.folderMirror', available: isBrowse && canMirror },
+    edit: { labelKey: 'shortcuts.folderEdit', available: !isBrowse },
+  }
+}

--- a/src/renderer/hooks/useFolderCommands.ts
+++ b/src/renderer/hooks/useFolderCommands.ts
@@ -1,0 +1,97 @@
+// The folder screen's palette entries, registered while FolderView is mounted and unregistered
+// with it. That mount lifetime IS the scoping: the folder screen is the only place FolderView
+// renders, so "this folder" in a label can only ever mean the folder on screen, and the command
+// context never has to carry a share id. Which entries are offered, and under which label, is
+// decided by deriveFolderCommands; this hook only binds them to the screen's handlers.
+import { useRegisterCommand } from '../keyboard/KeyboardProvider.js'
+import { deriveFolderCommands } from '../folderCommands.js'
+import type { ShareRole } from '../types.js'
+
+export interface FolderCommandsArgs {
+  name: string
+  role: ShareRole
+  paused: boolean
+  sourceMissing: boolean
+  canMirror: boolean
+  onOpen: () => void
+  onLocate: () => void
+  onSetPaused: (paused: boolean) => void
+  onMirror: () => void
+  onEdit: () => void
+}
+
+// Every label and availability value appears in its command's dependency list, not just the ones
+// the closure reads: useRegisterCommand freezes labelKey at registration time, and the provider
+// only re-filters the palette when a register/unregister bumps its version. A predicate that
+// quietly changed its answer would leave a stale row in an already-open palette.
+export function useFolderCommands({
+  name,
+  role,
+  paused,
+  sourceMissing,
+  canMirror,
+  onOpen,
+  onLocate,
+  onSetPaused,
+  onMirror,
+  onEdit,
+}: FolderCommandsArgs): void {
+  const spec = deriveFolderCommands({ role, paused, sourceMissing, canMirror })
+  const labelParams = { name }
+
+  useRegisterCommand(
+    {
+      id: 'folder.open',
+      labelKey: spec.open.labelKey,
+      labelParams,
+      group: 'space',
+      when: () => spec.open.available,
+      run: onOpen,
+    },
+    [name, spec.open.labelKey, spec.open.available],
+  )
+  useRegisterCommand(
+    {
+      id: 'folder.locate',
+      labelKey: spec.locate.labelKey,
+      labelParams,
+      group: 'space',
+      when: () => spec.locate.available,
+      run: onLocate,
+    },
+    [name, spec.locate.labelKey, spec.locate.available],
+  )
+  useRegisterCommand(
+    {
+      id: 'folder.toggleSync',
+      labelKey: spec.toggleSync.labelKey,
+      labelParams,
+      group: 'space',
+      when: () => spec.toggleSync.available,
+      run: () => onSetPaused(!paused),
+    },
+    [name, spec.toggleSync.labelKey, spec.toggleSync.available],
+  )
+  useRegisterCommand(
+    {
+      id: 'folder.mirror',
+      labelKey: spec.mirror.labelKey,
+      labelParams,
+      group: 'space',
+      when: () => spec.mirror.available,
+      run: onMirror,
+    },
+    [name, spec.mirror.labelKey, spec.mirror.available],
+  )
+  useRegisterCommand(
+    {
+      id: 'folder.edit',
+      labelKey: spec.edit.labelKey,
+      labelParams,
+      group: 'space',
+      when: () => spec.edit.available,
+      run: onEdit,
+    },
+    [name, spec.edit.labelKey, spec.edit.available],
+  )
+}

--- a/src/renderer/keyboard/KeyboardProvider.tsx
+++ b/src/renderer/keyboard/KeyboardProvider.tsx
@@ -166,6 +166,7 @@ export function useRegisterCommand(cmd: Command, deps: DependencyList): void {
       labelParams: cmd.labelParams,
       group: cmd.group,
       accelerator: cmd.accelerator ?? acceleratorFor(cmd.id),
+      hiddenInPalette: cmd.hiddenInPalette,
       when: cmd.when ? (ctx) => (cmdRef.current.when ? cmdRef.current.when(ctx) : true) : undefined,
       run: (ctx) => cmdRef.current.run(ctx),
     }

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -599,6 +599,12 @@
     "addFavorite": "Diesen Space zu Favoriten hinzufügen",
     "removeFavorite": "Diesen Space aus Favoriten entfernen",
     "manageStorage": "Speicher dieses Space verwalten",
+    "folderOpen": "Ordner {{name}} öffnen",
+    "folderLocate": "Ordner {{name}} suchen",
+    "folderPause": "Synchronisierung von {{name}} pausieren",
+    "folderResume": "Synchronisierung von {{name}} fortsetzen",
+    "folderMirror": "{{name}} auf Festplatte spiegeln",
+    "folderEdit": "Ordner {{name}} bearbeiten",
     "whatsNew": "Was ist neu",
     "sendFeedback": "Feedback senden",
     "openDocs": "Dokumentation öffnen"

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -623,6 +623,12 @@
     "addFavorite": "Add this space to Favorites",
     "removeFavorite": "Remove this space from Favorites",
     "manageStorage": "Manage storage for this space",
+    "folderOpen": "Open folder {{name}}",
+    "folderLocate": "Locate folder {{name}}",
+    "folderPause": "Pause syncing {{name}}",
+    "folderResume": "Resume syncing {{name}}",
+    "folderMirror": "Mirror {{name}} to disk",
+    "folderEdit": "Edit folder {{name}}",
     "whatsNew": "What's new",
     "sendFeedback": "Send feedback",
     "openDocs": "Open documentation"

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -599,6 +599,12 @@
     "addFavorite": "Añadir este espacio a favoritos",
     "removeFavorite": "Quitar este espacio de favoritos",
     "manageStorage": "Gestionar el almacenamiento de este espacio",
+    "folderOpen": "Abrir carpeta {{name}}",
+    "folderLocate": "Localizar carpeta {{name}}",
+    "folderPause": "Pausar sincronización de {{name}}",
+    "folderResume": "Reanudar sincronización de {{name}}",
+    "folderMirror": "Replicar {{name}} en disco",
+    "folderEdit": "Editar carpeta {{name}}",
     "whatsNew": "Novedades",
     "sendFeedback": "Enviar comentarios",
     "openDocs": "Abrir la documentación"

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -599,6 +599,12 @@
     "addFavorite": "Ajouter cet espace aux favoris",
     "removeFavorite": "Retirer cet espace des favoris",
     "manageStorage": "Gérer le stockage de cet espace",
+    "folderOpen": "Ouvrir le dossier {{name}}",
+    "folderLocate": "Localiser le dossier {{name}}",
+    "folderPause": "Suspendre la synchronisation de {{name}}",
+    "folderResume": "Reprendre la synchronisation de {{name}}",
+    "folderMirror": "Mettre {{name}} en miroir sur le disque",
+    "folderEdit": "Modifier le dossier {{name}}",
     "whatsNew": "Quoi de neuf",
     "sendFeedback": "Envoyer un commentaire",
     "openDocs": "Ouvrir la documentation"

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -599,6 +599,12 @@
     "addFavorite": "Aggiungi questo spazio ai preferiti",
     "removeFavorite": "Rimuovi questo spazio dai preferiti",
     "manageStorage": "Gestisci l'archiviazione di questo spazio",
+    "folderOpen": "Apri cartella {{name}}",
+    "folderLocate": "Individua cartella {{name}}",
+    "folderPause": "Sospendi sincronizzazione di {{name}}",
+    "folderResume": "Riprendi sincronizzazione di {{name}}",
+    "folderMirror": "Replica {{name}} sul disco",
+    "folderEdit": "Modifica cartella {{name}}",
     "whatsNew": "Novità",
     "sendFeedback": "Invia feedback",
     "openDocs": "Apri la documentazione"

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -32,6 +32,7 @@ import { useOwnedMount } from '../hooks/useFolderMount.js'
 import { useIndexProgress } from '../hooks/useIndexProgress.js'
 import { deriveIndexSummary } from '../indexSummary.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
+import { useFolderCommands } from '../hooks/useFolderCommands.js'
 import { useToast } from '../components/toast/useToast.js'
 import type { ShareWithRole } from '../hooks/useShares.js'
 import type { FileTreeNode } from '../types.js'
@@ -266,6 +267,21 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   }
 
   const paused = isYou ? indexPaused : !foreignEnabled
+  // The same acts the header offers, reachable from the command palette while this folder is on
+  // screen. Deliberately not the destructive pair: Delete and Unmount are gated on work that is
+  // still running, and an Enter keypress in a search field is the wrong place to confirm either.
+  useFolderCommands({
+    name: share.name,
+    role: share.role,
+    paused,
+    sourceMissing,
+    canMirror: !!onMirror,
+    onOpen: handleRevealFolder,
+    onLocate: handleLocate,
+    onSetPaused: (next) => { void setPaused(next) },
+    onMirror: () => onMirror?.(share),
+    onEdit: () => setShowEdit(true),
+  })
   // Destructive entries are disabled while the folder is working — not the trigger, because Pause
   // lives in this menu and is the one control you reach for while it runs.
   const destructive: ActionMenuItemConfig = isYou

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -121,6 +121,7 @@ import s120 from './scenarios/s120-folder-index-summary.mjs'
 import s121 from './scenarios/s121-index-pause-resume.mjs'
 import s122 from './scenarios/s122-folder-filter.mjs'
 import s123 from './scenarios/s123-edit-folder.mjs'
+import s124 from './scenarios/s124-folder-commands.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -187,7 +188,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s124-folder-commands.mjs
+++ b/test/frontend/scenarios/s124-folder-commands.mjs
@@ -1,0 +1,106 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, assert } from '../assert.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { workDir } from '../paths.mjs'
+
+// The folder screen's acts are reachable from the command palette, scoped to the folder on screen.
+// Three properties are worth proving through the UI, because none of them is visible to a unit
+// test: the entries exist only while that folder is open, sync is offered as a swinging LABEL
+// rather than a dead row, and which entries appear follows the role.
+//
+// Every assertion is a string strictly LONGER than the query typed to reach it. The palette input's
+// own value is part of the window text, so asserting on the query itself would pass against the
+// typing rather than against a rendered row.
+export default async function s124 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Archive')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'readme.txt'), 'so the folder exists at share time')
+
+  const palette = async (I, query) => {
+    await I.press('cmd+k')
+    await new Promise((res) => setTimeout(res, 600))
+    await I.type({ role: 'combobox' }, query)
+    await new Promise((res) => setTimeout(res, 400))
+  }
+
+  try {
+    await r.ok('A and B share a space; A owns "Archive"', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B)
+      await A.focus()
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Archive', 60000)
+      await A.openFolder('Archive')
+    })
+
+    await r.ok('the owner\'s folder acts are listed, and the mirror act is not', async () => {
+      await palette(A, 'archive')
+      assert(await A.hasText('Open folder Archive'), 'Open is offered')
+      assert(await A.hasText('Pause syncing Archive'), 'Pause is offered')
+      assert(await A.hasText('Edit folder Archive'), 'Edit is offered')
+      // Absent rather than greyed: mirroring a folder you own is meaningless, not blocked.
+      assert(!(await A.hasText('Mirror Archive to disk')), 'no mirror act on a folder you own')
+      assert(!(await A.hasText('Locate folder Archive')), 'no locate act while the source is present')
+      await A.shot('s124-A-palette-owner', runDir)
+      await A.press('escape')
+    })
+
+    // The design's centre of gravity: a folder that is not syncing offers Resume, never a listed
+    // dead Pause. One id, one row, a label that swings with the folder's state.
+    await r.ok('firing Pause from the palette swings the entry to Resume', async () => {
+      await palette(A, 'pause syncing')
+      assert(await A.hasText('Pause syncing Archive'), 'the row is there to fire')
+      await A.press('return')
+      await A.waitText('Paused', 30000)
+      await palette(A, 'syncing')
+      assert(await A.hasText('Resume syncing Archive'), 'the same entry now offers the way back')
+      assert(!(await A.hasText('Pause syncing Archive')), 'and never lists both verbs at once')
+      await A.shot('s124-A-palette-resume', runDir)
+      await A.press('escape')
+    })
+
+    await r.ok('leaving the folder takes its acts out of the palette', async () => {
+      await A.back()
+      await A.waitText('Drop to Share', 30000)
+      await palette(A, 'archive')
+      assert(!(await A.hasText('Resume syncing Archive')), 'no folder act survives the screen')
+      assert(!(await A.hasText('Open folder Archive')), 'no folder act survives the screen')
+      assert(!(await A.hasText('Edit folder Archive')), 'no folder act survives the screen')
+      await A.shot('s124-A-palette-out-of-scope', runDir)
+      await A.press('escape')
+    })
+
+    // REGRESSION: useRegisterCommand rebuilt each command without carrying hiddenInPalette, so the
+    // one command flagged to stay out of the list — the palette's own opener — was listed inside it.
+    await r.ok('REGRESSION: the palette does not list itself', async () => {
+      await palette(A, 'command palette')
+      assert(!(await A.hasText('Open command palette')), 'the palette opener stays hidden')
+      assert(await A.hasText('No commands match'), 'and nothing else claims that query')
+      await A.press('escape')
+    })
+
+    await r.ok('a browsed folder offers the mirror act instead, and it works', async () => {
+      await B.focus()
+      await B.waitText('Archive', 60000)
+      await B.openFolder('Archive')
+      await palette(B, 'mirror')
+      assert(await B.hasText('Mirror Archive to disk'), 'the mirror act is offered')
+      assert(!(await B.hasText('Pause syncing Archive')), 'nothing to pause on a folder you only browse')
+      assert(!(await B.hasText('Open folder Archive')), 'and no local folder to open')
+      await B.shot('s124-B-palette-browse', runDir)
+      await B.press('return')
+      await B.waitText('Mirror location on your disk', 20000)
+      await B.shot('s124-B-mirror-modal', runDir)
+      await B.press('escape')
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/unit/folder-commands.test.js
+++ b/test/unit/folder-commands.test.js
@@ -1,0 +1,91 @@
+import test from 'brittle'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { deriveFolderCommands } from '../../src/renderer/folderCommands.js'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+const ROLES = ['mine', 'mirrored', 'browse']
+const BOOL = [false, true]
+
+function each (fn) {
+  for (const role of ROLES) {
+    for (const paused of BOOL) {
+      for (const sourceMissing of BOOL) {
+        for (const canMirror of BOOL) {
+          fn({ role, paused, sourceMissing, canMirror })
+        }
+      }
+    }
+  }
+}
+
+test('a browsed folder offers only the mirror act', (t) => {
+  each((input) => {
+    if (input.role !== 'browse') return
+    const c = deriveFolderCommands(input)
+    const label = JSON.stringify(input)
+    t.is(c.mirror.available, input.canMirror, `mirror follows canMirror ${label}`)
+    t.absent(c.open.available, `no open ${label}`)
+    t.absent(c.locate.available, `no locate ${label}`)
+    t.absent(c.toggleSync.available, `no pause/resume ${label}`)
+    t.absent(c.edit.available, `no edit ${label}`)
+  })
+})
+
+test('mirror is never offered on a folder you own or already mirror', (t) => {
+  each((input) => {
+    if (input.role === 'browse') return
+    t.absent(deriveFolderCommands(input).mirror.available, `no mirror ${JSON.stringify(input)}`)
+  })
+})
+
+// The point of the whole design: sync is a toggle, so it is offered in both directions rather
+// than listed-but-dead in one of them. A regression here reintroduces the disabled row.
+test('pause/resume is offered whichever way the folder is currently set', (t) => {
+  each((input) => {
+    if (input.role === 'browse') return
+    const c = deriveFolderCommands(input)
+    t.ok(c.toggleSync.available, `offered ${JSON.stringify(input)}`)
+    t.is(
+      c.toggleSync.labelKey,
+      input.paused ? 'shortcuts.folderResume' : 'shortcuts.folderPause',
+      `label swings on paused ${JSON.stringify(input)}`,
+    )
+  })
+})
+
+test('open and locate are exclusive: a folder is opened or found, never both', (t) => {
+  each((input) => {
+    if (input.role === 'browse') return
+    const c = deriveFolderCommands(input)
+    t.absent(c.open.available && c.locate.available, `not both ${JSON.stringify(input)}`)
+    if (input.role === 'mine') {
+      t.ok(c.open.available || c.locate.available, `always one ${JSON.stringify(input)}`)
+      t.is(c.locate.available, input.sourceMissing, `locate follows sourceMissing ${JSON.stringify(input)}`)
+    } else {
+      // A mirror has no mount point of its own to go looking for.
+      t.absent(c.locate.available, `mirror never locates ${JSON.stringify(input)}`)
+    }
+  })
+})
+
+test('editing stays available on any folder that is not browse-only', (t) => {
+  each((input) => {
+    t.is(deriveFolderCommands(input).edit.available, input.role !== 'browse', JSON.stringify(input))
+  })
+})
+
+test('every label key the folder commands can emit is translated in English', (t) => {
+  const en = JSON.parse(readFileSync(join(root, 'src', 'renderer', 'locales', 'en', 'common.json'), 'utf8'))
+  const keys = new Set()
+  each((input) => {
+    for (const spec of Object.values(deriveFolderCommands(input))) keys.add(spec.labelKey)
+  })
+  t.is(keys.size, 6, 'six distinct labels across the matrix')
+  for (const key of keys) {
+    const value = key.split('.').reduce((node, part) => (node && typeof node === 'object' ? node[part] : undefined), en)
+    t.ok(typeof value === 'string' && value.length > 0, `${key} is translated`)
+    t.ok(value.includes('{{name}}'), `${key} names the folder it acts on`)
+  }
+})


### PR DESCRIPTION
## What & why

The folder screen's acts were unreachable from the command palette. They now
register while `FolderView` is mounted, so they are offered only for the folder
on screen and vanish with it — the command context needs no share id.

| id | offered when | label |
|---|---|---|
| `folder.open` | not browse, source present | Open folder {{name}} |
| `folder.locate` | owner, source missing | Locate folder {{name}} |
| `folder.toggleSync` | not browse — always | Pause / Resume syncing {{name}} |
| `folder.mirror` | browse, and the screen can route it | Mirror {{name}} to disk |
| `folder.edit` | not browse | Edit folder {{name}} |

No disabled-row machinery was added, because none of the three kinds of
unavailability wants one: a wrong role makes an act meaningless (absent), sync
is a toggle (the label swings), and the acts blocked by running work — Delete,
Unmount — are kept out of the palette entirely.

Labels carry the folder name: the palette renders one flat list with no group
headings, so it is the only thing marking these rows as folder-scoped.

Also fixes a live bug found on the way: `useRegisterCommand` rebuilt each
command without copying `hiddenInPalette`, so the palette listed its own opener.

## Coverage

- **Unit** — `test/unit/folder-commands.test.js`, the full role × paused ×
  sourceMissing × canMirror matrix over the pure `deriveFolderCommands`.
- **Frontend** — `s124-folder-commands`, two peers so owner and browse-only are
  both exercised; carries the REGRESSION step for the palette fix.
- **Accessibility** — no new DOM; rows join the existing listbox.
- Integration/flow skipped: nothing under `src/shared` or `src/worker` changed.

## Ran locally

`npm run test:fe s124` — 6/6, both peers. Flows: owner palette listing, firing
Pause and seeing the entry swing to Resume, the acts leaving the palette on
navigating away, the palette not listing itself, and a browse peer mirroring
from the palette into the mirror modal.

VoiceOver spot-check not done — the palette's ARIA scaffolding is untouched, but
that is an argument rather than a check.
