### PR TITLE
[test] Induce the folder fault the only way it can happen

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -281,3 +281,17 @@ outlives a tick is a bug until proven otherwise.
 **A geometry harness cannot tell you whether something looks right.** The sticky filter row measured perfectly — 0px between its right edge and the rows', 4px from the scrollport top while scrolled, every ring clear — and it still looked broken on screen. Numbers prove alignment, not appearance: they say nothing about a sliver of content showing through a transparent strip, a scrollbar that renders differently at `thin`, or a band whose background does not match what it covers. **A user-facing visual change gets pushed and PR'd only after the user has run it locally and said so.** Green tests are the precondition for asking, not a substitute for the answer.
 
 **A `dark:` base and a `hover:` state have the same specificity, so source order decides.** `dark:bg-x` compiles to `.dark\:bg-x:is(.dark *)` — (0,2,0), identical to `.hover\:bg-y:hover` — and Tailwind emitted the dark base *later*, so the secondary button's hover silently did nothing in dark mode while working fine in light. It had been written `dark:hover:bg-…`, a combined variant at (0,3,0), which is why the original worked and my "simplification" to a single `hover:` utility broke it. The fix is a token that flips per theme (`surface-control`), leaving the base at (0,1,0) so any interactive state outranks it. Reach for a theme-flipping token, not a `dark:` variant, on anything that also has hover/focus/active states — and when a hover "looks too subtle", check the cascade before adjusting the colour.
+
+**chokidar emits no `add` for a file that is unreadable when it would report it.** MEASURED with the
+app's own watcher options (chokidar 4, `awaitWriteFinish`, `alwaysStat`, `usePolling:false`): write a
+file then `chmod 000` it, and the watcher produces **no event at all** — not an `add`, not an
+`error`. A sibling plain file in the same directory reports normally. So an owner's
+permission-fault-on-read is undetectable by the watcher **by construction**; only a scan
+(mount, resume, the periodic reconcile, or a user-driven retry) ever finds it.
+
+Two consequences, both paid for once already:
+1. A UI scenario that induces this fault through the watcher can never pass. Induce it with a scan.
+2. An integration test that stubs the publish call to throw proves the WIRING, never the PREMISE —
+   the double is more cooperative than the real code. When a test asserts on a fault class, drive at
+   least one case with the real condition (a real 000 file), or a scenario built on an impossible
+   lever will be the thing that finds out.

--- a/test/frontend/README.md
+++ b/test/frontend/README.md
@@ -65,7 +65,7 @@ Owner-side filesystem operations — adding, editing, deleting, moving, or copyi
 | s9 | `s9-folder-lifecycle.mjs` | Delete an owned folder via card menu + confirm → tombstone disappears for the peer. |
 | s12 | `s12-add-folder-validation.mjs` | AddFolder validation: name-collision error and invalid-name error each block "Next: Preview". |
 | s23 | `s23-relocate.mjs` | Source folder moved on disk → "missing on disk" state → Locate re-points the share ("Reconnected"). |
-| s127 | `s127-folder-fault-strip.mjs` | **REGRESSION (FIX-PI12)** an unreadable file in the shared folder surfaces the fault strip ("couldn't be added — Permission denied", never the errno); it survives a restart, carries a Try again, and clears when that verb runs a clean pass. |
+| s127 | `s127-folder-fault-strip.mjs` | **REGRESSION (FIX-PI12)** sharing a folder holding an unreadable file surfaces the fault strip ("couldn't be added — Permission denied", never the errno); it survives a restart, carries a Try again, and clears when that verb runs a clean pass. Induced by a SCAN, not the watcher: **measured** — chokidar emits no add at all for a file that is unreadable when it would report it. |
 
 ### H. Mirroring — peer side
 | ID | File | Covers |

--- a/test/frontend/scenarios/s127-folder-fault-strip.mjs
+++ b/test/frontend/scenarios/s127-folder-fault-strip.mjs
@@ -12,10 +12,12 @@ import { workDir } from '../paths.mjs'
 // publish that fails is counted per item and the pass still resolved, which settled the folder to
 // 'active'.)
 //
-// The fault is induced through the genuine path: an unreadable file inside the shared folder. The
-// watcher publishes it, the read fails EACCES, and the catch-up pass that follows settles the
-// mount. Nothing here forces a status — this is the whole chain, which is why it belongs at this
-// layer rather than as a rendered-given-state check.
+// The fault is induced the only way it can be: a file the app cannot read, found by a SCAN.
+// MEASURED (chokidar 4, the app's own watcher options): a file that is unreadable when the
+// watcher would report it produces no add event at all — no event, no error, silently dropped.
+// So this fault class never reaches the watcher, and the scan is not a shortcut here but the
+// genuine path. That is also why the strip carries a retry: nothing else re-runs a scan inside
+// six hours.
 export default async function s127 ({ runDir }) {
   mkdirSync(runDir, { recursive: true })
   const r = makeReport()
@@ -24,22 +26,21 @@ export default async function s127 ({ runDir }) {
   const ownDir = path.join(workDir('own-'), 'Reports')
   mkdirSync(ownDir, { recursive: true })
   writeFileSync(path.join(ownDir, 'q1.txt'), 'numbers')
-  const secret = path.join(ownDir, 'sealed.txt')
+  const sealed = path.join(ownDir, 'sealed.txt')
+  writeFileSync(sealed, 'cannot read this')
+  chmodSync(sealed, 0o000)
 
   try {
-    await r.ok('A shares "Reports" and it settles healthy', async () => {
+    await r.ok('A shares a folder holding one file it cannot read', async () => {
       await A.launch()
       await A.createSpaceOnly('Aurora')
       await A.addOwnedFolder(ownDir)
       await A.waitText('Reports', 60000)
       await A.openFolder('Reports')
       await A.waitText('q1.txt', 20000)
-      assert(!(await A.hasText('Problem')), 'precondition: a healthy folder shows no fault')
     })
 
-    await r.ok('a file it cannot read surfaces the fault, named in plain language', async () => {
-      writeFileSync(secret, 'cannot read this')
-      chmodSync(secret, 0o000)
+    await r.ok('the fault is named in plain language, never as an errno', async () => {
       await waitFor(async () => {
         const text = allText(await A.snap())
         return /couldn't be added/i.test(text) && /permission denied/i.test(text)
@@ -66,10 +67,10 @@ export default async function s127 ({ runDir }) {
     })
 
     await r.ok('fixing the file and pressing the verb clears it', async () => {
-      chmodSync(secret, 0o644)
-      // The strip's own verb, not a Pause/Resume detour: it runs a full pass, and the pass that
-      // succeeds is the recovery. Nothing else would clear it here — the mount-point probe only
-      // fires on a path that came back, and this path never went away.
+      chmodSync(sealed, 0o644)
+      // The strip's own verb runs a full pass, and the pass that succeeds is the recovery. Nothing
+      // else would clear it here — the mount-point probe only fires on a path that came back, and
+      // this path never went away.
       await A.click({ role: 'button', name: 'Try again' })
       await waitFor(async () => {
         const text = allText(await A.snap())

--- a/test/integration/owned-mount-fault.test.js
+++ b/test/integration/owned-mount-fault.test.js
@@ -64,6 +64,28 @@ test('an unclassified publish failure is not a mount fault', async (t) => {
   t.is(mount.status, 'active', 'pausing a folder on an error nobody can act on would be worse than the log line')
 })
 
+// The stubs above prove the wiring; this proves the PREMISE. A file the app genuinely cannot read
+// is the fault this feature exists for, and nothing else in the suite drives the real publish path
+// with one — which is how a UI scenario built on an impossible lever got as far as being run.
+test('a genuinely unreadable file faults the mount through the real publish path', async (t) => {
+  const ctx = await setupOwnedShare(t, { files: { 'a.txt': 'aa' } })
+  const sealed = path.join(ctx.mountPath, 'sealed.txt')
+  fs.writeFileSync(sealed, 'cannot read this')
+  fs.chmodSync(sealed, 0o000)
+  t.teardown(() => { try { fs.chmodSync(sealed, 0o644) } catch {} })
+
+  const result = await ctx.root.mounts.settleScanStatus(
+    initialPublishScan(ctx.spaceId, ctx.share.id, ctx.mountPath, []),
+    ctx.spaceId, ctx.share.id,
+  )
+  t.is(result.uploaded, 1, 'the readable file still published — one bad file is not a bad folder')
+  t.is(result.failed, 1)
+
+  const mount = await getOwnedMount(ctx.spaceId, ctx.share.id)
+  t.is(mount.status, 'paused-error')
+  t.is(mount.lastError, ErrorCodes.TRANSFER_PERMISSION, 'classified from the real errno, not a double')
+})
+
 test('REGRESSION (FIX-PI12-2: a classified whole-pass failure records the code, never err.message)', async (t) => {
   const ctx = await setupOwnedShare(t)
   const err = errno('ENOSPC', "ENOSPC: no space left on device, write '/Users/someone/Docs/x.tmp'")


### PR DESCRIPTION
Follow-up to #168. Its UI scenario could never pass: it induced the fault by
writing a file into the shared folder and `chmod 000`-ing it, expecting the
watcher to report it.

**Measured** with the app's own chokidar options (`awaitWriteFinish`,
`alwaysStat`, `usePolling:false`): a file that is unreadable when the watcher
would report it produces **no event at all** — not an `add`, not an `error`. A
plain sibling in the same directory reports normally. The app log from the
failed run agrees: watcher started at mount, then nothing for 90s.

So this fault class is undetectable by the watcher by construction, and only a
scan ever finds it. s127 now shares a folder that already holds an unreadable
file, so the mount's own scan is the trigger — the production path, not a
shortcut. The retry verb clears it at the end, as before.

Also adds the integration case that would have caught this: every existing test
stubbed `publishAdd` to throw, which proves the wiring but never the premise.
One case now drives the real publish path with a real `chmod 000` file
(`uploaded: 1, failed: 1` — one bad file is not a bad folder).

Lesson recorded in `.claude/lessons.md`.

## Tests

`owned-mount-fault` 13/13 · unit + integration suites green · typecheck +
`lint:ci` clean. `test:fe s127` still needs a local run.
