### PR TITLE
[fix] Record what a folder-share download did

### DIFF
--- a/src/renderer/auditRow.js
+++ b/src/renderer/auditRow.js
@@ -186,6 +186,9 @@ export function metaParts(entry) {
   const parts = []
   if (entry.space?.name) parts.push({ text: entry.space.name })
   const subject = entry.subject || {}
+  // Which folder a transferred file came from. A proper noun like the space name, so it is pushed
+  // as text and needs no catalogue entry; null on a loose file, which renders no segment.
+  if (typeof subject.folder === 'string' && subject.folder) parts.push({ text: subject.folder })
   if (Number.isFinite(subject.fileCount)) {
     const files = formatCount(subject.fileCount)
     if (files !== null) {

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -13,6 +13,8 @@ import { shouldIgnore, DEFAULT_IGNORE, shouldHonorDeletions, relToDriveKey, driv
 // `./foreign-folders.js` import path; the implementation lives in `path-keys.js`.
 export { shouldHonorDeletions }
 import { isOwnerOnline } from '../transfer/swarm.js'
+import { record } from '../audit/audit-log.js'
+import { createIntegritySeen } from './integrity-seen.js'
 import { getSpace } from '../spaces/space.js'
 import { getLocalPublicKeyHex } from '../spaces/profile.js'
 import { getResourceCaps } from '../core/runtime-config.js'
@@ -583,6 +585,32 @@ export function classifyMirrorMiss(attempted) {
   return attempted ? 'failed' : 'no-holder'
 }
 
+const integritySeen = createIntegritySeen({
+  onCap: (mountKey, limit) => log.warn('mirror integrity rows capped at', limit, 'for', mountKey,
+    '— further hash mismatches on this mount are logged but not audited until it is remounted'),
+})
+
+// The ONE thing a mirror audits. contract/audit-kinds.js deliberately records no per-file folder
+// sync, and this is not sync bookkeeping: it is a claim about what a member of this space served.
+function recordMirrorIntegrityFailure(mount, share, entry) {
+  if (!integritySeen.admit(loopKey(mount.spaceId, mount.shareId), entry.relPath, entry.contentHash)) return
+  getSpace(mount.spaceId).then((space) => {
+    record('security.integrity_failure', {
+      actor: { type: 'self' },
+      space: { id: mount.spaceId, name: space?.name ?? null },
+      target: { kind: 'file', id: entry.relPath ?? null, name: path.basename(entry.relPath || '') || null },
+      subject: {
+        bytes: entry.size ?? null,
+        ownerKey: mount.ownerKey ?? null,
+        folder: share?.displayName || share?.name || null,
+        shareId: mount.shareId ?? null,
+      },
+      outcome: 'error',
+      code: 'TRANSFER_CHECKSUM',
+    })
+  }).catch((err) => log.debug('mirror integrity audit failed:', err.message))
+}
+
 // Overlay share: the bytes never enter a drive, so the mirror fetches the file by
 // its content hash straight to the mount path (hash-verified by the overlay). No
 // ensureRemote/release handshake — the holder serves on demand, gated by the
@@ -590,11 +618,15 @@ export function classifyMirrorMiss(attempted) {
 // A local I/O failure pauses the mount via the shared pauseMountForIoError
 // classification (full disk / permission / vanished mount); anything else is a
 // logged fetch miss.
-async function handleOverlayMirrorFetchError(mount, entry, err, diag) {
+async function handleOverlayMirrorFetchError(mount, share, entry, err, diag) {
+  // Order matters: a local I/O fault pauses the mount and is NOT a peer act. Auditing it would
+  // blame a holder for our own full disk.
   if (await pauseMountForIoError(mount, err)) return
   diag.finish('failed')
-  if (err?.code === 'EHASHMISMATCH') log.warn('overlay mirror integrity failure — holder served bytes not matching the content hash:', entry.relPath)
-  else log.debug('overlay mirror fetch failed:', entry.relPath, '-', err.message)
+  if (err?.code === 'EHASHMISMATCH') {
+    log.warn('overlay mirror integrity failure — holder served bytes not matching the content hash:', entry.relPath)
+    recordMirrorIntegrityFailure(mount, share, entry)
+  } else log.debug('overlay mirror fetch failed:', entry.relPath, '-', err.message)
 }
 
 async function materializeOverlayFile(mount, share, entry, opts = {}) {
@@ -659,7 +691,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
     // ECANCELLED is a deliberate pause/unmount abort (stopForeignLoop), not a
     // give-up: log it as a stop and keep whatever partial cancelFetch chose to keep.
     if (err?.code === 'ECANCELLED') { diag.finish('paused'); return 'missing' }
-    await handleOverlayMirrorFetchError(mount, entry, err, diag)
+    await handleOverlayMirrorFetchError(mount, share, entry, err, diag)
     return 'missing'
   } finally {
     activeOverlayFetches.delete(streamKey)
@@ -956,7 +988,7 @@ async function stopAllForeignLoops({ settleMs = 5000 } = {}) {
 export class ForeignMirrors extends Subsystem {
   constructor(name, deps) { super(name, deps); this.require('ipc') }
   async _open() { initForeignFolders(this.deps.ipc) }
-  async _close() { await stopAllForeignLoops() }
+  async _close() { await stopAllForeignLoops(); integritySeen.clear() }
 
   // Counts, not identifiers: diagnostics:export is user-shareable and redacts peer keys and
   // topics, so space and share ids must not ride along. The probe names the mount in the worker
@@ -986,6 +1018,9 @@ function resetForeignSyncState(spaceId, shareId) {
 
 export async function unmountForeignFolder(spaceId, shareId) {
   stopForeignLoop(spaceId, shareId, { discardPartial: true })
+  // Only here, not in stopForeignLoop: that runs on pause and on a health restart too, and
+  // re-arming there would re-record the same mismatch on every resume.
+  integritySeen.forget(loopKey(spaceId, shareId))
   // Overlay copies no bytes into a drive (it serves straight from the owner's
   // source), so there is no per-share blob cache to reclaim on unmount — the
   // materialized files stay on disk, matching owner-delete behaviour.

--- a/src/shared/folders/integrity-seen.js
+++ b/src/shared/folders/integrity-seen.js
@@ -1,0 +1,38 @@
+// One integrity row per (mount, file, advertised hash) — not one per retry tick. A mirror
+// re-materializes on a 30 s poll AND on every owner catalog append, so a holder that keeps serving
+// bytes failing their hash would otherwise write the same fact thousands of times a day and burn
+// the audit log's per-kind rate budget, collapsing real rows into audit.suppressed.
+//
+// Keyed on the hash as well as the path, because a re-publish is a NEW claim: the owner
+// advertising different bytes under a new hash and failing again is a second fact, not a repeat.
+//
+// Bounded per mount. At the cap the mount stops recording and announces it once — 512 rows already
+// say "this holder is serving corrupt content", and an unbounded Set on a 150k-file mirror is a
+// leak. This is a bounded gap, not a silent one: every suppressed case still produced its console
+// warning, and the cap itself is logged.
+export const DEFAULT_INTEGRITY_ROW_CAP = 512
+
+export function createIntegritySeen({ limit = DEFAULT_INTEGRITY_ROW_CAP, onCap = () => {} } = {}) {
+  const byMount = new Map()
+
+  return {
+    admit(mountKey, relPath, contentHash) {
+      let seen = byMount.get(mountKey)
+      if (!seen) {
+        seen = new Set()
+        byMount.set(mountKey, seen)
+      }
+      const claim = relPath + '\0' + (contentHash || '')
+      if (seen.has(claim)) return false
+      if (seen.size >= limit) return false
+      seen.add(claim)
+      if (seen.size === limit) onCap(mountKey, limit)
+      return true
+    },
+    // An unmount/remount is a fresh session: the user re-pointing the mount is a new decision and
+    // deserves to be told the folder is still corrupt.
+    forget(mountKey) { byMount.delete(mountKey) },
+    clear() { byMount.clear() },
+    size(mountKey) { return byMount.get(mountKey)?.size ?? 0 },
+  }
+}

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -509,6 +509,7 @@ async function reconcileActiveOverlayTransfers(spaceId, share) {
     if (decision !== 'restart' && supersedeDecision(inflightHash, state?.contentHash) !== 'restart') continue
     engine().supersede(transferId, {
       spaceId, pendingKey: slot.pendingKey, path: slot.pendingKey, relPath, shareId: share.id, ...catalogKeyField(keyHex, encrypted),
+      folderName: folderLabel(share),
       transferId,
       contentHash: state.contentHash, size: state.size || 0, sourceSeq: state.seq,
       ownerPublicKey: share.owner, verifyKey: share.id + '|' + relPath,
@@ -532,6 +533,11 @@ async function peerEntry(spaceId, share, relPath) {
 // (parity with the loose path's per-space path keys). The renderer merges it at render, gated on
 // the worker-derived status, so a lingering entry after a missed `done` stays invisible.
 const shareDeco = (job, p) => ipcRef?.emit('event:decoration', { channel: 'transfer', spaceId: job.spaceId, key: shareDecoKey(job.shareId, job.relPath), ...p })
+
+// The label share:rename writes, carried on the job so the engine's audit row can name the folder
+// without a join — a row outlives the share it describes. Null when the owner's descriptor is
+// unreadable (offline), which is still worth recording.
+const folderLabel = (share) => share?.displayName || share?.name || null
 
 let folderEngine = null
 
@@ -593,6 +599,7 @@ export const folderChannel = {
       removed: false, seq: state.seq,
       job: {
         spaceId, pendingKey: row.filePath, path: row.filePath, relPath: row.relPath, shareId: row.shareId, ...catalogKeyField(keyHex, encrypted),
+        folderName: folderLabel(share),
         transferId: transferIdFor(spaceId, row.shareId, row.relPath),
         contentHash: state.contentHash, size: state.size || 0, sourceSeq: state.seq,
         ownerPublicKey: row.ownerKey, verifyKey: row.shareId + '|' + row.relPath,
@@ -622,6 +629,7 @@ export async function overlayRequestDownload(spaceId, share, relPath) {
   return engine().start({
     express: true,
     spaceId, pendingKey: drivePath, path: drivePath, relPath, shareId: share.id, ...catalogKeyField(keyHex, encrypted),
+    folderName: folderLabel(share),
     transferId: transferIdFor(spaceId, share.id, relPath),
     contentHash: entry.contentHash, size: entry.size || 0, sourceSeq: entry.seq,
     ownerPublicKey: share.owner, verifyKey: share.id + '|' + relPath,

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -15,6 +15,7 @@ import {
   recordPending, clearPending, recordPendingError, getPendingFor, updatePendingProgress, listPendingForSpace,
 } from '../../pending-transfers.js'
 import { makeProgressTicker } from '../../progress-ticker.js'
+import { recordTransferOutcome } from '../../transfer-audit.js'
 import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js'
 import { republishDecision } from '../../supersede-decision.js'
 import { makeKeyedCoalescer } from '../../../state/coalesce.js'
@@ -129,6 +130,17 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       log.warn('could not persist the transfer error — auto-resume is suppressed only until restart:', job.relPath, code, '-', err.message)
     }
   }
+
+  // The single terminal-failure exit. Every failing path lands here so the audit row cannot
+  // depend on which channel is driving — the divergence that left folder-share downloads
+  // unrecorded for the whole life of the Activity Log. `recordTerminal` stays at its own call
+  // sites: three of the four await it and the supersede-restart deliberately does not.
+  function failTerminal (job, code) {
+    recordTransferOutcome(job, 'error', code)
+    channel.emitError(job, code)
+    channel.emitUpdated(job.spaceId)
+  }
+
   const ownerOnline = (pk) => (channel.isOwnerOnline ?? isOwnerOnline)(pk)
   // transferId -> { dry, bytes, timer } for a stall being retried. `dry` counts CONSECUTIVE
   // attempts that banked no new bytes, so a throttled holder (which always banks some) retries
@@ -281,8 +293,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     else if (code === ErrorCodes.TRANSFER_DEST_UNAVAILABLE) log.warn('overlay fetch failed — download folder unavailable:', path.dirname(job.finalPath))
     else log.debug('overlay fetch failed:', job.relPath, '-', r.code)
     await recordTerminal(job, code)
-    channel.emitError(job, code)
-    channel.emitUpdated(job.spaceId)
+    failTerminal(job, code)
   }
 
   // Resolve a finished fetch. Reads the LIVE slot, because a pause/cancel/supersede/republish
@@ -388,6 +399,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       log.warn('could not clear the pending row of a completed download:', job.relPath, '-', err.message)
     }
     channel.emitUpdated(job.spaceId)
+    recordTransferOutcome(job, 'ok', null)
     channel.emitComplete(job, job.finalPath)
   }
 
@@ -451,8 +463,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
         registry.delete(transferId)
         log.warn('overlay download refused — download folder unavailable:', path.dirname(job.finalPath))
         await recordTerminal(job, ErrorCodes.TRANSFER_DEST_UNAVAILABLE)
-        channel.emitError(job, ErrorCodes.TRANSFER_DEST_UNAVAILABLE)
-        channel.emitUpdated(job.spaceId)
+        failTerminal(job, ErrorCodes.TRANSFER_DEST_UNAVAILABLE)
         return { queued: true }
       }
 
@@ -465,8 +476,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
         registry.delete(transferId)
         log.warn('overlay download refused — not enough free disk space:', job.relPath, 'needs', job.size, 'bytes')
         await recordTerminal(job, ErrorCodes.TRANSFER_DISK_FULL)
-        channel.emitError(job, ErrorCodes.TRANSFER_DISK_FULL)
-        channel.emitUpdated(job.spaceId)
+        failTerminal(job, ErrorCodes.TRANSFER_DISK_FULL)
         return { queued: true }
       }
 
@@ -611,8 +621,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       (res) => { if (res && res.queued) channel.emitPaused?.(job, pauseReasonFor(job)) },
       (err) => {
         log.debug('overlay supersede-restart failed:', err.message)
-        channel.emitError(job, ErrorCodes.DOWNLOAD_FAILED)
-        channel.emitUpdated(job.spaceId)
+        failTerminal(job, ErrorCodes.DOWNLOAD_FAILED)
       },
     )
   }

--- a/src/shared/transfer/backends/overlay/overlay-runtime.js
+++ b/src/shared/transfer/backends/overlay/overlay-runtime.js
@@ -7,6 +7,7 @@
 import { Subsystem } from '../../../core/subsystem.js'
 import { isOverlayEnabled, isInPlaceFilesEnabled } from '../../../core/runtime-config.js'
 import { createOverlayDownloadEngine } from './overlay-download.js'
+import { drainTransferAudit } from '../../transfer-audit.js'
 import { initOverlay, teardownOverlay, attachOverlay, revokeServesForSpace, bumpServeEpoch } from './overlay-instance.js'
 import { serveIndex } from './overlay-serve-index.js'
 import {
@@ -73,6 +74,10 @@ export class OverlayBackend extends Subsystem {
     this.folderEngine?.drainAdmission()
     this.looseEngine?.drainAdmission()
     await teardownOverlay()
+    // After the teardown, which settles the in-flight fetches that produce these rows, and before
+    // the durable tier closes the audit bee: boot.js starts the audit log in `durable` and this
+    // subsystem in `life`, so `life` is always torn down first.
+    await drainTransferAudit()
     this.overlay = null
     setFolderEngine(null)
     setLooseEngine(null)

--- a/src/shared/transfer/loose-overlay.js
+++ b/src/shared/transfer/loose-overlay.js
@@ -14,7 +14,6 @@ import { markListIncomplete } from './list-deficits.js'
 import { markOwnedSource, getOwnedSourcePath, clearOwnedSource } from './files.js'
 import { getPendingFor, recordPending } from './pending-transfers.js'
 import { reuseDest } from './download-dest.js'
-import { record } from '../audit/audit-log.js'
 import { observePeerCatalog } from '../audit/peer-watch.js'
 import { getDownloadDir } from '../core/paths.js'
 import { listSpaces, getSpace } from '../spaces/space.js'
@@ -395,24 +394,6 @@ async function buildLooseJob (spaceId, member, drivePath, prevPending, entry) {
 // bytes in the renderer's per-key decoration map.
 const deco = (spaceId, key, p) => ipcRef?.emit('event:decoration', { channel: 'transfer', spaceId, key, ...p })
 
-// One row per finished download, at its terminal outcome — never per chunk. An integrity
-// failure is promoted out of the generic failure kind because it is a security signal, not a
-// network one: the bytes a holder served did not match the hash they were advertised under.
-function recordTransferOutcome(job, outcome, errorCode) {
-  const fileName = path.basename(job.relPath || job.path || '')
-  const isIntegrity = errorCode === 'TRANSFER_CHECKSUM' || errorCode === 'EHASHMISMATCH'
-  getSpace(job.spaceId).then((space) => {
-    record(isIntegrity ? 'security.integrity_failure' : outcome === 'ok' ? 'transfer.completed' : 'transfer.failed', {
-      actor: { type: 'self' },
-      space: { id: job.spaceId, name: space?.name ?? null },
-      target: { kind: 'file', id: job.path ?? null, name: fileName || null },
-      subject: { bytes: job.size ?? null, ownerKey: job.ownerKey ?? null },
-      outcome: outcome === 'ok' ? 'ok' : 'error',
-      code: errorCode || null,
-    })
-  }).catch(() => {})
-}
-
 let looseEngine = null
 
 export function setLooseEngine(next) { looseEngine = next }
@@ -431,8 +412,8 @@ export const looseChannel = {
   // remain as signals for notifications; the row's status is re-derived from files:list.
   emitProgress: (job, p) => deco(job.spaceId, job.path, { bytes: p.bytes, total: p.total, speed: p.speed, eta: p.eta }),
   emitVerifying: (job, fraction) => deco(job.spaceId, job.path, { phase: 'verifying', verifyFraction: fraction, bytes: job.prevBytes || 0, total: job.size }),
-  emitError: (job, errorCode) => { ipcRef?.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode }); recordTransferOutcome(job, 'error', errorCode); deco(job.spaceId, job.path, { done: true }) },
-  emitComplete: (job, localPath) => { ipcRef?.emit('event:transfer-complete', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, localPath }); recordTransferOutcome(job, 'ok', null); deco(job.spaceId, job.path, { done: true }) },
+  emitError: (job, errorCode) => { ipcRef?.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode }); deco(job.spaceId, job.path, { done: true }) },
+  emitComplete: (job, localPath) => { ipcRef?.emit('event:transfer-complete', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, localPath }); deco(job.spaceId, job.path, { done: true }) },
   emitCancelled: (spaceId, transferId, pendingKey) => deco(spaceId, pendingKey, { done: true }),
   emitSuperseded: (job) => { ipcRef?.emit('event:transfer-superseded', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, fileName: path.basename(job.relPath) }); deco(job.spaceId, job.path, { bytes: 0, total: job.size, speed: 0, eta: null }) },
   // [mirall] FIX-BW9 — `retrying` means the engine has an automatic retry armed for this row.

--- a/src/shared/transfer/transfer-audit.js
+++ b/src/shared/transfer/transfer-audit.js
@@ -1,0 +1,68 @@
+// One audit row per finished consumer download, at its terminal outcome — never per chunk, and
+// never per mirror-tick file (contract/audit-kinds.js records no per-file folder sync; a download
+// the user asked for is not folder sync).
+//
+// Called by the download ENGINE, not by a channel. It used to live inside loose-overlay.js, which
+// is why folder-share downloads silently recorded nothing for as long as the Activity Log has
+// existed: recording an outcome is a step of the algorithm, identical for every channel, so a
+// channel that forgets it is a bug the type system cannot see. The engine owns it now, and a
+// channel added later is audited by construction.
+//
+// An integrity failure is promoted out of the generic failure kind because it is a security
+// signal, not a network one: the bytes a holder served did not match the hash they advertised.
+import path from 'bare-path'
+import { record } from '../audit/audit-log.js'
+import { getSpace } from '../spaces/space.js'
+import { createLogger } from '../core/logger.js'
+
+const log = createLogger('transfer-audit')
+
+// Every recordTransferOutcome() still in flight. The write is a spaces-bee read followed by an
+// audit-bee write in a microtask nobody holds, so without this a download landing during shutdown
+// records nothing — the bug serve-ledger.js fixed as LIFECYCLE-2e and this path never did.
+const pending = new Set()
+
+// 'EHASHMISMATCH' is the raw vendor code; the engine maps it to TRANSFER_CHECKSUM before this is
+// reached. Both are accepted so a caller that has not been through terminalCodeFor classifies the
+// same way.
+const INTEGRITY_CODES = new Set(['TRANSFER_CHECKSUM', 'EHASHMISMATCH'])
+
+function kindFor(outcome, errorCode) {
+  if (INTEGRITY_CODES.has(errorCode)) return 'security.integrity_failure'
+  return outcome === 'ok' ? 'transfer.completed' : 'transfer.failed'
+}
+
+export function recordTransferOutcome(job, outcome, errorCode) {
+  const fileName = path.basename(job.relPath || job.path || '')
+  const write = getSpace(job.spaceId).then((space) => {
+    record(kindFor(outcome, errorCode), {
+      actor: { type: 'self' },
+      space: { id: job.spaceId, name: space?.name ?? null },
+      target: { kind: 'file', id: job.path ?? null, name: fileName || null },
+      // ownerPublicKey, NOT ownerKey: no job in the codebase has an `ownerKey` field, so the old
+      // spelling wrote null on every row it ever produced. `folder` is null for a loose file and
+      // is what lets the viewer name the folder without a join — a row outlives its share.
+      subject: {
+        bytes: job.size ?? null,
+        ownerKey: job.ownerPublicKey ?? null,
+        folder: job.folderName ?? null,
+        shareId: job.shareId ?? null,
+      },
+      outcome: outcome === 'ok' ? 'ok' : 'error',
+      code: errorCode || null,
+    })
+  }).catch((err) => log.debug('transfer audit failed:', err.message))
+  pending.add(write)
+  write.finally(() => pending.delete(write))
+}
+
+// Awaits the writes already issued, bounded: a hung spaces-bee read must not hold the shutdown
+// past its budget.
+export async function drainTransferAudit({ settleMs = 2000 } = {}) {
+  if (!pending.size) return
+  await Promise.race([
+    Promise.allSettled([...pending]),
+    new Promise((resolve) => { const t = setTimeout(resolve, settleMs); t.unref?.() }),
+  ])
+  pending.clear()
+}

--- a/test/flow/audit-coverage.test.js
+++ b/test/flow/audit-coverage.test.js
@@ -155,6 +155,15 @@ test('one realistic session produces every expected kind, and nothing else', { t
   await B.until('share:list', { spaceId }, (l) => l.some((s) => s.id === aShare.id), { ms: 60000, every: 500 })
   await B.request('foreign-folder:mount', { spaceId, shareId: aShare.id, ownerKey: aKey, mountPath: mkTmpDir(t) })
   await A.until('audit:list', { limit: 200 }, (p) => kindsOf(p.entries).has('mirror.peer_mirrored'))
+
+  // B downloads a file OUT of A's folder share — the folder-engine counterpart of the loose
+  // download above. Without this the session drives one producer of transfer.completed, which is
+  // how the folder path stayed unrecorded through an "every declared kind has a call site" test.
+  await B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: aShare.id, relPath: 'doc.txt' })
+  await B.until('audit:list', { limit: 200 }, (p) => p.entries.some(
+    (e) => e.kind === 'transfer.completed' && e.subject?.folder === 'AliceFolder'
+  ), { ms: 90000, every: 500 })
+
   await B.request('foreign-folder:unmount', { spaceId, shareId: aShare.id })
   await A.until('audit:list', { limit: 200 }, (p) => kindsOf(p.entries).has('mirror.peer_unmirrored'))
 

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -122,6 +122,7 @@ import s121 from './scenarios/s121-index-pause-resume.mjs'
 import s122 from './scenarios/s122-folder-filter.mjs'
 import s123 from './scenarios/s123-edit-folder.mjs'
 import s124 from './scenarios/s124-folder-commands.mjs'
+import s125 from './scenarios/s125-activity-log-folder-download.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -188,7 +189,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s125-activity-log-folder-download.mjs
+++ b/test/frontend/scenarios/s125-activity-log-folder-download.mjs
@@ -1,0 +1,75 @@
+import { mkdirSync, writeFileSync, existsSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { flatten } from '../tree.mjs'
+import { workDir } from '../paths.mjs'
+
+// Defect 11 through the UI: a file downloaded out of a FOLDER share left no trace in the Activity
+// Log at all, while the same download of a space-root file recorded one. The row's meta line has to
+// name the folder as well as the space, or a folder row is indistinguishable from a loose one.
+export default async function s125 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Brand Assets')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'logo.txt'), 'the mark'.repeat(64))
+
+  try {
+    await r.ok('A shares "Brand Assets"; B sees it', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      // s124's idiom: bring A forward explicitly before the native Add-Folder trigger rather
+      // than relying on press()'s is_focused short-circuit after a multi-peer handshake.
+      await A.focus()
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Brand Assets', 60000)
+      await B.waitText('Brand Assets', 60000)
+    })
+
+    await r.ok('B downloads a file out of the folder', async () => {
+      await B.focus()
+      await B.openFolder('Brand Assets')
+      await B.waitText('logo.txt', 20000)
+      await B.click({ role: 'button', name: 'Download' })
+      await waitFor(() => existsSync(path.join(B.downloadFolder, 'logo.txt')), 60000, 'logo.txt downloaded')
+      await B.waitText('On your device', 20000)
+    })
+
+    await r.ok('the download appears in the Activity Log', async () => {
+      await B.openActivityLog()
+      await B.waitText('logo.txt', 20000)
+      await B.shot('s125-folder-download-row', runDir)
+    })
+
+    // The C4 change, and the only part of this a user can see. One logical string per accessible
+    // node: the folder name must be its own AX text leaf, not a fragment of a joined meta string.
+    await r.ok('the row names the folder as well as the space', async () => {
+      const nodes = flatten(await B.snap())
+      assert(nodes.some((n) => n.name === 'Aurora' || n.value === 'Aurora'), 'the space is named on the row')
+      assert(
+        nodes.some((n) => n.name === 'Brand Assets' || n.value === 'Brand Assets'),
+        'the folder is named on the row, as one accessible node — without it a folder row reads exactly like a loose one'
+      )
+    })
+
+    await r.ok('the row is a Files row, not a Security one', async () => {
+      await B.click({ role: 'checkbox', name: 'Files' })
+      await B.waitText('logo.txt', 10000)
+      await B.click({ name: 'Clear all' })
+      await B.click({ role: 'checkbox', name: 'Security' })
+      // Wait for the filtered list to settle on its empty state before asserting an ABSENCE —
+      // hasText snapshots immediately, so without this it races the re-render and the row is
+      // still on screen from the previous filter.
+      await B.waitText('No events match', 10000)
+      assert(!(await B.hasText('logo.txt')), 'a completed download is not a security event')
+      await B.shot('s125-security-filter-empty', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/integration/folder-download-audit.test.js
+++ b/test/integration/folder-download-audit.test.js
@@ -1,0 +1,222 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { freshPeer } from '../helpers/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
+import { folderChannel } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
+import { looseChannel } from '../../src/shared/transfer/loose-overlay.js'
+import { queryAudit, flushAudit } from '../../src/shared/audit/audit-log.js'
+import { drainTransferAudit } from '../../src/shared/transfer/transfer-audit.js'
+
+// The audit row for a download is written by the ENGINE, so these drive the engine over the REAL
+// channels. A hand-written channel double would prove nothing here: the two hand-written channels
+// diverging is the defect.
+
+const OWNER = 'p'.repeat(64)
+
+async function rows (kind) {
+  await drainTransferAudit()
+  await flushAudit()
+  const { entries } = await queryAudit({ limit: 100 })
+  return kind ? entries.filter((e) => e.kind === kind) : entries
+}
+
+// start() hands the fetch to a background task, so the terminal row lands after it resolves.
+async function settle (kind, { tries = 60 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const found = await rows(kind)
+    if (found.length) return found
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  return await rows(kind)
+}
+
+const quiet = () => new Promise((r) => setTimeout(r, 150))
+
+function folderJob (ctx, spaceId, over = {}) {
+  return {
+    spaceId,
+    pendingKey: '/Brand Assets/logo.svg',
+    path: '/Brand Assets/logo.svg',
+    relPath: 'logo.svg',
+    shareId: 'sh1',
+    folderName: 'Brand Assets',
+    catalogKey: 'cat-hex',
+    transferId: spaceId + '|sh1|logo.svg',
+    contentHash: 'h'.repeat(64),
+    size: 4096,
+    ownerPublicKey: OWNER,
+    verifyKey: 'sh1|logo.svg',
+    finalPath: path.join(ctx.tmpDir('dl'), 'logo.svg'),
+    ...over,
+  }
+}
+
+async function setup (t, over = {}) {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Design Team')
+  const engine = createOverlayDownloadEngine({ ...folderChannel, isOwnerOnline: () => true })
+  return { ctx, space, engine, job: folderJob(ctx, space.spaceId, over) }
+}
+
+function throwsWith (code, message) {
+  return async () => {
+    const err = new Error(message)
+    err.code = code
+    throw err
+  }
+}
+
+// REGRESSION (FIX-D11-1: a folder-share download produced no audit row at all. `record(` appeared
+// zero times in overlay-backend.js while the loose channel recorded from its own emitComplete, so
+// "You downloaded X" existed for a space-root file and for nothing inside a folder.)
+test('REGRESSION (FIX-D11-1): a completed folder-share download records transfer.completed', async (t) => {
+  const { engine, job } = await setup(t)
+  fs.writeFileSync(job.finalPath, 'bytes')
+  getOverlay().fetchFile = async () => ({ destPath: job.finalPath, local: false, size: 5 })
+
+  await engine.start(job)
+  const found = await settle('transfer.completed')
+
+  t.is(found.length, 1, 'exactly one row, at the terminal outcome')
+  if (!found.length) return
+  t.is(found[0].target.name, 'logo.svg', 'the file is named in the row — nothing is joined at render')
+  t.is(found[0].subject.folder, 'Brand Assets', 'and the folder it came out of')
+  t.is(found[0].subject.bytes, 4096)
+  t.is(found[0].subject.shareId, 'sh1')
+  t.is(found[0].outcome, 'ok')
+  t.is(found[0].actor.type, 'self')
+  t.is(found[0].space.name, 'Design Team', 'the space name is snapshotted, not joined')
+})
+
+// The recorder read job.ownerKey, but every job builder writes ownerPublicKey — so the holder was
+// null on every transfer row ever written, loose ones included.
+test('REGRESSION (FIX-D11-1b): the row attributes the holder it fetched from', async (t) => {
+  const { engine, job } = await setup(t)
+  fs.writeFileSync(job.finalPath, 'bytes')
+  getOverlay().fetchFile = async () => ({ destPath: job.finalPath, local: false, size: 5 })
+
+  await engine.start(job)
+  const [row] = await settle('transfer.completed')
+  if (!row) return t.fail('no transfer.completed row to attribute')
+  t.is(row.subject.ownerKey, OWNER, 'read from job.ownerPublicKey, which is the field that exists')
+})
+
+// REGRESSION (FIX-D11-2: a holder serving bytes that fail their advertised hash was logged to the
+// console and dropped. security.integrity_failure exists for exactly this and had no folder-side
+// producer.)
+test('REGRESSION (FIX-D11-2): a hash mismatch records security.integrity_failure, not transfer.failed', async (t) => {
+  const { engine, job } = await setup(t)
+  getOverlay().fetchFile = throwsWith('EHASHMISMATCH', 'hash mismatch')
+
+  await engine.start(job)
+  const found = await settle('security.integrity_failure')
+
+  t.is(found.length, 1, 'promoted out of the generic failure kind')
+  if (!found.length) return
+  t.is(found[0].category, 'security', "so the viewer's security filter surfaces it")
+  t.is(found[0].code, 'TRANSFER_CHECKSUM')
+  t.is(found[0].outcome, 'error')
+  t.is(found[0].subject.folder, 'Brand Assets')
+  t.is((await rows('transfer.failed')).length, 0, 'and NOT also counted as a network failure')
+})
+
+// REGRESSION (FIX-D11-3: the folder channel only ever emitted an EVENT, and only for three codes.
+// A folder download failing for any other reason left no trace anywhere.)
+test('REGRESSION (FIX-D11-3): a terminal failure records transfer.failed carrying its code', async (t) => {
+  const { engine, job } = await setup(t)
+  getOverlay().fetchFile = throwsWith('ENOSPC', 'no space left on device')
+
+  await engine.start(job)
+  const found = await settle('transfer.failed')
+
+  t.is(found.length, 1)
+  if (!found.length) return
+  t.is(found[0].code, 'TRANSFER_DISK_FULL')
+  t.is(found[0].outcome, 'error')
+  t.is(found[0].target.name, 'logo.svg')
+})
+
+test('a paused download records nothing — a pause is not an outcome', async (t) => {
+  const { engine, job } = await setup(t)
+  let rejectFetch = null
+  getOverlay().fetchFile = () => new Promise((_, reject) => { rejectFetch = reject })
+  getOverlay().cancelFetch = () => {
+    const err = new Error('cancelled')
+    err.code = 'ECANCELLED'
+    rejectFetch?.(err)
+    return true
+  }
+
+  await engine.start(job)
+  await quiet()
+  await engine.pause(job.transferId)
+  await quiet()
+
+  t.is((await rows('transfer.completed')).length, 0)
+  t.is((await rows('transfer.failed')).length, 0, 'a resumable row must not read as a failure in the log')
+  t.is((await rows('security.integrity_failure')).length, 0)
+})
+
+// C1 moved the recorder OUT of loose-overlay.js. A forgotten deletion shows up here as two rows.
+test('a loose download still records exactly one row after the move', async (t) => {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Design Team')
+  const engine = createOverlayDownloadEngine({ ...looseChannel, isOwnerOnline: () => true })
+  const finalPath = path.join(ctx.tmpDir('dl'), 'notes.txt')
+  const job = {
+    spaceId: space.spaceId, pendingKey: '/notes.txt', path: '/notes.txt', relPath: 'notes.txt',
+    shareId: '__loose__', transferId: space.spaceId + '|__loose__|notes.txt',
+    contentHash: 'h'.repeat(64), size: 12, ownerPublicKey: OWNER, verifyKey: '__loose__|notes.txt',
+    finalPath,
+  }
+  fs.writeFileSync(finalPath, 'x')
+  getOverlay().fetchFile = async () => ({ destPath: finalPath, local: false, size: 1 })
+
+  await engine.start(job)
+  const found = await settle('transfer.completed')
+
+  t.is(found.length, 1, 'one recorder, one row')
+  if (!found.length) return
+  t.is(found[0].subject.folder, null, 'a loose file has no folder — the meta line must not invent one')
+  t.is(found[0].subject.ownerKey, OWNER)
+})
+
+// REGRESSION (FIX-D11-6: the guard that was missing. audit-coverage.test.js asserts every KIND has
+// a call site somewhere in the data layer, which one channel satisfied for both — so a channel that
+// records nothing was invisible to every suite. Recording belongs to the engine; this pins that a
+// channel cannot opt out of it, which is what makes the whole class of bug unrepresentable.)
+test('REGRESSION (FIX-D11-6): a channel that knows nothing about auditing still produces a row', async (t) => {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Design Team')
+  const finalPath = path.join(ctx.tmpDir('dl'), 'third.bin')
+  const bare = {
+    diagLabel: 'third channel',
+    inPlace: false,
+    isOwnerOnline: () => true,
+    ownsPendingRow: (row) => row.thirdChannel === true,
+    pendingExtra: () => ({ thirdChannel: true }),
+    emitProgress: () => {},
+    emitError: () => {},
+    emitComplete: () => {},
+    emitCancelled: () => {},
+    emitUpdated: () => {},
+    transferIdForRow: (spaceId, row) => spaceId + '|third|' + row.relPath,
+    resolvePendingRow: async () => ({ removed: false, seq: undefined, job: null }),
+  }
+  const engine = createOverlayDownloadEngine(bare)
+  const job = {
+    spaceId: space.spaceId, pendingKey: '/third.bin', path: '/third.bin', relPath: 'third.bin',
+    shareId: 'third', folderName: 'Third', transferId: space.spaceId + '|third|third.bin',
+    contentHash: 'h'.repeat(64), size: 3, ownerPublicKey: OWNER, verifyKey: 'third|third.bin',
+    finalPath,
+  }
+  fs.writeFileSync(finalPath, 'abc')
+  getOverlay().fetchFile = async () => ({ destPath: finalPath, local: false, size: 3 })
+
+  await engine.start(job)
+  const found = await settle('transfer.completed')
+  t.is(found.length, 1, 'the engine records; the channel is not asked to')
+})

--- a/test/integration/mirror-integrity-audit.test.js
+++ b/test/integration/mirror-integrity-audit.test.js
@@ -1,0 +1,164 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { freshPeer } from '../helpers/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { materializeCatalogFile, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
+import { saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { queryAudit, flushAudit } from '../../src/shared/audit/audit-log.js'
+
+// src/shared/folders/ contained ZERO record( calls: a mirror holder serving bytes that fail their
+// advertised hash produced a console warning and nothing else. Everything else the mirror does per
+// file stays unrecorded on purpose (contract/audit-kinds.js) — these pin both halves.
+
+const OWNER = 'o'.repeat(64)
+const SHARE = 'sh-mirror'
+
+async function rows (kind) {
+  await flushAudit()
+  const { entries } = await queryAudit({ limit: 100 })
+  return kind ? entries.filter((e) => e.kind === kind) : entries
+}
+
+async function integrityRows ({ tries = 40 } = {}) {
+  for (let i = 0; i < tries; i++) {
+    const found = await rows('security.integrity_failure')
+    if (found.length) return found
+    await new Promise((r) => setTimeout(r, 25))
+  }
+  return await rows('security.integrity_failure')
+}
+
+const quiet = () => new Promise((r) => setTimeout(r, 200))
+
+async function setup (t) {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Design Team')
+  const mountPath = ctx.tmpDir('mirror')
+  const mount = {
+    spaceId: space.spaceId, shareId: SHARE, ownerKey: OWNER,
+    mountPath, enabled: true, status: 'active', syncedPaths: [],
+  }
+  await saveForeignMount(mount)
+  const share = { id: SHARE, name: 'Brand Assets', owner: OWNER, spaceId: space.spaceId }
+  return { ctx, space, mount, share, mountPath }
+}
+
+const entry = (over = {}) => ({ relPath: 'a/report.pdf', contentHash: 'h1'.repeat(32), size: 900, ...over })
+
+function throwsWith (code, message) {
+  return async () => {
+    const err = new Error(message)
+    err.code = code
+    throw err
+  }
+}
+
+// REGRESSION (FIX-D11-4: the mirror caught EHASHMISMATCH and answered with a log.warn — not
+// exported, not searchable, not retained, invisible to the user — while the same event on a loose
+// file recorded security.integrity_failure.)
+test('REGRESSION (FIX-D11-4): a mirror hash mismatch records security.integrity_failure', async (t) => {
+  const { mount, share, space } = await setup(t)
+  getOverlay().fetchFile = throwsWith('EHASHMISMATCH', 'hash mismatch')
+
+  await materializeCatalogFile(mount, share, entry())
+  const found = await integrityRows()
+
+  t.is(found.length, 1)
+  if (!found.length) return
+  t.is(found[0].target.name, 'report.pdf', 'the file is named in the row')
+  t.is(found[0].subject.folder, 'Brand Assets', 'and the folder it was mirroring')
+  t.is(found[0].subject.ownerKey, OWNER, 'the row names WHICH member served the bad bytes')
+  t.is(found[0].space.name, 'Design Team', 'snapshotted — the row outlives the space')
+  t.is(found[0].category, 'security')
+  t.is(found[0].outcome, 'error')
+  t.is(found[0].space.id, space.spaceId)
+})
+
+test('five ticks against the same bad file record exactly one row', async (t) => {
+  const { mount, share } = await setup(t)
+  getOverlay().fetchFile = throwsWith('EHASHMISMATCH', 'hash mismatch')
+
+  for (let i = 0; i < 5; i++) await materializeCatalogFile(mount, share, entry())
+  await quiet()
+
+  t.is((await rows('security.integrity_failure')).length, 1,
+    'a 30s poll must not turn one fact into thousands of rows and starve the rate budget')
+})
+
+test('a re-publish under a new hash is a new claim', async (t) => {
+  const { mount, share } = await setup(t)
+  getOverlay().fetchFile = throwsWith('EHASHMISMATCH', 'hash mismatch')
+
+  await materializeCatalogFile(mount, share, entry({ contentHash: 'a'.repeat(64) }))
+  await materializeCatalogFile(mount, share, entry({ contentHash: 'b'.repeat(64) }))
+  await quiet()
+
+  t.is((await rows('security.integrity_failure')).length, 2, 'different bytes advertised, failed again')
+})
+
+test('two different bad files record two rows', async (t) => {
+  const { mount, share } = await setup(t)
+  getOverlay().fetchFile = throwsWith('EHASHMISMATCH', 'hash mismatch')
+
+  await materializeCatalogFile(mount, share, entry({ relPath: 'one.bin' }))
+  await materializeCatalogFile(mount, share, entry({ relPath: 'two.bin' }))
+  await quiet()
+
+  t.is((await rows('security.integrity_failure')).length, 2)
+})
+
+test('a local disk fault records nothing — it is not a peer act', async (t) => {
+  const { mount, share } = await setup(t)
+  getOverlay().fetchFile = throwsWith('ENOSPC', 'no space left on device')
+
+  await materializeCatalogFile(mount, share, entry())
+  await quiet()
+
+  t.is((await rows('security.integrity_failure')).length, 0, 'our full disk must never blame a holder')
+  const after = await getForeignMount(mount.spaceId, mount.shareId)
+  t.is(after.enabled, false, 'the mount paused instead')
+})
+
+test('a mirror fetch that finds no holder records nothing', async (t) => {
+  const { mount, share } = await setup(t)
+  getOverlay().fetchFile = async () => null
+
+  await materializeCatalogFile(mount, share, entry())
+  await quiet()
+
+  t.is((await rows()).length, 0, 'per-file folder sync is deliberately unrecorded')
+})
+
+test('a mirror fetch that succeeds records nothing', async (t) => {
+  const { mount, share, mountPath } = await setup(t)
+  const dest = path.join(mountPath, 'a', 'report.pdf')
+  getOverlay().fetchFile = async (hash, opts) => {
+    fs.mkdirSync(path.dirname(opts.destPath), { recursive: true })
+    fs.writeFileSync(opts.destPath, 'ok')
+    return { destPath: opts.destPath, local: false, size: 2 }
+  }
+
+  const outcome = await materializeCatalogFile(mount, share, entry())
+  await quiet()
+
+  t.is(outcome, 'present', 'the file landed')
+  t.ok(fs.existsSync(dest))
+  t.is((await rows()).length, 0, 'a 5,000-file mirror pass must not write 5,000 rows')
+})
+
+test('unmounting re-arms the memo — a remount is a fresh session', async (t) => {
+  const { mount, share } = await setup(t)
+  getOverlay().fetchFile = throwsWith('EHASHMISMATCH', 'hash mismatch')
+
+  await materializeCatalogFile(mount, share, entry())
+  await quiet()
+  await unmountForeignFolder(mount.spaceId, mount.shareId)
+  await saveForeignMount(mount)
+  await materializeCatalogFile(mount, share, entry())
+  await quiet()
+
+  t.is((await rows('security.integrity_failure')).length, 2,
+    'the user re-pointed the mount and deserves to be told the folder is still corrupt')
+})

--- a/test/integration/shutdown-audit.test.js
+++ b/test/integration/shutdown-audit.test.js
@@ -4,6 +4,7 @@ import { serveIndex } from '../../src/shared/transfer/backends/overlay/overlay-s
 import { onServeStart, onChunkServed } from '../../src/shared/transfer/serve-ledger.js'
 import { createSpace } from '../../src/shared/spaces/space.js'
 import { queryAudit } from '../../src/shared/audit/audit-log.js'
+import { recordTransferOutcome } from '../../src/shared/transfer/transfer-audit.js'
 
 const HASH = 'h'.repeat(64)
 const PEER = 'p'.repeat(64)
@@ -37,5 +38,33 @@ test('REGRESSION (LIFECYCLE-2e): a serve still live at shutdown is recorded', as
   const rows = await completed()
   t.is(rows.length, 1, 'the interrupted serve was recorded during the shutdown')
   t.is(rows[0].subject.bytes, 512, 'with the bytes actually served')
+  await after.tier.close()
+})
+
+// recordTransferOutcome issues an unawaited getSpace().then(record); OverlayBackend._close drains
+// those before the durable tier closes the audit bee. This asserts the OUTCOME — a burst settling at
+// shutdown loses no rows — and deliberately does NOT claim to be a regression test for the drain:
+// measured, it passes with the drain removed, because 100 queued spaces-bee reads still finish long
+// before the durable tier goes down. The window the drain closes is the one LIFECYCLE-2e proved real
+// for serve.completed, where the rows are created BY the teardown itself and the remaining time is a
+// fraction of this; reproducing that for a download needs a fetch settling mid-close, which is a race
+// no assertion can pin. The drain is defence in depth against a known-reachable window, not dead code.
+test('a burst of transfers settling during shutdown loses no audit rows', async (t) => {
+  const ctx = await freshPeer(t)
+  const space = await createSpace('Aurora')
+  const BURST = 100
+
+  for (let i = 0; i < BURST; i++) {
+    recordTransferOutcome({
+      spaceId: space.spaceId, path: '/Brand Assets/late-' + i + '.bin', relPath: 'late-' + i + '.bin',
+      shareId: 'sh1', folderName: 'Brand Assets', size: 2048, ownerPublicKey: PEER,
+    }, 'ok', null)
+  }
+  await ctx.root.close()
+
+  const after = await freshDurable(t, { storage: ctx.storage, displayName: null, masterSecret: ctx.masterSecret })
+  const rows = (await queryAudit({ limit: 500 })).entries.filter((e) => e.kind === 'transfer.completed')
+  t.is(rows.length, BURST, 'every audit write issued before the close landed')
+  t.is(rows[0].subject.folder, 'Brand Assets')
   await after.tier.close()
 })

--- a/test/unit/audit-row.test.js
+++ b/test/unit/audit-row.test.js
@@ -134,6 +134,23 @@ test("REGRESSION (FIX-META-I18N: the meta line's file count is translatable)", (
   for (const part of parts) t.ok(part.key || typeof part.text === 'string', 'every part is resolvable')
 })
 
+test('a folder-file transfer names its folder, between the space and the size', (t) => {
+  const parts = metaParts(row({
+    kind: 'transfer.completed',
+    subject: { folder: 'Brand Assets', bytes: 2411724, ownerKey: 'abc', shareId: 'sh1' },
+  }))
+  t.alike(parts.map((p) => p.text), ['Design Team', 'Brand Assets', formatBytes(2411724)])
+})
+
+test('a loose-file transfer renders no folder segment', (t) => {
+  const parts = metaParts(row({ kind: 'transfer.completed', subject: { folder: null, bytes: 1024 } }))
+  t.alike(parts.map((p) => p.text), ['Design Team', formatBytes(1024)])
+})
+
+test('an empty folder name renders nothing rather than an empty segment', (t) => {
+  t.alike(metaParts(row({ subject: { folder: '' } })), [{ text: 'Design Team' }])
+})
+
 test('meta line omits absent detail rather than printing empties', (t) => {
   t.alike(metaParts(row({ space: null, subject: null })), [])
   t.alike(metaParts(row({ subject: { bytes: null, fileCount: null } })), [{ text: 'Design Team' }])

--- a/test/unit/integrity-seen.test.js
+++ b/test/unit/integrity-seen.test.js
@@ -1,0 +1,76 @@
+import test from 'brittle'
+import { createIntegritySeen, DEFAULT_INTEGRITY_ROW_CAP } from '../../src/shared/folders/integrity-seen.js'
+
+const M = 'space1|folder1'
+
+test('the first claim is admitted and every repeat is refused', (t) => {
+  const seen = createIntegritySeen()
+  t.ok(seen.admit(M, 'a/doc.pdf', 'h1'), 'the first mismatch is a new fact')
+  t.absent(seen.admit(M, 'a/doc.pdf', 'h1'), 'the next 30s tick is the same fact')
+  t.absent(seen.admit(M, 'a/doc.pdf', 'h1'))
+  t.is(seen.size(M), 1)
+})
+
+test('a re-publish under a new hash is a NEW claim', (t) => {
+  const seen = createIntegritySeen()
+  t.ok(seen.admit(M, 'a/doc.pdf', 'h1'))
+  t.ok(seen.admit(M, 'a/doc.pdf', 'h2'), 'different bytes were advertised and they failed too')
+  t.is(seen.size(M), 2)
+})
+
+test('two files on one mount are two claims', (t) => {
+  const seen = createIntegritySeen()
+  t.ok(seen.admit(M, 'one.bin', 'h1'))
+  t.ok(seen.admit(M, 'two.bin', 'h1'))
+})
+
+test('two mounts do not share a memo', (t) => {
+  const seen = createIntegritySeen()
+  t.ok(seen.admit(M, 'doc.pdf', 'h1'))
+  t.ok(seen.admit('space1|folder2', 'doc.pdf', 'h1'), 'same file, different mount, different claim')
+})
+
+test('forget re-arms one mount and leaves the others alone', (t) => {
+  const seen = createIntegritySeen()
+  seen.admit(M, 'doc.pdf', 'h1')
+  seen.admit('space1|folder2', 'doc.pdf', 'h1')
+  seen.forget(M)
+  t.ok(seen.admit(M, 'doc.pdf', 'h1'), 'a remount is a fresh session')
+  t.absent(seen.admit('space1|folder2', 'doc.pdf', 'h1'), 'the sibling mount kept its memo')
+})
+
+test('clear re-arms everything', (t) => {
+  const seen = createIntegritySeen()
+  seen.admit(M, 'doc.pdf', 'h1')
+  seen.clear()
+  t.ok(seen.admit(M, 'doc.pdf', 'h1'))
+})
+
+test('a missing hash still forms a usable claim', (t) => {
+  const seen = createIntegritySeen()
+  t.ok(seen.admit(M, 'doc.pdf', null))
+  t.absent(seen.admit(M, 'doc.pdf', null))
+})
+
+test('the per-mount cap bounds the memo and announces itself exactly once', (t) => {
+  const capped = []
+  const seen = createIntegritySeen({ limit: 3, onCap: (key, n) => capped.push([key, n]) })
+  t.ok(seen.admit(M, 'f1', 'h'))
+  t.ok(seen.admit(M, 'f2', 'h'))
+  t.ok(seen.admit(M, 'f3', 'h'))
+  t.absent(seen.admit(M, 'f4', 'h'), 'past the cap nothing is admitted')
+  t.absent(seen.admit(M, 'f5', 'h'))
+  t.is(seen.size(M), 3, 'a 150k-file mirror cannot grow the memo without bound')
+  t.alike(capped, [[M, 3]], 'announced once, not on every later refusal')
+})
+
+test('one mount hitting its cap does not silence another', (t) => {
+  const seen = createIntegritySeen({ limit: 1 })
+  t.ok(seen.admit(M, 'f1', 'h'))
+  t.absent(seen.admit(M, 'f2', 'h'))
+  t.ok(seen.admit('space1|folder2', 'f2', 'h'))
+})
+
+test('the shipped default cap is a positive integer', (t) => {
+  t.ok(Number.isInteger(DEFAULT_INTEGRITY_ROW_CAP) && DEFAULT_INTEGRITY_ROW_CAP > 0)
+})


### PR DESCRIPTION
Closes architecture-review Defect 11 — the folder engine wrote no audit rows.

## What was broken

The Activity Log was retrofitted onto a codebase that already had two download channels, and it was attached to one of them. So a file downloaded out of a **folder share** produced no row at all: no `transfer.completed`, no `transfer.failed`, and — the one that matters — no `security.integrity_failure` when a holder served bytes that did not match their advertised hash. The same event on a space-root file has always been recorded. The mirror engine had the same gap: it caught `EHASHMISMATCH` and answered with a `log.warn`.

## Approach

Recording a terminal outcome is a step of the algorithm, not per-channel variance — it was misclassified. It moves into the **engine** (`transfer-audit.js`, called from one `failTerminal` exit plus one line on the success path), so no channel can skip it and a channel added later is audited by construction. Collapsing the four failure sites into one exit also removed a 4× duplicated `emitError` + `emitUpdated` pair.

The mirror gains only the integrity row, deduped per `(mount, file, hash)` and capped per mount. Routine per-file folder sync stays unrecorded, per the deliberate exclusion in `contract/audit-kinds.js`. No new audit kinds, so no i18n change.

Two latent bugs fixed rather than copied forward: `subject.ownerKey` read a field no job has (`ownerPublicKey`) and was `null` on every row ever written, and in-flight audit writes are now drained on shutdown.

## Testing

Unit (integrity memo, meta line) · Integration (`folder-download-audit`, `mirror-integrity-audit`, shutdown) · Flow (`audit-coverage` now drives a folder download) · Frontend `s125` **5/5**, exercising: A shares a folder → B downloads a file → the row appears in B's Activity Log reading "You downloaded logo.txt / Aurora · Brand Assets · 512 B" → survives the Files filter, absent under Security.

Red-first verified: disabling the engine's record calls turns the regression tests red (`actual: 0, expected: 1`).

Local runs: `typecheck` clean · `lint:ci` 0 errors · `test:node:core` 1616/1616 · `test:bare` 952/952 · `test:flow` audit-coverage 3/3 · `test:fe s125` 5/5 · dev axe clean, no new a11y violations (one added text node, no new interactive control).

## Note for plan-parallel-impl-01

Its factory should now drop `audit` from the descriptor and the `recordAudit` flag entirely, and extend `folder-download-audit.test.js` rather than recreate it.
