### PR TITLE
[fix] Make the path field readable and honest while it loads

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -432,8 +432,18 @@ once the first freezes at zero width Chromium leaves the rest overflowing, which
 folder name ended up painted over the Browse button. `npm run test:layout:truncation` pins it.
 
 - **The label follows the state, not the caller.** No path yet → `pathField.browse` ("Browse…");
-  a path in the field → `actions.change` ("Change"). Callers used to pass it and had picked four
-  different strings for the one action. `actionLabel` overrides, and nothing currently needs to.
+  a path in the field, **or one still loading** → `actions.change` ("Change"). Callers used to pass
+  it and had picked four different strings for the one action. There is no override: the one that
+  replaced those four was forbidden to every caller by the same test that introduced it.
+- **`loading` is a third state, not an empty path.** A download folder always resolves to
+  something — a space's override, else the global default — so a read still in flight is a path
+  whose text has not arrived, not the absence of one. Conflating them offered a first pick for a
+  folder that already exists and flipped the button label when the read landed. The field says
+  `pathField.loading` and the button already reads "Change".
+- **The placeholder is `text-on-surface-variant`, never `text-outline`.** `outline` is the
+  badge/dropzone *border* token; as the field's only content it measures 2.63:1 (light) and 1.90:1
+  (dark) at 70% opacity, well under the 4.5:1 AA floor. The muted-text token clears it in both
+  themes (8.4–12:1), and italic is what still reads it as a hint.
 - **`fill` picks the ramp step**, because the ground differs: `low` (default) sits on a modal
   panel, which is `surface-container-lowest`. A settings card is itself `surface-container-low` —
   same token, same hex in both themes — so a row inside one passes `fill="lowest"` or the field

--- a/src/renderer/components/modals/EditSpaceModal.tsx
+++ b/src/renderer/components/modals/EditSpaceModal.tsx
@@ -32,7 +32,9 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   const [saving, setSaving] = useState(false)
   // undefined = untouched, null = reset to the global default, string = new override.
   const [folderEdit, setFolderEdit] = useState<string | null | undefined>(undefined)
-  const [globalDefault, setGlobalDefault] = useState('')
+  // null until the read lands. A space always resolves to SOME folder — its own override or the
+  // global default — so an unresolved read is a path still loading, not the absence of one.
+  const [globalDefault, setGlobalDefault] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
   const browseRef = useRef<HTMLButtonElement>(null)
 
@@ -40,13 +42,19 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
     let cancelled = false
     window.bridge.getDownloadFolder()
       .then((folder) => { if (!cancelled) setGlobalDefault(folder) })
-      .catch(() => {})
+      .catch((err) => {
+        if (cancelled) return
+        setGlobalDefault('')
+        setError(err instanceof Error ? err.message : String(err))
+      })
     return () => { cancelled = true }
   }, [])
 
-  const effectiveFolder = folderEdit === undefined
-    ? (space.downloadFolder ?? globalDefault)
-    : (folderEdit ?? globalDefault)
+  // Only the fallback to the global default can be pending; a picked folder or the space's own
+  // override is already in hand.
+  const ownFolder = folderEdit === undefined ? space.downloadFolder : folderEdit
+  const awaitingDefault = !ownFolder && globalDefault === null
+  const effectiveFolder = ownFolder ?? globalDefault ?? ''
   const isOverridden = folderEdit === undefined ? !!space.downloadFolder : folderEdit !== null
 
   const hasChanges = name.trim() !== space.name || icon !== space.icon || folderEdit !== undefined
@@ -136,6 +144,7 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
                 path is a path, whichever door you came through. */}
             <PathRow
               path={effectiveFolder || null}
+              loading={awaitingDefault}
               onAction={handleBrowse}
               ariaDescribedBy="edit-space-folder-label edit-space-folder-desc"
               actionRef={browseRef}

--- a/src/renderer/components/widgets/PathRow.tsx
+++ b/src/renderer/components/widgets/PathRow.tsx
@@ -6,8 +6,12 @@ interface PathRowProps {
   path: string | null
   /** Shown in place of the path when there is none yet. Defaults to the pick-a-location hint. */
   placeholder?: string
-  /** Overrides the label. Leave unset — the default already says the right verb for the state. */
-  actionLabel?: string
+  /**
+   * A path exists but its text has not arrived yet. Distinct from having none: the field says so
+   * instead of offering a first pick, and the button already reads as a re-pick, so the label does
+   * not flip once the read lands.
+   */
+  loading?: boolean
   /** Omit for a display-only row — the field keeps its shape, the button is absent. */
   onAction?: () => void
   ariaDescribedBy?: string
@@ -37,9 +41,13 @@ const FILL = {
 // way, and the button's presence is what says whether you can change it.
 //
 // The label follows the state rather than the caller: nothing picked yet is a first pick
-// ("Browse…"), a path already in the field is a re-pick ("Change"). Callers used to choose, and
-// chose four different strings for the one action.
-export default function PathRow({ path, placeholder, actionLabel, onAction, ariaDescribedBy, actionRef, fill = 'low' }: PathRowProps) {
+// ("Browse…"), a path already in the field — or one still loading — is a re-pick ("Change").
+// Callers used to choose, and chose four different strings for the one action.
+//
+// The placeholder is muted TEXT, not an outline: `outline` is the badge/dropzone border token and
+// fails AA against every fill in both themes (2.5:1 and worse in dark), which is what a field
+// showing its hint as its only content was rendering.
+export default function PathRow({ path, placeholder, loading = false, onAction, ariaDescribedBy, actionRef, fill = 'low' }: PathRowProps) {
   const { t } = useTranslation()
   return (
     <div className="flex items-center gap-3">
@@ -47,7 +55,9 @@ export default function PathRow({ path, placeholder, actionLabel, onAction, aria
         {path ? (
           <FilePath path={path} className="flex-1 text-sm text-accent font-medium" />
         ) : (
-          <span className="text-sm text-outline/70 italic">{placeholder ?? t('pathField.placeholder')}</span>
+          <span className="text-sm text-on-surface-variant italic">
+            {loading ? t('pathField.loading') : placeholder ?? t('pathField.placeholder')}
+          </span>
         )}
       </div>
       {onAction && (
@@ -58,7 +68,7 @@ export default function PathRow({ path, placeholder, actionLabel, onAction, aria
           aria-describedby={ariaDescribedBy}
           className="shrink-0 bg-surface-control text-accent rounded-xl px-5 py-3.5 font-headline font-bold text-sm hover:bg-surface-control-hover active:scale-95 transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30"
         >
-          {actionLabel ?? (path ? t('actions.change') : t('pathField.browse'))}
+          {path || loading ? t('actions.change') : t('pathField.browse')}
         </button>
       )}
     </div>

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -172,6 +172,7 @@
   },
   "pathField": {
     "browse": "Durchsuchen…",
+    "loading": "Wird geladen…",
     "placeholder": "Ort auswählen…"
   },
   "folder": {

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -196,6 +196,7 @@
   },
   "pathField": {
     "browse": "Browse…",
+    "loading": "Loading…",
     "placeholder": "Select location…"
   },
   "folder": {

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -172,6 +172,7 @@
   },
   "pathField": {
     "browse": "Examinar…",
+    "loading": "Cargando…",
     "placeholder": "Selecciona una ubicación…"
   },
   "folder": {

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -172,6 +172,7 @@
   },
   "pathField": {
     "browse": "Parcourir…",
+    "loading": "Chargement…",
     "placeholder": "Choisir un emplacement…"
   },
   "folder": {

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -172,6 +172,7 @@
   },
   "pathField": {
     "browse": "Sfoglia…",
+    "loading": "Caricamento…",
     "placeholder": "Seleziona posizione…"
   },
   "folder": {

--- a/src/renderer/screens/StorageSettings.tsx
+++ b/src/renderer/screens/StorageSettings.tsx
@@ -78,7 +78,9 @@ function samePath(a: string, b: string) {
 export default function StorageSettings({ onBack }: StorageSettingsProps) {
   const { t } = useTranslation()
   const { t: tErr } = useTranslation('errors')
-  const [downloadFolder, setDownloadFolder] = useState<string>('')
+  // null until the read lands: the field says it is loading rather than offering a first pick
+  // for a folder that always exists.
+  const [downloadFolder, setDownloadFolder] = useState<string | null>(null)
   const [folderError, setFolderError] = useState<string | null>(null)
   const [detailsOpen, setDetailsOpen] = useState(false)
   const { unavailable: unavailableRoots, refresh: refreshRootStatus } = useDownloadRootStatus()
@@ -95,7 +97,13 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
     let cancelled = false
     window.bridge.getDownloadFolder()
       .then((folder) => { if (!cancelled) setDownloadFolder(folder) })
-      .catch(() => {})
+      // Swallowed, this left the row claiming to be loading for the rest of the session. Say it,
+      // and drop out of the loading state so the row offers the pick that would fix it.
+      .catch((err) => {
+        if (cancelled) return
+        setDownloadFolder('')
+        setFolderError(err instanceof Error ? err.message : String(err))
+      })
     return () => { cancelled = true }
   }, [])
 
@@ -123,8 +131,10 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
   // main stores the path the picker returned, the worker stores its own resolved + NFC-normalized
   // copy — so compare them normalized instead of raw, or a folder with an umlaut in its name
   // silently fails to match and the warning never shows.
-  const folderUnavailable = downloadFolder.length > 0
-    && unavailableRoots.some((root) => samePath(root, downloadFolder))
+  // Not yet read is not "unavailable": the warning stays down until there is a folder to test.
+  const knownFolder = downloadFolder ?? ''
+  const folderUnavailable = knownFolder.length > 0
+    && unavailableRoots.some((root) => samePath(root, knownFolder))
 
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
 
@@ -152,7 +162,7 @@ export default function StorageSettings({ onBack }: StorageSettingsProps) {
                   `surface-container-low`, which the field's default fill would vanish into. */}
               <PathRow
                 path={downloadFolder || null}
-                placeholder={t('storageSettings.calculating')}
+                loading={downloadFolder === null}
                 onAction={handleBrowseFolder}
                 ariaDescribedBy="storage-download-folder-desc"
                 fill="lowest"

--- a/test/unit/path-field-harmonized.test.js
+++ b/test/unit/path-field-harmonized.test.js
@@ -57,13 +57,45 @@ test('every path the user can re-pick goes through PathRow', (t) => {
 
 test('the path button label is derived, never passed', (t) => {
   // Four strings once said the one thing — "Browse…", "Change", "Change…", "Change folder" — one
-  // per caller. PathRow now derives it from whether there is a path yet, so a caller that passes
-  // its own is re-opening that drift.
-  t.ok(/actionLabel \?\? \(path \? t\('actions\.change'\) : t\('pathField\.browse'\)\)/.test(pathRow),
+  // per caller. PathRow derives it from whether there is a path, so a caller that passes its own is
+  // re-opening that drift. The override that replaced those four was itself unreachable: this test
+  // forbade every caller from passing it, so the prop existed only to be refused.
+  t.ok(/path \|\| loading \? t\('actions\.change'\) : t\('pathField\.browse'\)/.test(pathRow),
     'PathRow derives the label from the presence of a path')
+  t.absent(/actionLabel/.test(pathRow), 'and keeps no override for a caller to reach for')
   for (const f of files) {
     if (f.rel === 'components/widgets/PathRow.tsx') continue
     t.absent(/<PathRow[^>]*actionLabel/s.test(f.src), `${f.rel} must not override the path button label`)
+  }
+})
+
+// REGRESSION (FIX-PATHFIELD-1: the field rendered its only content in `outline`, a border token
+// that fails AA against every fill in both themes — 2.63:1 light and 1.90:1 dark at 70% opacity).
+test('the path field placeholder is muted TEXT, not a border colour', (t) => {
+  const placeholder = pathRow.slice(pathRow.indexOf('<span className="text-sm'))
+  t.absent(/text-outline/.test(placeholder), 'outline is the badge/dropzone border token, not a text one')
+  t.ok(/text-on-surface-variant/.test(placeholder), 'muted secondary text is the token design.md assigns')
+})
+
+// A path that is still loading is not a path the user has yet to pick. Conflating them showed the
+// first-pick affordance — "Select location…" plus "Browse…" — for a folder that always exists, and
+// flipped the button label once the read landed.
+test('a path still loading is a third state, not an absent path', (t) => {
+  t.ok(/loading \? t\('pathField\.loading'\)/.test(pathRow), 'the field says it is loading')
+  t.ok(/loading\?: boolean/.test(pathRow), 'and the state is declared, not inferred from an empty string')
+  for (const rel of ['screens/StorageSettings.tsx', 'components/modals/EditSpaceModal.tsx']) {
+    const src = files.find((f) => f.rel === rel).src
+    t.ok(/<PathRow[^>]*loading=/s.test(src), `${rel} resolves its folder asynchronously and must say so`)
+  }
+})
+
+// Both reads fell back to a folder that always exists, so a swallowed failure left the row
+// describing a state that would never end.
+test('a failed download-folder read is surfaced, never swallowed', (t) => {
+  for (const rel of ['screens/StorageSettings.tsx', 'components/modals/EditSpaceModal.tsx']) {
+    const src = files.find((f) => f.rel === rel).src
+    const read = src.slice(src.indexOf('window.bridge.getDownloadFolder()'))
+    t.absent(/^\s*\.catch\(\(\) => \{\}\)/m.test(read.slice(0, 600)), `${rel} must not swallow the read`)
   }
 })
 


### PR DESCRIPTION
Follow-up corrections to the path-field unification (#164), found by review of that commit.

**Contrast (a11y).** The field rendered its only content in `text-outline/70` — `outline` is the badge/dropzone *border* token. Measured against the actual tokens: **2.63:1** light and **1.90:1** dark, against a 4.5:1 AA floor. Dropping the `/70` would not have fixed it (4.48 / 2.51). Now `text-on-surface-variant`, the token design.md assigns to muted text: **8.4–12:1** across both themes and both fills.

**Wrong string.** Storage settings passed `storageSettings.calculating` — "Calculating storage…", the *disk-size* string — as the path placeholder.

**Loading is a third state.** A download folder always resolves to something (a space's override, else the global default), so an unresolved read was never "no path". It showed the first-pick affordance for a folder that exists and flipped the button label when the read landed. `PathRow` now takes `loading`; the button reads "Change" from first paint.

**Swallowed reads.** `getDownloadFolder().catch(() => {})` in both screens is what made the above permanent — on failure the row kept its fallback state for the session. Each now surfaces the error through the screen's existing `role="alert"`.

**Dead API.** `actionLabel` had zero callers and was forbidden to all of them by the test that introduced it. Removed with its unreachable branch.

## Layers

Unit (`path-field-harmonized`, +3 checks incl. a labelled contrast regression) · Frontend + a11y (local).

`test:fe` s107 7/7 · s109 6/6 · s52 2/2 · s5 7/7 · s6 5/5 — s5/s6 included deliberately, to prove the *non-loading* callers still read "Browse…". `test:layout:truncation` ok. jsx-a11y clean.

Unrelated, found while running: `s47-cache-setting.mjs` exists but `run.mjs` never imports or registers it, so it is unreachable and crashes if named. Left alone — registering or deleting it is its own decision.