### PR TITLE
[fix] Three renderer store and scope defects

### DIFF
--- a/src/renderer/components/modals/MirrorFolderModal.tsx
+++ b/src/renderer/components/modals/MirrorFolderModal.tsx
@@ -54,11 +54,16 @@ export default function MirrorFolderModal({
   const { preview, progress: previewProgress, loading: previewLoading, run: runPreview, cancel: cancelPreview, reset: resetPreview } = usePreviewFlow(cancelForeignPreview)
   const ownerName = owner?.displayName ?? '?'
 
-  // The folder's file count and byte total change when the owner's catalog does, which is exactly
-  // what the share-files scope announces. This modal is unmounted on close and the read resolves a
-  // PEER's catalog over the network, so the shared copy is what lets a reopen paint the totals it
-  // already has instead of starting from the placeholder again.
-  const infoScopes = useMemo(() => [Scope.shareFiles(share.spaceId, share.id)], [share.spaceId, share.id])
+  // The folder's file count and byte total change when the owner's catalog does. Two scopes, the
+  // same pair useShareFiles lists: share-files carries our own changes to this share, but an
+  // append to a PEER's catalog — the only thing that moves these totals for a share we neither own
+  // nor mirror — surfaces as event:files-updated, i.e. the space-wide files scope
+  // (ensurePeerCatalogWatch). Pinning share-files alone left the cached totals frozen for the
+  // whole app session, where the pre-cache per-open fetch had refreshed them.
+  const infoScopes = useMemo(
+    () => [Scope.shareFiles(share.spaceId, share.id), Scope.files(share.spaceId)],
+    [share.spaceId, share.id],
+  )
   const { data: info, error: infoError } = useQuery<FolderInfo>(
     'share:folder-info',
     { spaceId: share.spaceId, ownerKey: share.owner, shareId: share.id },

--- a/src/renderer/store/main-store.d.ts
+++ b/src/renderer/store/main-store.d.ts
@@ -9,7 +9,13 @@ export interface MainSnapshot<T> {
 
 export declare function configureMainStore (bridge: MirallBridge): void
 export declare function fetchMain<K extends MainQueryName> (name: K): Promise<MainQueryValue[K]>
-export declare function writeMain<K extends MainQueryName> (name: K, value: MainQueryValue[K]): Promise<MainQueryValue[K]>
+// `payload` is what main is sent when it differs from the optimistic value — prefs send a bare
+// patch and display the merge. Defaults to `value`.
+export declare function writeMain<K extends MainQueryName> (
+  name: K,
+  value: MainQueryValue[K],
+  opts?: { payload?: MainQueryValue[K] | Partial<MainQueryValue[K]> },
+): Promise<MainQueryValue[K]>
 export declare function setMainData<K extends MainQueryName> (name: K, data: MainQueryValue[K] | undefined): void
 export declare function subscribeMain (name: MainQueryName, notify: () => void): () => void
 export declare function peekMain<K extends MainQueryName> (name: K): MainSnapshot<MainQueryValue[K]>

--- a/src/renderer/store/main-store.js
+++ b/src/renderer/store/main-store.js
@@ -104,7 +104,11 @@ export function fetchMain (name) {
 // Optimistic, then authoritative, then rolled back — visible to every screen at once instead of
 // only the one that issued the write. The rollback is what keeps a failed write from leaving the
 // UI showing a value main never stored.
-export async function writeMain (name, value) {
+//
+// `payload` is what main is SENT when that differs from what the app should show meanwhile: prefs
+// send a bare patch (main merges it into the only authoritative copy) while displaying the merge.
+// It defaults to `value`, which is the case for every fact whose write is a whole-value replace.
+export async function writeMain (name, value, { payload = value } = {}) {
   const spec = specFor(name)
   const entry = entryFor(name)
   const previous = entry.data
@@ -116,15 +120,22 @@ export async function writeMain (name, value) {
   publish(entry)
 
   try {
-    const persisted = await spec.write(bridge, value)
+    const persisted = await spec.write(bridge, payload)
     entry.seq += 1
     entry.data = persisted
     publish(entry)
     return persisted
   } catch (err) {
+    // The rollback restores the last value the app actually read — but the error is deliberately
+    // NOT recorded on the entry. `error` means "there is no value to show, and here is why", which
+    // is how every consumer renders it (`readError`, `folderReadError`, `defaultError`); a write
+    // failure belongs to the caller, and writeMain throws it. Recording it here outlived the
+    // action: fetchMain answers a cached entry without clearing the error, so one failed write
+    // became a permanent banner on that screen AND an alert on every other screen sharing the
+    // entry. Consumers already handle their own write failures (NetworkSettings relies on this
+    // rollback; StorageSettings catches and shows its own message).
     entry.seq += 1
     entry.data = previous
-    entry.error = err
     publish(entry)
     throw err
   }

--- a/src/renderer/store/prefs-store.js
+++ b/src/renderer/store/prefs-store.js
@@ -19,12 +19,19 @@ export function loadPrefs () {
   return fetchMain(NAME)
 }
 
-// A PATCH where writeMain is a REPLACE. Prefs is the only fact with patch semantics; merging here
-// rather than in the store keeps the store's contract single-meaning. Collapsing this into
-// writeMain(NAME, patch) would drop every pref the caller did not name.
+// A PATCH where writeMain is a REPLACE. Prefs is the only fact with patch semantics.
+//
+// The merge is what we DISPLAY (so a screen keeps the prefs it already showed while the write is
+// in flight); the bare patch is what main is SENT. Main merges it into its own copy and returns
+// the whole record, which then replaces ours.
+//
+// Sending our merged record instead would clobber keys main owns: `main:prefs` has no push
+// channel, and main flips `firstHideNoticeShown` on its own when it first hides to the tray. Our
+// cached copy still reads `false`, so the next unrelated toggle wrote that `false` back over
+// main's `true` — and the tray notice fired a second time.
 export function writePrefs (patch) {
   const current = peekMain(NAME).data
-  return writeMain(NAME, current ? { ...current, ...patch } : { ...patch })
+  return writeMain(NAME, current ? { ...current, ...patch } : { ...patch }, { payload: patch })
 }
 
 // A test hook. It clears the whole main store, not just the prefs entry, because the old

--- a/test/unit/main-store.test.js
+++ b/test/unit/main-store.test.js
@@ -137,7 +137,67 @@ test('REGRESSION (FIX-R04-2-D3): a failed write restores the previous value', as
   bridge.fail(1, new Error('main refused'))
   await t.exception(write, 'the rejection reaches the caller')
   t.alike(peekMain(CAPS).data, UNLIMITED, 'and the displayed cap is back to what main actually has')
-  t.ok(peekMain(CAPS).error, 'with the failure on the entry')
+  t.is(peekMain(CAPS).error, null, 'the rejection went to the caller, not onto the entry')
+})
+
+// REGRESSION (FIX-WRITE-ERROR-STICKY: a failed write recorded its error on the shared entry, and
+// fetchMain answers a cached entry without clearing it — so nothing ever did. One refused
+// setBandwidth made NetworkSettings show "couldn't save" on every later visit, and a refused
+// setDownloadFolder made EditSpaceModal render an alert for a read of its own that had succeeded.)
+test('REGRESSION (FIX-WRITE-ERROR-STICKY): a failed write leaves no error for the next reader', async (t) => {
+  const bridge = setup(t)
+
+  const load = fetchMain(CAPS)
+  bridge.settle(0, UNLIMITED)
+  await load
+
+  const write = writeMain(CAPS, { downloadKBps: 512, uploadKBps: 0 })
+  bridge.fail(1, new Error('main refused'))
+  await t.exception(write)
+
+  // What a remount does: the effect re-reads, and the entry answers from cache.
+  t.alike(await fetchMain(CAPS), UNLIMITED, 'the cached value still answers')
+  t.is(peekMain(CAPS).error, null, 'and the screen has nothing stale to render')
+  t.is(peekMain(CAPS).loading, false, 'nor is it stuck loading')
+})
+
+// The invariant the fix establishes: `error` means "there is no value to show". A read is only
+// ever issued for an entry with no data, so the two can never both be set.
+test('an entry never carries data and an error at once', async (t) => {
+  const bridge = setup(t)
+
+  const failed = fetchMain(FOLDER)
+  bridge.fail(0, new Error('main refused'))
+  await t.exception(failed)
+  t.ok(peekMain(FOLDER).error, 'a failed read with nothing cached reports the error')
+  t.is(peekMain(FOLDER).data, undefined, 'and has no value to show alongside it')
+
+  const retry = fetchMain(FOLDER)
+  bridge.settle(1, '/Users/me/Downloads')
+  await retry
+  t.is(peekMain(FOLDER).error, null, 'a later success clears it')
+  t.is(peekMain(FOLDER).data, '/Users/me/Downloads')
+})
+
+// The seam prefs needs: display the merge, send the patch.
+test('writeMain sends `payload` when it differs from the optimistic value', async (t) => {
+  const bridge = setup(t)
+
+  const write = writeMain(FOLDER, '/Users/me/Merged', { payload: '/Users/me/Patch' })
+  t.is(peekMain(FOLDER).data, '/Users/me/Merged', 'the optimistic paint uses the value')
+  t.ok(bridge.calls.includes('setDownloadFolder:/Users/me/Patch'), 'while main is sent the payload')
+
+  bridge.settle(0, '/Users/me/FromMain')
+  t.is(await write, '/Users/me/FromMain')
+  t.is(peekMain(FOLDER).data, '/Users/me/FromMain', "and main's answer replaces both")
+})
+
+test('payload defaults to the value for a whole-value replace', async (t) => {
+  const bridge = setup(t)
+  const write = writeMain(FOLDER, '/Users/me/Plain')
+  t.ok(bridge.calls.includes('setDownloadFolder:/Users/me/Plain'))
+  bridge.settle(0, '/Users/me/Plain')
+  await write
 })
 
 test('a successful write publishes what main stored, not what was asked for', async (t) => {

--- a/test/unit/prefs-store.test.js
+++ b/test/unit/prefs-store.test.js
@@ -87,9 +87,9 @@ test('a write is optimistic, then authoritative', async (t) => {
   await writePrefs({ openAtLogin: true })
   // The optimistic publish paints before the round-trip; the authoritative one confirms it.
   t.alike(seen, [false, true, true], 'load, optimistic, authoritative')
-  // The MERGED record, not the bare patch: prefs-store folds the patch into the cached value
-  // before handing it to the store, whose write contract is a replace.
-  t.alike(bridge.setCalls, [{ ...LOADED, openAtLogin: true }], 'one write, carrying every pref')
+  // The bare PATCH goes over the wire — main owns the merge, because it owns prefs it writes
+  // itself and we would otherwise send a stale copy of them back.
+  t.alike(bridge.setCalls, [{ openAtLogin: true }], 'one write, naming only what changed')
 })
 
 // The React 19 contract for useSyncExternalStore: getSnapshot is compared by identity, so a
@@ -140,13 +140,36 @@ test('peekPrefs returns null, not undefined, before the first load', (t) => {
   t.is(peekPrefs(), null, 'null, not undefined')
 })
 
-test('writePrefs merges a patch rather than replacing the record', async (t) => {
+test('writePrefs shows the merge but sends only the patch', async (t) => {
   const bridge = setup(t)
   const load = loadPrefs()
   bridge.settleGet(0, LOADED)
   await load
 
   await writePrefs({ openAtLogin: true })
-  t.alike(bridge.setCalls, [{ ...LOADED, openAtLogin: true }], 'the untouched prefs went along')
-  t.alike(peekPrefs(), { ...LOADED, openAtLogin: true }, 'and none of them were dropped')
+  t.alike(bridge.setCalls, [{ openAtLogin: true }], 'main is sent the bare patch — it owns the merge')
+  t.alike(peekPrefs(), { ...LOADED, openAtLogin: true }, 'while the screen keeps every pref it showed')
+})
+
+// REGRESSION (FIX-PREFS-CLOBBER: writePrefs sent the renderer's MERGED record. `main:prefs` has no
+// push channel and main flips firstHideNoticeShown itself when it first hides to the tray, so the
+// renderer's cached copy still read false — and the next unrelated toggle wrote that false back
+// over main's true, firing the tray notice a second time.)
+test('REGRESSION (FIX-PREFS-CLOBBER): a write never clobbers a pref main owns', async (t) => {
+  const bridge = setup(t)
+  const load = loadPrefs()
+  // What the renderer read at boot: the notice had not been shown yet.
+  bridge.settleGet(0, { ...LOADED, firstHideNoticeShown: false })
+  await load
+
+  // Main hid to the tray meanwhile and flipped the flag on its own copy. Nothing pushed it here.
+  bridge.setPrefs = (patch) => {
+    t.absent('firstHideNoticeShown' in patch, 'the patch does not name a pref the user did not touch')
+    return Promise.resolve({ ...LOADED, firstHideNoticeShown: true, ...patch })
+  }
+
+  const persisted = await writePrefs({ openAtLogin: true })
+  t.is(persisted.firstHideNoticeShown, true, "main's value survived the write")
+  t.is(peekPrefs().firstHideNoticeShown, true, 'and the cache took main\'s record as authoritative')
+  t.is(peekPrefs().openAtLogin, true, 'while still carrying the change the user made')
 })

--- a/test/unit/renderer-reconcile-subscriptions.test.js
+++ b/test/unit/renderer-reconcile-subscriptions.test.js
@@ -2,6 +2,7 @@ import test from 'brittle'
 import { readFileSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
+import { Scope, scopeMatches } from '../../src/shared/contract/scope.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const hookSrc = (name) => readFileSync(path.join(here, '..', '..', 'src', 'renderer', 'hooks', name), 'utf8')
@@ -44,4 +45,35 @@ test('reconcile-driven hooks subscribe the reconcile channel, not the named poke
     }
     for (const e of events) t.absent(subscribes(src, e), `${file} no longer subscribes ${e}`)
   }
+})
+
+const rendererSrc = (...parts) => readFileSync(path.join(here, '..', '..', 'src', 'renderer', ...parts), 'utf8')
+
+// REGRESSION (FIX-PEER-INFO-SCOPE: a view of a PEER's catalog pinned only the share-files scope.
+// For a share this app neither owns nor mirrors, nothing local emits event:share-files-updated —
+// the owner's append reaches us through ensurePeerCatalogWatch, which emits event:files-updated,
+// i.e. the space-wide files scope. scopeMatches requires equal kinds, so the share-files-only view
+// was never invalidated and its cached totals were frozen for the app session.)
+test('REGRESSION (FIX-PEER-INFO-SCOPE): a peer-catalog view lists the files scope too', (t) => {
+  const views = {
+    'components/modals/MirrorFolderModal.tsx': 'share:folder-info',
+    'hooks/useShareFiles.ts': 'share:list-files',
+  }
+  for (const [file, request] of Object.entries(views)) {
+    const src = rendererSrc(...file.split('/'))
+    t.ok(src.includes(request), `${file} still reads ${request}`)
+    const shareScoped = /Scope\.shareFiles\(|kind: 'share-files'/.test(src)
+    const spaceScoped = /Scope\.files\(|kind: 'files'/.test(src)
+    t.ok(shareScoped, `${file} pins the share-files scope`)
+    t.ok(spaceScoped, `${file} ALSO pins the space files scope — a peer append arrives on that one`)
+  }
+})
+
+// The reason both are needed, asserted directly rather than left to the comment above.
+test('a files hint cannot invalidate a share-files view', (t) => {
+  t.absent(
+    scopeMatches(Scope.files('sp1'), Scope.shareFiles('sp1', 'sh1')),
+    'kinds must be equal — a space-wide files poke never reaches a share-files view',
+  )
+  t.ok(scopeMatches(Scope.files('sp1'), Scope.files('sp1')), 'while it does reach a files view')
 })


### PR DESCRIPTION
Three defects found by review of `a0ec77c`, each verified against the code and fixed red-first.

**Prefs write-through clobbered keys main owns.** `writePrefs` sent the renderer's *merged* record. `main:prefs` has no push channel and main flips `firstHideNoticeShown` itself on first hide-to-tray, so our cached copy still read `false` — and the next unrelated toggle wrote it back, firing the notice a second time. Main's `prefs:set` already merges, so the fix is to send the bare patch. `writeMain` gained an optional `payload` (show the merge, send the patch).

**A failed write poisoned the shared entry.** The rollback recorded the error, and `fetchMain` answers a cached entry without clearing it — so one refused `setBandwidth` made NetworkSettings show a read-failure message on every later visit, and a refused `setDownloadFolder` made EditSpaceModal render an alert for its own successful read. Every consumer names that field `readError`/`defaultError`, and both writers already handle their own failures, so the error now goes to the caller only. This makes `data` and `error` simultaneously-set unreachable — pinned as an invariant test.

**A peer folder's totals never refreshed.** `MirrorFolderModal` pinned only `share-files`, but an append to a peer's catalog reaches us as `event:files-updated` (`ensurePeerCatalogWatch`), and `scopeMatches` requires equal kinds. Cached counts were frozen for the app session. Now lists both scopes, like `useShareFiles`.

## Layers

Unit — the bug's layer for all three. Two existing assertions pinned the old prefs behaviour (`prefs-store.test.js` :92 and :150, both asserting the full record went over the wire); they now assert the patch.

Red-first verified by reverting each fix in isolation: unfixed store → 6 failures including both new `REGRESSION` tests; unfixed modal → the `FIX-PEER-INFO-SCOPE` ratchet fails.

`typecheck` · `lint:ci` · `test:unit` 1706/1706.

`test:fe` not run: no rendered output changes, only when a cached value refreshes. No scenario holds the mirror dialog open across a peer append.