### PR TITLE
[feat] Recover a stalled subsystem instead of leaving it wedged

### DIFF
--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -140,6 +140,10 @@ const DEFAULTED = {
   // Foreign-mirror materialize poll cadence. Tests shrink it to assert orphan-mount teardown
   // (owner left → unmount) promptly; production uses the 30s default.
   foreignPollIntervalMs: 30_000,
+  // How often the supervisor asks every subsystem whether its units are still advancing. 60s
+  // matches the cadence the mirror probe ran at, so the two-consecutive-bad rule still acts about
+  // two minutes into a stall. Tests shrink it.
+  supervisionProbeIntervalMs: 60_000,
   // How many mirror ticks may skip the walk before one runs in full regardless. The owner's catalog
   // version cannot see a LOCAL change (a user deleting a mirrored file) and a foreign mount has no
   // filesystem watcher, so this backstop is what repairs it — within 5 min at the 30s poll.
@@ -280,6 +284,10 @@ export function getOverlayServeLimit() {
 
 export function getDeepReconcileEvery() {
   return config.deepReconcileEvery
+}
+
+export function getSupervisionProbeIntervalMs() {
+  return config.supervisionProbeIntervalMs ?? DEFAULTED.supervisionProbeIntervalMs
 }
 
 // A budget that is multiplied by a live count must be finite and non-negative: Infinity yields

--- a/src/shared/core/stall-verdict.js
+++ b/src/shared/core/stall-verdict.js
@@ -1,0 +1,14 @@
+// Progress, not elapsed time. Supervised work in the worker is a keyed pass with at most one in
+// flight, so a pass that never settles holds its key permanently. But a legitimate pass over
+// thousands of files, or a roster fold over hundreds of peers, is genuinely slow — an elapsed-time
+// rule would recover healthy work mid-pass. Only a pass that is in flight AND not advancing is
+// stalled, which is why every caller has to supply a heartbeat.
+export function stallVerdict(liveness, { now, windowMs }) {
+  const { startedAt = 0, progressAt = 0 } = liveness || {}
+  if (!startedAt) return { ok: true, detail: null }
+  // A pass that has not reported progress yet falls back to its start, rather than reading as
+  // stalled from the epoch.
+  const stalledForMs = now - (progressAt || startedAt)
+  if (stalledForMs <= windowMs) return { ok: true, detail: null }
+  return { ok: false, detail: `no progress for ${Math.round(stalledForMs / 1000)}s` }
+}

--- a/src/shared/core/subsystem.js
+++ b/src/shared/core/subsystem.js
@@ -42,6 +42,23 @@ export class Subsystem extends ReadyResource {
     return { ok: !this.closed && !this.stopping, detail: null }
   }
 
+  // The units this subsystem can recover, identified. Deliberately separate from health(): that is
+  // the redacted report reaching the shareable diagnostics bundle, while these rows carry the space
+  // and share ids the supervisor keys its counters on and names in the worker log. A subsystem with
+  // nothing recoverable returns nothing and is never probed.
+  // Rows: { key, ok, detail, label } — `key` is stable within the subsystem, `label` is log-safe.
+  supervise(_opts) { return [] }
+
+  // Recover one unit: abandon the stalled pass and re-arm it. It never replaces this instance — a
+  // holder that captured the subsystem at construction would be handed a dead one, and for several
+  // subsystems close() means something quite different from "pause".
+  async recover(key) {
+    throw new Error(`${this.name}: no recovery for unit "${key}"`)
+  }
+
+  // Per-subsystem overrides for the supervision policy, or null for the defaults.
+  get supervisionPolicy() { return null }
+
   // A missing collaborator fails at construction — at boot, in the root, with the subsystem's
   // name — instead of as a `hook?.()` that never fires.
   require(...names) {

--- a/src/shared/core/supervision.js
+++ b/src/shared/core/supervision.js
@@ -1,0 +1,69 @@
+// The probe-to-action rule for supervised units, kept pure and separate from the driver: a policy
+// that can only be exercised by running a real subsystem is a policy nothing asserts.
+//
+// Three guards, each of which a hand-built probe had to reinvent:
+//   consecutiveBad — one slow sample must not recover work that is merely busy
+//   maxRecoveries  — a unit that cannot be recovered is stated once, not recovered forever
+//   pruning        — a unit that disappeared drops its counters, or the next unit to reuse the key
+//                    inherits a spent budget
+export const DEFAULT_POLICY = { consecutiveBad: 2, maxRecoveries: 3 }
+
+export function createSupervisionPolicy(overrides = {}) {
+  const bad = new Map()
+  const spent = new Map()
+  const gaveUp = new Set()
+
+  function limitsFor(name) {
+    return { ...DEFAULT_POLICY, ...(overrides[name] || {}) }
+  }
+
+  function prune(rows) {
+    const live = new Set(rows.map((row) => row.id))
+    for (const id of [...bad.keys()]) if (!live.has(id)) bad.delete(id)
+    for (const id of [...spent.keys()]) if (!live.has(id)) spent.delete(id)
+    for (const id of [...gaveUp]) if (!live.has(id)) gaveUp.delete(id)
+  }
+
+  // Rows: { id, name, key, ok, detail }. Returns a decision per row that needs one, with `action`
+  // in 'note' | 'recover' | 'gave-up'. The counters are mutated here, so a caller that evaluates
+  // and then declines to act leaves the unit permanently one probe short of its recovery.
+  function evaluate(rows) {
+    prune(rows)
+    const out = []
+    for (const row of rows) {
+      if (row.ok) { bad.delete(row.id); continue }
+      const limits = limitsFor(row.name)
+      const n = (bad.get(row.id) || 0) + 1
+      bad.set(row.id, n)
+      if (n < limits.consecutiveBad) {
+        out.push({ row, action: 'note', badCount: n, badLimit: limits.consecutiveBad })
+        continue
+      }
+      const used = spent.get(row.id) || 0
+      if (used >= limits.maxRecoveries) {
+        if (!gaveUp.has(row.id)) {
+          gaveUp.add(row.id)
+          out.push({ row, action: 'gave-up', spentCount: used })
+        }
+        continue
+      }
+      spent.set(row.id, used + 1)
+      // Cleared, not decremented: a unit that recovers and re-stalls starts a fresh streak, so it
+      // spends its next strike a full window later rather than on the first probe after recovery.
+      bad.delete(row.id)
+      out.push({ row, action: 'recover', spentCount: used + 1 })
+    }
+    return out
+  }
+
+  return {
+    evaluate,
+    stats() {
+      return {
+        recoveries: Object.fromEntries(spent),
+        unhealthy: Object.fromEntries(bad),
+        gaveUp: [...gaveUp],
+      }
+    },
+  }
+}

--- a/src/shared/core/supervisor.js
+++ b/src/shared/core/supervisor.js
@@ -1,0 +1,118 @@
+// Polls every started subsystem's supervisable units and recovers the ones the policy condemns.
+// Started LAST so the lifecycle's reverse close order stops it FIRST — structural, rather than a
+// line in the shutdown path someone has to remember.
+//
+// It recovers a UNIT inside a subsystem, never a subsystem: closing one and constructing another
+// hands every holder that captured it a dead instance, and the subsystems worth supervising are
+// exactly the ones where close() means something other than "pause" — one stops every mirror loop
+// and starts none, another resets its module collaborators to no-ops while the swarm is live.
+//
+// Recoveries are narrow on purpose. A recovery broader than the fault is itself the outage: a
+// peer's socket is the single mux carrying every core and transfer for that peer, a Corestore-backed
+// handle belongs to whoever closes it, and a close() that awaits the stalled pass never settles. A
+// recovery abandons; it does not drain.
+import { Subsystem } from './subsystem.js'
+import { createSupervisionPolicy, DEFAULT_POLICY } from './supervision.js'
+import { getSupervisionProbeIntervalMs } from './runtime-config.js'
+
+export class Supervisor extends Subsystem {
+  constructor(name, deps) {
+    super(name, deps)
+    this.require('lifecycle')
+    this.paused = false
+    this.probing = false
+    this.overrides = {}
+    this.policy = createSupervisionPolicy(this.overrides)
+  }
+
+  async _open() {
+    this.timers.setInterval(() => {
+      this.probe().catch((err) => this.log.debug('supervision probe failed:', err.message))
+    }, getSupervisionProbeIntervalMs())
+  }
+
+  // Stops probing without closing. The shutdown path runs three steps and a flush window BEFORE
+  // life.close() reaches this subsystem, and no subsystem's `stopping` is set in that window — a
+  // probe firing there reads a healthy lifecycle and could re-arm work the shutdown just stopped.
+  pause() { this.paused = true }
+
+  collectRows() {
+    const rows = []
+    for (const subsystem of this.deps.lifecycle.started) {
+      if (subsystem === this || subsystem.stopping || subsystem.closed) continue
+      let units = []
+      try {
+        units = subsystem.supervise() || []
+      } catch (err) {
+        this.log.warn(subsystem.name, 'supervise() failed:', err.message)
+        continue
+      }
+      if (!units.length) continue
+      if (subsystem.supervisionPolicy) this.overrides[subsystem.name] = subsystem.supervisionPolicy
+      for (const unit of units) {
+        rows.push({ ...unit, name: subsystem.name, id: subsystem.name + ' ' + unit.key, subsystem })
+      }
+    }
+    return rows
+  }
+
+  async probe() {
+    // A probe overlapping its own recovery would abandon a pass twice. Skipped, not queued: the
+    // next probe is a full interval away and the state it reads will be fresher.
+    if (this.paused || this.stopping || this.probing) return
+    this.probing = true
+    try {
+      for (const decision of this.policy.evaluate(this.collectRows())) {
+        if (!this.actOn(decision)) continue
+        // Re-checked inside the loop, not only at entry: this awaits, so a shutdown can begin
+        // between two units and the second recovery would re-arm work the teardown already stopped.
+        if (this.paused || this.stopping || decision.row.subsystem.stopping) return
+        const { row } = decision
+        this.log.warn('recovering', row.name, row.label || row.key, '-', row.detail || '')
+        try {
+          await row.subsystem.recover(row.key)
+        } catch (err) {
+          this.log.warn('recovery failed for', row.name, row.label || row.key, '-', err.message)
+        }
+      }
+    } finally {
+      this.probing = false
+    }
+  }
+
+  // Logs the non-acting decisions; returns true only for the ones that need a recovery.
+  actOn({ row, action, badCount, badLimit, spentCount }) {
+    if (action === 'note') {
+      const limit = badLimit ?? DEFAULT_POLICY.consecutiveBad
+      this.log.warn('unhealthy:', row.name, row.label || row.key, '-', row.detail || '', `(${badCount}/${limit})`)
+      return false
+    }
+    if (action === 'gave-up') {
+      this.log.error(row.name, 'still unhealthy after', spentCount, 'recoveries — leaving it down:',
+        row.label || row.key, '-', row.detail || '')
+      return false
+    }
+    return true
+  }
+
+  // Counts by subsystem name only. This reaches the shareable diagnostics bundle and unit keys
+  // carry space and share ids; the worker log is where a unit is named.
+  stats() {
+    const raw = this.policy.stats()
+    const tally = (ids) => {
+      const out = {}
+      for (const [id, n] of ids) {
+        const name = id.slice(0, id.indexOf(' '))
+        out[name] = (out[name] || 0) + n
+      }
+      return out
+    }
+    return {
+      recoveries: tally(Object.entries(raw.recoveries)),
+      unhealthy: tally(Object.entries(raw.unhealthy)),
+      gaveUp: tally(raw.gaveUp.map((id) => [id, 1])),
+    }
+  }
+
+  async _close() { this.paused = true }
+}

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -933,7 +933,7 @@ export function mirrorHealth({ now = Date.now() } = {}) {
   for (const loop of activeLoops.values()) {
     const key = loopKey(loop.spaceId, loop.shareId)
     const verdict = mirrorVerdict(mirrorLiveness.get(key), { now, pollIntervalMs })
-    rows.push({ spaceId: loop.spaceId, shareId: loop.shareId, ...verdict })
+    rows.push({ key, spaceId: loop.spaceId, shareId: loop.shareId, ...verdict })
   }
   return rows
 }
@@ -1006,7 +1006,7 @@ async function stopAllForeignLoops({ settleMs = 5000 } = {}) {
 // Owns the mirror loops as a set: _open is the module's wiring, _close is the bulk stop the
 // per-mount stopForeignLoop never had a caller for.
 export class ForeignMirrors extends Subsystem {
-  constructor(name, deps) { super(name, deps); this.require('ipc') }
+  constructor(name, deps) { super(name, deps); this.require('ipc'); this.units = new Map() }
   async _open() { initForeignFolders(this.deps.ipc) }
   async _close() { await stopAllForeignLoops(); integritySeen.clear() }
 
@@ -1022,6 +1022,23 @@ export class ForeignMirrors extends Subsystem {
       detail: wedged.length ? wedged.map((mirror) => mirror.detail).join('; ') : null,
       mirrors: { total: mirrors.length, wedged: wedged.length },
     }
+  }
+
+  // One unit per mount with a live loop. A mount without one is not reported: it is paused,
+  // unmounted or gone, none of which a recovery can or should address. The ids are remembered so
+  // recover() needs no key parsing — a share id is opaque and splitting it would be a guess.
+  supervise({ now = Date.now() } = {}) {
+    if (this.closed || this.stopping) return []
+    const rows = mirrorHealth({ now })
+    this.units = new Map(rows.map((row) => [row.key, { spaceId: row.spaceId, shareId: row.shareId }]))
+    return rows.map((row) => ({ key: row.key, ok: row.ok, detail: row.detail, label: row.shareId }))
+  }
+
+  async recover(key) {
+    if (this.stopping) return
+    const unit = this.units.get(key)
+    if (!unit) return
+    await restartForeignLoop(unit.spaceId, unit.shareId)
   }
 }
 

--- a/src/shared/folders/mirror-health.js
+++ b/src/shared/folders/mirror-health.js
@@ -1,17 +1,11 @@
-// The wedged/healthy rule for a mirror loop, kept pure so it is asserted directly rather than
-// through a live loop.
-//
-// Progress, not elapsed time: runMaterializeTick serialises passes per mount by handing every
-// later tick the in-flight promise, so a pass that never settles wedges the mount permanently while
-// the interval keeps firing. But an initial scan over thousands of files is legitimately slow, and
-// an elapsed-time rule would restart it mid-scan. Only a pass that is in flight AND not advancing
-// is wedged.
+// The stalled/healthy rule for a mirror loop, kept pure so it is asserted directly rather than
+// through a live loop. runMaterializeTick serialises passes per mount by handing every later tick
+// the in-flight promise, so a pass that never settles wedges the mount permanently while the
+// interval keeps firing.
+import { stallVerdict } from '../core/stall-verdict.js'
+
 export const STALL_FACTOR = 20
 
 export function mirrorVerdict(liveness, { now, pollIntervalMs, stallFactor = STALL_FACTOR }) {
-  const { startedAt = 0, progressAt = 0 } = liveness || {}
-  if (!startedAt) return { ok: true, detail: null }
-  const stalledForMs = now - (progressAt || startedAt)
-  if (stalledForMs <= pollIntervalMs * stallFactor) return { ok: true, detail: null }
-  return { ok: false, detail: `no progress for ${Math.round(stalledForMs / 1000)}s` }
+  return stallVerdict(liveness, { now, windowMs: pollIntervalMs * stallFactor })
 }

--- a/src/shared/spaces/member-registry.js
+++ b/src/shared/spaces/member-registry.js
@@ -438,4 +438,25 @@ export class MemberViews extends Subsystem {
     // A second boot in one process must not inherit the first boot's closures.
     deps = { ...DEFAULT_DEPS }
   }
+
+  // One unit per open view, keyed by space. Only the worker log ever sees the id.
+  supervise ({ now = Date.now() } = {}) {
+    if (this.closed || this.stopping) return []
+    const rows = []
+    for (const [spaceId, entry] of views) {
+      if (!entry.view?.foldHealth) continue
+      const verdict = entry.view.foldHealth({ now })
+      rows.push({ key: spaceId, ok: verdict.ok, detail: verdict.detail, label: spaceId })
+    }
+    return rows
+  }
+
+  // Re-arms the fold and nothing else. Deliberately NOT closeMemberView + openMemberView: that
+  // path drops the leave tombstones and the prior-membership belief, releases the roster captures,
+  // and awaits a fold that is not settling. Re-seeding the tombstones reads only the DURABLE ones,
+  // so a leave frame whose persist failed would be forgotten and the leaver would come back.
+  async recover (spaceId) {
+    if (this.stopping) return
+    views.get(spaceId)?.view?.restartFold?.()
+  }
 }

--- a/src/shared/spaces/member-view.js
+++ b/src/shared/spaces/member-view.js
@@ -4,6 +4,7 @@ import { openProfileBee, readMembershipRecord, readPeerRequests, readPeerDenials
 import { foldMembership } from './member-set.js'
 import { createDerivedView } from '../state/derived-view.js'
 import { getResourceCaps } from '../core/runtime-config.js'
+import { peerReadTimeoutMs } from '../core/with-timeout.js'
 import { SHARE_PREFIX } from '../shares/shares.js'
 
 // Transitive discovery + fold. Walks the approval graph FORWARD from the creator (the
@@ -84,6 +85,10 @@ export function viewSignature ({ members, approved, requests, denied, memberTs, 
   return b4a.toString(crypto.hash(b4a.from(canon)), 'hex')
 }
 
+// Twenty per-peer read budgets. Each roster read is bounded on its own, so a fold that has not
+// completed ONE of them in that span is not slow, it is stalled.
+const FOLD_STALL_FACTOR = 20
+
 // Live member-set view for a space: re-derives whenever any roster peer's bee changes —
 // locally OR via replication — and reports the current member set via onMembers. Built on
 // createDerivedView (bursts coalesced, folds serialized). Seeds from creator + self; the
@@ -101,7 +106,12 @@ export function createMemberView ({ spaceId, creatorKey, selfKey, onMembers, onE
     if (!bee) bees.set(key, bee = openProfileBee(b4a.from(key, 'hex')))
     return bee
   }
-  const readRecord = (key) => readMembershipRecord(key, spaceId)
+  // Every read is individually bounded, but the fold walks the roster SERIALLY, so a space whose
+  // members are all unreachable spends one read budget per member before it settles. The heartbeat
+  // is what separates that legitimately slow fold from one that has stopped advancing.
+  const readRecord = async (key) => {
+    try { return await readMembershipRecord(key, spaceId) } finally { view.noteProgress() }
+  }
 
   // Active follow: an open live download per roster bee so a co-member's approval AND the joiner's
   // own membership record reach us even when that peer never sends us a frame directly (it reached
@@ -206,5 +216,13 @@ export function createMemberView ({ spaceId, creatorKey, selfKey, onMembers, onE
   if (self && self !== creatorKey) trackKey(self)
   view.recompute()   // initial derive
 
-  return { recompute: view.recompute, trackKey, close }
+  return {
+    recompute: view.recompute,
+    trackKey,
+    close,
+    foldHealth: ({ now = Date.now() } = {}) => view.health({ now, windowMs: peerReadTimeoutMs() * FOLD_STALL_FACTOR }),
+    // Abandon the fold in flight and start a fresh one. Everything else about the view — the bees,
+    // the follows, the watchers — is left alone: the fold is what stalled, not the subscriptions.
+    restartFold: () => { view.abandon(); view.recompute() },
+  }
 }

--- a/src/shared/state/derived-view.js
+++ b/src/shared/state/derived-view.js
@@ -18,6 +18,8 @@
 //    safe — the fold is deterministic and idempotent, so an extra recompute only costs
 //    a fold, never correctness.
 
+import { stallVerdict } from '../core/stall-verdict.js'
+
 export function createDerivedView ({ fold, onChange, range, onError, debounceMs = 0 } = {}) {
   if (typeof fold !== 'function') throw new Error('createDerivedView: fold is required')
   if (typeof onChange !== 'function') throw new Error('createDerivedView: onChange is required')
@@ -29,6 +31,8 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
   let again = false            // a change landed mid-fold → run exactly once more after
   let timer = null             // pending debounce timer (debounceMs > 0)
   let inFlight = null          // the running fold, so close() can wait for the reads it holds
+  let gen = 0                  // bumped by abandon(); a fold from an older generation is inert
+  let liveness = { startedAt: 0, progressAt: 0, completedAt: 0 }
 
   // Coalesce a burst of change signals into one fold and serialize folds so two changes
   // can't run overlapping folds whose results land out of order. If a change arrives while
@@ -51,15 +55,48 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
     scheduled = false
     timer = null
     running = true
+    const mine = gen
+    const startedAt = Date.now()
+    liveness = { startedAt, progressAt: startedAt, completedAt: liveness.completedAt }
     try {
       const view = await fold()
-      if (!closed) onChange(view)
+      // Identity-guarded: a fold abandoned by a recovery must not publish a view the fold that
+      // replaced it has already superseded, nor clear that fold's `running` flag below.
+      if (!closed && mine === gen) onChange(view)
     } catch (err) {
-      if (!closed) (onError || noop)(err)
+      if (!closed && mine === gen) (onError || noop)(err)
     } finally {
-      running = false
-      if (again && !closed) { again = false; recompute() }
+      if (mine === gen) {
+        running = false
+        liveness = { startedAt: 0, progressAt: 0, completedAt: Date.now() }
+        if (again && !closed) { again = false; recompute() }
+      }
     }
+  }
+
+  // Bumped by the caller once per unit of work the fold completes. Without it the stall rule would
+  // have to tolerate the worst-case fold — a roster of hundreds of unreachable peers, each read at
+  // its own budget — and a window that generous is a window that never fires.
+  function noteProgress () {
+    if (liveness.startedAt) liveness.progressAt = Date.now()
+  }
+
+  function health ({ now = Date.now(), windowMs }) {
+    return stallVerdict(liveness, { now, windowMs })
+  }
+
+  // Abandon the fold in flight and let the next recompute start a fresh one. NOT close(): that
+  // awaits `inFlight` so the peer reads it holds cannot outlive the store, which for a fold that is
+  // not settling is a promise that never resolves. The generation bump is what makes the abandoned
+  // fold inert rather than merely unawaited.
+  function abandon () {
+    gen += 1
+    running = false
+    scheduled = false
+    again = false
+    if (timer) { clearTimeout(timer); timer = null }
+    inFlight = null
+    liveness = { startedAt: 0, progressAt: 0, completedAt: liveness.completedAt }
   }
 
   // Start watching a source bee (idempotent per key). Each change within `range` —
@@ -90,7 +127,7 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
     watchers.clear()
   }
 
-  return { track, tracking, size, recompute, close }
+  return { track, tracking, size, recompute, close, abandon, noteProgress, health }
 }
 
 function noop () {}

--- a/src/worker/boot.js
+++ b/src/worker/boot.js
@@ -10,6 +10,7 @@
 // renderer-facing handlers, the shutdown deadline and `Bare.exit`. boot() and close() never exit
 // the process, which is exactly what lets a test call them twice.
 import { createLifecycle } from '../shared/core/subsystem.js'
+import { Supervisor } from '../shared/core/supervisor.js'
 import { getPeerPresenceDwellMs, isSharePrepareProgressEnabled, getRelayConfig } from '../shared/core/runtime-config.js'
 import { hydrateDownloadRoots, listDownloadRoots } from '../shared/core/paths.js'
 import { IntentsBee, getIntentsBee } from '../shared/core/intent-store.js'
@@ -136,6 +137,7 @@ export async function boot(bootstrap, {
   let durable = null
   let publishService = null
   let overlayBackend = null
+  let supervisor = null
 
   // The reverse of boot, defined BEFORE anything starts and handed to the caller at once. A
   // shutdown can arrive at any point during boot — the pipe closes when Electron main dies, and
@@ -156,6 +158,11 @@ export async function boot(bootstrap, {
   // skip the durable tier outright — including the store's own close, which on the way out is what
   // releases the RocksDB lock, and the ledger flush that records the shutdown's own audit rows.
   async function close({ budgetMs = 1500, durableBudgetMs = 1500 } = {}) {
+    // First, ahead of the flush window below: no subsystem's `stopping` is set until life.close()
+    // runs, so a probe firing in between reads a healthy lifecycle and could re-arm work this
+    // shutdown has already stopped. The lifecycle's reverse close order covers the timer, not a
+    // probe already awaiting a recovery.
+    try { supervisor?.pause() } catch {}
     if (swarm) { try { broadcastDeparture() } catch {} }
     try { abortInFlightPublishes() } catch {}
     try { publishService?.halt() } catch {}
@@ -306,10 +313,16 @@ export async function boot(bootstrap, {
       log.warn('leftover metadata cleanup failed:', err.message)
     }
 
+    // After every subsystem it will supervise, so the lifecycle's reverse close order stops it
+    // FIRST. It reads life.started; the durable tier is deliberately unsupervised — nothing there
+    // has a recoverable unit, and closing a store-backed handle would close every session with it.
+    supervisor = await life.start(new Supervisor('supervision', { lifecycle: life }))
+
     return {
       close, store, mounts, intents, auditLog, ownedFolders, publishService, overlayBackend, activeSpaces,
       applyRelayConfig: () => applyRelayConfig(log),
       health: () => [...(durable?.health() || []), ...life.health()],
+      supervision: () => supervisor?.stats() ?? null,
     }
   }
 }

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1718,7 +1718,12 @@ ipc.handle('diagnostics:export', async (msg) => {
     counters: getDiagnosticCounters(),
     requestFailures: getRequestFailureCounters(),
     requestMetrics: getRequestMetrics(),
-    health: health.snapshot({ queueDepth: getQueueDepth(), subsystems: root?.health() || [], inFlightRequests: getInFlightCount() }),
+    health: health.snapshot({
+      queueDepth: getQueueDepth(),
+      subsystems: root?.health() || [],
+      supervision: root?.supervision() || null,
+      inFlightRequests: getInFlightCount(),
+    }),
     peerSamples: getPeerSamples(),
   }, msg?.redact !== false)
 })

--- a/src/worker/mounts-runtime.js
+++ b/src/worker/mounts-runtime.js
@@ -14,14 +14,11 @@ import { listDownloadRoots } from '../shared/core/paths.js'
 import { AppError, ErrorCodes, classifyLocalIoFault } from '../shared/core/errors.js'
 import { setOwnedMountStatus, setOwnedIndexPaused, patchOwnedMount, listOwnedMounts, listAllMounts, listForeignMounts, getOwnedMount, getForeignMount } from '../shared/folders/mount-store.js'
 import { periodicReconcile, stopOwnedFolder, cancelIndex, mountRootAvailable } from '../shared/folders/owned-folders.js'
-import { startForeignLoop, initialMaterializeScan, resumeAutoPausedForeignMount, autoPauseForeignMountGone, mirrorHealth, restartForeignLoop } from '../shared/folders/foreign-folders.js'
+import { startForeignLoop, initialMaterializeScan, resumeAutoPausedForeignMount, autoPauseForeignMountGone } from '../shared/folders/foreign-folders.js'
 import { ensureMirror } from '../shared/folders/mirror-records.js'
 
 const RECONCILE_INTERVAL_MS = 6 * 60 * 60 * 1000
 const MOUNT_PROBE_INTERVAL_MS = 60_000
-// Two consecutive bad probes before acting, so one slow sample cannot restart a working mirror.
-const MIRROR_BAD_PROBES = 2
-const MIRROR_MAX_RESTARTS = 3
 
 
 // The download-root twin of owned-folders' mountRootAvailable, deliberately kept separate: a
@@ -41,10 +38,6 @@ function ownedFaultStatus(code) {
   return code === ErrorCodes.TRANSFER_DISK_FULL ? 'paused-enospc' : 'paused-error'
 }
 
-function mirrorKey(spaceId, shareId) {
-  return spaceId + '/' + shareId
-}
-
 function sameRootSet(a, b) {
   return a.length === b.length && a.every((root, i) => root === b[i])
 }
@@ -60,11 +53,6 @@ export class MountsRuntime extends Subsystem {
     // maintained by the probe loop; a transition is what drives every status event.
     this.lastMountPointStatus = new Map()
     this.unavailableRoots = []
-    // spaceId/shareId → consecutive unhealthy probes, restarts spent, and whether the budget
-    // running out has already been reported.
-    this.mirrorBadProbes = new Map()
-    this.mirrorRestarts = new Map()
-    this.mirrorGaveUp = new Set()
   }
 
   async _open() {
@@ -73,7 +61,6 @@ export class MountsRuntime extends Subsystem {
     this.timers.setInterval(() => {
       this.probeMountPoints().catch((err) => this.log.debug('mount probe failed:', err.message))
       try { this.probeDownloadRoots() } catch (err) { this.log.debug('download-root probe failed:', err.message) }
-      this.probeMirrorLiveness().catch((err) => this.log.debug('mirror liveness probe failed:', err.message))
     }, MOUNT_PROBE_INTERVAL_MS)
   }
 
@@ -153,48 +140,6 @@ export class MountsRuntime extends Subsystem {
       }
     } catch (err) {
       this.log.warn('foreign-folder restart failed:', err.message)
-    }
-  }
-
-  // A mirror whose pass is in flight but no longer advancing is wedged: every later tick coalesces
-  // onto the dead promise, so the folder stops syncing until the app restarts. Restart the loop
-  // rather than the subsystem — ForeignMirrors._open only re-wires the module, it starts no loops.
-  async probeMirrorLiveness() {
-    // The base clears the interval on close, but this probe awaits a restart: a shutdown starting
-    // mid-pass would otherwise re-arm a loop stopAllForeignLoops just stopped.
-    if (this.stopping) return
-    const rows = mirrorHealth()
-    const live = new Set(rows.map((row) => mirrorKey(row.spaceId, row.shareId)))
-    for (const key of this.mirrorBadProbes.keys()) if (!live.has(key)) this.mirrorBadProbes.delete(key)
-    for (const key of this.mirrorRestarts.keys()) if (!live.has(key)) this.mirrorRestarts.delete(key)
-    for (const key of this.mirrorGaveUp) if (!live.has(key)) this.mirrorGaveUp.delete(key)
-
-    for (const row of rows) {
-      const key = mirrorKey(row.spaceId, row.shareId)
-      if (row.ok) { this.mirrorBadProbes.delete(key); continue }
-
-      const bad = (this.mirrorBadProbes.get(key) || 0) + 1
-      this.mirrorBadProbes.set(key, bad)
-      if (bad < MIRROR_BAD_PROBES) continue
-
-      const spent = this.mirrorRestarts.get(key) || 0
-      if (spent >= MIRROR_MAX_RESTARTS) {
-        if (!this.mirrorGaveUp.has(key)) {
-          this.mirrorGaveUp.add(key)
-          this.log.error('mirror still wedged after', MIRROR_MAX_RESTARTS, 'restarts — leaving it down:', row.shareId, '-', row.detail)
-        }
-        continue
-      }
-
-      if (this.stopping) return
-      this.mirrorRestarts.set(key, spent + 1)
-      this.mirrorBadProbes.delete(key)
-      this.log.warn('mirror wedged, restarting its loop:', row.shareId, '-', row.detail)
-      try {
-        await restartForeignLoop(row.spaceId, row.shareId)
-      } catch (err) {
-        this.log.warn('mirror loop restart failed:', row.shareId, '-', err.message)
-      }
     }
   }
 

--- a/test/flow/supervision-shutdown-order.test.js
+++ b/test/flow/supervision-shutdown-order.test.js
@@ -1,0 +1,46 @@
+import test from 'brittle'
+import path from 'path'
+import crypto from 'crypto'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
+import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled, unscaled } from '../helpers/timing.js'
+
+const kekHex = () => crypto.randomBytes(32).toString('hex')
+const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
+const v2flags = () => ({ overlayEnabled: true, inPlaceFilesEnabled: true, identityKEK: kekHex() })
+
+// The supervisor is a new subsystem in the composition root, started after every subsystem it
+// supervises so the lifecycle's reverse close order stops it first. Adding a subsystem to boot.js
+// reorders teardown, and a dependency expressed as a silent fallthrough degrades rather than breaks
+// — the class that has passed unit and integration green through ordering regressions before. Only
+// a real quit against a real peer shows it.
+//
+// The recovery path itself is not driven here: a stalled pass needs an in-process hung fetch or a
+// connected-then-silent peer, and no IPC request, config knob or peer action produces one, because
+// the production code is written not to hang. Both recoveries are red-first one layer down.
+test('the supervisor rides the boot order without changing the departure conveyance',
+  { timeout: scaled(180000) }, async (t) => {
+    const bootstrap = await localTestnet(t)
+    const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), flags: v2flags() })
+    const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
+    const spaceId = await connectInSpaceWithApproval(t, A, B)
+    const aKey = (await A.request('profile:get')).publicKey
+
+    // The supervisor reached the real worker, not just the unit harness: its counters are in the
+    // diagnostics bundle, which is also the only place a user-reported stall would ever show.
+    const diag = await A.request('diagnostics:export')
+    t.ok(diag.health, 'the health block is present')
+    t.ok(diag.health.supervision, 'and carries the supervision counters')
+    t.alike(Object.keys(diag.health.supervision).sort(), ['gaveUp', 'recoveries', 'unhealthy'],
+      'counts by subsystem, with no unit key to carry a space or share id')
+    t.absent(JSON.stringify(diag.health.supervision).includes(spaceId),
+      'the shareable bundle names no space')
+
+    // The departure datagram must still leave UDX before any socket drops — the first three steps
+    // of boot.close(), which now run behind supervisor.pause().
+    await A.request('shutdown').catch(() => {})
+    // Under the un-scaled presence TTL, so a broken announce cannot pass as plain lease expiry.
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: unscaled(12000) })
+    t.pass('the peer saw the departure promptly, so the shutdown order is intact')
+  })

--- a/test/helpers/wedged-mirror.js
+++ b/test/helpers/wedged-mirror.js
@@ -1,0 +1,73 @@
+// A foreign mount whose materialize pass never settles: overlay.fetchFile hangs and cancelFetch is
+// inert, so nothing the stop path does can settle it. The test holds every rejecter and settles
+// them itself, which is what makes the ordering exact. Shared by the mirror-restart suite (the
+// loop's own behaviour) and the supervision suite (the mechanism that drives the restart).
+import { freshPeer } from './store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
+import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
+import { saveForeignMount } from '../../src/shared/folders/mount-store.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { startForeignLoop, stopForeignLoop } from '../../src/shared/folders/foreign-folders.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+
+export const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+
+export async function waitUntil (pred, ms = 5000) {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (pred()) return
+    await delay(20)
+  }
+  throw new Error('condition not met within ' + ms + 'ms')
+}
+
+export function cancelled () {
+  const err = new Error('cancelled'); err.code = 'ECANCELLED'
+  return err
+}
+
+export function settleAll (spy) { for (const reject of spy.rejecters.splice(0)) reject(cancelled()) }
+
+export async function wedgedMirror (t, {
+  relPath = 'big.bin', contentHash = 'a'.repeat(64), size = 96 * 1024 * 1024, pollMs = 30_000,
+} = {}) {
+  const ctx = await freshPeer(t)
+  setRuntimeConfig({ ...getRuntimeConfig(), overlayEnabled: true, foreignPollIntervalMs: pollMs })
+  await initOverlay()
+  t.teardown(async () => { await teardownOverlay() })
+
+  const space = await createSpace('Aurora')
+  const spaceId = space.spaceId
+  const shareId = generateShareId()
+  await publishShare(spaceId, {
+    id: shareId, type: 'owned-folder', name: 'Mirror', owner: getLocalPublicKeyHex(),
+    contentMode: 'overlay', catalogKey: 'c'.repeat(64), createdAt: Date.now(),
+  })
+
+  const origListPeer = overlayBackend.listPeerWithMeta
+  overlayBackend.listPeerWithMeta = async () => ({ entries: [{ relPath, contentHash, size }], complete: true })
+  t.teardown(() => { overlayBackend.listPeerWithMeta = origListPeer })
+
+  const overlay = getOverlay()
+  const origFetch = overlay.fetchFile
+  const origCancel = overlay.cancelFetch
+  t.teardown(() => { overlay.fetchFile = origFetch; overlay.cancelFetch = origCancel })
+  const spy = { fetches: 0, rejecters: [], opts: [] }
+  overlay.fetchFile = (_hash, options) => {
+    spy.fetches += 1
+    spy.opts.push(options)
+    return new Promise((_res, rej) => { spy.rejecters.push(rej) })
+  }
+  overlay.cancelFetch = () => true
+
+  await saveForeignMount({
+    spaceId, shareId, ownerKey: getLocalPublicKeyHex(), mountPath: ctx.tmpDir('mirror'),
+    enabled: true, attachedAt: Date.now(), status: 'active', syncedPaths: [],
+  })
+  await startForeignLoop({ spaceId, shareId })
+  t.teardown(() => { stopForeignLoop(spaceId, shareId, { discardPartial: true }) })
+  t.teardown(async () => { settleAll(spy); await delay(50) })
+  return { spaceId, shareId, spy }
+}

--- a/test/integration/foreign-mirror-restart.test.js
+++ b/test/integration/foreign-mirror-restart.test.js
@@ -1,87 +1,17 @@
 import test from 'brittle'
-import fs from 'bare-fs'
-import path from 'bare-path'
-import { freshPeer } from '../helpers/store.js'
-import { createSpace } from '../../src/shared/spaces/space.js'
-import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
-import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
-import { saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
-import { setRuntimeConfig, getRuntimeConfig, getResourceCaps } from '../../src/shared/core/runtime-config.js'
+import { getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { getResourceCaps } from '../../src/shared/core/runtime-config.js'
 import {
   runMaterializeTick, startForeignLoop, stopForeignLoop, restartForeignLoop, mirrorHealth,
   unmountForeignFolder,
 } from '../../src/shared/folders/foreign-folders.js'
 import { STALL_FACTOR } from '../../src/shared/folders/mirror-health.js'
-import { MountsRuntime } from '../../src/worker/mounts-runtime.js'
-import { createFakeIpc } from '../helpers/fake-ipc.js'
-import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
-import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+import { wedgedMirror, waitUntil, delay } from '../helpers/wedged-mirror.js'
 
 // runMaterializeTick serialises passes per mount: a tick arriving while one runs is handed the
 // in-flight promise. A pass that never settles therefore wedges the mount permanently — the poll
-// interval keeps firing and every fire is a no-op. These tests reproduce that with an overlay
-// fetchFile that hangs and a cancelFetch that does NOT rescue it, which is what separates a real
-// wedge from the pause path (covered in foreign-pause-aborts-fetch.test.js).
-
-const delay = (ms) => new Promise((r) => setTimeout(r, ms))
-
-async function waitUntil (pred, ms = 5000) {
-  const deadline = Date.now() + ms
-  while (Date.now() < deadline) {
-    if (pred()) return
-    await delay(20)
-  }
-  throw new Error('condition not met within ' + ms + 'ms')
-}
-
-async function wedgedMirror (t, { relPath = 'big.bin', contentHash = 'a'.repeat(64), size = 96 * 1024 * 1024, pollMs = 30_000 } = {}) {
-  const ctx = await freshPeer(t)
-  setRuntimeConfig({ ...getRuntimeConfig(), overlayEnabled: true, foreignPollIntervalMs: pollMs })
-  await initOverlay()
-  t.teardown(async () => { await teardownOverlay() })
-
-  const space = await createSpace('Aurora')
-  const spaceId = space.spaceId
-  const shareId = generateShareId()
-  await publishShare(spaceId, {
-    id: shareId, type: 'owned-folder', name: 'Mirror', owner: getLocalPublicKeyHex(),
-    contentMode: 'overlay', catalogKey: 'c'.repeat(64), createdAt: Date.now(),
-  })
-
-  const origListPeer = overlayBackend.listPeerWithMeta
-  overlayBackend.listPeerWithMeta = async () => ({ entries: [{ relPath, contentHash, size }], complete: true })
-  t.teardown(() => { overlayBackend.listPeerWithMeta = origListPeer })
-
-  // fetchFile hangs and cancelFetch is inert, so nothing the stop path does can settle the pass.
-  // The test holds every rejecter and settles them itself, which is what makes the ordering exact.
-  const overlay = getOverlay()
-  const origFetch = overlay.fetchFile
-  const origCancel = overlay.cancelFetch
-  t.teardown(() => { overlay.fetchFile = origFetch; overlay.cancelFetch = origCancel })
-  const spy = { fetches: 0, rejecters: [], opts: [] }
-  overlay.fetchFile = (_hash, options) => {
-    spy.fetches += 1
-    spy.opts.push(options)
-    return new Promise((_res, rej) => { spy.rejecters.push(rej) })
-  }
-  overlay.cancelFetch = () => true
-
-  await saveForeignMount({
-    spaceId, shareId, ownerKey: getLocalPublicKeyHex(), mountPath: ctx.tmpDir('mirror'),
-    enabled: true, attachedAt: Date.now(), status: 'active', syncedPaths: [],
-  })
-  await startForeignLoop({ spaceId, shareId })
-  t.teardown(() => { stopForeignLoop(spaceId, shareId, { discardPartial: true }) })
-  t.teardown(async () => { settleAll(spy); await delay(50) })
-  return { spaceId, shareId, spy }
-}
-
-function cancelled () {
-  const err = new Error('cancelled'); err.code = 'ECANCELLED'
-  return err
-}
-
-function settleAll (spy) { for (const reject of spy.rejecters.splice(0)) reject(cancelled()) }
+// interval keeps firing and every fire is a no-op. These tests cover the loop's own behaviour; the
+// probe-and-budget policy that drives the restart is covered in subsystem-supervision.test.js.
 
 test('a hung pass wedges the mount and every later tick is a no-op', async (t) => {
   const { spaceId, shareId, spy } = await wedgedMirror(t)
@@ -145,52 +75,6 @@ test('bytes arriving keep a slow download healthy', async (t) => {
 
   spy.opts[0].onProgress(4096)
   t.is(mirrorHealth({ now: startedAt + window + 1 })[0].ok, true, 'bytes arriving reset the stall clock')
-})
-
-test('the probe restarts a wedged mirror once, after two consecutive bad probes', async (t) => {
-  const { spaceId, shareId, spy } = await wedgedMirror(t, { pollMs: 50 })
-  const runtime = new MountsRuntime('mounts', { ipc: createFakeIpc() })
-
-  runMaterializeTick(spaceId, shareId)
-  await waitUntil(() => spy.fetches === 1)
-  await waitUntil(() => mirrorHealth()[0]?.ok === false)
-
-  await runtime.probeMirrorLiveness()
-  t.is(spy.fetches, 1, 'one bad probe is not enough to act')
-
-  await runtime.probeMirrorLiveness()
-  await waitUntil(() => spy.fetches === 2)
-  t.is(spy.fetches, 2, 'the second consecutive bad probe restarts the loop')
-})
-
-// The base clears the probe interval on close, but the probe awaits a restart — one already in
-// flight when a shutdown starts would re-arm a loop stopAllForeignLoops just stopped.
-test('the probe does nothing once the runtime is stopping', async (t) => {
-  const { spaceId, shareId, spy } = await wedgedMirror(t, { pollMs: 50 })
-  const runtime = new MountsRuntime('mounts', { ipc: createFakeIpc() })
-
-  runMaterializeTick(spaceId, shareId)
-  await waitUntil(() => spy.fetches === 1)
-  await waitUntil(() => mirrorHealth()[0]?.ok === false)
-
-  runtime._stopping = true
-  await runtime.probeMirrorLiveness()
-  await runtime.probeMirrorLiveness()
-  await delay(50)
-  t.is(spy.fetches, 1, 'no loop is restarted during teardown')
-})
-
-// The probe being correct proves nothing about it running: requestFailures and requestMetrics both
-// shipped as no-ops because the producer was built and never wired. _open's interval body is what
-// would silently drop it, and constructing the runtime for real needs a booted store, so the wiring
-// is pinned by source text — the same way the crash-backstop suite pins boot.js.
-test('REGRESSION (FIX-R09-2 wiring): the mount probe actually calls the liveness probe', (t) => {
-  const src = fs.readFileSync(path.join(
-    path.dirname(import.meta.url.replace(/^file:\/\//, '')), '..', '..', 'src', 'worker', 'mounts-runtime.js'
-  ), 'utf8')
-  const openBody = src.slice(src.indexOf('async _open()'), src.indexOf('async _resumeOwnedMounts'))
-  t.ok(/this\.probeMirrorLiveness\(\)/.test(openBody), 'the periodic probe body calls probeMirrorLiveness')
-  t.ok(/restartForeignLoop/.test(src), 'and the runtime imports the restart it drives')
 })
 
 // stopForeignLoop bumps cancelGen before the restart re-arms, so the pass being abandoned is

--- a/test/integration/member-view-supervision.test.js
+++ b/test/integration/member-view-supervision.test.js
@@ -1,0 +1,121 @@
+import test from 'brittle'
+import crypto from 'hypercore-crypto'
+import b4a from 'b4a'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { freshPeerWithIdentity, offlineMemberRegistry } from '../helpers/store.js'
+import { createSpace, pinCreatorKey } from '../../src/shared/spaces/space.js'
+import { markOwnMembership } from '../../src/shared/spaces/profile.js'
+import {
+  MemberViews, openMemberView, closeMemberView, markLeft, isLeft,
+} from '../../src/shared/spaces/member-registry.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { peerReadTimeoutMs } from '../../src/shared/core/with-timeout.js'
+
+// The member fold walks the roster SERIALLY, one bounded peer read per member, so a space whose
+// members are unreachable over the network freezes its member set, join requests and share list for
+// the sum of those budgets with nothing reporting it.
+//
+// MEASURED, and it shapes this file: a fold with no REPLICATING peer settles immediately — an
+// unknown roster key resolves to an empty local core and boundedUpdate returns at once, because
+// there is no peer to wait for. A parked fold needs a peer that is connected and then silent, which
+// no single-process test can produce. So the stalled/advancing/idle rule and the abandon-and-rearm
+// behaviour are asserted directly on the primitive in test/unit/derived-view.test.js (red-first),
+// and this file covers what only a real member view can show: the unit rows, and that the recovery
+// touches the fold and nothing else.
+
+const READ_BUDGET_MS = 30_000
+const FOLD_WINDOW_MS = READ_BUDGET_MS * 20
+
+const randomKey = () => b4a.toString(crypto.keyPair().publicKey, 'hex')
+const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function spaceWithView (t) {
+  await freshPeerWithIdentity(t)
+  setRuntimeConfig({ ...getRuntimeConfig(), peerReadTimeoutMs: READ_BUDGET_MS })
+  const { spaceId } = await createSpace('Aurora')
+  await markOwnMembership(spaceId)
+  await pinCreatorKey(spaceId, randomKey())
+  await openMemberView(spaceId)
+  t.teardown(() => closeMemberView(spaceId))
+  const views = new MemberViews('member-views', { overlayBackend: {}, ...offlineMemberRegistry })
+  await delay(50)
+  return { spaceId, views }
+}
+
+test('every open view is one supervisable unit, keyed and labelled by its space', async (t) => {
+  const { spaceId, views } = await spaceWithView(t)
+
+  const rows = views.supervise({ now: Date.now() })
+  t.is(rows.length, 1, 'one unit per open view')
+  t.is(rows[0].key, spaceId)
+  t.is(rows[0].label, spaceId, 'the log-safe label is the space id')
+  t.is(rows[0].ok, true)
+
+  t.is(views.supervise({ now: Date.now() + FOLD_WINDOW_MS + 1000 })[0].ok, true,
+    'a view with no fold in flight is healthy however much time passes — idle is not stalled')
+
+  await closeMemberView(spaceId)
+  t.alike(views.supervise(), [], 'a closed view is no longer a unit')
+})
+
+// closeMemberView drops the in-memory leave tombstones and re-seeds only the DURABLE ones, so a
+// leave frame whose persist failed would be forgotten and the leaver re-added by the next fold.
+// The recovery must restart the fold and leave everything else alone.
+test('REGRESSION (FIX-SUP-2: a recovery preserves a leave tombstone that never reached disk)', async (t) => {
+  const { spaceId, views } = await spaceWithView(t)
+
+  const leaver = randomKey()
+  markLeft(spaceId, leaver, Date.now())
+  t.ok(isLeft(spaceId, leaver), 'the leave frame was applied in memory')
+
+  await views.recover(spaceId)
+  await delay(50)
+  t.ok(isLeft(spaceId, leaver), 'and it survived the recovery')
+  t.is(views.supervise().length, 1, 'the view is still open — the recovery did not close it')
+
+  await closeMemberView(spaceId)
+  t.absent(isLeft(spaceId, leaver), 'closing the view is what drops it, which is why recovery must not close')
+})
+
+test('a recovery for a space with no open view is a no-op', async (t) => {
+  await freshPeerWithIdentity(t)
+  const views = new MemberViews('member-views', { overlayBackend: {}, ...offlineMemberRegistry })
+  await views.recover('no-such-space')
+  t.alike(views.supervise(), [], 'nothing to supervise, nothing to recover')
+})
+
+test('a stopping subsystem reports no units and recovers nothing', async (t) => {
+  const { spaceId, views } = await spaceWithView(t)
+  t.is(views.supervise().length, 1)
+
+  views._stopping = true
+  t.alike(views.supervise(), [], 'a teardown in progress reports nothing to recover')
+  await views.recover(spaceId)
+  t.pass('and the recovery is a no-op rather than a throw')
+})
+
+test('the fold window scales with the budget each roster read is capped at', (t) => {
+  setRuntimeConfig({ ...getRuntimeConfig(), peerReadTimeoutMs: READ_BUDGET_MS })
+  t.is(peerReadTimeoutMs(), READ_BUDGET_MS)
+})
+
+// The recovery route is the whole safety argument, and a future edit could quietly swap it for the
+// obvious-looking close-and-reopen. Pinned by source text, the way the crash-backstop suite pins boot.js.
+test('REGRESSION (FIX-SUP-2 wiring): the recovery restarts the fold and never closes the view', (t) => {
+  const src = fs.readFileSync(path.join(
+    path.dirname(import.meta.url.replace(/^file:\/\//, '')), '..', '..',
+    'src', 'shared', 'spaces', 'member-registry.js'
+  ), 'utf8')
+  const body = src.slice(src.indexOf('async recover (spaceId)'))
+  t.ok(/restartFold\?\.\(\)/.test(body), 'it re-arms the fold')
+  t.absent(/closeMemberView|openMemberView/.test(body), 'and does not close or reopen the view')
+
+  const view = fs.readFileSync(path.join(
+    path.dirname(import.meta.url.replace(/^file:\/\//, '')), '..', '..',
+    'src', 'shared', 'spaces', 'member-view.js'
+  ), 'utf8')
+  t.ok(/view\.noteProgress\(\)/.test(view), 'the fold reports a heartbeat per roster read')
+  t.ok(/restartFold: \(\) => \{ view\.abandon\(\); view\.recompute\(\) \}/.test(view),
+    'and the restart abandons the stalled fold rather than awaiting it')
+})

--- a/test/integration/subsystem-supervision.test.js
+++ b/test/integration/subsystem-supervision.test.js
@@ -1,0 +1,146 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { createLifecycle } from '../../src/shared/core/subsystem.js'
+import { Supervisor } from '../../src/shared/core/supervisor.js'
+import { DEFAULT_POLICY } from '../../src/shared/core/supervision.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import {
+  ForeignMirrors, runMaterializeTick, mirrorHealth, unmountForeignFolder,
+} from '../../src/shared/folders/foreign-folders.js'
+import { createFakeIpc } from '../helpers/fake-ipc.js'
+import { wedgedMirror, waitUntil, delay } from '../helpers/wedged-mirror.js'
+
+// The mirror loop's own wedge and restart are covered in foreign-mirror-restart.test.js. This file
+// covers the mechanism that decides WHEN to restart it: the probe cadence, the consecutive-bad
+// rule, the recovery budget and the teardown guards, all of which used to be hand-built inside
+// MountsRuntime and are now shared by every subsystem that declares supervisable units.
+
+const silentLog = { debug () {}, info () {}, warn () {}, error () {} }
+
+async function supervised (t, opts) {
+  const wedge = await wedgedMirror(t, opts)
+  // A probe interval long enough that only the explicit probe() calls below drive the policy.
+  setRuntimeConfig({ ...getRuntimeConfig(), supervisionProbeIntervalMs: 3_600_000 })
+  const life = createLifecycle({ log: silentLog })
+  const mirrors = await life.start(new ForeignMirrors('foreign-mirrors', { ipc: createFakeIpc().ipc }))
+  const supervisor = await life.start(new Supervisor('supervision', { lifecycle: life }))
+  supervisor.log = silentLog
+  mirrors.log = silentLog
+  // Closing ForeignMirrors stops every loop, which the wedged-mirror teardown also does; ordering
+  // is handled by brittle running this before the helper's own teardown.
+  t.teardown(() => life.close())
+  return { ...wedge, life, mirrors, supervisor }
+}
+
+test('a wedged mirror is reported as a supervisable unit labelled with its share id', async (t) => {
+  const { spaceId, shareId, spy, mirrors } = await supervised(t, { pollMs: 50 })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  t.alike(mirrors.supervise().map((row) => row.ok), [true], 'a pass that just started is not wedged')
+
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+  const rows = mirrors.supervise()
+  t.is(rows.length, 1)
+  t.is(rows[0].ok, false)
+  t.is(rows[0].label, shareId, 'the log-safe label is the share id')
+  t.ok(rows[0].key.includes(shareId), 'and the key identifies the mount')
+})
+
+// REGRESSION (FIX-R09-2 / SUP-1: the mirror probe was hand-built inside MountsRuntime, so no other
+// subsystem could be supervised at all). The behaviour asserted here is what #138 shipped; what is
+// new is that it now runs through the shared supervisor.
+test('REGRESSION (SUP-1: the supervisor recovers a wedged mirror after two consecutive bad probes)', async (t) => {
+  const { spaceId, shareId, spy, supervisor } = await supervised(t, { pollMs: 50 })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+
+  await supervisor.probe()
+  t.is(spy.fetches, 1, 'one bad probe is not enough to act')
+
+  await supervisor.probe()
+  await waitUntil(() => spy.fetches === 2)
+  t.is(spy.fetches, 2, 'the second consecutive bad probe restarts the loop')
+  t.is(supervisor.stats().recoveries['foreign-mirrors'], 1)
+})
+
+// The base clears the probe interval on close, but a probe already awaiting a recovery when a
+// shutdown begins would re-arm a loop the teardown just stopped.
+test('the supervisor recovers nothing once it is paused', async (t) => {
+  const { spaceId, shareId, spy, supervisor } = await supervised(t, { pollMs: 50 })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+
+  supervisor.pause()
+  await supervisor.probe()
+  await supervisor.probe()
+  await delay(50)
+  t.is(spy.fetches, 1, 'no loop is restarted during teardown')
+})
+
+test('a mirror that cannot be recovered spends its budget and is then left down', async (t) => {
+  const { spaceId, shareId, spy, supervisor } = await supervised(t, { pollMs: 50 })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+
+  // Every restart re-wedges, because fetchFile hangs for every pass.
+  for (let i = 0; i < DEFAULT_POLICY.maxRecoveries; i++) {
+    await waitUntil(() => mirrorHealth()[0]?.ok === false)
+    await supervisor.probe()
+    await supervisor.probe()
+    await waitUntil(() => spy.fetches === i + 2)
+  }
+  t.is(spy.fetches, DEFAULT_POLICY.maxRecoveries + 1, 'the budget bought three restarts')
+
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+  await supervisor.probe()
+  await supervisor.probe()
+  await delay(80)
+  t.is(spy.fetches, DEFAULT_POLICY.maxRecoveries + 1, 'and then it stops rather than restarting forever')
+  t.is(supervisor.stats().gaveUp['foreign-mirrors'], 1)
+})
+
+test('an unmounted mount stops being supervised and leaves no spent budget behind', async (t) => {
+  const { spaceId, shareId, spy, mirrors, supervisor } = await supervised(t, { pollMs: 50 })
+
+  runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.fetches === 1)
+  await waitUntil(() => mirrorHealth()[0]?.ok === false)
+  await supervisor.probe()
+  await supervisor.probe()
+  t.is(supervisor.stats().recoveries['foreign-mirrors'], 1)
+
+  await unmountForeignFolder(spaceId, shareId)
+  t.alike(mirrors.supervise(), [], 'a mount with no live loop is not a supervisable unit')
+  await supervisor.probe()
+  t.alike(supervisor.stats().recoveries, {}, 'and its counters are pruned with it')
+})
+
+// A correct probe proves nothing about it running: requestFailures and requestMetrics both shipped
+// as no-ops because the producer was built and never wired. Constructing the real root needs a
+// booted store, so the wiring is pinned by source text, the way the crash-backstop suite pins boot.js.
+test('REGRESSION (SUP-1 wiring): the supervisor is started last, paused first, and mirrors declare units', (t) => {
+  const root = path.join(path.dirname(import.meta.url.replace(/^file:\/\//, '')), '..', '..', 'src')
+  const boot = fs.readFileSync(path.join(root, 'worker', 'boot.js'), 'utf8')
+  const mirrors = fs.readFileSync(path.join(root, 'shared', 'folders', 'foreign-folders.js'), 'utf8')
+  const mounts = fs.readFileSync(path.join(root, 'worker', 'mounts-runtime.js'), 'utf8')
+
+  t.ok(boot.indexOf('new Supervisor(') > boot.indexOf('new Sweeps('),
+    'the supervisor starts after every subsystem it supervises, so it closes first')
+  const closeBody = boot.slice(boot.indexOf('async function close({'), boot.indexOf('onPartialRoot?.('))
+  t.ok(closeBody.indexOf('supervisor?.pause()') < closeBody.indexOf('broadcastDeparture()'),
+    'and it is paused before the shutdown flush window, not only by life.close()')
+  t.ok(/supervision: \(\) => supervisor/.test(boot), 'its counters reach the root for diagnostics')
+
+  t.ok(/^ {2}supervise\(/m.test(mirrors), 'ForeignMirrors declares its supervisable units')
+  t.ok(/^ {2}async recover\(/m.test(mirrors), 'and the recovery the supervisor drives')
+
+  t.absent(/probeMirrorLiveness/.test(mounts), 'the hand-built probe is gone, not duplicated')
+  t.absent(/restartForeignLoop/.test(mounts), 'and the mount runtime no longer drives the restart')
+})

--- a/test/unit/derived-view.test.js
+++ b/test/unit/derived-view.test.js
@@ -190,3 +190,129 @@ test('a watched bee change schedules a coalesced recompute', async (t) => {
   t.is(folds, 1, 'a replicated/local change triggers a fold')
   await dv.close()
 })
+
+// A recovery abandons the fold in flight rather than awaiting it (close() awaits `inFlight`, so a
+// fold that is not settling can never be closed). Without a generation guard the abandoned fold
+// still runs to completion and then clears the LIVE fold's `running` flag and publishes its own
+// superseded result — un-serialising two folds, which is what the flag exists to prevent.
+test('REGRESSION (FIX-SUP-2a: an abandoned fold cleared the live fold\'s running flag)', async (t) => {
+  let releaseFirst = null
+  let folds = 0
+  const view = createDerivedView({
+    fold: () => {
+      folds += 1
+      if (folds === 1) return new Promise((resolve) => { releaseFirst = () => resolve('stale') })
+      return new Promise(() => {})
+    },
+    onChange: () => {},
+  })
+
+  view.recompute()
+  await tick()
+  t.is(folds, 1)
+
+  view.abandon()
+  view.recompute()
+  await tick()
+  t.is(folds, 2, 'a fresh fold started')
+
+  releaseFirst()
+  await tick()
+
+  view.recompute()
+  await tick()
+  t.is(folds, 2, 'the live fold still holds the lane — the stale settle did not release it')
+  // close() awaits the fold in flight, and this one never settles — abandoning first is exactly
+  // what the recovery path does.
+  view.abandon()
+  await view.close()
+})
+
+test('REGRESSION (FIX-SUP-2b: an abandoned fold published a stale view after the fresh one)', async (t) => {
+  const seen = []
+  let releaseFirst = null
+  let folds = 0
+  const view = createDerivedView({
+    fold: () => {
+      folds += 1
+      if (folds === 1) return new Promise((resolve) => { releaseFirst = () => resolve('stale') })
+      return Promise.resolve('fresh')
+    },
+    onChange: (v) => seen.push(v),
+  })
+
+  view.recompute()
+  await tick()
+  view.abandon()
+  view.recompute()
+  await tick()
+  t.alike(seen, ['fresh'])
+
+  releaseFirst()
+  await tick()
+  t.alike(seen, ['fresh'], 'the abandoned fold published nothing after the fold that replaced it')
+  await view.close()
+})
+
+test('abandon() does not await the fold in flight', async (t) => {
+  const view = createDerivedView({ fold: () => new Promise(() => {}), onChange: () => {} })
+  view.recompute()
+  await tick()
+  view.abandon()
+  t.pass('returned against a promise that never settles')
+  await view.close()
+})
+
+test('an abandoned fold does not fire the trailing recompute it queued', async (t) => {
+  let releaseFirst = null
+  let folds = 0
+  const view = createDerivedView({
+    fold: () => {
+      folds += 1
+      if (folds === 1) return new Promise((resolve) => { releaseFirst = () => resolve(null) })
+      return new Promise(() => {})
+    },
+    onChange: () => {},
+  })
+
+  view.recompute()
+  await tick()
+  view.recompute()
+  t.is(folds, 1, 'the second change is queued as a trailing fold')
+
+  view.abandon()
+  releaseFirst()
+  await tick()
+  t.is(folds, 1, 'the abandoned fold ran no trailing fold of its own')
+  await view.close()
+})
+
+test('health reports idle, advancing and stalled folds', async (t) => {
+  let release = null
+  const view = createDerivedView({
+    fold: () => new Promise((resolve) => { release = resolve }),
+    onChange: () => {},
+  })
+  t.is(view.health({ now: Date.now(), windowMs: 1000 }).ok, true, 'idle between folds')
+
+  view.recompute()
+  await tick()
+  const now = Date.now()
+  t.is(view.health({ now, windowMs: 1000 }).ok, true, 'a fold that just started is healthy')
+  t.is(view.health({ now: now + 5000, windowMs: 1000 }).ok, false, 'no progress past the window is stalled')
+
+  view.noteProgress()
+  t.is(view.health({ now: Date.now() + 500, windowMs: 1000 }).ok, true, 'progress resets the stall clock')
+
+  release(null)
+  await tick()
+  t.is(view.health({ now: Date.now() + 5000, windowMs: 1000 }).ok, true, 'and a settled fold is idle again')
+  await view.close()
+})
+
+test('noteProgress does nothing while no fold is in flight', async (t) => {
+  const view = createDerivedView({ fold: async () => null, onChange: () => {} })
+  view.noteProgress()
+  t.is(view.health({ now: Date.now(), windowMs: 1000 }).ok, true)
+  await view.close()
+})

--- a/test/unit/stall-verdict.test.js
+++ b/test/unit/stall-verdict.test.js
@@ -1,0 +1,33 @@
+import test from 'brittle'
+import { stallVerdict } from '../../src/shared/core/stall-verdict.js'
+
+const W = 1000
+
+test('a unit with no pass in flight is healthy', (t) => {
+  t.alike(stallVerdict({ startedAt: 0, progressAt: 0 }, { now: 10_000, windowMs: W }), { ok: true, detail: null })
+})
+
+test('null or undefined liveness is healthy, not a throw', (t) => {
+  t.is(stallVerdict(null, { now: 1, windowMs: W }).ok, true)
+  t.is(stallVerdict(undefined, { now: 1, windowMs: W }).ok, true)
+})
+
+test('a pass that is still advancing is healthy however long it has run', (t) => {
+  t.is(stallVerdict({ startedAt: 1, progressAt: 900_000 }, { now: 900_500, windowMs: W }).ok, true)
+})
+
+test('a pass with no progress past the window is stalled, with the elapsed seconds in detail', (t) => {
+  const v = stallVerdict({ startedAt: 1000, progressAt: 1000 }, { now: 6000, windowMs: W })
+  t.is(v.ok, false)
+  t.is(v.detail, 'no progress for 5s')
+})
+
+test('a pass that never reported progress falls back to its start time', (t) => {
+  t.is(stallVerdict({ startedAt: 1000, progressAt: 0 }, { now: 1500, windowMs: W }).ok, true, 'not stalled from the epoch')
+  t.is(stallVerdict({ startedAt: 1000, progressAt: 0 }, { now: 3000, windowMs: W }).ok, false)
+})
+
+test('exactly at the threshold is still healthy', (t) => {
+  t.is(stallVerdict({ startedAt: 1000, progressAt: 1000 }, { now: 2000, windowMs: W }).ok, true)
+  t.is(stallVerdict({ startedAt: 1000, progressAt: 1000 }, { now: 2001, windowMs: W }).ok, false)
+})

--- a/test/unit/supervision.test.js
+++ b/test/unit/supervision.test.js
@@ -1,0 +1,75 @@
+import test from 'brittle'
+import { createSupervisionPolicy, DEFAULT_POLICY } from '../../src/shared/core/supervision.js'
+
+const row = (key, ok, name = 'mirrors') => ({ id: name + ' ' + key, name, key, ok, detail: ok ? null : 'stuck' })
+const actions = (out) => out.map((d) => d.action)
+
+test('a healthy unit is never acted on', (t) => {
+  const policy = createSupervisionPolicy()
+  t.alike(actions(policy.evaluate([row('a', true)])), [])
+  t.alike(actions(policy.evaluate([row('a', true)])), [])
+})
+
+test('a recovery needs consecutiveBad probes, not one', (t) => {
+  const policy = createSupervisionPolicy()
+  t.alike(actions(policy.evaluate([row('a', false)])), ['note'], 'one bad probe only notes it')
+  t.alike(actions(policy.evaluate([row('a', false)])), ['recover'])
+})
+
+test('one healthy probe resets the streak', (t) => {
+  const policy = createSupervisionPolicy()
+  policy.evaluate([row('a', false)])
+  policy.evaluate([row('a', true)])
+  t.alike(actions(policy.evaluate([row('a', false)])), ['note'], 'the streak restarted from zero')
+})
+
+test('a recovery clears the streak, so the next one costs a full window again', (t) => {
+  const policy = createSupervisionPolicy()
+  policy.evaluate([row('a', false)])
+  t.alike(actions(policy.evaluate([row('a', false)])), ['recover'])
+  t.alike(actions(policy.evaluate([row('a', false)])), ['note'], 'not a second recovery on the very next probe')
+})
+
+test('the budget is enforced and the give-up is reported exactly once', (t) => {
+  const policy = createSupervisionPolicy()
+  for (let i = 0; i < DEFAULT_POLICY.maxRecoveries; i++) {
+    policy.evaluate([row('a', false)])
+    t.alike(actions(policy.evaluate([row('a', false)])), ['recover'], 'recovery ' + (i + 1))
+  }
+  policy.evaluate([row('a', false)])
+  t.alike(actions(policy.evaluate([row('a', false)])), ['gave-up'], 'the budget is spent')
+  t.alike(actions(policy.evaluate([row('a', false)])), [], 'and it is not restated every probe')
+  t.is(policy.stats().recoveries['mirrors a'], DEFAULT_POLICY.maxRecoveries)
+})
+
+test('a unit that disappears drops its counters', (t) => {
+  const policy = createSupervisionPolicy()
+  policy.evaluate([row('a', false)])
+  policy.evaluate([row('a', false)])
+  t.is(policy.stats().recoveries['mirrors a'], 1)
+
+  policy.evaluate([])
+  t.alike(policy.stats().recoveries, {}, 'an unmounted unit leaves no spent budget behind')
+  t.alike(actions(policy.evaluate([row('a', false)])), ['note'], 'and a key reused later starts fresh')
+})
+
+test('a per-subsystem override replaces the defaults for that subsystem only', (t) => {
+  const policy = createSupervisionPolicy({ mirrors: { consecutiveBad: 1, maxRecoveries: 1 } })
+  const both = () => [row('a', false), row('b', false, 'views')]
+  t.alike(actions(policy.evaluate(both())), ['recover', 'note'], 'one bad probe is enough for mirrors, not for views')
+  t.alike(actions(policy.evaluate(both())), ['gave-up', 'recover'], 'the override budget is one; views still has three')
+})
+
+test('two subsystems using the same unit key are counted separately', (t) => {
+  const policy = createSupervisionPolicy()
+  const rows = [row('shared', false, 'mirrors'), row('shared', false, 'views')]
+  t.alike(actions(policy.evaluate(rows)), ['note', 'note'])
+  t.alike(actions(policy.evaluate(rows)), ['recover', 'recover'], 'neither pooled the other\'s strikes')
+})
+
+test('one unhealthy unit does not disturb a healthy sibling', (t) => {
+  const policy = createSupervisionPolicy()
+  policy.evaluate([row('a', false), row('b', true)])
+  const out = policy.evaluate([row('a', false), row('b', true)])
+  t.alike(out.map((d) => d.row.key), ['a'])
+})

--- a/test/unit/supervisor.test.js
+++ b/test/unit/supervisor.test.js
@@ -1,0 +1,183 @@
+import test from 'brittle'
+import { Subsystem, createLifecycle } from '../../src/shared/core/subsystem.js'
+import { Supervisor } from '../../src/shared/core/supervisor.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+
+const silentLog = { debug () {}, info () {}, warn () {}, error () {} }
+const quiet = (subsystem) => { subsystem.log = silentLog; return subsystem }
+
+class Wedgeable extends Subsystem {
+  constructor (name, units = [{ key: 'u1', ok: true, detail: null }]) {
+    super(name)
+    this.units = units
+    this.recovered = []
+    quiet(this)
+  }
+
+  supervise () { return this.units }
+  async recover (key) { this.recovered.push(key) }
+  wedge (key = 'u1') { this.units = [{ key, ok: false, detail: 'stuck' }] }
+  heal (key = 'u1') { this.units = [{ key, ok: true, detail: null }] }
+}
+
+async function harness (t, subsystems) {
+  const life = createLifecycle({ log: silentLog })
+  for (const subsystem of subsystems) await life.start(subsystem)
+  const supervisor = quiet(await life.start(new Supervisor('supervision', { lifecycle: life })))
+  t.teardown(() => life.close())
+  return { life, supervisor }
+}
+
+test('a subsystem with no supervisable units is never probed', async (t) => {
+  class Silent extends Subsystem {}
+  const { supervisor } = await harness(t, [quiet(new Silent('silent'))])
+  await supervisor.probe()
+  t.alike(supervisor.collectRows(), [], 'nothing to supervise')
+  t.alike(supervisor.stats().recoveries, {})
+})
+
+test('a unit is recovered only after two consecutive bad probes', async (t) => {
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [mirrors])
+  mirrors.wedge()
+
+  await supervisor.probe()
+  t.alike(mirrors.recovered, [], 'one bad probe is not enough to act')
+  await supervisor.probe()
+  t.alike(mirrors.recovered, ['u1'])
+  t.is(supervisor.stats().recoveries.mirrors, 1)
+})
+
+test('a healthy unit is never recovered', async (t) => {
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [mirrors])
+  await supervisor.probe()
+  await supervisor.probe()
+  await supervisor.probe()
+  t.alike(mirrors.recovered, [])
+})
+
+test('a subsystem whose supervise() throws does not blind the supervisor to the rest', async (t) => {
+  class Broken extends Subsystem {
+    supervise () { throw new Error('nope') }
+  }
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [quiet(new Broken('broken')), mirrors])
+  mirrors.wedge()
+
+  await supervisor.probe()
+  await supervisor.probe()
+  t.alike(mirrors.recovered, ['u1'], 'the healthy reporter is still supervised')
+})
+
+test('a recovery that throws does not stop the probe', async (t) => {
+  class Failing extends Wedgeable {
+    async recover () { throw new Error('cannot') }
+  }
+  const failing = new Failing('failing')
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [failing, mirrors])
+  failing.wedge()
+  mirrors.wedge()
+
+  await supervisor.probe()
+  await supervisor.probe()
+  t.alike(mirrors.recovered, ['u1'], 'the second subsystem was still reached')
+})
+
+test('pause() stops acting even though the lifecycle still looks healthy', async (t) => {
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [mirrors])
+  mirrors.wedge()
+
+  await supervisor.probe()
+  supervisor.pause()
+  await supervisor.probe()
+  await supervisor.probe()
+  t.alike(mirrors.recovered, [], 'the shutdown window is covered before any stopping flag is set')
+})
+
+test('a subsystem already stopping is skipped', async (t) => {
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [mirrors])
+  mirrors.wedge()
+  await supervisor.probe()
+  mirrors._stopping = true
+  await supervisor.probe()
+  t.alike(mirrors.recovered, [])
+})
+
+test('a shutdown beginning between two units stops the second recovery', async (t) => {
+  const first = new Wedgeable('first')
+  const second = new Wedgeable('second')
+  const { supervisor } = await harness(t, [first, second])
+  first.wedge()
+  second.wedge()
+  first.recover = async (key) => { first.recovered.push(key); supervisor.pause() }
+
+  await supervisor.probe()
+  await supervisor.probe()
+  t.alike(first.recovered, ['u1'])
+  t.alike(second.recovered, [], 'an entry-only guard would have recovered this one too')
+})
+
+test('a probe overlapping a slow recovery is skipped, not queued', async (t) => {
+  const mirrors = new Wedgeable('mirrors')
+  const { supervisor } = await harness(t, [mirrors])
+  mirrors.wedge()
+  await supervisor.probe()
+
+  let release = null
+  mirrors.recover = async (key) => {
+    mirrors.recovered.push(key)
+    await new Promise((resolve) => { release = resolve })
+  }
+  const slow = supervisor.probe()
+  await supervisor.probe()
+  await supervisor.probe()
+  release()
+  await slow
+  t.alike(mirrors.recovered, ['u1'], 'the re-entrant probes did nothing')
+})
+
+test('the supervisor does not supervise itself', async (t) => {
+  const { supervisor } = await harness(t, [])
+  supervisor.supervise = () => [{ key: 'self', ok: false, detail: 'stuck' }]
+  await supervisor.probe()
+  await supervisor.probe()
+  t.alike(supervisor.stats().recoveries, {})
+})
+
+test('stats() reports counts by subsystem and never a unit key', async (t) => {
+  const mirrors = new Wedgeable('mirrors', [{ key: 'space-abc/share-def', ok: false, detail: 'stuck' }])
+  const { supervisor } = await harness(t, [mirrors])
+  await supervisor.probe()
+  await supervisor.probe()
+
+  const serialised = JSON.stringify(supervisor.stats())
+  t.is(supervisor.stats().recoveries.mirrors, 1)
+  t.absent(serialised.includes('space-abc'), 'no space id reaches the shareable bundle')
+  t.absent(serialised.includes('share-def'), 'no share id either')
+})
+
+// The supervisor is started LAST so the lifecycle's reverse close order stops it FIRST. That
+// ordering is the whole guard: a probe interval outliving the subsystems it supervises would
+// recover work a shutdown has already stopped.
+test('REGRESSION (SUP-1): the supervisor closes first and leaves no probe armed', async (t) => {
+  setRuntimeConfig({ ...getRuntimeConfig(), supervisionProbeIntervalMs: 20 })
+  const closed = []
+  class Recorder extends Subsystem {
+    async _close () { closed.push(this.name) }
+  }
+  const life = createLifecycle({ log: silentLog })
+  await life.start(quiet(new Recorder('mirrors')))
+  await life.start(quiet(new Recorder('sweeps')))
+  const supervisor = quiet(await life.start(new Supervisor('supervision', { lifecycle: life })))
+  supervisor.on('close', () => closed.push(supervisor.name))
+  t.is(supervisor.timers.size, 1, 'the probe interval is armed while open')
+
+  await life.close()
+  t.alike(closed, ['supervision', 'sweeps', 'mirrors'], 'stopped before anything it supervises')
+  t.is(supervisor.timers.size, 0, 'and its probe interval is gone')
+  t.ok(supervisor.timers.closed, 'with the timer set closed, so nothing can re-arm one')
+})


### PR DESCRIPTION
Closes the remaining third of r09-1. The process supervises itself (#135) and the mirror loop is supervised by hand (#138); nothing generalised it, so any other subsystem that stalls stays stalled until the app restarts.

## The verb is `recover(unit)`, not `restart(subsystem)`

Re-derived from the code, and it still holds: a `Subsystem` here is not a restartable unit. The close-and-reconstruct-safe set (`EchoGuardPurge`, `PeerWatch`, `Sweeps`) is exactly the set with nothing worth recovering, while every subsystem worth supervising is fatal to replace — `ForeignMirrors._open` starts no loops, `MemberViews._close` resets its collaborators to no-ops, `ContentSwarm._close` detaches the shared overlay backend.

So the subsystem reports its own supervisable units and knows how to recover one; the supervisor owns only the policy. The instance is never replaced, so no holder is ever handed a dead collaborator — which is what turns this from a design problem into a refactor.

## Measured, because it decides the whole approach

The obvious cheaper objection is "put a deadline on the work instead of a watchdog over it". It does not apply: every network await on the mirror path is already bounded, and the innermost one by a *lease* — `ChunkScheduler`'s 30s idle timeout, re-armed on every chunk. What is unbounded is `stat`, `mkdir` and a whole-file hash on a hung network mount, and a blocking filesystem syscall cannot be given a deadline. Detect-and-re-arm is the only mechanism left for that class.

## Two clients, deliberately

`ForeignMirrors` migrates onto the shared mechanism with identical timing and budget — `mounts-runtime.js` loses 56 lines, and the wedge/restart tests are unchanged and still pass, which is the evidence the behaviour survived. `MemberViews` is the second, and is the subsystem the earlier attempt could not touch at all: its roster fold reads serially at one bounded read per member, so a space whose members are unreachable can freeze its member list, join requests and share list while `health()` reports fine.

Recovery there re-arms the fold alone. Closing the view would drop leave tombstones that a failed persist never wrote, and would await a fold that is not settling.

Includes a latent bug the recovery would have activated: `createDerivedView` had no generation guard, so an abandoned fold cleared the live fold's `running` flag and published its superseded result — the same defect #138 had to fix first in the mirror map. Landed on its own commit, red-first.

## Layers

Unit (`stall-verdict`, `supervision`, `supervisor`, `derived-view` +6 red-first) · Integration (`subsystem-supervision`, `member-view-supervision`) · Flow (`supervision-shutdown-order`).

Frontend + a11y: **SKIP** — no renderer changes. The only new surface is `diagnostics:export`, which has no UI.

All gates run on the rebased tree: unit 1612/1612, bare 945/945, flow 195/195.

Two tests were dropped rather than deferred, both because the layer cannot reach them: a flow test that wedges a mirror needs an in-process hung fetch, and a stalled-fold integration test needs a peer that connects then goes silent — a local fold with no replicating peer settles immediately. Both rules are asserted red-first one layer down.