### PR TITLE
[fix] Watch loose files on network volumes

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -42,6 +42,8 @@ Compact, actionable rules distilled from real debugging — gotchas, root causes
 
 Testing/a11y **discipline** — the layers, the change-type→coverage matrix, the a11y bar, and frontend scenario authoring (file-sizing, offline-edge, async-probe waits, split-text `sr-only`, timeout-vs-absent) — lives in `testing.md`. Dep-bump baseline-diffing lives in `dependency-updates.md`. Only debugging tactics that aren't reference material stay here:
 
+**A unit test asserting platform-conditional behavior must pin `process.platform`.** CI runs Linux and development happens on macOS, so a test built around `/Volumes/NAS/x` asserted the right thing locally and the *opposite* thing on CI — `looksLikeNetworkPath` is deliberately platform-scoped (`/Volumes` darwin-only, `/mnt`+`/media` linux-only, UNC everywhere). The failure is silent in the worst way: the file's own predicate table test already stubbed the platform and documented the asymmetry, while the routing tests next to it inherited the machine's. Pin it per case (`withPlatform(name, fn)` in `test/helpers/with-platform.js`) and use the UNC form wherever the test is about something else; verify by re-running under `NODE_OPTIONS="--import file://…"` with `process.platform` redefined, and check the assert COUNT matches across both — an unpinned case silently asserts less rather than failing.
+
 **Never blanket-replace `console.log/warn/error` in a brittle test** — the runner emits its own TAP through them, so a blanket stub both miscounts (inflated by exactly the number of prior asserts) and swallows the failure diagnostic. Capture by discriminating on the code-under-test's own prefix/tag; forward everything else to the saved real console.
 
 ## UI copy

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -42,6 +42,19 @@ export const moduleLevelTimerRestrictions = [{
   message: 'No module-level timers — arm it in a Subsystem _open so close() can clear it.',
 }]
 
+// Mechanism invariant: chokidar's options are per-INSTANCE, not per-path, and its sharp edges —
+// native events never reach a network mount, an erroring watcher spins forever — were learned
+// once on the owned-folder watcher and never carried to the loose-file watcher, so a file shared
+// from /Volumes, /mnt, /media or a UNC path silently stopped re-publishing. src/main/watch-host.js
+// is now the single owner of every chokidar decision; a second `require('chokidar')` is exactly how
+// that divergence would come back. Exported so test/unit/watch-host-single-owner.test.js enforces
+// the same grammar through eslint's parser.
+const chokidarMessage = 'Only src/main/watch-host.js may load chokidar — arm the watch through createWatchHost so network polling, the error-storm cut-off and the option bag stay in one place.'
+export const chokidarSingleOwnerRestrictions = [
+  { selector: "CallExpression[callee.name='require'][arguments.0.value='chokidar']", message: chokidarMessage },
+  { selector: "ImportDeclaration[source.value='chokidar']", message: chokidarMessage },
+]
+
 export default [
   // Vendored hyper-overlay v2 subset — third-party code kept re-diffable
   // against upstream (PROVENANCE.md), so our complexity/style rules don't apply.
@@ -94,6 +107,16 @@ export default [
       sourceType: 'commonjs',
       globals: { ...globals.node, ...globals.browser },
     },
-    rules: { ...unusedVars, ...complexityBudget },
+    rules: {
+      ...unusedVars,
+      ...complexityBudget,
+      'no-restricted-syntax': ['error', ...chokidarSingleOwnerRestrictions],
+    },
+  },
+
+  // The one module the rule above exists to protect.
+  {
+    files: ['src/main/watch-host.js'],
+    rules: { 'no-restricted-syntax': 'off' },
   },
 ]

--- a/src/main/loose-file-watchers.js
+++ b/src/main/loose-file-watchers.js
@@ -1,33 +1,35 @@
-const chokidar = require('chokidar')
+// One watch host over a dynamic set of individual absolute file paths (in-place loose files
+// are scattered, not under one root). The same file can be shared in several spaces, so each
+// path maps to the set of spaces watching it and an event fans out to all of them. That
+// fan-out is the only loose-specific logic here; polling for network paths, the error-storm
+// cut-off and the chokidar option bag belong to watch-host.js and are shared with
+// owned-folder-watchers.js.
+const { createWatchHost } = require('./watch-host.js')
 
-// One watcher over a dynamic set of individual absolute file paths (in-place loose
-// files are scattered, not under one root). The same file can be shared in several
-// spaces, so each path maps to the set of spaces watching it and an event fans out
-// to all of them. followSymlinks is off so the path reported back is exactly the
-// one armed (matches owned-folder-watchers).
-let watcher = null
+let host = null
 const watched = new Map()
 let emitEvent = null
 let emitError = null
 
 function ensure () {
-  if (watcher) return
-  watcher = chokidar.watch([], {
-    ignoreInitial: true,
-    alwaysStat: true,
-    awaitWriteFinish: { stabilityThreshold: 1000, pollInterval: 100 },
+  if (host) return
+  // atomic:true — a loose entry is a single tracked path with no diff pass behind it, so an
+  // editor that saves by rename-over must arrive as one `change`; a transient unlink would
+  // tombstone the entry and un-share the file. The owned side sets false for the opposite
+  // reason; see owned-folder-watchers.js.
+  host = createWatchHost({
+    label: 'loose',
     atomic: true,
-    followSymlinks: false,
+    onEvent: ({ action, absPath }) => {
+      const spaces = watched.get(absPath)
+      if (!spaces || !emitEvent) return
+      for (const spaceId of spaces) emitEvent({ spaceId, absPath, action })
+    },
+    onError: (err) => { if (emitError) emitError(err) },
+    // The host has already stopped itself. Drop the bookkeeping so the next armed path builds
+    // a fresh host rather than adding to a dead one.
+    onStorm: () => { host = null; watched.clear() },
   })
-  const handler = (action) => (abs) => {
-    const spaces = watched.get(abs)
-    if (!spaces || !emitEvent) return
-    for (const spaceId of spaces) emitEvent({ spaceId, absPath: abs, action })
-  }
-  watcher.on('add', handler('add'))
-  watcher.on('change', handler('change'))
-  watcher.on('unlink', handler('unlink'))
-  watcher.on('error', (err) => { if (emitError) emitError(err) })
 }
 
 function addLooseWatch (spaceId, absPath, onEvent, onError) {
@@ -35,7 +37,7 @@ function addLooseWatch (spaceId, absPath, onEvent, onError) {
   emitError = onError
   ensure()
   let spaces = watched.get(absPath)
-  if (!spaces) { watched.set(absPath, (spaces = new Set())); watcher.add(absPath) }
+  if (!spaces) { watched.set(absPath, (spaces = new Set())); host.add(absPath) }
   spaces.add(spaceId)
 }
 
@@ -45,13 +47,13 @@ function removeLooseWatch (spaceId, absPath) {
   spaces.delete(spaceId)
   if (spaces.size === 0) {
     watched.delete(absPath)
-    if (watcher) watcher.unwatch(absPath)
+    if (host) host.remove(absPath)
   }
 }
 
 function stopLooseWatchers () {
-  if (watcher) { try { watcher.close() } catch (err) { console.warn('loose watcher.close failed -', err.message) } }
-  watcher = null
+  if (host) host.stop()
+  host = null
   watched.clear()
   emitEvent = null
   emitError = null

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -1067,8 +1067,11 @@ async function handleMainRequest(command, args, worker) {
           if (debug) console.error('loose fs-event write failed:', err.message)
         }
       },
+      // Not behind `debug`: console.warn feeds the log ring unconditionally, and the
+      // error-storm message is the one signal saying this file stopped syncing and will not
+      // resume on its own. Behind the flag it never reaches a user's diagnostics bundle.
       (err) => {
-        if (debug) console.warn('loose watcher error', args.absPath, '-', err.message)
+        console.warn('loose watcher error', args.absPath, '-', err.message)
       },
     )
     return
@@ -1088,8 +1091,10 @@ async function handleMainRequest(command, args, worker) {
           if (debug) console.error('fs-event write failed:', err.message)
         }
       },
+      // See the loose-file callback above: the storm message must reach the log ring on a
+      // release build, or the report it explains is unreproducible.
       (err) => {
-        if (debug) console.warn('watcher error', args.shareId, '-', err.message)
+        console.warn('watcher error', args.shareId, '-', err.message)
       },
     )
     return
@@ -1114,7 +1119,7 @@ ipcMain.handle('owned-folder:start-watcher', (_evt, { shareId, mountPath, ignore
       }
     },
     (err) => {
-      if (debug) console.warn('owned-folder watcher error', shareId, '-', err.message)
+      console.warn('owned-folder watcher error', shareId, '-', err.message)
     },
   )
   return { ok: true }

--- a/src/main/owned-folder-watchers.js
+++ b/src/main/owned-folder-watchers.js
@@ -1,10 +1,13 @@
-// Recursive chokidar watchers over owned-folder mounts, one per share. They
-// live in Electron main because the Bare worker has no recursive filesystem
-// watch; add/change/unlink events are forwarded to the worker, which publishes
-// the changes into the share catalog. Network-looking mounts fall back to
-// polling, and a watcher that storms errors is stopped rather than left spinning.
-const chokidar = require('chokidar')
+// Recursive watchers over owned-folder mounts, one per share. They live in Electron main
+// because the Bare worker has no recursive filesystem watch; add/change/unlink events are
+// forwarded to the worker, which publishes the changes into the share catalog.
+//
+// Everything chokidar-shaped — the option bag, polling for network mounts, the error-storm
+// cut-off — belongs to watch-host.js and is shared with loose-file-watchers.js. A share needs
+// its own host rather than a shared one because `ignored` is a per-instance chokidar option
+// and each share's ignore patterns differ.
 const path = require('node:path')
+const { createWatchHost } = require('./watch-host.js')
 
 const watchers = new Map()
 let emitEvent = null
@@ -26,14 +29,6 @@ function defaultIgnore(name, ignorePatterns) {
   return false
 }
 
-function looksLikeNetworkPath(p) {
-  if (!p) return false
-  if (p.startsWith('\\\\')) return true
-  if (process.platform === 'darwin' && p.startsWith('/Volumes/')) return true
-  if (process.platform === 'linux' && (p.startsWith('/mnt/') || p.startsWith('/media/'))) return true
-  return false
-}
-
 function startWatcher(shareId, mountPath, ignorePatterns, onEvent, onError) {
   // Re-point BEFORE the has()-guard: on a worker respawn the new worker re-issues
   // start-watcher for a shareId whose chokidar watcher is still alive; without this the
@@ -47,48 +42,29 @@ function startWatcher(shareId, mountPath, ignorePatterns, onEvent, onError) {
     if (!rel) return false
     return defaultIgnore(rel.split(path.sep).join('/'), ignorePatterns)
   }
-
-  const usePolling = looksLikeNetworkPath(mountPath)
-  const watcher = chokidar.watch(mountPath, {
-    ignoreInitial: true,
-    awaitWriteFinish: { stabilityThreshold: 1000, pollInterval: 100 },
+  // atomic:false — the retire executor re-confirms presence (publish-runner's
+  // fileExactlyPresent) and the periodic reconcile re-derives the truth, so coalescing an
+  // unlink+add into a `change` would hide a genuine delete-then-create of a different file.
+  // The loose side sets true for the opposite reason; see loose-file-watchers.js.
+  const host = createWatchHost({
+    label: shareId,
     atomic: false,
     ignored: ignoreFn,
-    followSymlinks: false,
-    usePolling,
-    interval: usePolling ? 5000 : undefined,
-    alwaysStat: true,
+    onEvent: ({ action, absPath }) => {
+      const rel = path.relative(mountPath, absPath).split(path.sep).join('/')
+      emitEvent?.({ shareId, action, relPath: rel, absPath })
+    },
+    onError: (err) => emitError?.(err),
+    onStorm: () => { watchers.delete(shareId) },
   })
-
-  const errorWindow = []
-  const handler = (action) => (abs) => {
-    const rel = path.relative(mountPath, abs).split(path.sep).join('/')
-    emitEvent?.({ shareId, action, relPath: rel, absPath: abs })
-  }
-  watcher.on('add', handler('add'))
-  watcher.on('change', handler('change'))
-  watcher.on('unlink', handler('unlink'))
-
-  watcher.on('error', (err) => {
-    emitError?.(err)
-    const now = Date.now()
-    errorWindow.push(now)
-    while (errorWindow.length && now - errorWindow[0] > 10_000) errorWindow.shift()
-    if (errorWindow.length > 5) {
-      stopWatcher(shareId)
-      emitError?.(new Error('error-storm: watcher stopped for ' + shareId))
-    }
-  })
-
-  watchers.set(shareId, { watcher, mountPath })
+  host.add(mountPath)
+  watchers.set(shareId, { host, mountPath })
 }
 
 function stopWatcher(shareId) {
   const entry = watchers.get(shareId)
   if (!entry) return
-  try { entry.watcher.close() } catch (err) {
-    console.warn('watcher.close failed for', shareId, '-', err.message)
-  }
+  entry.host.stop()
   watchers.delete(shareId)
 }
 

--- a/src/main/watch-host.js
+++ b/src/main/watch-host.js
@@ -1,0 +1,138 @@
+// The single owner of chokidar in this process. Two watcher modules sit on it —
+// owned-folder-watchers (one recursive root per share) and loose-file-watchers (a scattered
+// set of individual files) — because the three things chokidar makes you learn were learned
+// once on the owned side and never carried across:
+//
+//   1. Native filesystem events do not reach a network mount, so a watch there emits nothing
+//      at all. A file on one silently stops re-publishing: no error, no badge, no log line.
+//   2. An erroring watcher otherwise spins for the life of the process.
+//   3. The option bag itself, which drifted between the two callers.
+//
+// Options are per-INSTANCE in chokidar, not per-path, so `usePolling` cannot vary within one
+// watcher. A host therefore holds up to two instances — native and polling — and routes each
+// target by looksLikeNetworkPath. The polling instance is created lazily, so a user with no
+// network paths pays nothing. Only `atomic` and `ignored` vary per caller; both carry their
+// reason at the call site.
+const chokidar = require('chokidar')
+
+const ERROR_WINDOW_MS = 10_000
+const ERROR_STORM_LIMIT = 5
+const POLL_INTERVAL_MS = 5000
+// Polling stats every watched path every interval. Not a cap — silently not watching is the
+// defect this module exists to fix — just a single warning when the cost becomes worth knowing.
+const POLL_TARGET_WARN = 200
+
+// A path on a network mount is watched by polling or not at all. This predicate is the whole
+// difference between a file that re-publishes on edit and one that quietly stops.
+function looksLikeNetworkPath(p) {
+  if (!p) return false
+  if (p.startsWith('\\\\')) return true
+  if (process.platform === 'darwin' && p.startsWith('/Volumes/')) return true
+  if (process.platform === 'linux' && (p.startsWith('/mnt/') || p.startsWith('/media/'))) return true
+  return false
+}
+
+/**
+ * createWatchHost({
+ *   label,                       // names the host in the storm message
+ *   atomic,                      // owned: false, loose: true — deliberate, documented at both callers
+ *   ignored,                     // chokidar `ignored` predicate, or undefined
+ *   onEvent({ action, absPath }),
+ *   onError(err),
+ *   onStorm(),                   // the host has already stopped itself; drop the caller's bookkeeping
+ * })
+ */
+function createWatchHost({ label, atomic = false, ignored, onEvent, onError, onStorm }) {
+  const instances = new Map() // 'native' | 'polling' -> chokidar instance
+  const errorWindow = []
+  let pollTargets = 0
+  let pollWarned = false
+  let stopped = false
+
+  function optionsFor(mode) {
+    const opts = {
+      ignoreInitial: true,
+      awaitWriteFinish: { stabilityThreshold: 1000, pollInterval: 100 },
+      atomic,
+      followSymlinks: false,
+      alwaysStat: true,
+    }
+    if (ignored) opts.ignored = ignored
+    if (mode === 'polling') {
+      opts.usePolling = true
+      opts.interval = POLL_INTERVAL_MS
+    } else {
+      opts.usePolling = false
+    }
+    return opts
+  }
+
+  function instance(mode) {
+    const existing = instances.get(mode)
+    if (existing) return existing
+    const watcher = chokidar.watch([], optionsFor(mode))
+    const handler = (action) => (absPath) => {
+      if (!stopped) onEvent?.({ action, absPath })
+    }
+    watcher.on('add', handler('add'))
+    watcher.on('change', handler('change'))
+    watcher.on('unlink', handler('unlink'))
+    watcher.on('error', (err) => {
+      onError?.(err)
+      const now = Date.now()
+      errorWindow.push(now)
+      while (errorWindow.length && now - errorWindow[0] > ERROR_WINDOW_MS) errorWindow.shift()
+      if (errorWindow.length > ERROR_STORM_LIMIT) {
+        stop()
+        onError?.(new Error('error-storm: watcher stopped for ' + label))
+        onStorm?.()
+      }
+    })
+    instances.set(mode, watcher)
+    return watcher
+  }
+
+  function modeFor(target) {
+    return looksLikeNetworkPath(target) ? 'polling' : 'native'
+  }
+
+  function add(target) {
+    if (stopped) return
+    const mode = modeFor(target)
+    if (mode === 'polling') {
+      pollTargets++
+      if (pollTargets > POLL_TARGET_WARN && !pollWarned) {
+        pollWarned = true
+        console.warn(label, 'watch host is polling', pollTargets, 'network targets every', POLL_INTERVAL_MS, 'ms')
+      }
+    }
+    instance(mode).add(target)
+  }
+
+  function remove(target) {
+    const mode = modeFor(target)
+    if (mode === 'polling' && pollTargets > 0) pollTargets--
+    const watcher = instances.get(mode)
+    if (!watcher) return
+    try { watcher.unwatch(target) } catch (err) {
+      console.warn(label, 'watcher.unwatch failed for', target, '-', err.message)
+    }
+  }
+
+  function stop() {
+    stopped = true
+    for (const watcher of instances.values()) {
+      try { watcher.close() } catch (err) {
+        console.warn(label, 'watcher.close failed -', err.message)
+      }
+    }
+    instances.clear()
+    errorWindow.length = 0
+    pollTargets = 0
+    pollWarned = false
+  }
+
+  return { add, remove, stop }
+}
+
+module.exports = { createWatchHost, looksLikeNetworkPath }

--- a/test/helpers/fake-chokidar.js
+++ b/test/helpers/fake-chokidar.js
@@ -1,0 +1,59 @@
+// A synchronous stand-in for chokidar, shared by every test that reaches src/main's watchers.
+// Real fsevents timing plus awaitWriteFinish makes an fs-watch test slow and flaky, and a unit
+// test must not touch the filesystem at all — so each fake watcher is an EventEmitter the test
+// emits on directly. It lives here rather than in each test file for the same reason
+// watch-host.js exists: one model of the chokidar surface, so the tests cannot drift from each
+// other about what that surface is.
+import { createRequire } from 'module'
+import { EventEmitter } from 'events'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const require = createRequire(import.meta.url)
+const root = path.join(path.dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+/**
+ * Load repo-relative CommonJS modules with `chokidar` stubbed out.
+ *
+ * @param {string[]} relPaths  modules to (re)load, dependencies first
+ * @returns {{ created: object[], modules: object[] }} every fake watcher constructed, and the
+ *          loaded module exports in the order requested
+ */
+export function loadWithFakeChokidar (relPaths) {
+  const created = []
+  const fakeChokidar = {
+    watch (targets, opts) {
+      const w = new EventEmitter()
+      w.opts = opts || {}
+      w.targets = Array.isArray(targets) ? [...targets] : targets ? [targets] : []
+      w.closed = false
+      w.closeError = null
+      w.add = (t) => { w.targets.push(t) }
+      w.unwatch = (t) => { w.targets = w.targets.filter((x) => x !== t) }
+      w.close = () => {
+        if (w.closeError) throw w.closeError
+        w.closed = true
+      }
+      created.push(w)
+      return w
+    },
+  }
+
+  const chokidarPath = require.resolve('chokidar')
+  const prev = require.cache[chokidarPath]
+  require.cache[chokidarPath] = { id: chokidarPath, filename: chokidarPath, loaded: true, exports: fakeChokidar }
+  const modules = []
+  try {
+    for (const rel of relPaths) {
+      const abs = require.resolve(path.join(root, rel))
+      delete require.cache[abs]
+      modules.push(require(abs))
+    }
+  } finally {
+    // Restore the real chokidar in the shared require cache — the modules above already
+    // captured the fake, so nothing else in a shared test process is affected.
+    if (prev) require.cache[chokidarPath] = prev
+    else delete require.cache[chokidarPath]
+  }
+  return { created, modules }
+}

--- a/test/helpers/with-platform.js
+++ b/test/helpers/with-platform.js
@@ -1,0 +1,25 @@
+// process.platform decides whether a path counts as a network mount: /Volumes is a darwin-only
+// signal, /mnt and /media are linux-only, and only a UNC path is one everywhere. Any test that
+// asserts that routing has to PIN the platform rather than inherit the machine's — CI runs
+// Linux and development happens on macOS, so an unpinned '/Volumes/…' test passes locally and
+// fails there. That is exactly how it went the first time.
+export function withPlatform (name, fn) {
+  const real = process.platform
+  Object.defineProperty(process, 'platform', { value: name, configurable: true })
+  try { return fn() } finally {
+    Object.defineProperty(process, 'platform', { value: real, configurable: true })
+  }
+}
+
+// A UNC path is a network path on every platform, so it is the one target that routes to polling
+// without pinning the platform first. Use it wherever the test is about something else.
+export const UNC_PATH = '\\\\server\\share\\report.pdf'
+
+// Every real-world shape of "this file lives where native fs events cannot reach", paired with
+// the platform that recognises it.
+export const NETWORK_CASES = [
+  { platform: 'darwin', path: '/Volumes/NAS/report.pdf', label: 'macOS /Volumes' },
+  { platform: 'linux', path: '/mnt/nas/report.pdf', label: 'Linux /mnt' },
+  { platform: 'linux', path: '/media/usb/report.pdf', label: 'Linux /media' },
+  { platform: 'win32', path: UNC_PATH, label: 'Windows UNC' },
+]

--- a/test/unit/loose-file-watchers.test.js
+++ b/test/unit/loose-file-watchers.test.js
@@ -1,5 +1,6 @@
 import test from 'brittle'
 import { loadWithFakeChokidar } from '../helpers/fake-chokidar.js'
+import { withPlatform, UNC_PATH, NETWORK_CASES } from '../helpers/with-platform.js'
 
 const { created, modules } = loadWithFakeChokidar(['src/main/watch-host.js', 'src/main/loose-file-watchers.js'])
 const { addLooseWatch, removeLooseWatch, stopLooseWatchers } = modules[1]
@@ -20,15 +21,21 @@ const native = () => created.filter((w) => !w.opts.usePolling)
 // stale version kept serving to every peer with no error and no badge. sweepLoosePresence was
 // no backstop: it reclaims files that vanished, not files that merely changed.)
 test('REGRESSION (FIX-PI3-1): a loose file on a network path is polled, and still fans out', (t) => {
-  const { events, onEvent, onError } = arm()
-  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
-  t.is(polling().length, 1, 'the network path is watched by a polling instance')
-  t.is(polling()[0].opts.interval, 5000)
-  polling()[0].emit('change', '/Volumes/NAS/report.pdf')
-  t.is(events.length, 1, 'the edit reached the worker')
-  t.is(events[0].spaceId, 'space-1')
-  t.is(events[0].action, 'change')
-  t.teardown(stopLooseWatchers)
+  // Pinned per case: /Volumes is darwin-only and /mnt is linux-only, so a test that inherits the
+  // machine's platform asserts nothing on the other one.
+  for (const { platform, path, label } of NETWORK_CASES) {
+    withPlatform(platform, () => {
+      const { events, onEvent, onError } = arm()
+      addLooseWatch('space-1', path, onEvent, onError)
+      t.is(polling().length, 1, label + ' is watched by a polling instance')
+      t.is(polling()[0].opts.interval, 5000, label + ' polls every 5s')
+      polling()[0].emit('change', path)
+      t.is(events.length, 1, label + ': the edit reached the worker')
+      t.is(events[0].spaceId, 'space-1')
+      t.is(events[0].action, 'change')
+      stopLooseWatchers()
+    })
+  }
 })
 
 test('a local loose file still uses native events — no polling regression', (t) => {
@@ -44,11 +51,11 @@ test('a local loose file still uses native events — no polling regression', (t
 test('local and network loose files coexist behind one host', (t) => {
   const { events, onEvent, onError } = arm()
   addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
-  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
+  addLooseWatch('space-1', UNC_PATH, onEvent, onError)
   t.is(created.length, 2, 'two instances, one host')
   native()[0].emit('change', '/Users/me/notes.md')
-  polling()[0].emit('change', '/Volumes/NAS/report.pdf')
-  t.alike(events.map((e) => e.absPath), ['/Users/me/notes.md', '/Volumes/NAS/report.pdf'])
+  polling()[0].emit('change', UNC_PATH)
+  t.alike(events.map((e) => e.absPath), ['/Users/me/notes.md', UNC_PATH])
   t.teardown(stopLooseWatchers)
 })
 
@@ -86,8 +93,8 @@ test('removing the last space unwatches the path', (t) => {
 
 test('removing a network path unwatches it on the polling instance', (t) => {
   const { onEvent, onError } = arm()
-  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
-  removeLooseWatch('space-1', '/Volumes/NAS/report.pdf')
+  addLooseWatch('space-1', UNC_PATH, onEvent, onError)
+  removeLooseWatch('space-1', UNC_PATH)
   t.alike(polling()[0].targets, [], 'unwatched on the polling instance')
   t.teardown(stopLooseWatchers)
 })
@@ -113,7 +120,7 @@ test('REGRESSION (FIX-PI3-2): a storm stops the host and clears the watched map'
 test('stopLooseWatchers closes the host and forgets every path', (t) => {
   const { events, onEvent, onError } = arm()
   addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
-  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
+  addLooseWatch('space-1', UNC_PATH, onEvent, onError)
   stopLooseWatchers()
   t.ok(created.every((w) => w.closed), 'both instances closed')
   created[0].emit('change', '/Users/me/notes.md')

--- a/test/unit/loose-file-watchers.test.js
+++ b/test/unit/loose-file-watchers.test.js
@@ -1,0 +1,136 @@
+import test from 'brittle'
+import { loadWithFakeChokidar } from '../helpers/fake-chokidar.js'
+
+const { created, modules } = loadWithFakeChokidar(['src/main/watch-host.js', 'src/main/loose-file-watchers.js'])
+const { addLooseWatch, removeLooseWatch, stopLooseWatchers } = modules[1]
+
+function arm () {
+  created.length = 0
+  const events = []
+  const errors = []
+  return { events, errors, onEvent: (e) => events.push(e), onError: (e) => errors.push(e) }
+}
+
+const polling = () => created.filter((w) => w.opts.usePolling)
+const native = () => created.filter((w) => !w.opts.usePolling)
+
+// REGRESSION (FIX-PI3-1: a loose file shared from a network volume — /Volumes on macOS, /mnt or
+// /media on Linux, a UNC path on Windows — got no watcher events at all, because the loose
+// watcher had no polling fallback. The user edited the file, the app never noticed, and the
+// stale version kept serving to every peer with no error and no badge. sweepLoosePresence was
+// no backstop: it reclaims files that vanished, not files that merely changed.)
+test('REGRESSION (FIX-PI3-1): a loose file on a network path is polled, and still fans out', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
+  t.is(polling().length, 1, 'the network path is watched by a polling instance')
+  t.is(polling()[0].opts.interval, 5000)
+  polling()[0].emit('change', '/Volumes/NAS/report.pdf')
+  t.is(events.length, 1, 'the edit reached the worker')
+  t.is(events[0].spaceId, 'space-1')
+  t.is(events[0].action, 'change')
+  t.teardown(stopLooseWatchers)
+})
+
+test('a local loose file still uses native events — no polling regression', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  t.is(polling().length, 0, 'no polling instance for a local path')
+  t.is(native().length, 1)
+  native()[0].emit('change', '/Users/me/notes.md')
+  t.is(events.length, 1)
+  t.teardown(stopLooseWatchers)
+})
+
+test('local and network loose files coexist behind one host', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
+  t.is(created.length, 2, 'two instances, one host')
+  native()[0].emit('change', '/Users/me/notes.md')
+  polling()[0].emit('change', '/Volumes/NAS/report.pdf')
+  t.alike(events.map((e) => e.absPath), ['/Users/me/notes.md', '/Volumes/NAS/report.pdf'])
+  t.teardown(stopLooseWatchers)
+})
+
+test('one path shared in two spaces fans one event out to both', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  addLooseWatch('space-2', '/Users/me/notes.md', onEvent, onError)
+  t.is(created.length, 1, 'the path is armed once')
+  t.alike(native()[0].targets, ['/Users/me/notes.md'], 'and added to chokidar once')
+  native()[0].emit('change', '/Users/me/notes.md')
+  t.alike(events.map((e) => e.spaceId).sort(), ['space-1', 'space-2'], 'both spaces were told')
+  t.teardown(stopLooseWatchers)
+})
+
+test('removing one space keeps the watch while another space still holds it', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  addLooseWatch('space-2', '/Users/me/notes.md', onEvent, onError)
+  removeLooseWatch('space-1', '/Users/me/notes.md')
+  t.alike(native()[0].targets, ['/Users/me/notes.md'], 'still watched')
+  native()[0].emit('change', '/Users/me/notes.md')
+  t.alike(events.map((e) => e.spaceId), ['space-2'], 'only the remaining space is told')
+  t.teardown(stopLooseWatchers)
+})
+
+test('removing the last space unwatches the path', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  removeLooseWatch('space-1', '/Users/me/notes.md')
+  t.alike(native()[0].targets, [], 'unwatched')
+  native()[0].emit('change', '/Users/me/notes.md')
+  t.is(events.length, 0, 'a late event fans out to nobody')
+  t.teardown(stopLooseWatchers)
+})
+
+test('removing a network path unwatches it on the polling instance', (t) => {
+  const { onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
+  removeLooseWatch('space-1', '/Volumes/NAS/report.pdf')
+  t.alike(polling()[0].targets, [], 'unwatched on the polling instance')
+  t.teardown(stopLooseWatchers)
+})
+
+// REGRESSION (FIX-PI3-2: the loose watcher forwarded errors and did nothing else, so a watcher
+// on a flaky mount spun for the life of the process. It now shares the owned side's cut-off.)
+test('REGRESSION (FIX-PI3-2): a storm stops the host and clears the watched map', (t) => {
+  const { events, errors, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  const stormed = created[0]
+  for (let i = 0; i < 6; i++) stormed.emit('error', new Error('boom'))
+  t.ok(/error-storm: watcher stopped for loose/.test(errors[errors.length - 1].message), 'the reason is reported')
+  t.ok(stormed.closed, 'the instance was closed')
+
+  // A fresh arm after a storm must build a clean host, not add to the dead one.
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  t.is(created.length, 2, 'a new host was built')
+  created[1].emit('change', '/Users/me/notes.md')
+  t.is(events.length, 1, 'and it delivers')
+  t.teardown(stopLooseWatchers)
+})
+
+test('stopLooseWatchers closes the host and forgets every path', (t) => {
+  const { events, onEvent, onError } = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  addLooseWatch('space-1', '/Volumes/NAS/report.pdf', onEvent, onError)
+  stopLooseWatchers()
+  t.ok(created.every((w) => w.closed), 'both instances closed')
+  created[0].emit('change', '/Users/me/notes.md')
+  t.is(events.length, 0, 'a late event is dropped')
+
+  addLooseWatch('space-1', '/Users/me/notes.md', onEvent, onError)
+  t.is(created.length, 3, 'a later arm builds a fresh host')
+  t.teardown(stopLooseWatchers)
+})
+
+test('a later arm re-points the callbacks (a respawned worker must receive the events)', (t) => {
+  const first = arm()
+  addLooseWatch('space-1', '/Users/me/notes.md', first.onEvent, first.onError)
+  const second = { events: [] }   // a respawned worker's callbacks; do not reset `created` here
+  addLooseWatch('space-2', '/Users/me/notes.md', (e) => second.events.push(e), () => {})
+  created[0].emit('change', '/Users/me/notes.md')
+  t.is(first.events.length, 0, 'the stale callback received nothing')
+  t.is(second.events.length, 2, 'the newest callback received both spaces')
+  t.teardown(stopLooseWatchers)
+})

--- a/test/unit/owned-folder-watchers-rebind.test.js
+++ b/test/unit/owned-folder-watchers-rebind.test.js
@@ -2,34 +2,14 @@ import test from 'brittle'
 import { readFileSync } from 'fs'
 import { dirname, join } from 'path'
 import { fileURLToPath } from 'url'
-import { createRequire } from 'module'
-import { EventEmitter } from 'events'
+import { loadWithFakeChokidar } from '../helpers/fake-chokidar.js'
 
-const require = createRequire(import.meta.url)
 const here = dirname(fileURLToPath(import.meta.url))
 
-// Inject a fake chokidar so the watcher's event routing is driven synchronously (real fsevents
-// timing + awaitWriteFinish make an fs-watch test flaky/slow). Each fake watcher is an
-// EventEmitter we can emit on directly to simulate an add/change/unlink.
-const created = []
-const fakeChokidar = {
-  watch () {
-    const w = new EventEmitter()
-    w.close = () => {}
-    created.push(w)
-    return w
-  },
-}
-const chokidarPath = require.resolve('chokidar')
-const prevChokidar = require.cache[chokidarPath]
-require.cache[chokidarPath] = { id: chokidarPath, filename: chokidarPath, loaded: true, exports: fakeChokidar }
-const modPath = require.resolve('../../src/main/owned-folder-watchers.js')
-delete require.cache[modPath]
-const { startWatcher, stopWatcher, stopAllWatchers } = require(modPath)
-// Restore the real chokidar in the shared require cache — the module already captured the fake,
-// so nothing else in a shared test process is affected.
-if (prevChokidar) require.cache[chokidarPath] = prevChokidar
-else delete require.cache[chokidarPath]
+// chokidar is stubbed (see the helper) so the watcher's event routing is driven synchronously:
+// real fsevents timing plus awaitWriteFinish makes an fs-watch test slow and flaky.
+const { created, modules } = loadWithFakeChokidar(['src/main/watch-host.js', 'src/main/owned-folder-watchers.js'])
+const { startWatcher, stopWatcher, stopAllWatchers } = modules[1]
 
 // REGRESSION (G3): after a worker "respawn" (a second startWatcher for the SAME shareId with a
 // NEW callback), fs events must route to the NEW callback. Before the fix the has()-guard

--- a/test/unit/watch-host-single-owner.test.js
+++ b/test/unit/watch-host-single-owner.test.js
@@ -1,0 +1,51 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { Linter } from 'eslint'
+import { chokidarSingleOwnerRestrictions } from '../../eslint.config.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainDir = path.join(here, '..', '..', 'src', 'main')
+const OWNER = path.join(mainDir, 'watch-host.js')
+
+function walk (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) walk(p, out)
+    else if (name.endsWith('.js')) out.push(p)
+  }
+  return out
+}
+
+function verify (linter, source, filename) {
+  return linter.verify(source, {
+    files: ['**/*.js'],
+    languageOptions: { ecmaVersion: 2023, sourceType: 'commonjs' },
+    rules: { 'no-restricted-syntax': ['error', ...chokidarSingleOwnerRestrictions] },
+  }, filename)
+}
+
+// REGRESSION (FIX-PI3-3: two modules each required chokidar and each learned its lessons alone.
+// The owned-folder watcher polled network mounts and cut off an error storm; the loose-file
+// watcher did neither, so a file on a network volume stopped re-publishing in silence. Extracting
+// watch-host.js fixes today's divergence; this rule is what stops the NEXT watcher re-learning it
+// wrong — a third `require('chokidar')` cannot reach main without failing lint.)
+test('REGRESSION (FIX-PI3-3): src/main/watch-host.js is the only module that loads chokidar', (t) => {
+  const linter = new Linter()
+
+  // The grammar itself, on fixtures: what must be caught, and what must stay legal.
+  t.ok(verify(linter, "const chokidar = require('chokidar')\n", 'control.js').length > 0, 'a bare require is caught')
+  t.ok(verify(linter, "const { watch } = require('chokidar')\n", 'control2.js').length > 0, 'a destructured require is caught')
+  t.ok(verify(linter, "require('chokidar').watch('/x')\n", 'control3.js').length > 0, 'an inline require is caught')
+  t.ok(verify(linter, "import chokidar from 'chokidar'\n", 'control4.js').length > 0, 'an ESM import is caught')
+  t.alike(verify(linter, "const { createWatchHost } = require('./watch-host.js')\n", 'ok.js'), [], 'the host is the supported door')
+  t.alike(verify(linter, "const chokidarish = require('chokidar-cli')\n", 'ok2.js'), [], 'a different package stays legal')
+
+  const files = walk(mainDir).filter((f) => f !== OWNER)
+  t.ok(files.length > 0, 'src/main was actually walked')
+  for (const file of files) {
+    t.alike(verify(linter, readFileSync(file, 'utf8'), file).map((m) => `${m.line}: ${m.message}`), [], path.relative(process.cwd(), file))
+  }
+  t.ok(/require\('chokidar'\)/.test(readFileSync(OWNER, 'utf8')), 'and watch-host.js is where chokidar actually lives')
+})

--- a/test/unit/watch-host.test.js
+++ b/test/unit/watch-host.test.js
@@ -1,0 +1,198 @@
+import test from 'brittle'
+import { loadWithFakeChokidar } from '../helpers/fake-chokidar.js'
+
+const { created, modules } = loadWithFakeChokidar(['src/main/watch-host.js'])
+const { createWatchHost, looksLikeNetworkPath } = modules[0]
+
+function host (opts = {}) {
+  created.length = 0
+  const events = []
+  const errors = []
+  const storms = []
+  const h = createWatchHost({
+    label: 't',
+    onEvent: (e) => events.push(e),
+    onError: (e) => errors.push(e),
+    onStorm: () => storms.push(true),
+    ...opts,
+  })
+  return { h, events, errors, storms }
+}
+
+const polling = () => created.filter((w) => w.opts.usePolling)
+const native = () => created.filter((w) => !w.opts.usePolling)
+
+// REGRESSION (FIX-PI3-1: a loose file on a network volume got no watcher events at all. Native
+// filesystem events do not cross a network mount, so the app kept serving a stale version —
+// silently, with no error and no badge. The owned-folder watcher polled such mounts from the
+// day it was written; the loose watcher never learned it. The host makes that impossible: a
+// target is routed by the same predicate no matter which caller armed it.)
+test('REGRESSION (FIX-PI3-1): a network path is watched by polling, not native events', (t) => {
+  const { h } = host()
+  h.add('/Volumes/NAS/a.txt')
+  t.is(polling().length, 1, 'a polling instance was created')
+  t.is(polling()[0].opts.interval, 5000, 'and it polls every 5s')
+  t.is(native().length, 0, 'no native instance for a network-only target')
+  t.teardown(() => h.stop())
+})
+
+test('a local path never creates a polling instance', (t) => {
+  const { h } = host()
+  h.add('/Users/me/Documents/a.txt')
+  t.is(polling().length, 0, 'no polling instance')
+  t.is(native().length, 1, 'one native instance')
+  t.is(native()[0].opts.usePolling, false)
+  t.absent(native()[0].opts.interval, 'no poll interval on the native instance')
+  t.teardown(() => h.stop())
+})
+
+test('one host serves both kinds of target from the same event callback', (t) => {
+  const { h, events } = host()
+  h.add('/Users/me/a.txt')
+  h.add('/Volumes/NAS/b.txt')
+  t.is(created.length, 2, 'two chokidar instances, one host')
+  native()[0].emit('change', '/Users/me/a.txt')
+  polling()[0].emit('change', '/Volumes/NAS/b.txt')
+  t.alike(events.map((e) => e.absPath), ['/Users/me/a.txt', '/Volumes/NAS/b.txt'], 'both route to the same onEvent')
+  t.alike(events.map((e) => e.action), ['change', 'change'])
+  t.teardown(() => h.stop())
+})
+
+test('the polling instance is created lazily — no network target, no polling cost', (t) => {
+  const { h } = host()
+  h.add('/Users/me/a.txt')
+  h.add('/Users/me/b.txt')
+  t.is(created.length, 1, 'one instance for two local targets')
+  t.teardown(() => h.stop())
+})
+
+test('add/change/unlink all reach onEvent', (t) => {
+  const { h, events } = host()
+  h.add('/Users/me/a.txt')
+  for (const action of ['add', 'change', 'unlink']) created[0].emit(action, '/Users/me/a.txt')
+  t.alike(events.map((e) => e.action), ['add', 'change', 'unlink'])
+  t.teardown(() => h.stop())
+})
+
+// REGRESSION (FIX-PI3-2: the loose watcher forwarded errors and did nothing else, so an erroring
+// watcher spun for the life of the process. The owned side stopped itself after five errors in
+// ten seconds; the cut-off now covers both.)
+test('REGRESSION (FIX-PI3-2): >5 errors in 10s stops the host and reports why', (t) => {
+  const { h, errors, storms } = host()
+  h.add('/Users/me/a.txt')
+  const w = created[0]
+  for (let i = 0; i < 6; i++) w.emit('error', new Error('boom' + i))
+  t.is(storms.length, 1, 'onStorm fired once')
+  t.is(errors.length, 7, 'six forwarded errors plus the storm report')
+  t.ok(/error-storm: watcher stopped for t/.test(errors[6].message), 'the report names the host')
+  t.ok(w.closed, 'the instance was closed')
+})
+
+test('errors spread beyond the window do not trip the storm cut-off', (t) => {
+  const realNow = Date.now
+  let now = 1_000_000
+  Date.now = () => now
+  t.teardown(() => { Date.now = realNow })
+
+  const { h, storms } = host()
+  h.add('/Users/me/a.txt')
+  const w = created[0]
+  for (let i = 0; i < 10; i++) { w.emit('error', new Error('slow' + i)); now += 4000 }
+  t.is(storms.length, 0, 'ten errors 4s apart is not a storm')
+  t.teardown(() => h.stop())
+})
+
+test('a stormed host stays stopped — add() must not re-arm it', (t) => {
+  const { h } = host()
+  h.add('/Users/me/a.txt')
+  for (let i = 0; i < 6; i++) created[0].emit('error', new Error('boom'))
+  const countAfterStorm = created.length
+  h.add('/Users/me/b.txt')
+  t.is(created.length, countAfterStorm, 'no new instance after a storm')
+})
+
+test('an event arriving after stop() is dropped', (t) => {
+  const { h, events } = host()
+  h.add('/Users/me/a.txt')
+  const w = created[0]
+  h.stop()
+  w.emit('change', '/Users/me/a.txt')
+  t.is(events.length, 0, 'no event after stop')
+})
+
+test('stop() closes every instance, and a close throw does not escape', (t) => {
+  const { h } = host()
+  h.add('/Users/me/a.txt')
+  h.add('/Volumes/NAS/b.txt')
+  created[0].closeError = new Error('close failed')
+  t.execution(() => h.stop(), 'stop() swallows a close throw')
+  t.ok(created[1].closed, 'the second instance was still closed')
+})
+
+test('remove() unwatches on the instance that holds the target', (t) => {
+  const { h } = host()
+  h.add('/Users/me/a.txt')
+  h.add('/Volumes/NAS/b.txt')
+  h.remove('/Volumes/NAS/b.txt')
+  t.alike(native()[0].targets, ['/Users/me/a.txt'], 'the native instance is untouched')
+  t.alike(polling()[0].targets, [], 'the polling instance dropped its target')
+  t.teardown(() => h.stop())
+})
+
+test('remove() before any matching instance exists is a no-op', (t) => {
+  const { h } = host()
+  t.execution(() => h.remove('/Volumes/NAS/gone.txt'))
+  t.is(created.length, 0, 'nothing was constructed just to unwatch')
+})
+
+// The descriptor is the ONLY place the two callers may differ. atomic and ignored come from it;
+// everything else is fixed by the host, which is what stops the option bags drifting apart again.
+test('the descriptor carries atomic and ignored; the rest of the option bag is fixed', (t) => {
+  const ignoreFn = () => false
+  const { h } = host({ atomic: true, ignored: ignoreFn })
+  h.add('/Users/me/a.txt')
+  const opts = created[0].opts
+  t.is(opts.atomic, true, 'atomic comes from the descriptor')
+  t.is(opts.ignored, ignoreFn, 'so does ignored')
+  t.is(opts.ignoreInitial, true)
+  t.is(opts.followSymlinks, false)
+  t.is(opts.alwaysStat, true)
+  t.alike(opts.awaitWriteFinish, { stabilityThreshold: 1000, pollInterval: 100 })
+  t.teardown(() => h.stop())
+})
+
+test('atomic defaults to false, and ignored is omitted when the caller has none', (t) => {
+  const { h } = host()
+  h.add('/Users/me/a.txt')
+  t.is(created[0].opts.atomic, false)
+  t.absent('ignored' in created[0].opts, 'no ignored key when the caller passed none')
+  t.teardown(() => h.stop())
+})
+
+test('looksLikeNetworkPath across the three platforms', (t) => {
+  const real = process.platform
+  const asPlatform = (p, fn) => {
+    Object.defineProperty(process, 'platform', { value: p, configurable: true })
+    try { fn() } finally { Object.defineProperty(process, 'platform', { value: real, configurable: true }) }
+  }
+  t.teardown(() => Object.defineProperty(process, 'platform', { value: real, configurable: true }))
+
+  asPlatform('win32', () => {
+    t.ok(looksLikeNetworkPath('\\\\server\\share\\a.txt'), 'UNC')
+    t.absent(looksLikeNetworkPath('C:\\Users\\me\\a.txt'), 'a local drive letter')
+  })
+  asPlatform('darwin', () => {
+    t.ok(looksLikeNetworkPath('/Volumes/NAS/a.txt'), '/Volumes')
+    t.ok(looksLikeNetworkPath('\\\\server\\share\\a.txt'), 'UNC is platform-independent')
+    t.absent(looksLikeNetworkPath('/Users/me/a.txt'), 'a home path')
+    t.absent(looksLikeNetworkPath('/mnt/x/a.txt'), '/mnt is a linux-only signal')
+  })
+  asPlatform('linux', () => {
+    t.ok(looksLikeNetworkPath('/mnt/nas/a.txt'), '/mnt')
+    t.ok(looksLikeNetworkPath('/media/usb/a.txt'), '/media')
+    t.absent(looksLikeNetworkPath('/Volumes/NAS/a.txt'), '/Volumes is a darwin-only signal')
+    t.absent(looksLikeNetworkPath('/home/me/a.txt'), 'a home path')
+  })
+  t.absent(looksLikeNetworkPath(''), 'empty')
+  t.absent(looksLikeNetworkPath(null), 'null')
+})

--- a/test/unit/watch-host.test.js
+++ b/test/unit/watch-host.test.js
@@ -1,5 +1,6 @@
 import test from 'brittle'
 import { loadWithFakeChokidar } from '../helpers/fake-chokidar.js'
+import { withPlatform, UNC_PATH, NETWORK_CASES } from '../helpers/with-platform.js'
 
 const { created, modules } = loadWithFakeChokidar(['src/main/watch-host.js'])
 const { createWatchHost, looksLikeNetworkPath } = modules[0]
@@ -28,12 +29,18 @@ const native = () => created.filter((w) => !w.opts.usePolling)
 // day it was written; the loose watcher never learned it. The host makes that impossible: a
 // target is routed by the same predicate no matter which caller armed it.)
 test('REGRESSION (FIX-PI3-1): a network path is watched by polling, not native events', (t) => {
-  const { h } = host()
-  h.add('/Volumes/NAS/a.txt')
-  t.is(polling().length, 1, 'a polling instance was created')
-  t.is(polling()[0].opts.interval, 5000, 'and it polls every 5s')
-  t.is(native().length, 0, 'no native instance for a network-only target')
-  t.teardown(() => h.stop())
+  // Pinned per case: /Volumes is darwin-only and /mnt is linux-only, so a test that inherits the
+  // machine's platform asserts nothing on the other one.
+  for (const { platform, path, label } of NETWORK_CASES) {
+    withPlatform(platform, () => {
+      const { h } = host()
+      h.add(path)
+      t.is(polling().length, 1, label + ' is watched by a polling instance')
+      t.is(polling()[0].opts.interval, 5000, label + ' polls every 5s')
+      t.is(native().length, 0, label + ' created no native instance')
+      h.stop()
+    })
+  }
 })
 
 test('a local path never creates a polling instance', (t) => {
@@ -49,11 +56,11 @@ test('a local path never creates a polling instance', (t) => {
 test('one host serves both kinds of target from the same event callback', (t) => {
   const { h, events } = host()
   h.add('/Users/me/a.txt')
-  h.add('/Volumes/NAS/b.txt')
+  h.add(UNC_PATH)
   t.is(created.length, 2, 'two chokidar instances, one host')
   native()[0].emit('change', '/Users/me/a.txt')
-  polling()[0].emit('change', '/Volumes/NAS/b.txt')
-  t.alike(events.map((e) => e.absPath), ['/Users/me/a.txt', '/Volumes/NAS/b.txt'], 'both route to the same onEvent')
+  polling()[0].emit('change', UNC_PATH)
+  t.alike(events.map((e) => e.absPath), ['/Users/me/a.txt', UNC_PATH], 'both route to the same onEvent')
   t.alike(events.map((e) => e.action), ['change', 'change'])
   t.teardown(() => h.stop())
 })
@@ -123,7 +130,7 @@ test('an event arriving after stop() is dropped', (t) => {
 test('stop() closes every instance, and a close throw does not escape', (t) => {
   const { h } = host()
   h.add('/Users/me/a.txt')
-  h.add('/Volumes/NAS/b.txt')
+  h.add(UNC_PATH)
   created[0].closeError = new Error('close failed')
   t.execution(() => h.stop(), 'stop() swallows a close throw')
   t.ok(created[1].closed, 'the second instance was still closed')
@@ -132,8 +139,8 @@ test('stop() closes every instance, and a close throw does not escape', (t) => {
 test('remove() unwatches on the instance that holds the target', (t) => {
   const { h } = host()
   h.add('/Users/me/a.txt')
-  h.add('/Volumes/NAS/b.txt')
-  h.remove('/Volumes/NAS/b.txt')
+  h.add(UNC_PATH)
+  h.remove(UNC_PATH)
   t.alike(native()[0].targets, ['/Users/me/a.txt'], 'the native instance is untouched')
   t.alike(polling()[0].targets, [], 'the polling instance dropped its target')
   t.teardown(() => h.stop())
@@ -141,7 +148,7 @@ test('remove() unwatches on the instance that holds the target', (t) => {
 
 test('remove() before any matching instance exists is a no-op', (t) => {
   const { h } = host()
-  t.execution(() => h.remove('/Volumes/NAS/gone.txt'))
+  t.execution(() => h.remove(UNC_PATH))
   t.is(created.length, 0, 'nothing was constructed just to unwatch')
 })
 
@@ -170,12 +177,7 @@ test('atomic defaults to false, and ignored is omitted when the caller has none'
 })
 
 test('looksLikeNetworkPath across the three platforms', (t) => {
-  const real = process.platform
-  const asPlatform = (p, fn) => {
-    Object.defineProperty(process, 'platform', { value: p, configurable: true })
-    try { fn() } finally { Object.defineProperty(process, 'platform', { value: real, configurable: true }) }
-  }
-  t.teardown(() => Object.defineProperty(process, 'platform', { value: real, configurable: true }))
+  const asPlatform = withPlatform
 
   asPlatform('win32', () => {
     t.ok(looksLikeNetworkPath('\\\\server\\share\\a.txt'), 'UNC')


### PR DESCRIPTION
Plan 03 of the parallel-implementations set. A loose file shared from a network path — `/Volumes`, `/mnt`, `/media`, or a Windows UNC path — emitted no watcher events at all, so edits kept serving stale content to peers silently. The owned-folder watcher had polled such mounts since it was written; the loose watcher never learned it.

**Pattern:** `src/main/watch-host.js` is now the single owner of chokidar. Options are per-instance, not per-path, so a host holds up to two instances (native + lazy polling) and routes each target by `looksLikeNetworkPath`. Callers pass a descriptor; only `atomic` and `ignored` vary, each with its reason at the call site. An eslint `no-restricted-syntax` invariant makes `require('chokidar')` an error outside the host, enforced through eslint's parser by a unit test — the same idiom as `moduleLevelTimerRestrictions`.

Also: the error-storm cut-off now covers loose files too, and its message reaches the log ring on release builds (it was behind `if (debug)`).

## Verification

- Red-first: the new loose suite fails against the pre-change module (`polling instance: actual 0, expected 1`), passes after.
- **Real `/Volumes` mount** (APFS image via `hdiutil`): `change` delivered 6.0 s after the edit — 5 s poll + 1 s `awaitWriteFinish`. Scope: proves the polling path on a real mount; the routing is what the unit tests assert.
- C1 control: the pre-existing `owned-folder-watchers-rebind.test.js` stayed 16/16. Verified against real chokidar 5.0.0 that `watch([]).add(dir)` still watches recursively.
- typecheck green · lint 0 errors / 20 warnings (ceiling 28) · full unit suite 12555/12555.
- `test:bare` + flow **SKIP** — `src/main` does not load under Bare; nothing in `src/shared` or `src/worker` changed. No renderer surface, so no a11y work.
