### PR TITLE
[feat] Unify the path field across every screen that shows one

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -348,11 +348,15 @@ Sizes: `sm` (`px-5 py-2.5 text-sm`, default), `lg` (`h-14 px-5 text-lg`).
 Optional leading icon at `size={20}`. `fullWidth` available; `ref` and
 `ariaDescribedBy` pass through for focus management and field wiring.
 
-**Never hand-roll these classes.** Settings/list action buttons ("Change folder",
-"Export", "Load more", "Clear filters", nav "Send feedback") are all
-`variant="secondary"` + `className="shrink-0"`, not a local copy of the class
-string — four screens once kept their own `ACTION_BUTTON` constant, and the copy
-that lost its `bg-*` pair is exactly how an unfilled Cancel button shipped.
+**Never hand-roll these classes.** Settings/list action buttons ("Export", "Load
+more", "Clear filters", nav "Send feedback") are all `variant="secondary"` +
+`className="shrink-0"`, not a local copy of the class string — four screens once
+kept their own `ACTION_BUTTON` constant, and the copy that lost its `bg-*` pair is
+exactly how an unfilled Cancel button shipped. The one deliberate exception is
+`PathRow`'s button: it wears the same `surface-control` pair but is sized to the
+48px field beside it (`py-3.5`, not `sm`'s `py-2.5`) and carries `text-accent`, so
+it belongs to the path field rather than to this primitive. Re-picking a path is
+that control's job — never a bare `secondary` button next to a line of text.
 
 ### Text button — `primitives/TextButton.tsx`
 The low-emphasis action: `text-sm font-bold text-secondary hover:underline`, no fill, no
@@ -415,16 +419,32 @@ focus via the universal ring (a **ring**, not a border). See `screens/Onboarding
 `keyboard/CommandPalette.tsx`.
 
 ### Path field — `widgets/PathRow.tsx`
-One filesystem path in a modal, always the same shape: the path in a filled
-`bg-surface-container-low px-5 py-3.5 rounded-xl` field (via `FilePath`, so it middle-truncates and
-carries the full path for assistive tech), with an optional button beside it that re-picks it.
+**Every** filesystem path the user can act on, in a modal or on a settings screen, always the same
+shape: the path in a filled `px-5 py-3.5 rounded-xl` field (via `FilePath`, so it middle-truncates
+and carries the full path for assistive tech), with an optional button beside it that re-picks it.
+Used by Add Folder, Mirror to Disk, Edit Folder, Edit Space and Storage settings. There is no
+second form — a bare line of path text next to a `secondary` button is the drift this replaced, and
+it read as a different kind of thing depending on which door you came through.
+
 `FilePath` and `FileName` keep **exactly one flexible run** next to a pinned ending (the final
 segment, or a filename's extension): ranking two shrinkable spans by `flex-shrink` does not work —
 once the first freezes at zero width Chromium leaves the rest overflowing, which is how a long
-folder name ended up painted over the Browse button. `npm run test:layout:truncation` pins it. Omit
-`onAction` for a display-only row — the field stays and the **absent button** is what says the path
-is fixed. Used by Add Folder, Mirror to Disk and Edit Folder. `EditSpaceModal` still renders the
-older bare-text form; converting it needs ref forwarding for its focus-managed Browse button.
+folder name ended up painted over the Browse button. `npm run test:layout:truncation` pins it.
+
+- **The label follows the state, not the caller.** No path yet → `pathField.browse` ("Browse…");
+  a path in the field → `actions.change` ("Change"). Callers used to pass it and had picked four
+  different strings for the one action. `actionLabel` overrides, and nothing currently needs to.
+- **`fill` picks the ramp step**, because the ground differs: `low` (default) sits on a modal
+  panel, which is `surface-container-lowest`. A settings card is itself `surface-container-low` —
+  same token, same hex in both themes — so a row inside one passes `fill="lowest"` or the field
+  disappears into the card. Same relationship `NetworkSettings`' number input already has.
+- **Omit `onAction` for a display-only row** — the field stays and the **absent button** is what
+  says the path is fixed. That is how Edit Folder shows a healthy owned source, which must not be
+  re-pointed outside the Locate flow.
+- `actionRef` forwards to the button, for `EditSpaceModal`, which hands focus back to it after
+  "Use default folder" unmounts itself.
+- Pass `ariaDescribedBy` with the ids of the field's label and description: the button's own name
+  is just the verb, so on its own it announces as a bare "Change".
 
 ### Modal — `primitives/Modal.tsx`
 react-aria `useDialog` + `<FocusScope contain restoreFocus autoFocus>`;

--- a/src/renderer/components/modals/AddFolderShareModal.tsx
+++ b/src/renderer/components/modals/AddFolderShareModal.tsx
@@ -63,8 +63,10 @@ function FolderShareEditStep({ isOpen, spaceName, mountPath, shareName, validati
 
       <div className="px-10 pb-10 space-y-6">
         <div className="space-y-3">
-          <label className="font-headline text-sm font-bold text-accent px-1">{t('addFolder.pathLabel')}</label>
-          <PathRow path={mountPath} onAction={onBrowse} />
+          <span id="add-folder-path-label" className="block font-headline text-sm font-bold text-accent px-1">
+            {t('addFolder.pathLabel')}
+          </span>
+          <PathRow path={mountPath} onAction={onBrowse} ariaDescribedBy="add-folder-path-label" />
           {validationError && (
             <p role="alert" className="text-xs text-error px-1">{validationError}</p>
           )}

--- a/src/renderer/components/modals/DeleteFolderShareModal.tsx
+++ b/src/renderer/components/modals/DeleteFolderShareModal.tsx
@@ -9,7 +9,6 @@ interface DeleteFolderShareModalProps {
   isOpen: boolean
   folderName: string
   spaceName: string
-  mountPath: string | null
   onClose: () => void
   onDelete: () => void | Promise<void>
 }
@@ -18,7 +17,6 @@ export default function DeleteFolderShareModal({
   isOpen,
   folderName,
   spaceName,
-  mountPath,
   onClose,
   onDelete,
 }: DeleteFolderShareModalProps) {
@@ -56,11 +54,6 @@ export default function DeleteFolderShareModal({
         <p className="text-on-surface-variant font-medium">
           {t('deleteFolder.body', { space: spaceName })}
         </p>
-        {mountPath && (
-          <p className="text-xs text-on-surface-variant px-1">
-            {t('deleteFolder.filesStay', { path: mountPath })}
-          </p>
-        )}
 
         <div className="pt-2 flex gap-4">
           <Button

--- a/src/renderer/components/modals/EditFolderModal.tsx
+++ b/src/renderer/components/modals/EditFolderModal.tsx
@@ -154,7 +154,6 @@ export default function EditFolderModal({
                 is what says whether you can re-point it. */}
             <PathRow
               path={effectivePath}
-              actionLabel={t('actions.change')}
               onAction={canRelocate ? handleBrowse : undefined}
               ariaDescribedBy="edit-folder-path-label edit-folder-path-desc"
             />

--- a/src/renderer/components/modals/EditSpaceModal.tsx
+++ b/src/renderer/components/modals/EditSpaceModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import type { Space } from '../../types.js'
 import { mountErrorI18nKey } from '../../errorMessages.js'
 import IconPicker from '../widgets/IconPicker.js'
-import FilePath from '../widgets/FilePath.js'
+import PathRow from '../widgets/PathRow.js'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
 import IconButton from '../primitives/IconButton.js'
@@ -132,18 +132,14 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
             <p id="edit-space-folder-desc" className="text-sm text-on-surface-variant px-1">
               {t('editSpace.downloadFolderDesc')}
             </p>
-            <div className="flex items-center gap-3">
-              <FilePath path={effectiveFolder} className="flex-1 text-sm text-accent" />
-              <Button
-                ref={browseRef}
-                variant="secondary"
-                onClick={handleBrowse}
-                ariaDescribedBy="edit-space-folder-label edit-space-folder-desc"
-                className="shrink-0"
-              >
-                {t('storageSettings.changeFolder')}
-              </Button>
-            </div>
+            {/* The same row Add Folder, Mirror to Disk, Edit Folder and Storage settings show — a
+                path is a path, whichever door you came through. */}
+            <PathRow
+              path={effectiveFolder || null}
+              onAction={handleBrowse}
+              ariaDescribedBy="edit-space-folder-label edit-space-folder-desc"
+              actionRef={browseRef}
+            />
             <div className="flex items-center min-h-5">
               {isOverridden && (
                 <button

--- a/src/renderer/components/modals/MirrorFolderModal.tsx
+++ b/src/renderer/components/modals/MirrorFolderModal.tsx
@@ -211,8 +211,10 @@ function MirrorEditStep({ isOpen, share, owner, ownerName, info, mountPath, vali
         </div>
 
         <div className="space-y-3">
-          <label className="font-headline text-sm font-bold text-accent px-1">{t('mirrorFolder.pathLabel')}</label>
-          <PathRow path={mountPath} onAction={onBrowse} />
+          <span id="mirror-folder-path-label" className="block font-headline text-sm font-bold text-accent px-1">
+            {t('mirrorFolder.pathLabel')}
+          </span>
+          <PathRow path={mountPath} onAction={onBrowse} ariaDescribedBy="mirror-folder-path-label" />
           {validationError && (
             <p role="alert" className="text-xs text-error px-1">{validationError}</p>
           )}

--- a/src/renderer/components/widgets/PathRow.tsx
+++ b/src/renderer/components/widgets/PathRow.tsx
@@ -1,43 +1,64 @@
+import type { Ref } from 'react'
 import { useTranslation } from 'react-i18next'
 import FilePath from './FilePath.js'
 
 interface PathRowProps {
   path: string | null
-  /** Shown in place of the path when there is none yet. Defaults to the browse hint. */
+  /** Shown in place of the path when there is none yet. Defaults to the pick-a-location hint. */
   placeholder?: string
-  /** Omit `onAction` for a display-only row — the field keeps its shape, the button is absent. */
+  /** Overrides the label. Leave unset — the default already says the right verb for the state. */
   actionLabel?: string
+  /** Omit for a display-only row — the field keeps its shape, the button is absent. */
   onAction?: () => void
   ariaDescribedBy?: string
+  /** Forwarded to the button, for callers that must hand focus back to it. */
+  actionRef?: Ref<HTMLButtonElement>
+  /**
+   * Which ramp step fills the field. The default suits a modal panel, which is
+   * `surface-container-lowest`. A settings card is itself `surface-container-low` — the same
+   * token, the same hex in both themes — so a row inside one passes `lowest` or the field
+   * disappears into the card it sits in.
+   */
+  fill?: 'low' | 'lowest'
 }
 
-// One filesystem path, presented the same way everywhere it appears in a modal: the path in a
-// filled field, with an optional button beside it that re-picks it. Add Folder, Mirror to Disk and
-// Edit Folder all show the same thing and had drifted — two of them shared this markup verbatim
-// while the third rendered a bare line of text, so the same fact looked like a different kind of
-// thing depending on how you arrived at it.
+const FILL = {
+  low: 'bg-surface-container-low',
+  lowest: 'bg-surface-container-lowest',
+} as const
+
+// One filesystem path, presented the same way everywhere it appears: the path in a filled field,
+// with an optional button beside it that re-picks it. Add Folder, Mirror to Disk, Edit Folder,
+// Storage settings and Edit Space all show the same thing and had drifted — three shared this
+// markup while two rendered a bare line of text next to a shorter, dimmer button, so the same fact
+// looked like a different kind of thing depending on how you arrived at it.
 //
 // Display-only keeps the field rather than falling back to bare text: a path is a value either
 // way, and the button's presence is what says whether you can change it.
-export default function PathRow({ path, placeholder, actionLabel, onAction, ariaDescribedBy }: PathRowProps) {
+//
+// The label follows the state rather than the caller: nothing picked yet is a first pick
+// ("Browse…"), a path already in the field is a re-pick ("Change"). Callers used to choose, and
+// chose four different strings for the one action.
+export default function PathRow({ path, placeholder, actionLabel, onAction, ariaDescribedBy, actionRef, fill = 'low' }: PathRowProps) {
   const { t } = useTranslation()
   return (
     <div className="flex items-center gap-3">
-      <div className="flex-grow flex items-center bg-surface-container-low px-5 py-3.5 rounded-xl min-w-0">
+      <div className={`flex-grow flex items-center ${FILL[fill]} px-5 py-3.5 rounded-xl min-w-0`}>
         {path ? (
           <FilePath path={path} className="flex-1 text-sm text-accent font-medium" />
         ) : (
-          <span className="text-sm text-outline/70 italic">{placeholder ?? t('addFolder.browsePlaceholder')}</span>
+          <span className="text-sm text-outline/70 italic">{placeholder ?? t('pathField.placeholder')}</span>
         )}
       </div>
       {onAction && (
         <button
+          ref={actionRef}
           type="button"
           onClick={onAction}
           aria-describedby={ariaDescribedBy}
           className="shrink-0 bg-surface-control text-accent rounded-xl px-5 py-3.5 font-headline font-bold text-sm hover:bg-surface-control-hover active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
         >
-          {actionLabel ?? t('addFolder.browseHint')}
+          {actionLabel ?? (path ? t('actions.change') : t('pathField.browse'))}
         </button>
       )}
     </div>

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -155,7 +155,6 @@
   "deleteFolder": {
     "title": "„{{name}}“ löschen?",
     "body": "Mitglieder von {{space}} sehen diesen Ordner nicht mehr.",
-    "filesStay": "Dateien in {{path}} bleiben auf deiner Festplatte.",
     "action": "Ordner löschen",
     "deleting": "Lösche…"
   },
@@ -163,8 +162,6 @@
     "title": "Ordner hinzufügen",
     "description": "Dateien in diesem Ordner sind für alle Mitglieder von {{space}} sichtbar.",
     "pathLabel": "Ordner auf deiner Festplatte",
-    "browseHint": "Durchsuchen…",
-    "browsePlaceholder": "Ort auswählen…",
     "nameLabel": "Freigabename",
     "nameHelp": "So erscheint dieser Ordner bei anderen Mitgliedern.",
     "next": "Weiter: Vorschau",
@@ -172,6 +169,10 @@
     "creating": "Ordner wird hinzugefügt…",
     "nameCollision": "Ein Ordner mit diesem Namen existiert bereits in diesem Raum.",
     "nameInvalid": "Der Name darf keine Schrägstriche oder Steuerzeichen enthalten und nicht leer sein."
+  },
+  "pathField": {
+    "browse": "Durchsuchen…",
+    "placeholder": "Ort auswählen…"
   },
   "folder": {
     "fileCount_one": "{{count}} Datei",
@@ -616,7 +617,6 @@
     "intro": "Datennutzung auf diesem Gerät anzeigen und verwalten.",
     "downloadFolder": "Download-Ordner",
     "downloadFolderDesc": "Hier speichert Mirall Dateien, die du von Mitgliedern deines Raums lädst.",
-    "changeFolder": "Ändern…",
     "appStorageDesc": "Speicher, den Mirall auf diesem Gerät zum Teilen und Synchronisieren deiner Dateien nutzt. Es wird nie eine zweite Kopie deiner Dateien angelegt.",
     "sharingIndex": "Freigabe-Index",
     "sharingIndexDesc": "Kompakte Verzeichnisse der von dir geteilten Dateien (nie die Dateiinhalte). Wird automatisch freigegeben, wenn du eine Datei nicht mehr teilst.",

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -154,7 +154,7 @@
   },
   "deleteFolder": {
     "title": "„{{name}}“ löschen?",
-    "body": "Mitglieder von {{space}} sehen diesen Ordner nicht mehr.",
+    "body": "Mitglieder von {{space}} sehen diesen Ordner nicht mehr. Deine Dateien bleiben auf deiner Festplatte.",
     "action": "Ordner löschen",
     "deleting": "Lösche…"
   },

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -179,7 +179,6 @@
   "deleteFolder": {
     "title": "Delete “{{name}}”?",
     "body": "Members of {{space}} will no longer see this folder.",
-    "filesStay": "Files in {{path}} stay on your disk.",
     "action": "Delete Folder",
     "deleting": "Deleting…"
   },
@@ -187,8 +186,6 @@
     "title": "Add Folder",
     "description": "Files in this folder will be visible to all members of {{space}}.",
     "pathLabel": "Folder on your disk",
-    "browseHint": "Browse…",
-    "browsePlaceholder": "Select location…",
     "nameLabel": "Share name",
     "nameHelp": "How this folder appears to other members.",
     "next": "Next: Preview",
@@ -196,6 +193,10 @@
     "creating": "Adding Folder…",
     "nameCollision": "A folder with this name already exists in this space.",
     "nameInvalid": "Name can't contain slashes, control characters, or be empty."
+  },
+  "pathField": {
+    "browse": "Browse…",
+    "placeholder": "Select location…"
   },
   "folder": {
     "fileCount_one": "{{count}} file",
@@ -640,7 +641,6 @@
     "intro": "View and manage Mirall data usage on this device.",
     "downloadFolder": "Download Folder",
     "downloadFolderDesc": "Where Mirall saves files downloaded from your space members.",
-    "changeFolder": "Change…",
     "folderError": "Could not set folder: {{error}}",
     "folderUnavailable": "This folder is currently unavailable. It may have been moved, deleted, or is on a disconnected drive — downloads will fail until you reconnect it or choose another folder.",
     "calculating": "Calculating storage...",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -178,7 +178,7 @@
   },
   "deleteFolder": {
     "title": "Delete “{{name}}”?",
-    "body": "Members of {{space}} will no longer see this folder.",
+    "body": "Members of {{space}} will no longer see this folder. Your files stay on your disk.",
     "action": "Delete Folder",
     "deleting": "Deleting…"
   },

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -154,7 +154,7 @@
   },
   "deleteFolder": {
     "title": "¿Eliminar «{{name}}»?",
-    "body": "Los miembros de {{space}} ya no verán esta carpeta.",
+    "body": "Los miembros de {{space}} ya no verán esta carpeta. Tus archivos permanecerán en tu disco.",
     "action": "Eliminar carpeta",
     "deleting": "Eliminando…"
   },

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -155,7 +155,6 @@
   "deleteFolder": {
     "title": "¿Eliminar «{{name}}»?",
     "body": "Los miembros de {{space}} ya no verán esta carpeta.",
-    "filesStay": "Los archivos en {{path}} permanecerán en tu disco.",
     "action": "Eliminar carpeta",
     "deleting": "Eliminando…"
   },
@@ -163,8 +162,6 @@
     "title": "Añadir carpeta",
     "description": "Los archivos de esta carpeta serán visibles para todos los miembros de {{space}}.",
     "pathLabel": "Carpeta en tu disco",
-    "browseHint": "Examinar…",
-    "browsePlaceholder": "Selecciona una ubicación…",
     "nameLabel": "Nombre del recurso compartido",
     "nameHelp": "Cómo aparece esta carpeta para los demás miembros.",
     "next": "Siguiente: vista previa",
@@ -172,6 +169,10 @@
     "creating": "Añadiendo carpeta…",
     "nameCollision": "Ya existe una carpeta con este nombre en este espacio.",
     "nameInvalid": "El nombre no puede contener barras, caracteres de control ni estar vacío."
+  },
+  "pathField": {
+    "browse": "Examinar…",
+    "placeholder": "Selecciona una ubicación…"
   },
   "folder": {
     "fileCount_one": "{{count}} archivo",
@@ -616,7 +617,6 @@
     "intro": "Consulta y gestiona el uso de datos de Mirall en este dispositivo.",
     "downloadFolder": "Carpeta de descargas",
     "downloadFolderDesc": "Dónde guarda Mirall los archivos descargados de los miembros de tu espacio.",
-    "changeFolder": "Cambiar…",
     "appStorageDesc": "Espacio que Mirall usa en este dispositivo para compartir y sincronizar tus archivos. Nunca guarda una segunda copia de tus archivos.",
     "sharingIndex": "Índice de archivos compartidos",
     "sharingIndexDesc": "Mapas compactos de los archivos que compartes (nunca su contenido). Se liberan automáticamente cuando dejas de compartir un archivo.",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -155,7 +155,6 @@
   "deleteFolder": {
     "title": "Supprimer « {{name}} » ?",
     "body": "Les membres de {{space}} ne verront plus ce dossier.",
-    "filesStay": "Les fichiers dans {{path}} restent sur votre disque.",
     "action": "Supprimer le dossier",
     "deleting": "Suppression…"
   },
@@ -163,8 +162,6 @@
     "title": "Ajouter un dossier",
     "description": "Les fichiers de ce dossier seront visibles par tous les membres de {{space}}.",
     "pathLabel": "Dossier sur votre disque",
-    "browseHint": "Parcourir…",
-    "browsePlaceholder": "Choisir un emplacement…",
     "nameLabel": "Nom du partage",
     "nameHelp": "Sous quel nom ce dossier apparaît aux autres membres.",
     "next": "Suivant : aperçu",
@@ -172,6 +169,10 @@
     "creating": "Ajout du dossier…",
     "nameCollision": "Un dossier portant ce nom existe déjà dans cet espace.",
     "nameInvalid": "Le nom ne peut pas contenir de barres obliques, de caractères de contrôle, ni être vide."
+  },
+  "pathField": {
+    "browse": "Parcourir…",
+    "placeholder": "Choisir un emplacement…"
   },
   "folder": {
     "fileCount_one": "{{count}} fichier",
@@ -616,7 +617,6 @@
     "intro": "Voir et gérer l'utilisation des données Mirall sur cet appareil.",
     "downloadFolder": "Dossier de téléchargement",
     "downloadFolderDesc": "Emplacement où Mirall enregistre les fichiers téléchargés depuis les membres de votre espace.",
-    "changeFolder": "Modifier…",
     "appStorageDesc": "Espace utilisé par Mirall sur cet appareil pour partager et synchroniser vos fichiers. Il ne conserve jamais une seconde copie de vos fichiers.",
     "sharingIndex": "Index des fichiers partagés",
     "sharingIndexDesc": "Cartes compactes des fichiers que vous partagez (jamais leur contenu). Libérées automatiquement lorsque vous cessez de partager un fichier.",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -154,7 +154,7 @@
   },
   "deleteFolder": {
     "title": "Supprimer « {{name}} » ?",
-    "body": "Les membres de {{space}} ne verront plus ce dossier.",
+    "body": "Les membres de {{space}} ne verront plus ce dossier. Vos fichiers restent sur votre disque.",
     "action": "Supprimer le dossier",
     "deleting": "Suppression…"
   },

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -155,7 +155,6 @@
   "deleteFolder": {
     "title": "Eliminare «{{name}}»?",
     "body": "I membri di {{space}} non vedranno più questa cartella.",
-    "filesStay": "I file in {{path}} restano sul tuo disco.",
     "action": "Elimina cartella",
     "deleting": "Eliminazione…"
   },
@@ -163,8 +162,6 @@
     "title": "Aggiungi cartella",
     "description": "I file in questa cartella saranno visibili a tutti i membri di {{space}}.",
     "pathLabel": "Cartella sul tuo disco",
-    "browseHint": "Sfoglia…",
-    "browsePlaceholder": "Seleziona posizione…",
     "nameLabel": "Nome della condivisione",
     "nameHelp": "Come appare questa cartella agli altri membri.",
     "next": "Avanti: anteprima",
@@ -172,6 +169,10 @@
     "creating": "Aggiunta della cartella…",
     "nameCollision": "Una cartella con questo nome esiste già in questo spazio.",
     "nameInvalid": "Il nome non può contenere barre, caratteri di controllo o essere vuoto."
+  },
+  "pathField": {
+    "browse": "Sfoglia…",
+    "placeholder": "Seleziona posizione…"
   },
   "folder": {
     "fileCount_one": "{{count}} file",
@@ -616,7 +617,6 @@
     "intro": "Visualizza e gestisci l'utilizzo dei dati di Mirall su questo dispositivo.",
     "downloadFolder": "Cartella download",
     "downloadFolderDesc": "Dove Mirall salva i file scaricati dai membri del tuo spazio.",
-    "changeFolder": "Cambia…",
     "appStorageDesc": "Spazio che Mirall usa su questo dispositivo per condividere e sincronizzare i tuoi file. Non conserva mai una seconda copia dei tuoi file.",
     "sharingIndex": "Indice dei file condivisi",
     "sharingIndexDesc": "Mappe compatte dei file che condividi (mai il contenuto). Liberate automaticamente quando smetti di condividere un file.",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -154,7 +154,7 @@
   },
   "deleteFolder": {
     "title": "Eliminare «{{name}}»?",
-    "body": "I membri di {{space}} non vedranno più questa cartella.",
+    "body": "I membri di {{space}} non vedranno più questa cartella. I tuoi file restano sul tuo disco.",
     "action": "Elimina cartella",
     "deleting": "Eliminazione…"
   },

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -508,7 +508,6 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
         isOpen={showDelete}
         folderName={share.name}
         spaceName={space?.name || ''}
-        mountPath={null}
         onClose={() => setShowDelete(false)}
         onDelete={async () => {
           await handleDelete()

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -596,7 +596,6 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
         isOpen={shareToDelete !== null}
         folderName={shareToDelete?.name ?? ''}
         spaceName={space?.name || t('space.fallbackName')}
-        mountPath={null}
         onClose={() => setShareToDelete(null)}
         onDelete={async () => {
           if (!shareToDelete) return

--- a/src/renderer/screens/StorageSettings.tsx
+++ b/src/renderer/screens/StorageSettings.tsx
@@ -10,7 +10,7 @@ import { useDownloadRootStatus } from '../hooks/useDownloadRootStatus.js'
 import CopyButton from '../components/primitives/CopyButton.js'
 import FilePath from '../components/widgets/FilePath.js'
 import Icon from '../components/primitives/Icon.js'
-import Button from '../components/primitives/Button.js'
+import PathRow from '../components/widgets/PathRow.js'
 import PageHeader from '../components/layout/PageHeader.js'
 import SectionHeading from '../components/layout/SectionHeading.js'
 
@@ -146,17 +146,17 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
           <section>
             <SectionHeading>{t('storageSettings.downloadFolder')}</SectionHeading>
             <div className="bg-surface-container-low rounded-xl p-6">
-              <p className="text-sm text-on-surface-variant mb-3">{t('storageSettings.downloadFolderDesc')}</p>
-              <div className="flex items-center gap-3">
-                {downloadFolder ? (
-                  <FilePath path={downloadFolder} className="flex-1 text-sm text-accent" />
-                ) : (
-                  <p className="flex-1 min-w-0 truncate text-sm text-on-surface-variant">{t('storageSettings.calculating')}</p>
-                )}
-                <Button variant="secondary" onClick={handleBrowseFolder} className="shrink-0">
-                  {t('storageSettings.changeFolder')}
-                </Button>
-              </div>
+              <p id="storage-download-folder-desc" className="text-sm text-on-surface-variant mb-3">{t('storageSettings.downloadFolderDesc')}</p>
+              {/* The same row Add Folder, Mirror to Disk, Edit Folder and Edit Space show — a path
+                  is a path, whichever screen you are on. `lowest` because this card is itself
+                  `surface-container-low`, which the field's default fill would vanish into. */}
+              <PathRow
+                path={downloadFolder || null}
+                placeholder={t('storageSettings.calculating')}
+                onAction={handleBrowseFolder}
+                ariaDescribedBy="storage-download-folder-desc"
+                fill="lowest"
+              />
               {/* A rejected pick leaves BOTH true — the old folder is still unavailable and the
                   new one was refused. Order matters for a screen reader: the rejection is what
                   just happened and what the user can act on, so it is announced first. */}

--- a/test/frontend/scenarios/s107-space-download-folder.mjs
+++ b/test/frontend/scenarios/s107-space-download-folder.mjs
@@ -70,7 +70,7 @@ export default async function s107 ({ runDir, bootstrap }) {
 
     await r.ok('picking a folder then closing discards the change', async () => {
       await openEditModal()
-      await B.click({ name: 'Change…' })
+      await B.click({ name: 'Change' })
       await B.nativeChoosePath(spaceDl)
       await pause(600)
       assert(await B.hasText(spaceDl), 'the picked path is staged in the modal')
@@ -82,7 +82,7 @@ export default async function s107 ({ runDir, bootstrap }) {
 
     await r.ok('saving a new folder flips the downloaded row back to available', async () => {
       await openEditModal()
-      await B.click({ name: 'Change…' })
+      await B.click({ name: 'Change' })
       await B.nativeChoosePath(spaceDl)
       await pause(600)
       await saveModal()
@@ -127,7 +127,7 @@ export default async function s107 ({ runDir, bootstrap }) {
     // scope — so pointing the space back at the folder restores it with no re-download.
     await r.ok('pointing the space back at the folder restores it with no re-download', async () => {
       await openEditModal()
-      await B.click({ name: 'Change…' })
+      await B.click({ name: 'Change' })
       await B.nativeChoosePath(otherDl)
       await pause(600)
       await saveModal()
@@ -138,7 +138,7 @@ export default async function s107 ({ runDir, bootstrap }) {
       await B.waitText('Archive', 20000)
 
       await openEditModal()
-      await B.click({ name: 'Change…' })
+      await B.click({ name: 'Change' })
       await B.nativeChoosePath(spaceDl)
       await pause(600)
       await saveModal()

--- a/test/frontend/scenarios/s109-download-folder-gone.mjs
+++ b/test/frontend/scenarios/s109-download-folder-gone.mjs
@@ -88,7 +88,7 @@ export default async function s109 ({ runDir, bootstrap }) {
     await r.ok('choosing a working folder clears the toast and the warning', async () => {
       // The Browse click is handed to nativeChoosePath as the trigger rather than fired here,
       // so a swallowed one is re-fired instead of timing out on a panel that never opens.
-      await B.nativeChoosePath(rescueDl, { trigger: () => B.click({ role: 'button', name: 'Change…' }) })
+      await B.nativeChoosePath(rescueDl, { trigger: () => B.click({ role: 'button', name: 'Change' }) })
       await pause(1200)
       assert(await B.hasText(rescueDl), 'the new folder is shown')
       await waitFor(async () => !(await B.hasText('This folder is currently unavailable')), 20000,

--- a/test/unit/path-field-harmonized.test.js
+++ b/test/unit/path-field-harmonized.test.js
@@ -1,0 +1,85 @@
+import test from 'brittle'
+import { readdirSync, readFileSync, statSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+// One filesystem path the user can act on has ONE presentation: `widgets/PathRow.tsx`. Five
+// surfaces show one (Add Folder, Mirror to Disk, Edit Folder, Edit Space, Storage settings) and
+// they had drifted into two shapes — three shared the filled field while two rendered a bare line
+// of text beside a shorter, dimmer `secondary` button, so the same fact looked like a different
+// kind of thing depending on which door you came through. Geometry and colour are not testable
+// from here; what IS testable is the drift's mechanism, and each check below pins one step of it.
+const here = path.dirname(fileURLToPath(import.meta.url))
+const RENDERER = path.resolve(here, '../../src/renderer')
+const read = (p) => readFileSync(p, 'utf8')
+
+function tsxFiles (dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = path.join(dir, entry)
+    if (statSync(full).isDirectory()) out.push(...tsxFiles(full))
+    else if (entry.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+const files = tsxFiles(RENDERER).map((f) => ({ rel: path.relative(RENDERER, f), src: read(f) }))
+const pathRow = read(path.join(RENDERER, 'components/widgets/PathRow.tsx'))
+
+// `FilePath` renders the path text alone. Beside an action it is the bare-text form this
+// consolidation removed, so its every use is listed here with the reason it is not a path field.
+// A new name in this list is the review question: should this be a PathRow?
+const FILE_PATH_CALLERS = new Set([
+  'components/widgets/PathRow.tsx',          // the path field itself
+  'components/modals/ScanPreviewModal.tsx',  // rows of a file list, not a path the user re-picks
+  'screens/StorageSettings.tsx',             // the app-storage location: display-only, with Copy
+])
+
+test('FilePath is rendered only where a path field would be wrong', (t) => {
+  const callers = files.filter((f) => f.src.includes('<FilePath')).map((f) => f.rel)
+  for (const rel of callers) {
+    t.ok(FILE_PATH_CALLERS.has(rel), `${rel} renders <FilePath> — use <PathRow> unless listed`)
+  }
+})
+
+test('every path the user can re-pick goes through PathRow', (t) => {
+  // The two folder pickers main exposes. A screen that opens one and shows the result IS a path
+  // field; the only callers that legitimately open one without showing a path are the action-menu
+  // entries (Locate / relocate from a card), which navigate rather than render a row.
+  const MENU_ONLY = new Set(['screens/SpaceView.tsx', 'screens/FolderView.tsx'])
+  const pickers = files.filter((f) => /window\.bridge\.browse(DownloadFolder|ShareFolder)\(/.test(f.src))
+  t.ok(pickers.length > 0, 'the picker calls were found at all')
+  for (const f of pickers) {
+    if (MENU_ONLY.has(f.rel)) continue
+    t.ok(f.src.includes('<PathRow'), `${f.rel} picks a folder and must show it in a PathRow`)
+  }
+})
+
+test('the path button label is derived, never passed', (t) => {
+  // Four strings once said the one thing — "Browse…", "Change", "Change…", "Change folder" — one
+  // per caller. PathRow now derives it from whether there is a path yet, so a caller that passes
+  // its own is re-opening that drift.
+  t.ok(/actionLabel \?\? \(path \? t\('actions\.change'\) : t\('pathField\.browse'\)\)/.test(pathRow),
+    'PathRow derives the label from the presence of a path')
+  for (const f of files) {
+    if (f.rel === 'components/widgets/PathRow.tsx') continue
+    t.absent(/<PathRow[^>]*actionLabel/s.test(f.src), `${f.rel} must not override the path button label`)
+  }
+})
+
+test('a path field on a settings screen is filled a step below its card', (t) => {
+  // The field's default fill IS the settings-card fill — the same token, so the same hex in both
+  // themes — and a field filled with its own background is an invisible field. Modals are safe
+  // (the panel is `surface-container-lowest`); a settings card is not, so a row inside one takes
+  // `fill="lowest"`. This is the same relationship NetworkSettings' number input already has.
+  const CARD_FILL = 'bg-surface-container-low'
+  t.ok(pathRow.includes(`low: '${CARD_FILL}'`), "PathRow's default fill is the settings-card token")
+  for (const f of files) {
+    if (!f.rel.startsWith('screens/')) continue
+    for (const m of f.src.matchAll(/<PathRow\b/g)) {
+      const row = f.src.slice(m.index, f.src.indexOf('/>', m.index))
+      t.ok(/fill="lowest"/.test(row),
+        `${f.rel} renders a PathRow inside a settings card and must pass fill="lowest"`)
+    }
+  }
+})

--- a/test/unit/path-field-harmonized.test.js
+++ b/test/unit/path-field-harmonized.test.js
@@ -83,3 +83,48 @@ test('a path field on a settings screen is filled a step below its card', (t) =>
     }
   }
 })
+
+// The `fill` prop is only worth anything while the two ramp steps it chooses between stay
+// visibly apart. They are adjacent tokens and the gap is small by design, so a future palette
+// nudge could quietly close it — and the failure is silent: a field that renders as a flat
+// rectangle of its own background, which is exactly what converting Storage settings would have
+// shipped had the default been kept.
+const lin = (c) => { c /= 255; return c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4 }
+const lum = (hex) => {
+  const m = hex.replace('#', '')
+  return 0.2126 * lin(parseInt(m.slice(0, 2), 16)) +
+         0.7152 * lin(parseInt(m.slice(2, 4), 16)) +
+         0.0722 * lin(parseInt(m.slice(4, 6), 16))
+}
+// CIE L*: a perceptual scale, unlike a contrast ratio. Two large adjacent fills are not text, so
+// WCAG's 3:1 says nothing useful about them — both pairs sit near 1.1:1 and read fine.
+const lstar = (hex) => { const y = lum(hex); return y > 216 / 24389 ? 116 * Math.cbrt(y) - 16 : y * 24389 / 27 }
+
+const css = readFileSync(path.resolve(RENDERER, 'styles/tailwind.css'), 'utf8')
+const tokensFor = (selector) => {
+  const start = css.indexOf(selector + ' {')
+  const block = css.slice(start, css.indexOf('}', start))
+  const out = {}
+  for (const m of block.matchAll(/--(color-[\w-]+):\s*(#[0-9a-fA-F]{6})/g)) out[m[1]] = m[2]
+  return out
+}
+
+// design.md's own step unit for neutral surfaces ("neutral ~3-4 L*"). Light is the tighter of the
+// two themes at 4.11 and lands right on it; dark has 6.15 to give.
+const NEUTRAL_STEP = 3
+
+test('the path field separates from its ground in BOTH themes', (t) => {
+  for (const theme of [':root', '.dark']) {
+    const k = tokensFor(theme)
+    const low = k['color-surface-container-low']
+    const lowest = k['color-surface-container-lowest']
+    const control = k['color-surface-control']
+    const gap = Math.abs(lstar(lowest) - lstar(low))
+    t.ok(gap >= NEUTRAL_STEP, `${theme}: the two fills are ${gap.toFixed(2)} L* apart`)
+    // And the button has to stay off both of them — it sits beside the field on either ground.
+    for (const [name, fill] of [['low', low], ['lowest', lowest]]) {
+      const d = Math.abs(lstar(control) - lstar(fill))
+      t.ok(d >= NEUTRAL_STEP, `${theme}: the button is ${d.toFixed(2)} L* off the ${name} fill`)
+    }
+  }
+})


### PR DESCRIPTION
Five surfaces show a filesystem path with a button beside it. Three used
`PathRow`; Storage settings and Edit Space rendered bare text next to a
shorter, dimmer `secondary` button, and four different strings said the one
action.

- `PathRow` gains `actionRef` (Edit Space returns focus to the button after
  "Use default folder" unmounts itself), a label derived from state
  (`Browse…` with no path, `Change` with one), and `fill` — the default is the
  settings-card token, so a row inside one takes `fill="lowest"` or the field
  is invisible.
- Storage settings and Edit Space converted; `ariaDescribedBy` now wired at all
  five sites, and Add Folder / Mirror to Disk lose two `<label>`s that
  associated with nothing.
- `storageSettings.changeFolder` dropped; the shared defaults move out of the
  `addFolder` namespace into `pathField`.
- `DeleteFolderShareModal`'s `mountPath` removed — both call sites passed
  `null`, so the path prose never rendered. Its reassurance is folded into the
  body sentence, path-free: deleting a folder keeps the local files.

`test/unit/path-field-harmonized.test.js` pins the four mechanisms the drift
came through, plus the fill's separation from its ground in both themes —
light is the tighter one at 4.11 L\* between the fills, 3.85 L\* to the button.
`s107`/`s109` retargeted to the unified label.

Verified: typecheck clean, `eslint src` 0 errors, `test:node:core` 1576/1576,
`test:layout:truncation` 0px overflow, `test:fe s6 s9 s107 s109 s123` 5/5 plus
`s9` again after the copy change.