### PR TITLE
[fix] Give the user a reason instead of a wrong one

### DIFF
--- a/src/renderer/components/modals/InviteModal.tsx
+++ b/src/renderer/components/modals/InviteModal.tsx
@@ -20,7 +20,7 @@ type ExpiryId = typeof EXPIRY[number]['id']
 interface InviteModalProps {
   isOpen: boolean
   onClose: () => void
-  onCreate: (opts: { autoApprove: boolean; expiresInMs: number }) => Promise<string | null>
+  onCreate: (opts: { autoApprove: boolean; expiresInMs: number }) => Promise<string>
 }
 
 const BADGE_BASE = 'inline-flex items-center leading-none px-3 pt-[7px] pb-[5px] text-[10px] font-bold rounded-full uppercase tracking-wider border border-outline'
@@ -42,15 +42,14 @@ export default function InviteModal({ isOpen, onClose, onCreate }: InviteModalPr
   const chosen = EXPIRY.find((e) => e.id === expiry) ?? EXPIRY[0]
   const expiresLabel = new Date(Date.now() + chosen.ms).toLocaleDateString(i18n.language, { weekday: 'short', day: 'numeric', month: 'short' })
 
-  // space:invite refuses a pending membership and a pre-encryption space. Unhandled, the rejection
-  // also skipped setCreating(false), so the button stayed disabled on "Creating…" with nothing on
-  // screen saying why.
+  // space:invite refuses a pending membership, a pre-encryption space and an unknown space, all as
+  // rejections. Unhandled, the rejection also skipped setCreating(false), so the button stayed
+  // disabled on "Creating…" with nothing on screen saying why.
   async function handleCreate() {
     setCreating(true)
     setError(null)
     try {
-      const created = await onCreate({ autoApprove, expiresInMs: chosen.ms })
-      if (created) setCode(created)
+      setCode(await onCreate({ autoApprove, expiresInMs: chosen.ms }))
     } catch (err) {
       setError(errorText(err))
     } finally {

--- a/src/renderer/errorText.js
+++ b/src/renderer/errorText.js
@@ -1,10 +1,22 @@
-import { errorI18nKey } from './errorMessages.js'
+import { ERROR_I18N_KEY_BY_CODE, errorI18nKey } from './errorMessages.js'
 
 export const FALLBACK_KEY = 'unexpected'
 
 function errorCodeOf (err) {
   if (typeof err !== 'object' || err === null) return null
   return typeof err.code === 'string' ? err.code : null
+}
+
+// window.bridge.isDev() is a synchronous round trip to the main process. errorTextFor runs during
+// render — an error pane re-reads it on every re-render while it is on screen — so the answer is
+// read at most once rather than once per call. Left unresolved until the bridge exists so an early
+// call cannot cache a false.
+let devMode
+function isDevMode () {
+  if (devMode === undefined && typeof window !== 'undefined' && window.bridge?.isDev) {
+    devMode = !!window.bridge.isDev()
+  }
+  return devMode === true
 }
 
 // The single place a failure becomes text a person reads.
@@ -19,7 +31,10 @@ function errorCodeOf (err) {
 export function errorTextFor (err, t, fallbackKey = FALLBACK_KEY) {
   const code = errorCodeOf(err)
   const key = errorI18nKey(code, fallbackKey)
-  if (key === fallbackKey && typeof window !== 'undefined' && window.bridge?.isDev?.()) {
+  // Membership in the map, not key === fallbackKey. A surface may pass a fallback that a code also
+  // maps to (DOWNLOAD_FAILED resolves to transferFailed, which useFiles passes as its fallback),
+  // and equality would report that deliberate mapping as missing.
+  if (code && !(code in ERROR_I18N_KEY_BY_CODE) && isDevMode()) {
     console.warn('[i18n] no user-facing message for error code', code, err?.message ?? String(err))
   }
   return t(key)

--- a/src/renderer/hooks/useSpaces.ts
+++ b/src/renderer/hooks/useSpaces.ts
@@ -85,7 +85,7 @@ export function useSpaces() {
   }
 
   async function createInvite(spaceId: string, opts: { autoApprove?: boolean; expiresInMs?: number } = {}) {
-    return await request('space:invite', { spaceId, autoAdmit: !!opts.autoApprove, expiresInMs: opts.expiresInMs }) as string | null
+    return await request('space:invite', { spaceId, autoAdmit: !!opts.autoApprove, expiresInMs: opts.expiresInMs }) as string
   }
 
   async function approveMember(spaceId: string, publicKey: string) {

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -468,7 +468,9 @@ export async function revealFile(spaceId, filePath) {
   return revealLocalPath(await resolveRevealTarget(spaceId, filePath))
 }
 
-export function revealLocalPath(target) {
+// missingCode is the caller's, because the same walk backs revealing a file and revealing a folder
+// and "This file isn't on this device yet." is the wrong sentence for a folder.
+export function revealLocalPath(target, missingCode = ErrorCodes.FILE_NOT_ON_DEVICE) {
   const platform = os.platform()
   const exists = fs.existsSync(target)
   const folder = path.dirname(target)
@@ -476,7 +478,7 @@ export function revealLocalPath(target) {
   log.info('reveal requested:', target, '(platform:', platform + ', exists:', exists + ')')
 
   if (!exists && !fs.existsSync(folder)) {
-    throw new AppError(ErrorCodes.FILE_NOT_ON_DEVICE, 'File is not on this device')
+    throw new AppError(missingCode, 'Reveal target is not on this device')
   }
 
   const opts = { stdio: 'ignore', detached: true }

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -840,7 +840,7 @@ ipc.handle('share:reveal-folder', async (msg) => {
     if (!foreignMount) throw new AppError(ErrorCodes.MOUNT_NOT_ON_DEVICE, 'Mirror not mounted')
     target = foreignMount.mountPath
   }
-  return revealLocalPath(target)
+  return revealLocalPath(target, ErrorCodes.MOUNT_NOT_ON_DEVICE)
 })
 
 ipc.handle('share:reveal-file', async (msg) => {

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1387,7 +1387,9 @@ ipc.handle('space:join', async (msg) => {
 })
 ipc.handle('space:invite', async (msg) => {
   const space = await getSpace(msg.spaceId)
-  if (!space?.topic) return null
+  // Throw rather than return null: a null resolved as success, so the modal re-enabled its button
+  // with no code and no reason on screen — the same dead end an unhandled rejection used to leave.
+  if (!space?.topic) throw new AppError(ErrorCodes.SPACE_NOT_FOUND, 'Space not found')
   // Hard block: a member-only capability. While pending we hold no content key, so
   // any invite we minted could never confer read access (the redeemer would stall
   // pending exactly as we do) — but it WOULD leak the space topic to outsiders. Refuse

--- a/test/flow/membership-approval.test.js
+++ b/test/flow/membership-approval.test.js
@@ -154,6 +154,9 @@ test('a pending member cannot invite, approve, deny, or rename the space', { tim
   t.is((await B.request('spaces:list')).find((s) => s.spaceId === space.spaceId)?.status, 'pending', 'B is pending')
 
   await t.exception(() => B.request('space:invite', { spaceId: space.spaceId }), /joined|member/i, 'invite refused while pending')
+  // REGRESSION (FIX-INVITE-NULL-1: an unknown space resolved null, which the modal read as success —
+  // the button re-enabled with no code and no reason shown.)
+  await t.exception(() => A.request('space:invite', { spaceId: 'no-such-space' }), /not found/i, 'unknown space rejects')
   t.is(await B.request('space:approve-member', { spaceId: space.spaceId, publicKey: 'a'.repeat(64) }), false, 'approve refused (no content key)')
   t.is(await B.request('space:deny-member', { spaceId: space.spaceId, publicKey: 'a'.repeat(64) }), false, 'deny refused while pending')
   t.is(await B.request('space:update', { spaceId: space.spaceId, name: 'Hijacked', icon: 'folder' }), null, 'rename refused while pending')

--- a/test/frontend/scenarios/s3-join-errors.mjs
+++ b/test/frontend/scenarios/s3-join-errors.mjs
@@ -5,7 +5,7 @@ import { encodeInvite } from '../../../src/shared/invite-envelope.js'
 
 // JoinSpaceModal validation: the Join action is disabled with no code, and a
 // malformed invite code is rejected with an inline error. The text is the worker's
-// code rendered through the errors catalog, not its English message — s126 pins that
+// code rendered through the errors catalog, not its English message — s128 pins that
 // in a non-English locale, where the difference is visible. The code field, Join
 // button (disabled state), and the role=alert error region must be addressable.
 // Pressing Enter in the auto-focused code field submits the join just like

--- a/test/integration/error-code-splits.test.js
+++ b/test/integration/error-code-splits.test.js
@@ -31,6 +31,15 @@ test('revealing a file that is not on disk reports FILE_NOT_ON_DEVICE', async (t
   t.is(await codeOf(() => revealLocalPath(missing)), ErrorCodes.FILE_NOT_ON_DEVICE)
 })
 
+// REGRESSION (FIX-REVEAL-FOLDER-1: share:reveal-folder shares this walk with share:reveal-file, so a
+// folder whose mount had been removed from disk was reported as "This file isn't on this device yet.")
+test('the caller chooses what a missing reveal target means', async (t) => {
+  await freshPeer(t)
+  const missing = path.join('/tmp', 'no-such-dir-' + Date.now(), 'folder')
+  t.is(await codeOf(() => revealLocalPath(missing, ErrorCodes.MOUNT_NOT_ON_DEVICE)), ErrorCodes.MOUNT_NOT_ON_DEVICE)
+  t.is(await codeOf(() => revealLocalPath(missing)), ErrorCodes.FILE_NOT_ON_DEVICE, 'the file wording stays the default')
+})
+
 test('adding a file to a space with no drive reports DRIVE_NOT_FOUND', async (t) => {
   const ctx = await freshPeer(t)
   const src = path.join(ctx.tmpDir('src'), 'a.txt')

--- a/test/unit/error-text.test.js
+++ b/test/unit/error-text.test.js
@@ -58,3 +58,37 @@ test('no renderer site falls back to a raw error message', (t) => {
   }
   t.alike(offenders, [], 'these files display a raw worker message instead of localized text')
 })
+
+// Runs last: resolving the dev flag caches it for the module's lifetime, so an earlier stub would
+// change what the tests above observe.
+//
+// REGRESSION (FIX-I18N-WARN-1: the warning keyed off key === fallbackKey, so a surface passing a
+// fallback that a code also maps to — useFiles passes 'transferFailed', which DOWNLOAD_FAILED maps
+// to — was told a deliberate mapping was missing. FIX-I18N-WARN-2: window.bridge.isDev() is a
+// synchronous main-process round trip and ran on every fallback-path call, including from inside
+// render.)
+test('REGRESSION (FIX-I18N-WARN-1, FIX-I18N-WARN-2): the dev warning is accurate and reads isDev once', (t) => {
+  const warnings = []
+  const realWarn = console.warn
+  const realWindow = globalThis.window
+  let isDevCalls = 0
+  console.warn = (...args) => warnings.push(args)
+  globalThis.window = { bridge: { isDev: () => { isDevCalls++; return true } } }
+
+  try {
+    t.is(errorTextFor(withCode('x', 'DOWNLOAD_FAILED'), tr, 'transferFailed'), 'T:transferFailed')
+    t.alike(warnings, [], 'a code that IS mapped never warns, even when it resolves to the fallback')
+
+    errorTextFor(withCode('diagnostic', 'EPATH'), tr)
+    errorTextFor(withCode('diagnostic', 'ENOENT_SOMETHING'), tr)
+    t.is(warnings.length, 2, 'an unmapped code still warns')
+
+    errorTextFor(new Error('boom'), tr)
+    t.is(warnings.length, 2, 'an uncoded failure is not a missing mapping')
+
+    t.is(isDevCalls, 1, 'the synchronous bridge call is made once, not once per render')
+  } finally {
+    console.warn = realWarn
+    globalThis.window = realWindow
+  }
+})


### PR DESCRIPTION
Four defects found reviewing the error-localization work in #173, plus a stale comment.

- **`errorText` warned about mappings that exist.** The dev warning keyed off `key === fallbackKey`, so a surface passing a fallback that a code also maps to — `useFiles` passes `transferFailed`, which `DOWNLOAD_FAILED` maps to — was told a deliberate mapping was missing. It also reported uncoded failures as `code null`. Now it checks membership in the map.
- **`isDev()` on every render.** `window.bridge.isDev()` is a synchronous main-process round trip and ran on every fallback-path call, including from inside render. Read once now.
- **`space:invite` resolved `null` for an unknown space.** The modal read that as success: the button re-enabled with no link and nothing on screen saying why. Fixed at the handler, which now rejects like its other refusals, rather than in the modal — the `catch` there was already correct.
- **Revealing a folder reported a file.** `share:reveal-folder` shares its walk with `share:reveal-file`, so a share folder whose mount had gone from disk said "This file isn't on this device yet." The caller now supplies the code.
- Stale scenario reference in an `s3` comment (`s126` to `s128`).

## Tests
- Unit: regression covering both `errorText` defects, including that `isDev` is read once.
- Integration: the reveal target's missing-code is the caller's, with the file wording still the default.
- Flow: an invite for an unknown space rejects.
- Both new regressions mutation-verified — restoring the old logic fails them.
- `test:node:core` 1686/1686 · `test:bare` 981/981 · `membership-approval` 9/9 · `test:fe s76 s19` 6/6.

a11y: no markup change. The invite failure path itself has no frontend scenario — it needs a `spaceId` the UI will not produce — so it is covered at the flow layer; `s76`/`s19` cover the success path through the changed modal code.