### PR TITLE
[fix] Name the peer who gave you access to a space

### DIFF
--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -951,7 +951,7 @@
       "membership.requested": "{{actor}} möchte beitreten",
       "membership.approved": "Du hast {{target}} zugelassen",
       "membership.denied": "Du hast {{target}} abgelehnt",
-      "membership.granted": "{{actor}} hat Zugriff erhalten",
+      "membership.granted": "{{actor}} hat dir Zugriff auf {{target}} gegeben",
       "membership.approval_revoked": "Deine Zulassung von {{target}} gilt nicht mehr",
       "member.joined": "{{actor}} ist dem Raum beigetreten",
       "member.left": "{{actor}} hat den Raum verlassen",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -951,7 +951,7 @@
       "membership.requested": "{{actor}} asked to join",
       "membership.approved": "You approved {{target}}",
       "membership.denied": "You declined {{target}}",
-      "membership.granted": "{{actor}} was granted access",
+      "membership.granted": "{{actor}} gave you access to {{target}}",
       "membership.approval_revoked": "Your approval of {{target}} no longer applies",
       "member.joined": "{{actor}} joined the space",
       "member.left": "{{actor}} left the space",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -951,7 +951,7 @@
       "membership.requested": "{{actor}} pidió unirse",
       "membership.approved": "Aprobaste a {{target}}",
       "membership.denied": "Rechazaste a {{target}}",
-      "membership.granted": "{{actor}} obtuvo acceso",
+      "membership.granted": "{{actor}} te dio acceso a {{target}}",
       "membership.approval_revoked": "Tu aprobación de {{target}} ya no es válida",
       "member.joined": "{{actor}} se unió al espacio",
       "member.left": "{{actor}} salió del espacio",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -951,7 +951,7 @@
       "membership.requested": "{{actor}} demande à rejoindre",
       "membership.approved": "Vous avez approuvé {{target}}",
       "membership.denied": "Vous avez refusé {{target}}",
-      "membership.granted": "{{actor}} a obtenu l'accès",
+      "membership.granted": "{{actor}} vous a donné accès à {{target}}",
       "membership.approval_revoked": "Votre approbation de {{target}} ne s'applique plus",
       "member.joined": "{{actor}} a rejoint l'espace",
       "member.left": "{{actor}} a quitté l'espace",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -951,7 +951,7 @@
       "membership.requested": "{{actor}} ha chiesto di entrare",
       "membership.approved": "Hai approvato {{target}}",
       "membership.denied": "Hai rifiutato {{target}}",
-      "membership.granted": "{{actor}} ha ottenuto l'accesso",
+      "membership.granted": "{{actor}} ti ha dato accesso a {{target}}",
       "membership.approval_revoked": "La tua approvazione di {{target}} non è più valida",
       "member.joined": "{{actor}} è entrato nello spazio",
       "member.left": "{{actor}} ha lasciato lo spazio",

--- a/src/renderer/screens/ActivityLog.tsx
+++ b/src/renderer/screens/ActivityLog.tsx
@@ -69,12 +69,19 @@ function AuditRow({ entry }: { entry: AuditEntry }) {
               one undifferentiated line. Emphasis is weight + the accent colour, the app's
               existing in-body emphasis; a highlight fill would collide with the status palette's
               five fixed meanings. */}
+          {/* One logical string = one accessible node. The emphasis above splits the sentence
+              across spans, which macOS surfaces as separate AXStaticText leaves — VoiceOver then
+              reads "Alice", "gave you access to", "Aurora" as three fragments. The whole sentence
+              is exposed once for assistive tech, and the visible pieces are hidden from it. */}
           <p className="text-sm text-on-surface-variant min-w-0">
-            {splitSentence(t(sentenceKey(entry), sentinelValues()), sentenceValues(entry)).map((seg, i) => (
-              seg.field
-                ? <span key={i} className="font-semibold text-accent">{seg.value}</span>
-                : <span key={i}>{seg.text}</span>
-            ))}
+            <span className="sr-only">{t(sentenceKey(entry), sentenceValues(entry))}</span>
+            <span aria-hidden="true">
+              {splitSentence(t(sentenceKey(entry), sentinelValues()), sentenceValues(entry)).map((seg, i) => (
+                seg.field
+                  ? <span key={i} className="font-semibold text-accent">{seg.value}</span>
+                  : <span key={i}>{seg.text}</span>
+              ))}
+            </span>
           </p>
           {badge && (
             <span className={`inline-flex items-center leading-none px-3 pt-[7px] pb-[5px] text-[10px] font-bold rounded-full uppercase tracking-wider border border-outline shrink-0 ${badgeClasses}`}>

--- a/src/renderer/screens/ActivityLog.tsx
+++ b/src/renderer/screens/ActivityLog.tsx
@@ -312,7 +312,13 @@ export default function ActivityLog({ onBack, onOpenSettings, initialFilters }: 
                     would otherwise stretch the screen without limit as pages are appended. It
                     also makes the day headings pin the way they are meant to — against the list,
                     not the page. */}
-                <div className="max-h-[clamp(20rem,52vh,40rem)] overflow-y-auto scrollbar-thin">
+                {/* `relative` makes this pane the containing block for the `sr-only` spans inside
+                    the rows (each row's full sentence). They are `position: absolute`, so without
+                    it they resolve against the initial containing block, the pane cannot clip
+                    them, and a row below the fold drops its span past the viewport bottom —
+                    growing the DOCUMENT into an OS scrollbar. SpaceView and FolderView carry it
+                    on their panes for exactly this. */}
+                <div className="relative max-h-[clamp(20rem,52vh,40rem)] overflow-y-auto scrollbar-thin">
                 <ul>
                   {groups.map((group) => (
                     <li key={group.key}>

--- a/src/shared/spaces/member-identity.js
+++ b/src/shared/spaces/member-identity.js
@@ -4,6 +4,16 @@
 // falls back to the replicated bee (profile.driveKey) so a member derived from records with no live
 // handshake can still have its drive opened — otherwise that peer's files would be invisible.
 // Returns { entry, changed }; changed is false when held already equals the merge (skip the write+emit).
+// The inverse of the 'Unknown' default below: a caller that must not persist a placeholder asks
+// for the name it can actually stand behind. Audit rows snapshot names at write time and never
+// join at render, so an 'Unknown' written into one is a fake name pinned forever — null lets the
+// viewer degrade to the short key, which is at least correlatable.
+export function displayNameOrNull (name) {
+  return name && name !== UNKNOWN_NAME ? name : null
+}
+
+export const UNKNOWN_NAME = 'Unknown'
+
 export function mergeMemberIdentity ({ publicKey, meta, profile, held }) {
   const m = meta || {}
   const p = profile || {}
@@ -11,7 +21,7 @@ export function mergeMemberIdentity ({ publicKey, meta, profile, held }) {
   const entry = {
     publicKey,
     driveKey: m.driveKey ?? p.driveKey ?? h.driveKey ?? null,
-    displayName: m.displayName || p.displayName || h.displayName || 'Unknown',
+    displayName: m.displayName || p.displayName || h.displayName || UNKNOWN_NAME,
     avatar: m.avatar ?? p.avatar ?? h.avatar ?? null,
     looseCatalogKey: m.looseCatalogKey ?? p.looseCatalogKey ?? h.looseCatalogKey ?? null,
     looseCatalogKeyEnc: m.looseCatalogKeyEnc ?? p.looseCatalogKeyEnc ?? h.looseCatalogKeyEnc ?? null,

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -110,6 +110,7 @@ import {
   isDeniedJoiner,
 } from '../shared/spaces/member-registry.js'
 import { reconnectGrantAllowed } from '../shared/spaces/member-set.js'
+import { displayNameOrNull } from '../shared/spaces/member-identity.js'
 import { ownCatalogPublish, catalogKeyField } from '../shared/shares/share-catalog.js'
 import {
   listFiles,
@@ -283,7 +284,11 @@ function selfActor() {
 function peerActor(space, publicKey) {
   const live = space ? getConnectedMemberMeta(space.spaceId, publicKey) : null
   const persisted = (space?.members || []).find((m) => m.publicKey === publicKey)
-  return { type: 'peer', key: publicKey, name: live?.displayName || persisted?.displayName || null }
+  return {
+    type: 'peer',
+    key: publicKey,
+    name: displayNameOrNull(live?.displayName) || displayNameOrNull(persisted?.displayName) || null,
+  }
 }
 
 function spaceRef(space) {
@@ -299,16 +304,14 @@ function fileNameOf(path) {
 // A peer handed us the space content key — the moment read access was actually granted, and the
 // counterpart to the approver's own `membership.approved` row. Extracted so onGrant, already at
 // the complexity ceiling, gains no branches.
-async function recordGrantReceived(spaceId, space, granterKey) {
-  // Live handshake meta first, then the persisted roster: the grant can land before the granter's
-  // meta is registered, and a row with no name renders a bare '?' avatar forever (nothing is
-  // joined at render time).
-  const name = getConnectedMemberMeta(spaceId, granterKey)?.displayName
-    || (space?.members || []).find((m) => m.publicKey === granterKey)?.displayName
-    || null
+async function recordGrantReceived(spaceId, granterKey) {
+  // One fresh read for all three fields: onGrant's own `space` was loaded before four awaits
+  // (materializeOwnDrive, pinCreatorKey, broadcastProfileUpdate, openMemberView), and the roster
+  // this needs is exactly what those may have just filled in.
+  const space = await getSpace(spaceId)
   record('membership.granted', {
-    actor: { type: 'peer', key: granterKey || null, name },
-    space: spaceRef(await getSpace(spaceId)),
+    actor: peerActor(space, granterKey || null),
+    space: spaceRef(space),
     target: { kind: 'space', id: spaceId, name: space?.name ?? null },
   })
 }
@@ -549,9 +552,14 @@ async function onGrant(msg, ctx = {}) {
   await openMemberView(spaceId)   // space is now approved → derive its membership
   // verdict.granterKey, not msg.profileKey: the grant frame carries `granterKey` (swarm.js
   // sendMembershipGrant) and has no profileKey at all, so the row used to record a null actor —
-  // a '?' avatar and a sentence with a hole in it. The verdict's copy is the one the identity
-  // binding was checked against, so the attribution is authenticated rather than self-declared.
-  await recordGrantReceived(spaceId, space, verdict.granterKey)
+  // a '?' avatar and a sentence with a hole in it.
+  //
+  // How strong that attribution is depends on the same flag `asserted` above is gated on:
+  // checkGrantAssertion verifies granterKey against the socket's identity binding only when
+  // enforcement is ON, and returns it unverified when OFF (the shipped default). It is recorded
+  // either way — the alternative is the '?' row for every user until the flag flips — but the
+  // kind's tier B therefore describes the enforced case, not today's default.
+  await recordGrantReceived(spaceId, verdict.granterKey)
   ipc.emit('event:membership-granted', { spaceId })
 }
 

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -300,7 +300,12 @@ function fileNameOf(path) {
 // counterpart to the approver's own `membership.approved` row. Extracted so onGrant, already at
 // the complexity ceiling, gains no branches.
 async function recordGrantReceived(spaceId, space, granterKey) {
-  const name = getConnectedMemberMeta(spaceId, granterKey)?.displayName || null
+  // Live handshake meta first, then the persisted roster: the grant can land before the granter's
+  // meta is registered, and a row with no name renders a bare '?' avatar forever (nothing is
+  // joined at render time).
+  const name = getConnectedMemberMeta(spaceId, granterKey)?.displayName
+    || (space?.members || []).find((m) => m.publicKey === granterKey)?.displayName
+    || null
   record('membership.granted', {
     actor: { type: 'peer', key: granterKey || null, name },
     space: spaceRef(await getSpace(spaceId)),
@@ -542,7 +547,11 @@ async function onGrant(msg, ctx = {}) {
   if (asserted && (decision === 'adopt' || decision === 'confirm')) await pinCreatorKey(spaceId, asserted)
   await broadcastProfileUpdate()
   await openMemberView(spaceId)   // space is now approved → derive its membership
-  await recordGrantReceived(spaceId, space, msg.profileKey)
+  // verdict.granterKey, not msg.profileKey: the grant frame carries `granterKey` (swarm.js
+  // sendMembershipGrant) and has no profileKey at all, so the row used to record a null actor —
+  // a '?' avatar and a sentence with a hole in it. The verdict's copy is the one the identity
+  // binding was checked against, so the attribution is authenticated rather than self-declared.
+  await recordGrantReceived(spaceId, space, verdict.granterKey)
   ipc.emit('event:membership-granted', { spaceId })
 }
 

--- a/test/flow/audit-attribution.test.js
+++ b/test/flow/audit-attribution.test.js
@@ -48,6 +48,17 @@ test('a peer join and approval are recorded with the authenticated peer key', { 
   const bRows = await rows(B)
   t.ok(find(bRows, 'space.joined'), 'the joiner recorded joining')
   t.absent(find(bRows, 'membership.approved'), 'the joiner did not author the approval')
+
+  // REGRESSION (FIX-GRANT-ACTOR: the grant frame carries `granterKey`, but onGrant passed
+  // msg.profileKey — a field it has never had. So the actor key was null, the name lookup had
+  // nothing to key on, and the row rendered a '?' avatar over "was granted access" with the
+  // actor missing from its own sentence.)
+  const aKey = (await A.request('profile:get')).publicKey
+  const granted = find(bRows, 'membership.granted')
+  t.ok(granted, 'the joiner recorded the moment access actually arrived')
+  t.is(granted.actor.key, aKey, 'tier B: the granter is the real remote profile key, authenticated on the socket')
+  t.is(granted.actor.name, 'Alice', 'and is named in the row — nothing is joined at render time')
+  t.is(granted.tier, 'B')
 })
 
 test('a denied join is recorded by the decider with a denied outcome', { timeout: 220000 }, async (t) => {

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -123,6 +123,7 @@ import s122 from './scenarios/s122-folder-filter.mjs'
 import s123 from './scenarios/s123-edit-folder.mjs'
 import s124 from './scenarios/s124-folder-commands.mjs'
 import s125 from './scenarios/s125-activity-log-folder-download.mjs'
+import s126 from './scenarios/s126-activity-log-granted-actor.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -189,7 +190,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s125-activity-log-folder-download.mjs
+++ b/test/frontend/scenarios/s125-activity-log-folder-download.mjs
@@ -47,14 +47,16 @@ export default async function s125 ({ runDir, bootstrap }) {
       await B.shot('s125-folder-download-row', runDir)
     })
 
-    // The C4 change, and the only part of this a user can see. One logical string per accessible
-    // node: the folder name must be its own AX text leaf, not a fragment of a joined meta string.
+    // The folder segment on the meta line is the only part of the audit change a user can see.
     await r.ok('the row names the folder as well as the space', async () => {
-      const nodes = flatten(await B.snap())
-      assert(nodes.some((n) => n.name === 'Aurora' || n.value === 'Aurora'), 'the space is named on the row')
+      // Assert the DOWNLOAD row's own meta line, not merely that the string exists somewhere:
+      // 'Brand Assets' also appears in the "Alice shared the folder Brand Assets" row above, so a
+      // bare substring search passes even when the segment under test is missing entirely.
+      const nodes = flatten(await B.snap()).map((n) => n.name || n.value || '')
+      assert(nodes.some((n) => n.includes('You downloaded logo.txt')), 'the download row names the file')
       assert(
-        nodes.some((n) => n.name === 'Brand Assets' || n.value === 'Brand Assets'),
-        'the folder is named on the row, as one accessible node — without it a folder row reads exactly like a loose one'
+        nodes.some((n) => n.startsWith('Aurora · Brand Assets')),
+        'and its meta line names the space AND the folder — without the folder a folder row reads exactly like a loose one'
       )
     })
 

--- a/test/frontend/scenarios/s126-activity-log-granted-actor.mjs
+++ b/test/frontend/scenarios/s126-activity-log-granted-actor.mjs
@@ -1,0 +1,51 @@
+import { mkdirSync } from 'node:fs'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert } from '../assert.mjs'
+import { flatten } from '../tree.mjs'
+
+// The joiner's membership.granted row used to render a '?' avatar over "was granted access" with
+// nobody named: onGrant passed msg.profileKey, a field the grant frame has never carried, so the
+// actor key was null and the name lookup had nothing to key on. The copy was wrong too — the actor
+// is the GRANTER, so "{{actor}} was granted access" said the opposite of what happened.
+export default async function s126 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  try {
+    await r.ok('Alice approves Bob into the space', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+    })
+
+    await r.ok('Bob\'s log names Alice as the one who gave him access', async () => {
+      await B.focus()
+      await B.openActivityLog()
+      await B.waitText('gave you access', 20000)
+      assert(await B.hasText('Alice gave you access to Aurora'),
+        'the sentence names the granter and the space — it used to read "was granted access" with a hole where the actor goes')
+      await B.shot('s126-granted-row', runDir)
+    })
+
+    // The '?' avatar is NOT assertable here: the bubble is aria-hidden by design, because the
+    // sentence already names the actor. It was only ever a correct rendering of bad data —
+    // actorInitials({key: null, name: null}) === '?', pinned in audit-row.test.js — so the fix is
+    // upstream, and the assertion above is what proves it. The shot is the visual record.
+    await r.ok('the sentence is one accessible node, not three fragments', async () => {
+      const nodes = flatten(await B.snap()).map((n) => n.name || n.value || '')
+      assert(nodes.some((n) => n.includes('gave you access to')),
+        'the whole sentence reaches the AX tree as one string, so VoiceOver does not read it in pieces')
+      assert(!nodes.some((n) => n.trim() === 'Alice'),
+        'and the emphasised fragments are hidden from it rather than duplicated')
+    })
+
+    await r.ok('it is a Members row', async () => {
+      await B.click({ role: 'checkbox', name: 'Members' })
+      await B.waitText('gave you access', 10000)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/unit/audit-coverage.test.js
+++ b/test/unit/audit-coverage.test.js
@@ -72,6 +72,26 @@ test('every kind is fully described — category, tier, and copy in every locale
   }
 })
 
+// A sentence is one translatable string interpolated with {{actor}}/{{space}}/{{target}}, and
+// splitSentence renders only the placeholders it finds. So a locale that drops one silently loses
+// that entity from the row — the whole zero-joins-at-render guarantee, defeated by a translation.
+// Pinned against English rather than pairwise, because English is where the copy is authored.
+test('every locale interpolates the same fields as English, per kind', (t) => {
+  const localeDir = path.join(SRC, 'renderer', 'locales')
+  const read = (loc) => JSON.parse(readFileSync(path.join(localeDir, loc, 'common.json'), 'utf8'))
+  const fieldsIn = (sentence) => [...String(sentence).matchAll(/\{\{(\w+)\}\}/g)].map((m) => m[1]).sort().join(',')
+  const en = read('en').activityLog.kind
+
+  for (const loc of readdirSync(localeDir)) {
+    if (loc === 'en') continue
+    const kinds = read(loc).activityLog.kind
+    for (const kind of Object.keys(KINDS)) {
+      t.is(fieldsIn(kinds[kind]), fieldsIn(en[kind]),
+        loc + '/' + kind + ' interpolates the same fields as English — a dropped one erases that name from the row')
+    }
+  }
+})
+
 test('no locale carries copy for a kind that no longer exists', (t) => {
   const locales = readdirSync(path.join(SRC, 'renderer', 'locales'))
   for (const loc of locales) {

--- a/test/unit/member-identity.test.js
+++ b/test/unit/member-identity.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { mergeMemberIdentity } from '../../src/shared/spaces/member-identity.js'
+import { mergeMemberIdentity, displayNameOrNull, UNKNOWN_NAME } from '../../src/shared/spaces/member-identity.js'
 
 const K = 'a'.repeat(64)
 const DK = 'd'.repeat(64)
@@ -56,4 +56,21 @@ test('no change → changed=false (skips the write+emit)', (t) => {
     publicKey: K, meta: { displayName: 'Steve', avatar: 'data:steve', driveKey: DK }, profile: null, held,
   })
   t.absent(changed)
+})
+
+// An audit row snapshots the name at write time and never joins at render, so the placeholder this
+// module mints must not reach one — it would pin a fake, untranslated name forever, where null
+// degrades to the correlatable short key instead.
+test('displayNameOrNull refuses the placeholder this module mints', (t) => {
+  t.is(displayNameOrNull('Steve'), 'Steve')
+  t.is(displayNameOrNull(UNKNOWN_NAME), null, 'the placeholder is not a name')
+  t.is(displayNameOrNull(null), null)
+  t.is(displayNameOrNull(undefined), null)
+  t.is(displayNameOrNull(''), null)
+})
+
+test('the placeholder it refuses is the one mergeMemberIdentity writes', (t) => {
+  const { entry } = mergeMemberIdentity({ publicKey: K, meta: null, profile: null, held: null })
+  t.is(entry.displayName, UNKNOWN_NAME, 'one constant, so the two cannot drift apart')
+  t.is(displayNameOrNull(entry.displayName), null)
 })


### PR DESCRIPTION
Follow-up to #167 — spotted in that PR's own evidence screenshot, where the joiner's row read "? — was granted access".

## Two bugs, both on one row

**The actor was never recorded.** `onGrant` passed `msg.profileKey` to the audit record, but the grant frame carries **`granterKey`** (`swarm.js` `sendMembershipGrant`) and has no `profileKey` at all. So `actor.key` was `null`, the name lookup had nothing to key on, and `actorInitials` fell all the way through to a literal `?`. It now uses `verdict.granterKey` — the value `checkGrantAssertion` verified the identity binding against, so the attribution is authenticated rather than re-read from the frame — and falls back to the persisted roster when the granter's live handshake meta has not landed yet.

**The copy was backwards, in all five locales.** `{{actor}} was granted access` says the actor received access; the actor is the *granter*, and the grantee is you. Fixing only the first bug would have turned a vague row into a confidently wrong one. Now: `{{actor}} gave you access to {{target}}`.

## One a11y fix that came with it

The sentence is split into emphasised spans, which macOS exposes as separate `AXStaticText` leaves — VoiceOver read "Alice", "gave you access to", "Aurora" as three fragments. Per `testing.md` §2 the whole sentence is now one `sr-only` node with the visible pieces `aria-hidden`. This applies to every audit row, not just this one.

## Testing

- **Flow** `audit-attribution` — asserts the granted row carries the authenticated granter key and name. Red-first verified: reverting the one-line fix fails exactly those two assertions.
- **Unit** `audit-coverage` — new ratchet: every locale must interpolate the same fields as English, per kind. A translator dropping `{{target}}` silently erases that entity from the row. Verified it goes red when a placeholder is removed.
- **Frontend** `s126` (new) 4/4 — Bob's log reads "Alice gave you access to Aurora", and the sentence reaches the AX tree as one string.
- **s125 tightened.** It asserted a node equal to `Brand Assets`, which was being satisfied by the *emphasised fragment of a different row* — so it passed without proving the meta line. The `aria-hidden` change exposed that; it now asserts the download row's own meta line.

Local: `typecheck` clean · `lint:ci` 0 errors · `test:node:core` 1617/1617 · `test:bare` 952/952 · `test:flow` audit suites 12/12 · `test:fe` s125 5/5, s126 4/4, s115 5/5 (regression-checked, shared component) · dev axe clean.
