### PR TITLE
[refactor] Decompose the foreign-folder mirror engine

### DIFF
--- a/src/renderer/mountFault.d.ts
+++ b/src/renderer/mountFault.d.ts
@@ -1,7 +1,2 @@
-export interface MountFault {
-  status: string
-  code: string | null
-}
-
-export function isMountFault(status: string | null | undefined): boolean
-export function mountFault(status: string | null | undefined, lastError?: string | null): MountFault | null
+export type { MountFault } from '../shared/contract/mount-fault.js'
+export { isMountFault, mountFault } from '../shared/contract/mount-fault.js'

--- a/src/renderer/mountFault.js
+++ b/src/renderer/mountFault.js
@@ -1,22 +1,4 @@
-// Whether a mount's durable status is a local fault, and what to name it by. Both roles write the
-// same two statuses and neither had anywhere to show them: every consumer of mount.status compared
-// against 'mount-point-gone' or 'paused' only, so a folder stopped by a full disk rendered exactly
-// like a healthy one once its 8-second toast had gone.
-//
-// `code` is an error code the renderer already translates, never a raw errno message. A status with
-// no reason recorded still names itself — 'paused-enospc' IS the disk-full case — which is what
-// keeps a mirror paused before this shipped from rendering a blank reason.
-const FAULT_STATUSES = new Set(['paused-error', 'paused-enospc'])
-
-const CODE_BY_STATUS = {
-  'paused-enospc': 'TRANSFER_DISK_FULL',
-}
-
-export function isMountFault (status) {
-  return FAULT_STATUSES.has(status)
-}
-
-export function mountFault (status, lastError) {
-  if (!isMountFault(status)) return null
-  return { status, code: lastError || CODE_BY_STATUS[status] || null }
-}
+// Whether a mount's durable status is a local fault, and what to name it by. The mapping lives in
+// shared/contract/mount-fault.js so the two worker writers and this reader cannot drift; this file
+// stays as the renderer's import path.
+export { isMountFault, mountFault } from '../shared/contract/mount-fault.js'

--- a/src/shared/contract/mount-fault.d.ts
+++ b/src/shared/contract/mount-fault.d.ts
@@ -1,0 +1,15 @@
+// Generated from mount-fault.js — contract-declarations.test.js asserts the two agree.
+export type MountFaultStatus = 'paused-enospc' | 'paused-error'
+export type AutoPauseStatus = 'mount-point-gone' | 'paused-enospc' | 'paused-error'
+
+export interface MountFault {
+  status: string
+  code: string | null
+}
+
+export declare const STATUS_MOUNT_GONE: 'mount-point-gone'
+export declare const AUTO_PAUSE_STATUSES: readonly ['mount-point-gone', 'paused-enospc', 'paused-error']
+export declare function statusForFaultCode(code: string | null | undefined): MountFaultStatus
+export declare function isAutoPauseStatus(status: string | null | undefined): boolean
+export declare function isMountFault(status: string | null | undefined): boolean
+export declare function mountFault(status: string | null | undefined, lastError?: string | null): MountFault | null

--- a/src/shared/contract/mount-fault.js
+++ b/src/shared/contract/mount-fault.js
@@ -1,0 +1,39 @@
+// The mapping between a local I/O fault code and the durable mount status that names it. It sits
+// in the contract package because it is a bridge between two contract vocabularies — CODES and
+// the *_MOUNT_STATUS tuples — and because all three runtimes read it: the mirror's pause path and
+// the owner's scan settle write these statuses, and the renderer reads them back.
+//
+// The errno half (which errno IS a fault) stays in the worker: it needs core/errors.js, and this
+// package imports nothing outside itself.
+import { CODES } from './errors.js'
+
+const STATUS_ENOSPC = 'paused-enospc'
+const STATUS_IO_ERROR = 'paused-error'
+export const STATUS_MOUNT_GONE = 'mount-point-gone'
+
+// The automatic (recoverable) pause statuses. A user pause ('paused') is deliberately absent: it
+// is a decision, and nothing but an explicit resume may lift it.
+export const AUTO_PAUSE_STATUSES = Object.freeze([STATUS_MOUNT_GONE, STATUS_ENOSPC, STATUS_IO_ERROR])
+
+// The inverse the renderer needs: a status that names its own reason when none was recorded.
+const CODE_BY_STATUS = Object.freeze({ [STATUS_ENOSPC]: CODES.TRANSFER_DISK_FULL })
+
+// A full disk outranks a permission fault: it stops the whole device rather than one subtree.
+export function statusForFaultCode (code) {
+  return code === CODES.TRANSFER_DISK_FULL ? STATUS_ENOSPC : STATUS_IO_ERROR
+}
+
+export function isAutoPauseStatus (status) {
+  return AUTO_PAUSE_STATUSES.includes(status)
+}
+
+export function isMountFault (status) {
+  return status === STATUS_ENOSPC || status === STATUS_IO_ERROR
+}
+
+// What the folder screen names the fault by. `code` is an error code the renderer already
+// translates, never a raw errno message, and a status with no reason recorded still names itself.
+export function mountFault (status, lastError) {
+  if (!isMountFault(status)) return null
+  return { status, code: lastError || CODE_BY_STATUS[status] || null }
+}

--- a/src/shared/core/pass-liveness.js
+++ b/src/shared/core/pass-liveness.js
@@ -1,0 +1,54 @@
+// Per-key progress bookkeeping for supervised work: one pass at a time per key, a heartbeat the
+// pass bumps as it advances, and a verdict from the shared stall rule. The rule lived in
+// stall-verdict.js already; the bookkeeping around it was hand-rolled twice (the mirror loop, the
+// derived-view fold) and missing entirely on the owner side, where a wedged diff reads as healthy.
+//
+// Progress, not elapsed time: a legitimate pass over thousands of files is genuinely slow, so only
+// a pass that is in flight AND not advancing is stalled.
+import { stallVerdict } from './stall-verdict.js'
+
+export function createPassLiveness ({ now = Date.now } = {}) {
+  const byKey = new Map()
+
+  return {
+    // Re-entrant on purpose: at most one pass per key is ever in flight, so a restart re-stamps
+    // rather than stacking.
+    started (key) {
+      const at = now()
+      const entry = byKey.get(key)
+      if (entry) { entry.startedAt = at; entry.progressAt = at } else {
+        byKey.set(key, { startedAt: at, progressAt: at, completedAt: 0 })
+      }
+    },
+    // A no-op for a key with no pass in flight, so a late callback from an abandoned pass cannot
+    // resurrect a heartbeat.
+    progress (key) {
+      const entry = byKey.get(key)
+      if (entry?.startedAt) entry.progressAt = now()
+    },
+    ended (key) {
+      const entry = byKey.get(key)
+      if (!entry) return
+      entry.startedAt = 0
+      entry.progressAt = 0
+      entry.completedAt = now()
+    },
+    verdict (key, { now: at = now(), windowMs }) {
+      return stallVerdict(byKey.get(key), { now: at, windowMs })
+    },
+    // Every key whose pass is in flight and not advancing, for a subsystem that reports on the
+    // set rather than probing one key it already knows about.
+    stalled ({ now: at = now(), windowMs } = {}) {
+      const out = []
+      for (const [key, entry] of byKey) {
+        const verdict = stallVerdict(entry, { now: at, windowMs })
+        if (!verdict.ok) out.push({ key, ...verdict })
+      }
+      return out
+    },
+    forget (key) { byKey.delete(key) },
+    clear () { byKey.clear() },
+    // A copy: nothing outside may mutate the heartbeat.
+    peek (key) { const e = byKey.get(key); return e ? { ...e } : null },
+  }
+}

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -6,12 +6,7 @@
 // owner is provably online, so a lagged replica or a user's own files are never wiped.
 import fs from 'bare-fs'
 import path from 'bare-path'
-import { makeProgressTicker } from '../transfer/progress-ticker.js'
-import { shouldIgnore, DEFAULT_IGNORE, shouldHonorDeletions, relToDriveKey, driveKeyToSegments, stripLongPathPrefix, isAbsoluteDriveKey, relKeyEscapes, nextFreeName } from './path-keys.js'
-
-// Re-exported so `test/integration/foreign-del-guard.test.js` keeps its
-// `./foreign-folders.js` import path; the implementation lives in `path-keys.js`.
-export { shouldHonorDeletions }
+import { shouldHonorDeletions, relKeyEscapes, dropUnsafeEntries } from './path-keys.js'
 import { isOwnerOnline } from '../transfer/swarm.js'
 import { record } from '../audit/audit-log.js'
 import { createIntegritySeen } from './integrity-seen.js'
@@ -24,124 +19,46 @@ import {
 import { setMirrorState, tombstoneMirror } from './mirror-records.js'
 import { mountRootAvailable } from './owned-folders.js'
 import { AppError, ErrorCodes, classifyLocalIoFault } from '../core/errors.js'
+import { pathFromMount } from '../transfer/path-guard.js'
+import { faultFromError, statusForFaultCode, isAutoPauseStatus, STATUS_MOUNT_GONE } from './mount-fault.js'
 import { getContentBackend, hasContentBackend } from '../transfer/content-backends.js'
 import { getOverlay } from '../transfer/backends/overlay/overlay-instance.js'
-import { overlayHashFile, makeFetchDiag, setOverlayCatalogChangeHook, overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
+import { overlayHashFile, setOverlayCatalogChangeHook, overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
+import { runOverlayFetch } from '../transfer/backends/overlay/fetch-run.js'
+import { createPausedHolders } from '../transfer/backends/overlay/paused-holders.js'
 import { shareDecoKey } from '../transfer/decoration-key.js'
 import { transferIdFor } from '../transfer/transfer-id.js'
-import { PARTIAL_SUFFIX } from '../transfer/partial-suffix.js'
 import { markVerified, isVerifiedUnchanged } from '../transfer/files.js'
-import { PREVIEW_DETAIL_MAX_FILES, includePerFile } from './preview-detail.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { mirrorVerdict } from './mirror-health.js'
+import { createMirrorLoops } from './mirror-loop.js'
+import { createMirrorState, localRelOf } from './mirror-state.js'
 import { shouldWalk } from './mirror-walk.js'
-import { mapLimit } from '../core/concurrency.js'
-import { AbortError } from './walk-disk.js'
+
+// Kept on this module so the worker and the existing tests keep their `./foreign-folders.js`
+// import path while the implementations live where they belong: the deletion gate in
+// `path-keys.js`, the preview in `foreign-preview.js`, and the on-disk path a renamed entry was
+// materialized as in `mirror-state.js` (share-listing must resolve it the way the engine wrote it).
+export { shouldHonorDeletions, localRelOf }
+export { previewMaterializeScan } from './foreign-preview.js'
 
 const log = createLogger('foreign-folders')
 
-const activeLoops = new Map()
-// Every in-flight materialize pass — the poll tick AND the initial scan — keyed by loopKey, so
-// the bulk stop has something to await. Declared with activeLoops because initialMaterializeScan,
-// far above its old home, registers into it.
-const tickInFlight = new Map()
-const pendingTicks = new Map()
-// loopKey -> { startedAt, progressAt, completedAt }. progressAt is bumped per file the pass
-// begins fetching, which is what separates a slow scan from a dead one.
-const mirrorLiveness = new Map()
+// The loop engine. Everything mount-specific stays here; the interval, the one-pass-at-a-time
+// serialisation, the cancellation generation and the liveness heartbeat live in mirror-loop.js.
+const loops = createMirrorLoops({
+  intervalMs: () => getResourceCaps().foreignPollIntervalMs,
+  runPass: ({ spaceId, shareId }) => materializeOnce(spaceId, shareId),
+  onStop: (key, { discardPartial = false } = {}) => {
+    cancelInflightFetch(key, discardPartial)
+    state.forgetConverged(key)
+  },
+  onError: (err) => log.debug('materialize tick failed:', err.message),
+})
+const state = createMirrorState({ keyOf: loopKey, isStopped: (key, gen) => loops.stopped(key, gen) })
+
 let ipcRef = null
-
-// The single guarded peer-key -> absolute-path conversion. Every site that turns
-// an owner-controlled drive key into a local path goes through this, so no caller
-// can forget the containment check: the pure segment guard, then an OS-level
-// path.relative belt that catches any escape regardless of separator or encoding.
-function safeMaterializePath (mountPath, relPath) {
-  if (relKeyEscapes(relPath)) {
-    throw new AppError(ErrorCodes.EPATH, `peer file path rejected — unsafe segment escapes the mount folder: ${relPath}`)
-  }
-  const abs = path.join(mountPath, ...driveKeyToSegments(relPath))
-  const rel = path.relative(mountPath, abs)
-  if (rel === '' || rel === '..' || rel.startsWith('..' + path.sep) || path.isAbsolute(rel)) {
-    throw new AppError(ErrorCodes.EPATH, `peer file path rejected — resolves outside the mount folder: ${relPath}`)
-  }
-  return abs
-}
-
-// Decide the on-disk relPath for a materialized owner entry, never clobbering a
-// file Mirall did not create, and idempotently so repeated ticks / re-mounts
-// converge on one sibling instead of breeding report (1).pdf, report (2).pdf …
-// Same invariant as download-dest.js::resolveDest — a download must never overwrite
-// the user's own file or adopt another transfer's orphan partial — but path-key
-// aware and persistent (the mapping survives across ticks):
-//  1) an established conflict mapping wins — idempotent across ticks;
-//  2) nothing on disk, or a path we already synced at its natural name -> natural;
-//  3) on-disk bytes already equal the share's hash -> natural (applyChange
-//  hash-skips it; this is what lets unmount->re-mount adopt the prior copy);
-//  4) a genuine pre-existing user file -> a free sibling, recorded in renamedPaths.
-async function resolveLocalRelPath (mount, ownerKey, ownerHash, hashOf = overlayHashFile, synced = syncedSetFor(mount), fresh = null) {
-  const mapped = mount.renamedPaths?.[ownerKey]
-  if (mapped) return mapped
-
-  const naturalAbs = safeMaterializePath(mount.mountPath, ownerKey)
-  if (!fs.existsSync(naturalAbs) || (synced.has(ownerKey) && !fresh?.has(ownerKey))) return ownerKey
-
-  // hashOf must match how ownerHash was computed: the overlay hasher for overlay shares — else
-  // the adopt-existing-copy check never matches and a collision sibling is minted.
-  //
-  // Deliberately NOT short-circuited by the verified-download record: that record proves some
-  // local path held this content, not that THIS natural path does. Consulting it here adopts a
-  // user's unrelated file at the natural name whenever the mirror had previously written the
-  // same content to a collision sibling — foreign-sync's rename case catches exactly that.
-  if (ownerHash) {
-    try { if (await hashOf(naturalAbs) === ownerHash) return ownerKey } catch {}
-  }
-
-  const segs = driveKeyToSegments(ownerKey)
-  const leaf = segs.pop()
-  const dir = segs.join('/')
-  const isTaken = (name) => {
-    const abs = safeMaterializePath(mount.mountPath, dir ? dir + '/' + name : name)
-    // A candidate is taken by a real file OR an in-flight partial (what
-    // materializeOverlayFile writes), so we never mint a sibling name onto
-    // another transfer's partial.
-    return fs.existsSync(abs) || fs.existsSync(abs + PARTIAL_SUFFIX)
-  }
-  const localRel = (dir ? dir + '/' : '') + nextFreeName(leaf, isTaken)
-  ;(mount.renamedPaths ||= {})[ownerKey] = localRel
-  syncDirty.add(loopKey(mount.spaceId, mount.shareId))
-  return localRel
-}
-
-// The on-disk relPath an owner key was materialized as (its natural name unless a
-// conflict forced a collision-free sibling).
-function localRelOf (mount, ownerKey) {
-  return mount.renamedPaths?.[ownerKey] || ownerKey
-}
-
-// Drop conflict mappings whose owner key the share no longer carries, so the map
-// can't accumulate stale entries across ticks.
-function pruneRenamedPaths (mount, onDrive) {
-  if (!mount.renamedPaths) return
-  for (const ownerKey of Object.keys(mount.renamedPaths)) {
-    if (onDrive.has(ownerKey)) continue
-    delete mount.renamedPaths[ownerKey]
-    syncDirty.add(loopKey(mount.spaceId, mount.shareId))
-  }
-}
-
-// Drop poisoned peer entries at ingest so they never enter syncedPaths or the
-// materialize batch — one bad key must not abort the tick or DoS the mirror. This
-// guards the catalog source (backend.listPeer).
-function dropUnsafeEntries (entries, sourceLabel) {
-  return entries.filter((e) => {
-    if (relKeyEscapes(e.relPath)) {
-      log.warn('refusing a peer file path that escapes the mount folder — skipping this entry (the owner drive may be malicious or corrupted):', e.relPath, '(source:', sourceLabel + ')')
-      return false
-    }
-    return true
-  })
-}
 
 export function initForeignFolders(_ipc) {
   ipcRef = _ipc
@@ -154,23 +71,16 @@ function loopKey(spaceId, shareId) {
   return spaceId + ':' + shareId
 }
 
+const APPEND_TICK_DEBOUNCE_MS = 250
+
 // The owner's content changed. Run a materialize tick now (debounced) for each
 // active mirror in that space instead of waiting for the 30s poll, so owner-side
 // edits/deletes reflect on the mirror's disk as promptly as they do in the folder
 // view.
 export function onPeerDriveChanged(spaceId) {
-  for (const loop of activeLoops.values()) {
+  for (const loop of loops.entries()) {
     if (loop.spaceId !== spaceId) continue
-    const key = loopKey(loop.spaceId, loop.shareId)
-    if (pendingTicks.has(key)) continue
-    const timer = setTimeout(() => {
-      pendingTicks.delete(key)
-      runMaterializeTick(loop.spaceId, loop.shareId).catch((err) => {
-        log.debug('append-driven materialize failed:', err.message)
-      })
-    }, 250)
-    timer.unref?.()
-    pendingTicks.set(key, timer)
+    loops.debounce(loop.key, { spaceId: loop.spaceId, shareId: loop.shareId }, APPEND_TICK_DEBOUNCE_MS)
   }
 }
 
@@ -202,15 +112,6 @@ function settleMirrorSyncState(mount, allPresent) {
   return syncMirrorRecord(mount.spaceId, mount.shareId, () => setMirrorState(mount.spaceId, mount.shareId, allPresent ? 'synced' : 'syncing'))
 }
 
-// The automatic (recoverable) pause statuses. Named once here and consumed by both
-// pauseMountForIoError (the writer) and AUTO_PAUSE_STATUSES (the resume gate), so the two
-// can't drift. A user pause ('paused', via setForeignEnabled) is deliberately not in this set.
-// mount-status-vocabulary.test.js asserts every status written here is one the contract declares.
-const STATUS_MOUNT_GONE = 'mount-point-gone'
-const STATUS_ENOSPC = 'paused-enospc'
-const STATUS_IO_ERROR = 'paused-error'
-const AUTO_PAUSE_STATUSES = new Set([STATUS_MOUNT_GONE, STATUS_ENOSPC, STATUS_IO_ERROR])
-
 async function pauseMount(mount, status, reason) {
   mount.enabled = false
   mount.status = status
@@ -218,10 +119,10 @@ async function pauseMount(mount, status, reason) {
   // an event-only reason left the strip generic after every reload.
   mount.lastError = reason ?? null
   // Carry the Set: a pause cancels the pass, so this write is what persists whatever it landed.
-  await saveForeignMount({ ...mount, ...syncFields(mount) })
+  await saveForeignMount({ ...mount, ...state.syncFields(mount) })
   // Symmetry with the user-pause path (setForeignEnabled(false)): stop the poll loop so an
   // auto-paused mount doesn't keep a live interval, its in-flight fetch is cancelled, and its
-  // cancelGen is bumped — the last point lets an in-progress scan bail before it would
+  // generation is bumped — the last point lets an in-progress scan bail before it would
   // otherwise overwrite this pause with a trailing status:'active'.
   stopForeignLoop(mount.spaceId, mount.shareId)
   await syncMirrorRecord(mount.spaceId, mount.shareId, () => setMirrorState(mount.spaceId, mount.shareId, 'paused'))
@@ -230,29 +131,28 @@ async function pauseMount(mount, status, reason) {
 
 // Pause the mount for a local I/O failure (overlay materializeOverlayFile write path). Returns
 // true if it paused — the caller then stops; false leaves the error for generic handling. The
-// errno→code decision is shared with the owner side; the code→status decision is ours, because a
-// mirror's pause really does stop its loop.
+// fault→status decision is shared with the owner side; stopping the loop is ours, because a
+// mirror's pause really does stop it.
 async function pauseMountForIoError(mount, err) {
-  const fault = classifyLocalIoFault(err)
-  if (fault === ErrorCodes.TRANSFER_DISK_FULL) { await pauseMount(mount, STATUS_ENOSPC, fault); return true }
-  if (fault) { await pauseMount(mount, STATUS_IO_ERROR, fault); return true }
+  const fault = faultFromError(err)
+  if (fault) { await pauseMount(mount, fault.status, fault.code); return true }
   if (err?.code === 'ENOENT' && !fs.existsSync(mount.mountPath)) { await pauseMount(mount, STATUS_MOUNT_GONE); return true }
   return false
 }
 
 // A mirror's INITIAL scan failing is not a pause: the poll loop still starts, and the next
 // successful tick clears this. So it records the fault without touching `enabled` — which is what
-// keeps it out of AUTO_PAUSE_STATUSES' resume gate.
+// keeps it out of the auto-pause resume gate.
 export async function recordMirrorScanFault(spaceId, shareId, err) {
   const code = classifyLocalIoFault(err)
-  const status = code === ErrorCodes.TRANSFER_DISK_FULL ? STATUS_ENOSPC : STATUS_IO_ERROR
+  const status = statusForFaultCode(code)
   await patchForeignMount(spaceId, shareId, { status, lastError: code })
   emitStatus(spaceId, shareId, status, { error: code })
   return status
 }
 
 export function isAutoPaused(mount) {
-  return !!mount && mount.enabled === false && AUTO_PAUSE_STATUSES.has(mount.status)
+  return !!mount && mount.enabled === false && isAutoPauseStatus(mount.status)
 }
 
 // Probe-driven twin of pauseMountForIoError for a mount whose local path vanished while the
@@ -280,13 +180,13 @@ export async function resumeAutoPausedForeignMount(spaceId, shareId) {
   return true
 }
 
-// The containment-guarded materialize primitive. safeMaterializePath rejects any
+// The containment-guarded materialize primitive. pathFromMount rejects any
 // owner-controlled relPath that escapes the mount BEFORE any local write/unlink —
 // the path-traversal guard the security suite exercises (foreign-path-containment).
 // Puts are fetched by the overlay path (materializeOverlayFile); this remains the
 // delete primitive used by the catalog deletion reconcile.
 export async function applyChange(mount, change) {
-  const abs = safeMaterializePath(mount.mountPath, change.localRelPath || change.relPath)
+  const abs = pathFromMount(mount.mountPath, change.localRelPath || change.relPath)
   if (change.action === 'del') {
     try { await fs.promises.unlink(abs) } catch (err) {
       if (err && err.code !== 'ENOENT') throw err
@@ -297,19 +197,12 @@ export async function applyChange(mount, change) {
 
 // The initial scan is launched unawaited at boot and on a fresh mount, and it walks the whole
 // catalog — so it is exactly the kind of in-flight pass stopAllForeignLoops has to wait for. It
-// honours cancelGen internally (bails between files, re-checks before the trailing persist), but
-// the bulk stop can only WAIT for what it can see, hence the same in-flight map the poll tick uses.
+// honours the generation internally (bails between files, re-checks before the trailing persist),
+// but the bulk stop can only WAIT for what it sees, hence the same in-flight map the poll tick uses.
 export async function initialMaterializeScan(mount) {
   const key = loopKey(mount.spaceId, mount.shareId)
-  forgetConverged(key)
-  const p = runInitialMaterializeScan(mount).finally(() => {
-    if (tickInFlight.get(key) !== p) return
-    tickInFlight.delete(key)
-    markMirrorPassEnded(key)
-  })
-  tickInFlight.set(key, p)
-  markMirrorPassStarted(key)
-  return await p
+  state.forgetConverged(key)
+  return await loops.adopt(key, runInitialMaterializeScan(mount))
 }
 
 async function runInitialMaterializeScan(mount) {
@@ -323,247 +216,33 @@ async function runInitialMaterializeScan(mount) {
   return { skipped: 'no-content-backend' }
 }
 
-const FOREIGN_PREVIEW_CONCURRENCY = 8
-const PREVIEW_PROGRESS_EVERY = 16
-
-// Resolve the peer share and enumerate its files from the overlay catalog.
-// Returns null when the share isn't visible / has no usable content backend.
-async function loadForeignListing(spaceId, ownerKey, shareId) {
-  const { readPeerShares } = await import('../shares/shares.js')
-  const shares = await readPeerShares(ownerKey, spaceId)
-  if (!shares) return null
-  const found = shares.find((s) => s.id === shareId)
-  if (!found) return null
-  const share = { ...found, spaceId, owner: ownerKey }
-  if (!hasContentBackend(share)) return null
-  const backend = getContentBackend(share)
-  const { entries } = await backend.listPeerWithMeta(spaceId, share)
-  return dropUnsafeEntries(entries.map((e) => ({ relPath: e.relPath, size: e.size, hash: e.contentHash })), 'preview')
-}
-
-// Outcome of one remote entry vs the destination, preserving the original loop's
-// semantics: absent -> download (no conflict); present but different -> download +
-// conflict; present and identical -> skip. A size mismatch alone proves a conflict
-// (different bytes can't hash-equal), and a verified-cache hit proves identity, so a
-// content hash is read only for a same-size, uncached file. A non-ENOENT stat error
-// means the file exists but is unreadable -> treat as a conflict.
-async function classifyForeignEntry(entry, mountPath, spaceId, shareId, hashOf) {
-  const abs = safeMaterializePath(mountPath, entry.relPath)
-  let stat = null
-  try {
-    stat = await fs.promises.stat(abs)
-  } catch (err) {
-    if (err && err.code === 'ENOENT') return { relPath: entry.relPath, size: entry.size, download: true, conflict: false }
-    return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
-  }
-  if (!stat.isFile()) return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
-  if (stat.size !== entry.size) return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
-  if (entry.hash && await isVerifiedUnchanged(spaceId, shareId + '|' + entry.relPath, entry.hash, entry.size, stat)) {
-    return { relPath: entry.relPath, size: entry.size, download: false }
-  }
-  try {
-    const onDisk = await hashOf(abs)
-    if (entry.hash && onDisk === entry.hash) return { relPath: entry.relPath, size: entry.size, download: false }
-    return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
-  } catch {
-    return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
-  }
-}
-
-export async function previewMaterializeScan(spaceId, ownerKey, shareId, mountPath, opts = {}) {
-  const { onProgress = null, signal = null, hashOf = overlayHashFile } = opts
-  const checkAborted = () => { if (signal && signal.aborted) throw new AbortError() }
-  const emit = (phase, scanned, total) => { if (onProgress) { try { onProgress({ phase, scanned, total, bytes: 0 }) } catch {} } }
-
-  // Local count (disk) and remote listing (network) are independent — overlap them.
-  emit('enumerating', 0, 0)
-  const [existingAtDestination, entries] = await Promise.all([
-    countFilesAtPath(mountPath),
-    loadForeignListing(spaceId, ownerKey, shareId),
-  ])
-  checkAborted()
-
-  if (!entries) {
-    return { flow: 'mount-foreign-folder', toUpload: 0, toDownload: 0, conflicts: 0, existingAtDestination, totalBytes: 0, perFile: [] }
-  }
-
-  let scanned = 0
-  const results = await mapLimit(entries, FOREIGN_PREVIEW_CONCURRENCY, async (entry) => {
-    checkAborted()
-    const r = await classifyForeignEntry(entry, mountPath, spaceId, shareId, hashOf)
-    scanned += 1
-    if (scanned % PREVIEW_PROGRESS_EVERY === 0) emit('scanning', scanned, entries.length)
-    return r
-  })
-  emit('scanning', entries.length, entries.length)
-
-  let toDownload = 0
-  let conflicts = 0
-  let totalBytes = 0
-  const candidates = []
-  for (const r of results) {
-    if (!r.download) continue
-    toDownload += 1
-    if (r.conflict) conflicts += 1
-    totalBytes += r.size
-    if (candidates.length <= PREVIEW_DETAIL_MAX_FILES) candidates.push({ relPath: r.relPath, size: r.size, conflict: !!r.conflict })
-  }
-
-  const detailed = includePerFile(toDownload)
-  return {
-    flow: 'mount-foreign-folder',
-    toUpload: 0,
-    toDownload,
-    conflicts,
-    existingAtDestination,
-    totalBytes,
-    perFile: detailed ? candidates : [],
-    perFileOmitted: !detailed,
-  }
-}
-
-async function countFilesAtPath(target) {
-  try {
-    const entries = await fs.promises.readdir(target, { recursive: true, withFileTypes: true })
-    // Same Windows `\\?\` long-path normalization as walkDisk (walk-disk.js):
-    // strip the extended-length prefix from both sides so a prefixed parentPath
-    // can't make path.relative emit an absolute path and throw the file count off.
-    const cleanTarget = stripLongPathPrefix(target)
-    let count = 0
-    for (const entry of entries) {
-      if (!entry.isFile()) continue
-      const dir = entry.parentPath ?? entry.path ?? target
-      const rel = relToDriveKey(path.relative(cleanTarget, stripLongPathPrefix(path.join(dir, entry.name))), path.sep)
-      if (rel === '..' || rel.startsWith('../') || isAbsoluteDriveKey(rel)) continue
-      // Ignore OS junk / temp files (.DS_Store, Thumbs.db, our own partials, …). The
-      // sync engine never touches them, and counting hidden files the user
-      // can't even see in Finder makes "N files already at the destination"
-      // wrong (a viewed folder always has a hidden .DS_Store).
-      if (!rel || shouldIgnore(rel, DEFAULT_IGNORE)) continue
-      count += 1
-    }
-    return count
-  } catch {
-    return 0
-  }
-}
-
 export async function startForeignLoop(mount) {
-  const key = loopKey(mount.spaceId, mount.shareId)
-  if (activeLoops.has(key)) return
-
-  const timer = setInterval(() => {
-    runMaterializeTick(mount.spaceId, mount.shareId).catch((err) => {
-      log.debug('materialize tick failed:', err.message)
-    })
-  }, getResourceCaps().foreignPollIntervalMs)
-  timer.unref?.()
-  activeLoops.set(key, { timer, spaceId: mount.spaceId, shareId: mount.shareId })
+  loops.start(loopKey(mount.spaceId, mount.shareId), { spaceId: mount.spaceId, shareId: mount.shareId })
 }
 
-const tickDirty = new Set()
-// Bumped by stopForeignLoop (pause / unmount). A long initial scan or poll tick
-// over thousands of files captures the generation at its start and bails between
-// files once it changes — otherwise the pass runs to completion (and its trailing
-// saveForeignMount can even resurrect an unmounted mount).
-const cancelGen = new Map()
 // The file the mirror is fetching right now (one per loopKey — the catalog materialize is
 // strictly sequential): contentHash so stopForeignLoop can abort the in-flight overlay
 // download, relPath so foreignFetchActive can identify the row.
 const activeOverlayFetches = new Map()
-// contentHash a pause left holders showing us paused for, after its in-flight fetch slot was
-// released — lets a later unmount tell the holder we stopped rather than leaving its "who is
-// downloading" row paused until the 5-min sweep. Mirrors overlay-download's pausedHashes.
-const pausedMirrorHashes = new Map()
+// The paused-stop markers this mount left with holders, so a later unmount can still tell them we
+// stopped rather than leaving their "who is downloading" row paused until the 5-min sweep.
+const pausedHolders = createPausedHolders({ notifyStopped: (hash) => getOverlay()?.notifyTransferStopped(hash) })
 // One in-memory Set of synced owner keys per mount — the authoritative copy while the process
 // lives. mount.syncedPaths (the persisted array) is its boot-time seed and durable snapshot,
 // written back only when the Set changed. Membership is asked once per catalog entry per tick,
 // so it must be O(1): the array scan it replaces made a fully-synced tick quadratic. The Set
 // outlives pause/resume (a stopped pass has already written files it must keep owning) and is
 // dropped only on unmount, with the record.
-const syncedSets = new Map() // loopKey -> Set<ownerKey>
-// loopKey -> the owner-catalog version the last CONVERGED pass walked, and how many ticks have
-// skipped since. A converged mirror re-walks only when that version moves or the backstop is due.
-const convergedHeads = new Map()
-const skippedTicks = new Map()
-
-function forgetConverged (key) {
-  convergedHeads.delete(key)
-  skippedTicks.delete(key)
-}
-const syncDirty = new Set()  // loopKeys whose Set / renamedPaths differ from the persisted record
-
-function syncedSetFor (mount) {
-  const key = loopKey(mount.spaceId, mount.shareId)
-  let set = syncedSets.get(key)
-  if (!set) {
-    set = new Set(mount.syncedPaths || [])
-    syncedSets.set(key, set)
-  }
-  return set
-}
-
-// `fresh` collects the keys this pass claimed. Ownership is recorded BEFORE the write lands (so a
-// cancelled pass still owns what it wrote), but the collision check must still see such a path as
-// NOT-yet-ours — otherwise a pre-existing user file at the natural name is adopted instead of
-// getting a sibling. The persisted record and the "did we write this before?" question are two
-// different things, and the pre-fix code kept them apart by reading the persisted array while
-// building a separate list.
-function recordSynced (key, set, ownerKey, fresh) {
-  if (set.has(ownerKey)) return
-  set.add(ownerKey)
-  fresh?.add(ownerKey)
-  syncDirty.add(key)
-}
-
-function forgetSynced (key, set, ownerKey) {
-  if (set.delete(ownerKey)) syncDirty.add(key)
-}
-
-function syncFields (mount) {
-  return { syncedPaths: [...syncedSetFor(mount)], renamedPaths: mount.renamedPaths || {} }
-}
-
-// Persist the sync bookkeeping once per pass, only when it changed, and never from a pass that
-// was cancelled: a pause persists the Set itself, and unmount deleted the record. The old code
-// wrote the whole record on EVERY tick of an owner-online mirror — about 36 B per path, so a
-// converged 5k-file mirror appended ~180 KB to the mounts bee every 30 s.
-async function persistSyncState (mount, key, gen) {
-  if (!syncDirty.has(key) || mirrorStopped(key, gen)) return
-  if (await patchForeignMount(mount.spaceId, mount.shareId, syncFields(mount))) syncDirty.delete(key)
-}
-
-function mirrorGen(key) { return cancelGen.get(key) || 0 }
-
 // Is the mirror loop actively fetching THIS row? Consulted by the worker's share:list-files
 // derivation so a materializing mirror row reports 'downloading'.
 export function foreignFetchActive(spaceId, shareId, relPath) {
   return activeOverlayFetches.get(loopKey(spaceId, shareId))?.relPath === relPath
 }
-function mirrorStopped(key, gen) { return mirrorGen(key) !== gen }
+const mirrorGen = (key) => loops.generationOf(key)
+const mirrorStopped = (key, gen) => loops.stopped(key, gen)
 
-// Serialize ticks per mount: the poll and the append-driven trigger must never
-// run concurrently, or overlapping ticks act on stale drive snapshots and
-// re-materialize files the other just deleted. A request that arrives while a
-// tick runs sets a dirty flag so exactly one follow-up tick runs after it.
 export async function runMaterializeTick(spaceId, shareId) {
-  const key = loopKey(spaceId, shareId)
-  if (tickInFlight.has(key)) {
-    tickDirty.add(key)
-    return tickInFlight.get(key)
-  }
-  const p = materializeOnce(spaceId, shareId).finally(() => {
-    // Identity-guarded, matching initialMaterializeScan: a stale pass settling after a restart
-    // replaced the entry must not delete the LIVE one, which would un-serialise two passes over
-    // the same mount.
-    if (tickInFlight.get(key) !== p) return
-    tickInFlight.delete(key)
-    markMirrorPassEnded(key)
-    if (tickDirty.delete(key)) runMaterializeTick(spaceId, shareId).catch(() => {})
-  })
-  tickInFlight.set(key, p)
-  markMirrorPassStarted(key)
-  return p
+  return await loops.tick(loopKey(spaceId, shareId), { spaceId, shareId })
 }
 
 async function materializeOnce(spaceId, shareId) {
@@ -652,8 +331,8 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   // Overlay content hashes are leaf/size-prefixed, NOT plain blake2b — compare
   // the on-disk copy with the overlay hasher, or the skip/adopt checks never
   // match and the mirror re-fetches every file every tick.
-  const localRelPath = await resolveLocalRelPath(mount, entry.relPath, entry.contentHash, hashOf, opts.synced || syncedSetFor(mount), opts.fresh)
-  const abs = safeMaterializePath(mount.mountPath, localRelPath)
+  const localRelPath = await state.resolveLocalRelPath(mount, entry.relPath, entry.contentHash, hashOf, opts.synced || state.syncedSetFor(mount), opts.fresh)
+  const abs = pathFromMount(mount.mountPath, localRelPath)
   let onDisk = null
   try { onDisk = await fs.promises.stat(abs) } catch {}
   if (onDisk?.isFile() && entry.contentHash) {
@@ -680,35 +359,35 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   // bytes; ticker.pushTo diffs them.
   const total = entry.size || 0
   const decoKey = shareDecoKey(mount.shareId, entry.relPath)
-  const ticker = makeProgressTicker(total, ({ bytes, speed, eta }) => {
-    ipcRef?.emit('event:decoration', {
-      channel: 'transfer', spaceId: mount.spaceId, key: decoKey, bytes, total, speed, eta,
-    })
-  })
-  const diag = makeFetchDiag('overlay mirror', entry.relPath, total, entry.contentHash)
-  let attempted = false // set once a chunk scheduler runs — i.e. a holder was found and asked
-  let res
   const streamKey = loopKey(mount.spaceId, mount.shareId)
+  let res
+  let attempted = false
+  let diag = null
   activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath })
-  markMirrorProgress(streamKey)
-  pausedMirrorHashes.delete(streamKey) // a fresh/resumed fetch supersedes any paused-stop marker
+  loops.noteProgress(streamKey)
+  pausedHolders.supersede(streamKey)
   // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.
   ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
   try {
-    res = await overlay.fetchFile(entry.contentHash, {
+    // The overlay scheduler reports CUMULATIVE bytes; the ticker diffs them into speed/ETA.
+    ;({ res, attempted, diag } = await runOverlayFetch(overlay, entry.contentHash, {
+      label: 'overlay mirror',
+      relPath: entry.relPath,
+      size: total,
       destPath: abs,
-      reSeed: false,
-      onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b); markMirrorProgress(streamKey) },
+      onProgress: ({ bytes, speed, eta }) => ipcRef?.emit('event:decoration', {
+        channel: 'transfer', spaceId: mount.spaceId, key: decoKey, bytes, total, speed, eta,
+      }),
       onVerify: (fraction) => ipcRef?.emit('event:decoration', {
         channel: 'transfer', spaceId: mount.spaceId, key: decoKey, phase: 'verifying', verifyFraction: fraction, bytes: 0, total,
       }),
-      onEnd: (info) => { attempted = true; diag.onEnd(info) },
-    })
+      onTick: () => loops.noteProgress(streamKey),
+    }))
   } catch (err) {
     // ECANCELLED is a deliberate pause/unmount abort (stopForeignLoop), not a
     // give-up: log it as a stop and keep whatever partial cancelFetch chose to keep.
-    if (err?.code === 'ECANCELLED') { diag.finish('paused'); return 'missing' }
-    await handleOverlayMirrorFetchError(mount, share, entry, err, diag)
+    if (err?.code === 'ECANCELLED') { err.diag.finish('paused'); return 'missing' }
+    await handleOverlayMirrorFetchError(mount, share, entry, err, err.diag)
     return 'missing'
   } finally {
     activeOverlayFetches.delete(streamKey)
@@ -741,16 +420,16 @@ async function initialMaterializeScanCatalog(mount, share) {
   const gen = mirrorGen(key)
   // Resolved before the first await: a pass cancelled by an unmount must never recreate a
   // re-mounted key's Set from its stale mount object.
-  const synced = syncedSetFor(mount)
+  const synced = state.syncedSetFor(mount)
   const fresh = new Set()
   const { entries: raw, complete } = await getContentBackend(share).listPeerWithMeta(mount.spaceId, share)
-  const entries = dropUnsafeEntries(raw, 'catalog-initial')
+  const entries = dropUnsafeEntries(raw, (rel) => log.warn('refusing a peer file path that escapes the mount folder — skipping this entry (the owner drive may be malicious or corrupted):', rel, '(source: catalog-initial)'))
   let allPresent = true
   for (const entry of entries) {
     if (mirrorStopped(key, gen)) return { stopped: true }
     // Own the path BEFORE the write lands: a pass cancelled mid-file must still own what it
     // wrote, or the owner's later delete of that file is never applied.
-    recordSynced(key, synced, entry.relPath, fresh)
+    state.recordSynced(key, synced, entry.relPath, fresh)
     try {
       if (await materializeCatalogFile(mount, share, entry, { synced, fresh }) === 'missing') allPresent = false
     } catch (err) {
@@ -765,19 +444,19 @@ async function initialMaterializeScanCatalog(mount, share) {
   // complete read is authoritative enough to replace the record, or to stamp the scan done.
   if (complete) {
     const listed = new Set(entries.map((e) => e.relPath))
-    for (const ownerKey of [...synced]) if (!listed.has(ownerKey)) forgetSynced(key, synced, ownerKey)
+    for (const ownerKey of [...synced]) if (!listed.has(ownerKey)) state.forgetSynced(key, synced, ownerKey)
     mount.initialScanCompletedAt = Date.now()
   }
   mount.status = 'active'
   await patchForeignMount(mount.spaceId, mount.shareId, {
-    ...syncFields(mount),
+    ...state.syncFields(mount),
     status: 'active',
     // A pass that got through clears the reason with the status: a stale one would name the next
     // fault that records none.
     lastError: null,
     ...(complete ? { initialScanCompletedAt: mount.initialScanCompletedAt } : {}),
   })
-  syncDirty.delete(key)
+  state.markClean(key)
   emitStatus(mount.spaceId, mount.shareId, 'active')
   // Skip the terminal state on an empty or partial listing: at mount the owner's catalog may not
   // have replicated yet, and publishing 'synced' with zero (or truncated) entries would falsely
@@ -795,16 +474,16 @@ async function materializeOnceCatalog(mount, share) {
   // Read BEFORE the listing: an append landing mid-walk leaves the head past the version this pass
   // records, so the next tick walks. A pass only ever converges against the snapshot it walked.
   const version = await getContentBackend(share).catalogVersion?.(mount.spaceId, share) ?? null
-  const skipped = skippedTicks.get(key) || 0
+  const skipped = state.skipped(key)
   const decision = shouldWalk({
     // Only a non-null version is ever stored, so a miss and an unknown both read as null.
-    watermark: convergedHeads.get(key) ?? null,
+    watermark: state.watermark(key),
     version,
     skipped,
     fullWalkEvery: getResourceCaps().foreignFullWalkEvery,
   })
   if (!decision.walk) {
-    skippedTicks.set(key, skipped + 1)
+    state.noteSkipped(key, skipped + 1)
     // No settle: the pass that converged already wrote the terminal state, and by definition
     // nothing has happened since.
     return
@@ -814,17 +493,17 @@ async function materializeOnceCatalog(mount, share) {
   // may re-establish one, so a pass that throws midway — an unlink the OS refuses, a bee put that
   // fails — cannot leave a stale watermark standing over a zeroed skip counter, which would retry
   // the failed work at the backstop's cadence instead of the poll's.
-  forgetConverged(key)
+  state.forgetConverged(key)
 
-  const synced = syncedSetFor(mount)
+  const synced = state.syncedSetFor(mount)
   const fresh = new Set()
   const { entries: raw, complete } = await getContentBackend(share).listPeerWithMeta(mount.spaceId, share)
-  const entries = dropUnsafeEntries(raw, 'catalog-tick')
+  const entries = dropUnsafeEntries(raw, (rel) => log.warn('refusing a peer file path that escapes the mount folder — skipping this entry (the owner drive may be malicious or corrupted):', rel, '(source: catalog-tick)'))
   const onDrive = new Map(entries.map((e) => [e.relPath, e]))
   let allPresent = true
   for (const [, entry] of onDrive) {
     if (mirrorStopped(key, gen)) return
-    recordSynced(key, synced, entry.relPath, fresh)
+    state.recordSynced(key, synced, entry.relPath, fresh)
     try {
       if (await materializeCatalogFile(mount, share, entry, { synced, fresh }) === 'missing') allPresent = false
     } catch (err) {
@@ -845,17 +524,17 @@ async function materializeOnceCatalog(mount, share) {
       if (onDrive.has(ownerKey)) continue
       if (relKeyEscapes(ownerKey)) {
         log.warn('refusing to honor a stored sync path that escapes the mount folder — skipping deletion:', ownerKey)
-        forgetSynced(key, synced, ownerKey)
+        state.forgetSynced(key, synced, ownerKey)
         continue
       }
       await applyChange(mount, { action: 'del', relPath: ownerKey, localRelPath: localRelOf(mount, ownerKey) })
-      forgetSynced(key, synced, ownerKey)
+      state.forgetSynced(key, synced, ownerKey)
     }
-    pruneRenamedPaths(mount, onDrive)
+    state.pruneRenamedPaths(mount, onDrive)
   }
   // Once per pass and only when something changed — the old code wrote the whole record on every
   // tick of an owner-online mirror, whether or not anything moved.
-  await persistSyncState(mount, key, gen)
+  await state.persist(mount, key, gen)
   // Nothing left to do: every file present, the listing a full read, and no path still owned that the
   // catalog no longer lists. Every entry in the listing was recorded into `synced` above, so the
   // listing is a subset of the Set and equal sizes prove the two agree — an O(1) test for
@@ -867,7 +546,7 @@ async function materializeOnceCatalog(mount, share) {
   // mirror keeps walking. A cancelled pass proves nothing, and a version we could not read cannot
   // authorise a later skip.
   const converged = allPresent && complete && synced.size === onDrive.size
-  if (converged && version !== null && !mirrorStopped(key, gen)) convergedHeads.set(key, version)
+  if (converged && version !== null && !mirrorStopped(key, gen)) state.setWatermark(key, version)
   // Re-check the generation adjacent to the enqueue (no await between) so a pause/unmount that
   // landed during the deletion-reconcile await above can't be overwritten by this terminal write.
   if (!mirrorStopped(key, gen)) await settleMirrorSyncState(mount, allPresent)
@@ -904,103 +583,49 @@ async function ownerLeftSpace(spaceId, ownerKey) {
   return !space.members.some((m) => m.publicKey === ownerKey)
 }
 
-function markMirrorPassStarted(key) {
-  const at = Date.now()
-  const entry = mirrorLiveness.get(key)
-  if (entry) { entry.startedAt = at; entry.progressAt = at } else {
-    mirrorLiveness.set(key, { startedAt: at, progressAt: at, completedAt: 0 })
-  }
-}
-
-function markMirrorProgress(key) {
-  const entry = mirrorLiveness.get(key)
-  if (entry) entry.progressAt = Date.now()
-}
-
-function markMirrorPassEnded(key) {
-  const entry = mirrorLiveness.get(key)
-  if (!entry) return
-  entry.startedAt = 0
-  entry.progressAt = 0
-  entry.completedAt = Date.now()
-}
-
 // One verdict per mount that has a live loop. A mount with no loop is not reported: it is paused,
 // unmounted or gone, none of which this can or should recover.
 export function mirrorHealth({ now = Date.now() } = {}) {
   const pollIntervalMs = getResourceCaps().foreignPollIntervalMs
-  const rows = []
-  for (const loop of activeLoops.values()) {
-    const key = loopKey(loop.spaceId, loop.shareId)
-    const verdict = mirrorVerdict(mirrorLiveness.get(key), { now, pollIntervalMs })
-    rows.push({ key, spaceId: loop.spaceId, shareId: loop.shareId, ...verdict })
-  }
-  return rows
+  return loops.entries().map((loop) => ({
+    ...loop,
+    ...mirrorVerdict(loops.liveness(loop.key), { now, pollIntervalMs }),
+  }))
 }
 
-// Un-wedge one mirror. stopForeignLoop bumps cancelGen, so a hung pass is generation-invalidated
-// and bails at its next checkpoint without writing; clearing the in-flight entry is the part the
-// stop does NOT do, and without it the fresh interval coalesces straight back onto the dead promise.
+// Un-wedge one mirror: the stop generation-invalidates a hung pass so it bails at its next
+// checkpoint without writing, and the restart drops the dead in-flight promise the stop leaves
+// behind — without that the fresh interval coalesces straight back onto it.
 export async function restartForeignLoop(spaceId, shareId) {
-  const key = loopKey(spaceId, shareId)
-  stopForeignLoop(spaceId, shareId)
-  tickInFlight.delete(key)
-  tickDirty.delete(key)
-  mirrorLiveness.delete(key)
-  forgetConverged(key)
-  await startForeignLoop({ spaceId, shareId })
-  runMaterializeTick(spaceId, shareId).catch((err) => log.debug('materialize tick after restart failed:', err.message))
+  loops.restart(loopKey(spaceId, shareId), { spaceId, shareId })
+    .catch((err) => log.debug('materialize tick after restart failed:', err.message))
 }
 
-export function stopForeignLoop(spaceId, shareId, { discardPartial = false } = {}) {
-  const key = loopKey(spaceId, shareId)
-  // Invalidate any in-flight scan/tick (it bails at the next file) and abort the
-  // file currently downloading, so pause/unmount stops the sync now — not after
-  // the whole folder finishes materialising.
-  cancelGen.set(key, mirrorGen(key) + 1)
-  // Overlay-catalog in-flight fetch: cancel by content hash. discardPartial:false
-  // (pause) keeps the partial + journal so the next tick resumes; true (unmount)
-  // unlinks it. cancelFetch also tells the holder we paused/stopped, so its
-  // "who is downloading" indicator clears now rather than on the idle sweep. A pause
-  // releases the fetch slot while the holder still shows us paused, so remember the hash
-  // and, on a later unmount with no live fetch, notify the holder we stopped.
+// Abort the file this mount is fetching right now. discardPartial:false (pause) keeps the partial
+// + journal so the next tick resumes; true (unmount) unlinks it. cancelFetch also tells the holder
+// we paused/stopped, so its "who is downloading" indicator clears now rather than on the idle
+// sweep. A pause releases the fetch slot while the holder still shows us paused, so the hash is
+// remembered and a later unmount with no live fetch tells the holder we stopped.
+function cancelInflightFetch(key, discardPartial) {
   const inflight = activeOverlayFetches.get(key)
   if (inflight) {
     try { getOverlay()?.cancelFetch(inflight.contentHash, { discardPartial }) } catch {}
     activeOverlayFetches.delete(key)
-    if (discardPartial) pausedMirrorHashes.delete(key)
-    else pausedMirrorHashes.set(key, inflight.contentHash)
+    if (discardPartial) pausedHolders.supersede(key)
+    else pausedHolders.remember(key, inflight.contentHash)
   } else if (discardPartial) {
-    const paused = pausedMirrorHashes.get(key)
-    if (paused) { try { getOverlay()?.notifyTransferStopped(paused) } catch {} }
-    pausedMirrorHashes.delete(key)
-  }
-  tickDirty.delete(key)
-  forgetConverged(key)
-  const handle = activeLoops.get(key)
-  if (handle) {
-    clearInterval(handle.timer)
-    activeLoops.delete(key)
-  }
-  const pending = pendingTicks.get(key)
-  if (pending) {
-    clearTimeout(pending)
-    pendingTicks.delete(key)
+    pausedHolders.stop(key)
   }
 }
 
-// Stop every mirror loop. Each stop bumps the loop's generation so a pass mid-iteration bails at
-// its next file; the bounded wait lets that bail land before the caller closes the cores the pass
-// reads. discardPartial stays false — a shutdown is a pause, not an unmount: the partial and its
-// journal are what let the next boot resume instead of refetching.
-async function stopAllForeignLoops({ settleMs = 5000 } = {}) {
-  for (const { spaceId, shareId } of [...activeLoops.values()]) stopForeignLoop(spaceId, shareId)
-  const inFlight = [...tickInFlight.values()]
-  if (inFlight.length === 0) return
-  await Promise.race([
-    Promise.allSettled(inFlight),
-    new Promise((resolve) => { setTimeout(resolve, settleMs).unref?.() }),
-  ])
+export function stopForeignLoop(spaceId, shareId, { discardPartial = false } = {}) {
+  loops.stop(loopKey(spaceId, shareId), { discardPartial })
+}
+
+// discardPartial stays false — a shutdown is a pause, not an unmount: the partial and its journal
+// are what let the next boot resume instead of refetching.
+function stopAllForeignLoops({ settleMs = 5000 } = {}) {
+  return loops.stopAll({ settleMs })
 }
 
 // Owns the mirror loops as a set: _open is the module's wiring, _close is the bulk stop the
@@ -1047,10 +672,8 @@ export class ForeignMirrors extends Subsystem {
 // inherited Set would claim files exist at a path the mount no longer uses.
 function resetForeignSyncState(spaceId, shareId) {
   const key = loopKey(spaceId, shareId)
-  syncedSets.delete(key)
-  syncDirty.delete(key)
-  mirrorLiveness.delete(key)
-  forgetConverged(key)
+  state.reset(key)
+  loops.forgetLiveness(key)
 }
 
 export async function unmountForeignFolder(spaceId, shareId) {
@@ -1083,8 +706,8 @@ export async function relocateForeignFolder(spaceId, shareId, mountPath) {
 
   const enabled = mount.enabled !== false
   // A disabled mount keeps the status it was disabled WITH. Collapsing an auto-pause
-  // ('mount-point-gone', 'paused-enospc') into a plain user 'paused' would take it out of
-  // AUTO_PAUSE_STATUSES and permanently disable the auto-resume that exists to rescue exactly the
+  // ('mount-point-gone', 'paused-enospc') into a plain user 'paused' would take it out of the
+  // auto-pause set and permanently disable the auto-resume that exists to rescue exactly the
   // mirrors this verb is used on.
   const status = enabled ? 'scanning' : (mount.status ?? 'paused')
   // A read-merge, never a whole-object write-back: the snapshot above predates this await, so
@@ -1094,10 +717,10 @@ export async function relocateForeignFolder(spaceId, shareId, mountPath) {
 
   stopForeignLoop(spaceId, shareId)
   resetForeignSyncState(spaceId, shareId)
-  // stopForeignLoop deliberately leaves tickInFlight alone; without this a pass still running
-  // against the OLD path makes every later tick coalesce onto that dead promise, and because a
-  // coalesced call never marks a pass started, the liveness probe reports the mirror healthy.
-  tickInFlight.delete(loopKey(spaceId, shareId))
+  // stopForeignLoop deliberately leaves the in-flight pass alone; without this a pass still
+  // running against the OLD path makes every later tick coalesce onto that dead promise, and
+  // because a coalesced call never marks a pass started, the liveness probe reports it healthy.
+  loops.dropInFlight(loopKey(spaceId, shareId))
   emitStatus(spaceId, shareId, status)
 
   const next = await getForeignMount(spaceId, shareId)
@@ -1117,7 +740,7 @@ export async function setForeignEnabled(spaceId, shareId, enabled) {
   mount.enabled = enabled
   mount.status = enabled ? 'active' : 'paused'
   if (enabled) mount.lastError = null
-  await saveForeignMount({ ...mount, ...syncFields(mount) })
+  await saveForeignMount({ ...mount, ...state.syncFields(mount) })
   if (enabled) {
     await startForeignLoop(mount)
     // Only a genuine resume (was paused) touches the record and re-evaluates now: set 'syncing',

--- a/src/shared/folders/foreign-preview.js
+++ b/src/shared/folders/foreign-preview.js
@@ -1,0 +1,101 @@
+// The mirror's read-only scan preview: what mounting this share at this path would download, and
+// how much of it would land on top of something already there. Reads nothing the mirror engine
+// owns — no loop state, no synced set — so it lives outside it.
+import fs from 'bare-fs'
+import { pathFromMount } from '../transfer/path-guard.js'
+import { DEFAULT_IGNORE, dropUnsafeEntries } from './path-keys.js'
+import { getContentBackend, hasContentBackend } from '../transfer/content-backends.js'
+import { overlayHashFile } from '../transfer/backends/overlay/overlay-backend.js'
+import { isVerifiedUnchanged } from '../transfer/files.js'
+import { createPreviewTally } from './preview-tally.js'
+import { createLogger } from '../core/logger.js'
+import { mapLimit } from '../core/concurrency.js'
+import { AbortError, walkDisk } from './walk-disk.js'
+
+const log = createLogger('foreign-preview')
+
+const FOREIGN_PREVIEW_CONCURRENCY = 8
+const PREVIEW_PROGRESS_EVERY = 16
+
+// Resolve the peer share and enumerate its files from the overlay catalog.
+// Returns null when the share isn't visible / has no usable content backend.
+async function loadForeignListing(spaceId, ownerKey, shareId) {
+  const { readPeerShares } = await import('../shares/shares.js')
+  const shares = await readPeerShares(ownerKey, spaceId)
+  if (!shares) return null
+  const found = shares.find((s) => s.id === shareId)
+  if (!found) return null
+  const share = { ...found, spaceId, owner: ownerKey }
+  if (!hasContentBackend(share)) return null
+  const backend = getContentBackend(share)
+  const { entries } = await backend.listPeerWithMeta(spaceId, share)
+  return dropUnsafeEntries(
+    entries.map((e) => ({ relPath: e.relPath, size: e.size, hash: e.contentHash })),
+    (rel) => log.warn('refusing a peer file path that escapes the mount folder — skipping this entry (the owner drive may be malicious or corrupted):', rel),
+  )
+}
+
+// Outcome of one remote entry vs the destination: absent -> download (no conflict); present but
+// different -> download + conflict; present and identical -> skip. A size mismatch alone proves a
+// conflict (different bytes can't hash-equal), and a verified-cache hit proves identity, so a
+// content hash is read only for a same-size, uncached file. A non-ENOENT stat error means the file
+// exists but is unreadable -> treat as a conflict.
+async function classifyForeignEntry(entry, mountPath, spaceId, shareId, hashOf) {
+  const abs = pathFromMount(mountPath, entry.relPath)
+  let stat = null
+  try {
+    stat = await fs.promises.stat(abs)
+  } catch (err) {
+    if (err && err.code === 'ENOENT') return { relPath: entry.relPath, size: entry.size, download: true, conflict: false }
+    return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
+  }
+  if (!stat.isFile()) return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
+  if (stat.size !== entry.size) return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
+  if (entry.hash && await isVerifiedUnchanged(spaceId, shareId + '|' + entry.relPath, entry.hash, entry.size, stat)) {
+    return { relPath: entry.relPath, size: entry.size, download: false }
+  }
+  try {
+    const onDisk = await hashOf(abs)
+    if (entry.hash && onDisk === entry.hash) return { relPath: entry.relPath, size: entry.size, download: false }
+    return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
+  } catch {
+    return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
+  }
+}
+
+export async function previewMaterializeScan(spaceId, ownerKey, shareId, mountPath, opts = {}) {
+  const { onProgress = null, signal = null, hashOf = overlayHashFile } = opts
+  const checkAborted = () => { if (signal && signal.aborted) throw new AbortError() }
+  const emit = (phase, scanned, total) => { if (onProgress) { try { onProgress({ phase, scanned, total, bytes: 0 }) } catch {} } }
+
+  // Local count (disk) and remote listing (network) are independent — overlap them.
+  emit('enumerating', 0, 0)
+  const [existingAtDestination, entries] = await Promise.all([
+    // Caught, not propagated: a preview of an unreadable destination reports zero rather than
+    // failing the dialog the user is standing in front of.
+    walkDisk(mountPath, DEFAULT_IGNORE).then((w) => w.onDisk.size).catch(() => 0),
+    loadForeignListing(spaceId, ownerKey, shareId),
+  ])
+  checkAborted()
+
+  if (!entries) {
+    return createPreviewTally().result('mount-foreign-folder', 'download', { existingAtDestination })
+  }
+
+  let scanned = 0
+  const results = await mapLimit(entries, FOREIGN_PREVIEW_CONCURRENCY, async (entry) => {
+    checkAborted()
+    const r = await classifyForeignEntry(entry, mountPath, spaceId, shareId, hashOf)
+    scanned += 1
+    if (scanned % PREVIEW_PROGRESS_EVERY === 0) emit('scanning', scanned, entries.length)
+    return r
+  })
+  emit('scanning', entries.length, entries.length)
+
+  const tally = createPreviewTally()
+  for (const r of results) {
+    if (!r.download) continue
+    tally.add({ relPath: r.relPath, size: r.size, conflict: !!r.conflict })
+  }
+  return tally.result('mount-foreign-folder', 'download', { existingAtDestination })
+}

--- a/src/shared/folders/mirror-loop.js
+++ b/src/shared/folders/mirror-loop.js
@@ -1,0 +1,139 @@
+// The per-mount loop the mirror engine runs on, with no knowledge of catalogs, hashes or mounts:
+// an interval per key, at most one pass in flight, a dirty flag so a request arriving mid-pass
+// costs exactly one follow-up, a cancellation generation a long pass checks between files, and the
+// liveness heartbeat the supervisor reads.
+//
+// The owner side gained this shape when its publish queue was extracted; the mirror kept it inline
+// through every later change. Same discipline, opposite direction of travel.
+//
+// No bare-* imports, so the scheduling rules unit-test under Node against a fake pass.
+import { createPassLiveness } from '../core/pass-liveness.js'
+
+export function createMirrorLoops ({ intervalMs, runPass, onStop = () => {}, onError = () => {} }) {
+  const loops = new Map()      // key -> { timer, spaceId, shareId }
+  const inFlight = new Map()   // key -> Promise
+  const dirty = new Set()
+  const pending = new Map()    // key -> debounce timer
+  const gen = new Map()
+  const liveness = createPassLiveness()
+
+  const generationOf = (key) => gen.get(key) || 0
+  const stopped = (key, at) => generationOf(key) !== at
+
+  // Identity-guarded: a stale pass settling after a restart replaced the entry must not delete the
+  // LIVE one, which would un-serialise two passes over the same mount.
+  function settle (key, p, ctx) {
+    if (inFlight.get(key) !== p) return
+    inFlight.delete(key)
+    liveness.ended(key)
+    if (dirty.delete(key) && ctx) tick(key, ctx).catch(onError)
+  }
+
+  function track (key, p, ctx) {
+    const tracked = p.finally(() => settle(key, tracked, ctx))
+    inFlight.set(key, tracked)
+    liveness.started(key)
+    return tracked
+  }
+
+  // Serialised per key: the poll and any event-driven trigger must never overlap, or two passes
+  // act on stale snapshots and each re-does what the other just undid. A request arriving while a
+  // pass runs sets the dirty flag so exactly one follow-up runs after it.
+  function tick (key, ctx) {
+    const running = inFlight.get(key)
+    if (running) {
+      dirty.add(key)
+      return running
+    }
+    // Invoked synchronously, like the interval callback it replaces: a caller that inspects the
+    // pass right after asking for it must see it already started.
+    let p
+    try { p = Promise.resolve(runPass(ctx)) } catch (err) { p = Promise.reject(err) }
+    return track(key, p, ctx)
+  }
+
+  // Register a pass started outside `tick` (the unawaited boot scan) so the bulk stop has
+  // something to await. It honours the generation itself; the stop can only wait for what it sees.
+  function adopt (key, promise) {
+    return track(key, promise, null)
+  }
+
+  function start (key, ctx) {
+    if (loops.has(key)) return
+    const timer = setInterval(() => { tick(key, ctx).catch(onError) }, intervalMs())
+    timer.unref?.()
+    loops.set(key, { timer, spaceId: ctx.spaceId, shareId: ctx.shareId })
+  }
+
+  function debounce (key, ctx, ms) {
+    if (pending.has(key)) return
+    const timer = setTimeout(() => {
+      pending.delete(key)
+      tick(key, ctx).catch(onError)
+    }, ms)
+    timer.unref?.()
+    pending.set(key, timer)
+  }
+
+  // Invalidate the pass in flight (it bails at its next checkpoint) and disarm the cadence.
+  // Deliberately does NOT clear inFlight: a pause must still be able to await the tail, and a
+  // restart is what clears it.
+  function stop (key, opts = {}) {
+    gen.set(key, generationOf(key) + 1)
+    onStop(key, opts)
+    dirty.delete(key)
+    const handle = loops.get(key)
+    if (handle) {
+      clearInterval(handle.timer)
+      loops.delete(key)
+    }
+    const queued = pending.get(key)
+    if (queued) {
+      clearTimeout(queued)
+      pending.delete(key)
+    }
+  }
+
+  // The un-wedge: clearing inFlight is the part `stop` does not do, and without it a fresh
+  // interval coalesces straight back onto the dead promise — and because a coalesced call never
+  // marks a pass started, the liveness probe would report the mirror healthy.
+  function restart (key, ctx) {
+    stop(key)
+    inFlight.delete(key)
+    dirty.delete(key)
+    liveness.forget(key)
+    start(key, ctx)
+    return tick(key, ctx)
+  }
+
+  // Each stop bumps the loop's generation so a pass mid-iteration bails at its next checkpoint;
+  // the bounded wait lets that bail land before the caller closes the resources the pass reads.
+  async function stopAll ({ settleMs = 5000 } = {}) {
+    for (const key of [...loops.keys()]) stop(key)
+    const running = [...inFlight.values()]
+    if (running.length === 0) return
+    await Promise.race([
+      Promise.allSettled(running),
+      new Promise((resolve) => { setTimeout(resolve, settleMs).unref?.() }),
+    ])
+  }
+
+  return {
+    start,
+    stop,
+    stopAll,
+    restart,
+    tick,
+    adopt,
+    debounce,
+    generationOf,
+    stopped,
+    // Only mounts with a live loop. One without is paused, unmounted or gone, none of which a
+    // health report or a recovery can or should address.
+    entries: () => [...loops.entries()].map(([key, l]) => ({ key, spaceId: l.spaceId, shareId: l.shareId })),
+    liveness: (key) => liveness.peek(key),
+    forgetLiveness: (key) => liveness.forget(key),
+    noteProgress: (key) => liveness.progress(key),
+    dropInFlight: (key) => inFlight.delete(key),
+  }
+}

--- a/src/shared/folders/mirror-state.js
+++ b/src/shared/folders/mirror-state.js
@@ -1,0 +1,153 @@
+// What a mirror owns on disk, and how much of that the persisted record still disagrees with.
+//
+// Three pieces of per-mount state that live and die together, which is why they share a module and
+// a single reset:
+//  - `synced`: the owner keys this mirror wrote. A deletion is honoured only for these, so the set
+//    is the evidence that makes an owner-side delete safe to apply. In memory it is the
+//    authoritative copy; mount.syncedPaths is its boot-time seed and durable snapshot.
+//  - `renamedPaths`: the collision mapping. A pre-existing user file at the natural name forces a
+//    sibling, and the mapping has to be idempotent across ticks or a re-mount breeds
+//    report (1).pdf, report (2).pdf …
+//  - the convergence watermark: the owner-catalog version the last converged pass walked, so a
+//    settled mirror re-walks only when that version moves.
+import fs from 'bare-fs'
+import { pathFromMount } from '../transfer/path-guard.js'
+import { PARTIAL_SUFFIX } from '../transfer/partial-suffix.js'
+import { driveKeyToSegments, nextFreeName } from './path-keys.js'
+import { patchForeignMount } from './mount-store.js'
+
+// The on-disk relPath an owner key was materialized as (its natural name unless a conflict forced
+// a collision-free sibling). Exported free-standing because share-listing must ask the same
+// question from a mount record alone: deriving it from the owner key renders a renamed-but-synced
+// file as 'remote'.
+export function localRelOf (mount, ownerKey) {
+  return mount.renamedPaths?.[ownerKey] || ownerKey
+}
+
+export function createMirrorState ({ keyOf, isStopped }) {
+  // loopKey -> Set<ownerKey>. Membership is asked once per catalog entry per tick, so it must be
+  // O(1): the array scan it replaces made a fully-synced tick quadratic. The set outlives
+  // pause/resume (a stopped pass has already written files it must keep owning) and is dropped
+  // only on unmount, with the record.
+  const syncedSets = new Map()
+  // loopKeys whose set / renamedPaths differ from the persisted record.
+  const dirty = new Set()
+  const convergedHeads = new Map()
+  const skippedTicks = new Map()
+
+  function syncedSetFor (mount) {
+    const key = keyOf(mount.spaceId, mount.shareId)
+    let set = syncedSets.get(key)
+    if (!set) {
+      set = new Set(mount.syncedPaths || [])
+      syncedSets.set(key, set)
+    }
+    return set
+  }
+
+  function syncFields (mount) {
+    return { syncedPaths: [...syncedSetFor(mount)], renamedPaths: mount.renamedPaths || {} }
+  }
+
+  // Decide the on-disk relPath for a materialized owner entry, never clobbering a file Mirall did
+  // not create, and idempotently so repeated ticks / re-mounts converge on one sibling. Same
+  // invariant as download-dest.js::resolveDest, but path-key aware and persistent:
+  //  1) an established conflict mapping wins — idempotent across ticks;
+  //  2) nothing on disk, or a path we already synced at its natural name -> natural;
+  //  3) on-disk bytes already equal the share's hash -> natural (this is what lets
+  //     unmount -> re-mount adopt the prior copy);
+  //  4) a genuine pre-existing user file -> a free sibling, recorded in renamedPaths.
+  async function resolveLocalRelPath (mount, ownerKey, ownerHash, hashOf, synced = syncedSetFor(mount), fresh = null) {
+    const mapped = mount.renamedPaths?.[ownerKey]
+    if (mapped) return mapped
+
+    const naturalAbs = pathFromMount(mount.mountPath, ownerKey)
+    if (!fs.existsSync(naturalAbs) || (synced.has(ownerKey) && !fresh?.has(ownerKey))) return ownerKey
+
+    // hashOf must match how ownerHash was computed: the overlay hasher for overlay shares — else
+    // the adopt-existing-copy check never matches and a collision sibling is minted.
+    //
+    // Deliberately NOT short-circuited by the verified-download record: that record proves some
+    // local path held this content, not that THIS natural path does. Consulting it here adopts a
+    // user's unrelated file at the natural name whenever the mirror had previously written the
+    // same content to a collision sibling.
+    if (ownerHash) {
+      try { if (await hashOf(naturalAbs) === ownerHash) return ownerKey } catch {}
+    }
+
+    const segs = driveKeyToSegments(ownerKey)
+    const leaf = segs.pop()
+    const dir = segs.join('/')
+    const isTaken = (name) => {
+      const abs = pathFromMount(mount.mountPath, dir ? dir + '/' + name : name)
+      // A candidate is taken by a real file OR an in-flight partial, so we never mint a sibling
+      // name onto another transfer's partial.
+      return fs.existsSync(abs) || fs.existsSync(abs + PARTIAL_SUFFIX)
+    }
+    const localRel = (dir ? dir + '/' : '') + nextFreeName(leaf, isTaken)
+    ;(mount.renamedPaths ||= {})[ownerKey] = localRel
+    dirty.add(keyOf(mount.spaceId, mount.shareId))
+    return localRel
+  }
+
+  // Drop conflict mappings whose owner key the share no longer carries, so the map can't
+  // accumulate stale entries across ticks.
+  function pruneRenamedPaths (mount, onDrive) {
+    if (!mount.renamedPaths) return
+    for (const ownerKey of Object.keys(mount.renamedPaths)) {
+      if (onDrive.has(ownerKey)) continue
+      delete mount.renamedPaths[ownerKey]
+      dirty.add(keyOf(mount.spaceId, mount.shareId))
+    }
+  }
+
+  return {
+    syncedSetFor,
+    syncFields,
+    resolveLocalRelPath,
+    pruneRenamedPaths,
+
+    // `fresh` collects the keys this pass claimed. Ownership is recorded BEFORE the write lands
+    // (so a cancelled pass still owns what it wrote), but the collision check must still see such
+    // a path as NOT-yet-ours — otherwise a pre-existing user file at the natural name is adopted
+    // instead of getting a sibling. The persisted record and the "did we write this before?"
+    // question are two different things.
+    recordSynced (key, set, ownerKey, fresh) {
+      if (set.has(ownerKey)) return
+      set.add(ownerKey)
+      fresh?.add(ownerKey)
+      dirty.add(key)
+    },
+    forgetSynced (key, set, ownerKey) {
+      if (set.delete(ownerKey)) dirty.add(key)
+    },
+    markClean: (key) => dirty.delete(key),
+
+    // Persist once per pass, only when something changed, and never from a pass that was
+    // cancelled: a pause persists the set itself, and unmount deleted the record. Writing it on
+    // every tick of an owner-online mirror appended ~36 B per path to the mounts bee every 30 s.
+    async persist (mount, key, gen) {
+      if (!dirty.has(key) || isStopped(key, gen)) return
+      if (await patchForeignMount(mount.spaceId, mount.shareId, syncFields(mount))) dirty.delete(key)
+    },
+
+    watermark: (key) => convergedHeads.get(key) ?? null,
+    setWatermark: (key, version) => convergedHeads.set(key, version),
+    skipped: (key) => skippedTicks.get(key) || 0,
+    noteSkipped: (key, n) => skippedTicks.set(key, n),
+    forgetConverged (key) {
+      convergedHeads.delete(key)
+      skippedTicks.delete(key)
+    },
+
+    // Every cache here is keyed by mount PATH in effect, not by path itself: the synced set
+    // records which entries this mount already owns on disk. Both unmount and relocate must drop
+    // them — an inherited set would claim files exist at a path the mount no longer uses.
+    reset (key) {
+      syncedSets.delete(key)
+      dirty.delete(key)
+      convergedHeads.delete(key)
+      skippedTicks.delete(key)
+    },
+  }
+}

--- a/src/shared/folders/mount-fault.js
+++ b/src/shared/folders/mount-fault.js
@@ -1,0 +1,22 @@
+// The worker's import path for the mount fault vocabulary: the status half comes from the
+// contract package (the renderer reads it too), and this adds the errno half, which needs
+// core/errors.js and so cannot live there.
+//
+// Four copies of this decision existed — the mirror's pause path, the owner's scan settle, the
+// renderer's fault reader, and a source-scanning test standing in for a type — and they had
+// already drifted once ('paused-enospc' reached the mirror before the owned vocabulary knew it).
+import { classifyLocalIoFault } from '../core/errors.js'
+import { statusForFaultCode } from '../contract/mount-fault.js'
+
+export {
+  STATUS_MOUNT_GONE, AUTO_PAUSE_STATUSES,
+  statusForFaultCode, isAutoPauseStatus, isMountFault, mountFault,
+} from '../contract/mount-fault.js'
+
+// null means "not a fault this classifies" — the caller falls through to its own handling rather
+// than pausing a mount on something transient. Whether a root actually vanished stays the
+// caller's question, because only it knows which path to stat.
+export function faultFromError (err) {
+  const code = classifyLocalIoFault(err)
+  return code ? { status: statusForFaultCode(code), code } : null
+}

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -10,22 +10,24 @@ import { AppError, ErrorCodes, classifyLocalIoFault } from '../core/errors.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { createCoalescingRunner } from '../core/coalescing-runner.js'
-import { getMaxFilesPerShare } from '../core/runtime-config.js'
+import { createPassLiveness } from '../core/pass-liveness.js'
 import { getContentBackend, isUnsupportedShare } from '../transfer/content-backends.js'
 import { listOwnShare } from '../shares/share-catalog.js'
-import { overlayHashFile, ensureServable, setPendingPublishProbe } from '../transfer/backends/overlay/overlay-backend.js'
+import { ensureServable, setPendingPublishProbe } from '../transfer/backends/overlay/overlay-backend.js'
 import { pathFromMount } from '../transfer/path-guard.js'
 import { makeKeyedCoalescer } from '../state/coalesce.js'
 import { walkDisk } from './walk-disk.js'
-import { exceedsShareFileLimit } from './share-limits.js'
-import { PREVIEW_DETAIL_MAX_FILES, includePerFile } from './preview-detail.js'
-import { relToDriveKey as relToKey, driveKeyToSegments, shouldIgnore, DEFAULT_IGNORE, isAbsoluteDriveKey, relKeyEscapes } from './path-keys.js'
+import { relToDriveKey as relToKey, shouldIgnore, DEFAULT_IGNORE, isAbsoluteDriveKey, relKeyEscapes } from './path-keys.js'
 import { OP, PRIORITY } from './work-item.js'
 import { mountRootAvailable } from './publish-runner.js'
 import { statFacts } from './disk-presence.js'
 import { registerPublishChannel, settleCatalog } from './publish-service.js'
 
 export { shouldIgnore, DEFAULT_IGNORE, mountRootAvailable }
+
+// Re-exported so the worker and the existing tests keep their `./owned-folders.js` import path;
+// the implementation lives in `owned-preview.js`.
+export { previewInitialPublishScan } from './owned-preview.js'
 
 const log = createLogger('owned-folders')
 
@@ -62,6 +64,12 @@ const CATCHUP_BACKOFF_MAX_MS = 60000
 // Longer than chokidar's awaitWriteFinish stabilityThreshold, so a catch-up diff that runs
 // mid-copy leaves the file to the watcher instead of reading it and reverting.
 const SCAN_SETTLE_MS = 2000
+// A diff over a large tree is legitimately slow, so the wedge signal is a pass that stats no
+// file for this long — not one that merely takes a while.
+const RECONCILE_STALL_WINDOW_MS = 10 * 60 * 1000
+// Tracked on the PASS, not on the coalescing wrapper: a caller that joins a run in flight must
+// not re-stamp its heartbeat and make a stalled pass read as fresh.
+const passLiveness = createPassLiveness()
 
 const shareCache = new Map()
 
@@ -294,8 +302,15 @@ const runDiff = createCoalescingRunner({
 })
 
 async function reconcileShare(spaceId, shareId, mountPath, ignore, { deep = false, deferFresh = false } = {}) {
-  return await runDiff(spaceId + ':' + shareId, { mountPath, ignore, deep, deferFresh },
-    (opts) => diffAndEnqueue(spaceId, shareId, opts))
+  const key = spaceId + ':' + shareId
+  return await runDiff(key, { mountPath, ignore, deep, deferFresh }, async (opts) => {
+    passLiveness.started(key)
+    try {
+      return await diffAndEnqueue(spaceId, shareId, opts)
+    } finally {
+      passLiveness.ended(key)
+    }
+  })
 }
 
 // Size+mtime is the "unchanged" signal. A deep pass distrusts mtimes (a relocated tree has fresh
@@ -333,7 +348,7 @@ async function readBothSides(spaceId, shareId, mountPath, ignore) {
   const signal = { aborted: false }
   scanSignals.set(key, signal)
   try {
-    const walk = await walkDisk(mountPath, ignore, { signal })
+    const walk = await walkDisk(mountPath, ignore, { signal, onProgress: () => passLiveness.progress(key) })
     // Commit the space batch first, or this read misses every hash materialized in the last flush
     // window and re-enqueues those files.
     await settleCatalog(spaceId)
@@ -437,63 +452,6 @@ export async function initialPublishScan(spaceId, shareId, mountPath, ignore, op
 
 export const periodicReconcile = initialPublishScan
 
-export async function previewInitialPublishScan(spaceId, shareId, mountPath, ignore, opts = {}) {
-  // Catalog side only matters when re-previewing an existing share (relocate). The
-  // Add-Folder UI passes shareId=null → onCatalog empty → a pure stat-only walk.
-  const onCatalog = new Map()
-  if (shareId) {
-    for await (const entry of listOwnShare(spaceId, shareId)) onCatalog.set(entry.relPath, entry)
-  }
-
-  const { onDisk } = await walkDisk(mountPath, ignore, { onProgress: opts.onProgress, signal: opts.signal })
-
-  let toUpload = 0
-  let conflicts = 0
-  let totalBytes = 0
-  const candidates = []
-  for (const [relPath, info] of onDisk) {
-    const existing = onCatalog.get(relPath)
-    let conflict = false
-    if (existing) {
-      if (existing.size === info.size && existing.mtime === info.mtime) continue
-      if (existing.size !== info.size) {
-        conflict = true
-      } else {
-        // Same size, different mtime: only a content hash can tell a real edit
-        // from a touch. Compare with the overlay hasher (catalog hashes are
-        // leaf/size-prefixed, not plain blake2b).
-        const abs = path.join(mountPath, ...driveKeyToSegments(relPath))
-        let diskHash = null
-        try { diskHash = await overlayHashFile(abs) } catch { diskHash = null }
-        if (diskHash != null && existing.contentHash != null && existing.contentHash === diskHash) continue
-        conflict = true
-      }
-      conflicts += 1
-    }
-    toUpload += 1
-    totalBytes += info.size
-    if (candidates.length <= PREVIEW_DETAIL_MAX_FILES) candidates.push({ relPath, size: info.size, conflict })
-  }
-
-  const detailed = includePerFile(toUpload)
-  // The limit is about how many files the folder HOLDS, not how many this scan would upload —
-  // a re-preview of an existing share uploads only the changed ones.
-  const totalFiles = onDisk.size
-  return {
-    flow: 'add-owned-folder',
-    toUpload,
-    toDownload: 0,
-    conflicts,
-    existingAtDestination: onDisk.size,
-    totalBytes,
-    perFile: detailed ? candidates : [],
-    perFileOmitted: !detailed,
-    totalFiles,
-    fileLimit: getMaxFilesPerShare(),
-    overFileLimit: exceedsShareFileLimit(totalFiles),
-  }
-}
-
 // The count the worker's admission gate reads. Stat-only, and it walks the same way the publish
 // scan does, so the gate can never admit a folder the scan would then find too large.
 export async function countFolderFiles(mountPath, ignore) {
@@ -564,6 +522,23 @@ export class OwnedFolders extends Subsystem {
     progress.reset()
     passFaults.clear()
     shareCache.clear()
+    passLiveness.clear()
+  }
+
+  // The mirror side has reported pass liveness since the supervision contract landed; the owner
+  // side never did, so a diff that never settles read as healthy. Reporting only: a wedged publish
+  // lane has no safe generic restart (an item mid-hash holds an fd), so this surfaces the wedge
+  // and leaves the remedy to an operator. Counts, not identifiers — diagnostics:export is
+  // user-shareable and redacts space and share ids.
+  health() {
+    const open = !this.closed && !this.stopping
+    if (!open) return { ok: false, detail: null }
+    const wedged = passLiveness.stalled({ windowMs: RECONCILE_STALL_WINDOW_MS })
+    return {
+      ok: wedged.length === 0,
+      detail: wedged.length ? `${wedged.length} folder scan(s) not advancing` : null,
+      scans: { wedged: wedged.length },
+    }
   }
 }
 

--- a/src/shared/folders/owned-preview.js
+++ b/src/shared/folders/owned-preview.js
@@ -1,0 +1,54 @@
+// The owner's read-only scan preview: what publishing this folder would upload, and which of
+// those files the catalog already carries under different bytes. Reads nothing the publish engine
+// owns — no queue, no scheduler — so it lives outside it.
+import path from 'bare-path'
+import { listOwnShare } from '../shares/share-catalog.js'
+import { overlayHashFile } from '../transfer/backends/overlay/overlay-backend.js'
+import { getMaxFilesPerShare } from '../core/runtime-config.js'
+import { driveKeyToSegments } from './path-keys.js'
+import { exceedsShareFileLimit } from './share-limits.js'
+import { createPreviewTally } from './preview-tally.js'
+import { walkDisk } from './walk-disk.js'
+
+export async function previewInitialPublishScan(spaceId, shareId, mountPath, ignore, opts = {}) {
+  // Catalog side only matters when re-previewing an existing share (relocate). The
+  // Add-Folder UI passes shareId=null → onCatalog empty → a pure stat-only walk.
+  const onCatalog = new Map()
+  if (shareId) {
+    for await (const entry of listOwnShare(spaceId, shareId)) onCatalog.set(entry.relPath, entry)
+  }
+
+  const { onDisk } = await walkDisk(mountPath, ignore, { onProgress: opts.onProgress, signal: opts.signal })
+
+  const tally = createPreviewTally()
+  for (const [relPath, info] of onDisk) {
+    const existing = onCatalog.get(relPath)
+    let conflict = false
+    if (existing) {
+      if (existing.size === info.size && existing.mtime === info.mtime) continue
+      if (existing.size !== info.size) {
+        conflict = true
+      } else {
+        // Same size, different mtime: only a content hash can tell a real edit
+        // from a touch. Compare with the overlay hasher (catalog hashes are
+        // leaf/size-prefixed, not plain blake2b).
+        const abs = path.join(mountPath, ...driveKeyToSegments(relPath))
+        let diskHash = null
+        try { diskHash = await overlayHashFile(abs) } catch { diskHash = null }
+        if (diskHash != null && existing.contentHash != null && existing.contentHash === diskHash) continue
+        conflict = true
+      }
+    }
+    tally.add({ relPath, size: info.size, conflict })
+  }
+
+  // The limit is about how many files the folder HOLDS, not how many this scan would upload —
+  // a re-preview of an existing share uploads only the changed ones.
+  const totalFiles = onDisk.size
+  return tally.result('add-owned-folder', 'upload', {
+    existingAtDestination: totalFiles,
+    totalFiles,
+    fileLimit: getMaxFilesPerShare(),
+    overFileLimit: exceedsShareFileLimit(totalFiles),
+  })
+}

--- a/src/shared/folders/path-keys.js
+++ b/src/shared/folders/path-keys.js
@@ -73,6 +73,17 @@ export function relKeyEscapes (relPath) {
   return false
 }
 
+// Drop poisoned peer entries at ingest so they never reach a materialize batch or a synced
+// record — one bad key must not abort a tick or DoS a mirror. `onDropped` is the caller's logger;
+// this module stays import-free (see the header), so it cannot log for itself.
+export function dropUnsafeEntries (entries, onDropped = () => {}) {
+  return entries.filter((e) => {
+    if (!relKeyEscapes(e.relPath)) return true
+    onDropped(e.relPath)
+    return false
+  })
+}
+
 // ─── share prefix + membership ────────────────────────────────────────────────
 export function sharePrefix (name) {
   return '/' + name + '/'

--- a/src/shared/folders/preview-tally.js
+++ b/src/shared/folders/preview-tally.js
@@ -1,0 +1,40 @@
+// The shape both scan previews return, and the one place the per-file detail cap is applied. The
+// two flows classify differently — an owner compares an mtime it trusts, a mirror compares a
+// verified-download record it wrote itself — but they answer the same dialog, and one component
+// renders both. Keeping the accumulator here makes "the two previews agree on their shape" an
+// assertion rather than a convention.
+//
+// No bare-* imports, so it unit-tests under Node alongside preview-detail.js.
+import { PREVIEW_DETAIL_MAX_FILES, includePerFile } from './preview-detail.js'
+
+export function createPreviewTally () {
+  let count = 0
+  let conflicts = 0
+  let totalBytes = 0
+  const candidates = []
+
+  return {
+    // One classified entry that WILL move bytes. Entries that will not move are never added.
+    add ({ relPath, size = 0, conflict = false }) {
+      count += 1
+      if (conflict) conflicts += 1
+      totalBytes += size
+      if (candidates.length <= PREVIEW_DETAIL_MAX_FILES) candidates.push({ relPath, size, conflict })
+    },
+    // `direction` is 'upload' or 'download' — the only axis the two flows differ on, and the
+    // reason one count can serve both.
+    result (flow, direction, extra = {}) {
+      const detailed = includePerFile(count)
+      return {
+        flow,
+        toUpload: direction === 'upload' ? count : 0,
+        toDownload: direction === 'download' ? count : 0,
+        conflicts,
+        totalBytes,
+        perFile: detailed ? candidates : [],
+        perFileOmitted: !detailed,
+        ...extra,
+      }
+    },
+  }
+}

--- a/src/shared/shares/share-listing.js
+++ b/src/shared/shares/share-listing.js
@@ -17,7 +17,7 @@ import { getOwnedMount, getForeignMount } from '../folders/mount-store.js'
 import { listPendingForSpace } from '../transfer/pending-transfers.js'
 import { isOwnerOnline } from '../transfer/swarm.js'
 import { getLocalPublicKeyHex } from '../spaces/profile.js'
-import { foreignFetchActive } from '../folders/foreign-folders.js'
+import { foreignFetchActive, localRelOf } from '../folders/foreign-folders.js'
 import { overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
 import {
   claimedPathFor,
@@ -62,7 +62,10 @@ function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, 
   const isVerified = Boolean(entry.contentHash) && verified.get(entry.relPath) === entry.contentHash
 
   if (foreignMount && foreignMount.enabled) {
-    const abs = pathFromMount(foreignMount.mountPath, entry.relPath)
+    // Not entry.relPath: a pre-existing user file at the natural name forces the mirror to
+    // materialize at a collision-free sibling, and stat'ing the natural name then reports a
+    // fully-mirrored file as 'remote'.
+    const abs = pathFromMount(foreignMount.mountPath, localRelOf(foreignMount, entry.relPath))
     if (statSizeOrNull(abs) === entry.size) return { status: 'synced', localPath: abs, verified: isVerified }
     // The mirror loop is pulling this row right now — 'downloading' so FolderView's
     // bar/speed/verify lane (all gated on the status) render during materialization.

--- a/src/shared/state/derived-view.js
+++ b/src/shared/state/derived-view.js
@@ -18,7 +18,10 @@
 //    safe — the fold is deterministic and idempotent, so an extra recompute only costs
 //    a fold, never correctness.
 
-import { stallVerdict } from '../core/stall-verdict.js'
+import { createPassLiveness } from '../core/pass-liveness.js'
+
+// One fold at a time, so the keyed bookkeeping carries a single key.
+const FOLD = 'fold'
 
 export function createDerivedView ({ fold, onChange, range, onError, debounceMs = 0 } = {}) {
   if (typeof fold !== 'function') throw new Error('createDerivedView: fold is required')
@@ -32,7 +35,7 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
   let timer = null             // pending debounce timer (debounceMs > 0)
   let inFlight = null          // the running fold, so close() can wait for the reads it holds
   let gen = 0                  // bumped by abandon(); a fold from an older generation is inert
-  let liveness = { startedAt: 0, progressAt: 0, completedAt: 0 }
+  const liveness = createPassLiveness()
 
   // Coalesce a burst of change signals into one fold and serialize folds so two changes
   // can't run overlapping folds whose results land out of order. If a change arrives while
@@ -56,8 +59,7 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
     timer = null
     running = true
     const mine = gen
-    const startedAt = Date.now()
-    liveness = { startedAt, progressAt: startedAt, completedAt: liveness.completedAt }
+    liveness.started(FOLD)
     try {
       const view = await fold()
       // Identity-guarded: a fold abandoned by a recovery must not publish a view the fold that
@@ -68,7 +70,7 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
     } finally {
       if (mine === gen) {
         running = false
-        liveness = { startedAt: 0, progressAt: 0, completedAt: Date.now() }
+        liveness.ended(FOLD)
         if (again && !closed) { again = false; recompute() }
       }
     }
@@ -78,11 +80,11 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
   // have to tolerate the worst-case fold — a roster of hundreds of unreachable peers, each read at
   // its own budget — and a window that generous is a window that never fires.
   function noteProgress () {
-    if (liveness.startedAt) liveness.progressAt = Date.now()
+    liveness.progress(FOLD)
   }
 
   function health ({ now = Date.now(), windowMs }) {
-    return stallVerdict(liveness, { now, windowMs })
+    return liveness.verdict(FOLD, { now, windowMs })
   }
 
   // Abandon the fold in flight and let the next recompute start a fresh one. NOT close(): that
@@ -96,7 +98,7 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
     again = false
     if (timer) { clearTimeout(timer); timer = null }
     inFlight = null
-    liveness = { startedAt: 0, progressAt: 0, completedAt: liveness.completedAt }
+    liveness.ended(FOLD)
   }
 
   // Start watching a source bee (idempotent per key). Each change within `range` —

--- a/src/shared/transfer/backends/overlay/fetch-run.js
+++ b/src/shared/transfer/backends/overlay/fetch-run.js
@@ -1,0 +1,33 @@
+// One overlay fetch, instrumented. Both consumers — the download engine's task and the mirror's
+// materialize — build the same ticker, the same diag and the same three callbacks. What differs
+// (where the bytes go, what a settle means durably, who owns the row) stays with the caller; only
+// the instrumentation lives here.
+//
+// `attempted` is true once a chunk scheduler ran — i.e. onEnd fired — which is what separates "a
+// holder was asked and the transfer died" (a give-up worth a WARN) from "no holder was ever
+// reachable" (a benign retry-next-tick). It rides the error too, so a caller that catches can
+// still tell the two apart.
+import { makeProgressTicker } from '../../progress-ticker.js'
+import { makeFetchDiag } from './overlay-backend.js'
+
+export async function runOverlayFetch (overlay, contentHash, {
+  label, relPath, size = 0, destPath, reSeed = false, onProgress, onVerify, onTick,
+}) {
+  const ticker = makeProgressTicker(size, onProgress)
+  const diag = makeFetchDiag(label, relPath, size, contentHash)
+  let attempted = false
+  try {
+    const res = await overlay.fetchFile(contentHash, {
+      destPath,
+      reSeed,
+      onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b); onTick?.() },
+      onVerify,
+      onEnd: (info) => { attempted = true; diag.onEnd(info) },
+    })
+    return { res, attempted, diag }
+  } catch (err) {
+    err.attempted = attempted
+    err.diag = diag
+    throw err
+  }
+}

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -15,6 +15,7 @@ import {
   recordPending, clearPending, recordPendingError, getPendingFor, updatePendingProgress, listPendingForSpace,
 } from '../../pending-transfers.js'
 import { makeProgressTicker } from '../../progress-ticker.js'
+import { createPausedHolders } from './paused-holders.js'
 import { recordTransferOutcome } from '../../transfer-audit.js'
 import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js'
 import { republishDecision } from '../../supersede-decision.js'
@@ -104,10 +105,10 @@ function discardPartial (finalPath) {
 //        ownerPublicKey, verifyKey, finalPath, prevBytes, ...channel-specific }
 export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContentToFile, hasOverlay = () => !!getOverlay(), freeBytes = defaultFreeBytes, stallRetry = {}, dirExists = defaultDirExists } = {}) {
   const registry = new Map() // transferId -> { contentHash, finalPath, paused, cancelled, fetching, spaceId, pendingKey, ownerPublicKey, restartJob }
-  // transferId -> contentHash for a paused transfer whose single-flight slot was
-  // released (the fetch IIFE deletes it on settle). Lets a later discard still tell
-  // the holder we stopped, since the registry no longer carries the hash.
-  const pausedHashes = new Map()
+  // Paused-transfer markers whose single-flight slot was released (the fetch IIFE deletes it on
+  // settle). The marker is the user's intent — it outranks every automatic resume — and its hash
+  // lets a later discard still tell the holder we stopped.
+  const pausedHashes = createPausedHolders({ notifyStopped: (hash) => getOverlay()?.notifyTransferStopped(hash) })
   // transferId -> ErrorCode for a terminal failure whose durable write FAILED. The row is the
   // only thing that keeps a checksum / disk-full / dest-unavailable row out of the next
   // level-triggered re-drive; when it cannot be written, this map keeps the verdict for the
@@ -413,7 +414,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   async function start (job) {
     if (!hasOverlay() || !job.contentHash) return { queued: true }
     const { transferId } = job
-    pausedHashes.delete(transferId) // a fresh start (resume) supersedes any paused marker
+    pausedHashes.supersede(transferId) // a fresh start (resume) supersedes any paused marker
     const existing = registry.get(transferId)
     if (existing) return { transferId, finalPath: existing.finalPath }
 
@@ -503,12 +504,12 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     const tr = registry.get(transferId)
     if (!tr) {
       cancelStallRetry(transferId)   // [mirall] FIX-BW9 — a pause during the retry backoff
-      pausedHashes.set(transferId, null)
+      pausedHashes.remember(transferId, null)
       return true
     }
     tr.paused = true
     cancelStallRetry(transferId)
-    pausedHashes.set(transferId, tr.contentHash) // remember the hash so a later discard can signal STOPPED
+    pausedHashes.remember(transferId, tr.contentHash) // remember the hash so a later discard can signal STOPPED
     if (tr.fetching) getOverlay()?.cancelFetch(tr.contentHash, { discardPartial: false })
     return true
   }
@@ -518,7 +519,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   // owner that just went offline) would otherwise leave the marker set — and a set marker makes
   // runReconcile skip the row as "manually paused" forever, so no reconnect ever resumes it.
   function clearPauseMarker (transferId) {
-    pausedHashes.delete(transferId)
+    pausedHashes.supersede(transferId)
     terminalCodes.delete(transferId)
     // [mirall] FIX-BW9 — a deliberate Resume/download click starts a fresh retry budget.
     // Inheriting a dry counter from earlier automatic attempts makes the click park after one
@@ -538,8 +539,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     } else {
       // Discarding an already-paused row (its single-flight slot is gone): the holder
       // still shows us paused, so tell it we stopped.
-      const hash = pausedHashes.get(transferId)
-      if (hash) getOverlay()?.notifyTransferStopped(hash)
+      pausedHashes.notify(transferId)
     }
     cancelStallRetry(transferId)
     // Clear the durable row FIRST. Everything after it is destructive and in-memory-only, so a
@@ -553,7 +553,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       channel.emitUpdated(spaceId)
       throw err
     }
-    pausedHashes.delete(transferId)
+    pausedHashes.supersede(transferId)
     const finalPath = pending?.finalPath
     if (finalPath) discardPartial(finalPath)
     terminalCodes.delete(transferId)

--- a/src/shared/transfer/backends/overlay/paused-holders.js
+++ b/src/shared/transfer/backends/overlay/paused-holders.js
@@ -1,0 +1,41 @@
+// The paused-transfer markers a producer leaves behind, and the "tell the holder we stopped"
+// protocol that goes with them. Shared by the download engine and the mirror loop.
+//
+// A pause releases the in-flight fetch slot while the holder is still showing us as paused, so the
+// hash has to outlive the slot: without it a later unmount/discard cannot notify the holder, and
+// its "who is downloading" row stays paused until the idle sweep.
+//
+// `notify` and `supersede` stay separate primitives rather than one `stop`, because the two
+// producers order them differently on purpose: the mirror forgets the marker as it notifies, while
+// the engine notifies first and only forgets after the durable row is cleared — a failed clear
+// there must not drop a marker whose absence would auto-resume a transfer the user paused.
+export function createPausedHolders ({ notifyStopped }) {
+  const byKey = new Map()
+
+  return {
+    // A slot released by a PAUSE. `contentHash` may be null: a pause with no live transfer still
+    // records the intent, it just has no holder to tell.
+    remember (key, contentHash) { byKey.set(key, contentHash ?? null) },
+    // Is this key marked paused? The engine reads this as the user's intent, which outranks every
+    // automatic resume.
+    has (key) { return byKey.has(key) },
+    peek (key) { return byKey.get(key) ?? null },
+    // Tell the holder we stopped, if a pause left it showing us paused. Leaves the marker.
+    // Returns whether a notification actually went out.
+    notify (key) {
+      const hash = byKey.get(key)
+      if (!hash) return false
+      try { notifyStopped(hash) } catch { return false }
+      return true
+    },
+    // A fresh or resumed fetch, or a completed teardown, supersedes the marker.
+    supersede (key) { byKey.delete(key) },
+    // Notify and forget in one step, for a producer with no durable row to clear in between.
+    stop (key) {
+      const notified = this.notify(key)
+      byKey.delete(key)
+      return notified
+    },
+    clear () { byKey.clear() },
+  }
+}

--- a/src/shared/transfer/path-guard.js
+++ b/src/shared/transfer/path-guard.js
@@ -2,8 +2,11 @@ import path from 'bare-path'
 import { relKeyEscapes } from '../folders/path-keys.js'
 import { AppError, ErrorCodes } from '../core/errors.js'
 
-// The single guarded mount-relative join shared by every content backend, so a
-// peer-supplied relPath can never read/hash/write a file outside the mount.
+// The single guarded mount-relative join shared by every content backend AND by the mirror
+// materialize path, so a peer-supplied relPath can never read/hash/write a file outside the
+// mount. Two guards on purpose: the pure segment check catches an encoded or separator-swapped
+// escape, and the path.relative belt catches anything that survives it, whatever the platform
+// separator or encoding.
 export function pathFromMount(mountPath, relPath) {
   if (relKeyEscapes(relPath)) {
     throw new AppError(ErrorCodes.EPATH, `file path rejected — unsafe segment escapes the share folder: ${relPath}`)

--- a/src/worker/mounts-runtime.js
+++ b/src/worker/mounts-runtime.js
@@ -11,7 +11,8 @@ import fs from 'bare-fs'
 import { Subsystem } from '../shared/core/subsystem.js'
 import { getDeepReconcileEvery } from '../shared/core/runtime-config.js'
 import { listDownloadRoots } from '../shared/core/paths.js'
-import { AppError, ErrorCodes, classifyLocalIoFault } from '../shared/core/errors.js'
+import { AppError, ErrorCodes } from '../shared/core/errors.js'
+import { faultFromError, statusForFaultCode } from '../shared/folders/mount-fault.js'
 import { setOwnedMountStatus, setOwnedIndexPaused, patchOwnedMount, listOwnedMounts, listAllMounts, listForeignMounts, getOwnedMount, getForeignMount } from '../shared/folders/mount-store.js'
 import { periodicReconcile, stopOwnedFolder, cancelIndex, mountRootAvailable } from '../shared/folders/owned-folders.js'
 import { startForeignLoop, initialMaterializeScan, resumeAutoPausedForeignMount, autoPauseForeignMountGone } from '../shared/folders/foreign-folders.js'
@@ -29,13 +30,6 @@ function rootAvailable(root) {
 
 function readUnavailableRoots() {
   return listDownloadRoots().filter((root) => !rootAvailable(root))
-}
-
-// A classified fault gets its own durable status where one exists, so the folder screen can name
-// the remedy instead of putting an errno in front of the user.
-// mount-status-vocabulary.test.js asserts every status written here is one the contract declares.
-function ownedFaultStatus(code) {
-  return code === ErrorCodes.TRANSFER_DISK_FULL ? 'paused-enospc' : 'paused-error'
 }
 
 function sameRootSet(a, b) {
@@ -198,7 +192,7 @@ export class MountsRuntime extends Subsystem {
       // A pass whose items failed on a classified fault is not a healthy scan. The pass resolving
       // does not mean its files reached the catalog — publish failures are per item — and reading
       // that resolution as 'active' is what made a full disk invisible to the owner.
-      else if (result?.faultCode) await this.setOwnedStatus(spaceId, shareId, ownedFaultStatus(result.faultCode), result.faultCode)
+      else if (result?.faultCode) await this.setOwnedStatus(spaceId, shareId, statusForFaultCode(result.faultCode), result.faultCode)
       else await this.setOwnedStatus(spaceId, shareId, 'active')
       return result
     } catch (err) {
@@ -213,9 +207,9 @@ export class MountsRuntime extends Subsystem {
   // raw message. An unclassified failure keeps its message — an unrecognised error with nothing to
   // say is worse than a raw one, and the renderer shows it as a generic reason either way.
   async recordScanFault(spaceId, shareId, err) {
-    const code = classifyLocalIoFault(err)
-    if (code) {
-      await this.setOwnedStatus(spaceId, shareId, ownedFaultStatus(code), code)
+    const fault = faultFromError(err)
+    if (fault) {
+      await this.setOwnedStatus(spaceId, shareId, fault.status, fault.code)
       return
     }
     // A root that vanished mid-pass: the probe would notice within its interval anyway, but going

--- a/test/integration/foreign-path-containment.test.js
+++ b/test/integration/foreign-path-containment.test.js
@@ -7,6 +7,8 @@ import { getDrive } from '../../src/shared/spaces/space.js'
 import { applyChange, initialMaterializeScan } from '../../src/shared/folders/foreign-folders.js'
 import { getForeignMount } from '../../src/shared/folders/mount-store.js'
 import { sharePrefix } from '../../src/shared/folders/path-keys.js'
+import { pathFromMount } from '../../src/shared/transfer/path-guard.js'
+import { ErrorCodes } from '../../src/shared/core/errors.js'
 
 // MIR-06: a malicious owner writes a RAW Hyperbee entry under Hyperdrive's
 // SubEncoder('files','utf-8') keyspace (hyperdrive/index.js:16), bypassing the
@@ -41,7 +43,7 @@ test('REGRESSION (MIR-06): a traversal del cannot unlink a file outside the moun
 
   await t.exception(
     applyChange(ctx.mount, { action: 'del', relPath }),
-    /escapes the mount folder|outside the mount folder/,
+    /escapes the share folder|outside the share folder/,
     'applyChange(del) on a traversal relPath throws',
   )
   t.ok(fs.existsSync(victim), 'victim outside the mount survives')
@@ -57,7 +59,7 @@ test('REGRESSION (MIR-06): a traversal put is refused', async (t) => {
 
   await t.exception(
     applyChange(ctx.mount, { action: 'put', relPath, hash: 'deadbeef', mtime: 0, size: 0 }),
-    /escapes the mount folder|outside the mount folder/,
+    /escapes the share folder|outside the share folder/,
     'applyChange(put) on a traversal relPath throws',
   )
   t.absent(fs.existsSync(path.join(outside, 'PWNED')), 'no directory created outside the mount')
@@ -85,4 +87,24 @@ test('a legitimate nested key still materializes after the guard', async (t) => 
   const ctx = await setupSelfMirror(t, { name: 'Docs', files: { 'sub/deep/ok.txt': 'fine' } })
   await initialMaterializeScan(ctx.mount)
   t.ok(fs.existsSync(path.join(ctx.mirrorPath, 'sub', 'deep', 'ok.txt')), 'nested legit file materialized')
+})
+
+// The mirror kept a byte-for-byte copy of this guard until it was merged away. Pin that the two
+// call sites now raise one contract, so a future fork of the message or the code is visible here.
+test('the mirror and the content backend reject an escaping key identically', async (t) => {
+  const ctx = await setupSelfMirror(t, { name: 'Docs', files: { 'real.txt': 'legit' } })
+  const bad = '../escape.txt'
+
+  // Captured by hand: brittle's t.exception asserts, it does not hand back the error, and the
+  // point here is to compare the two errors field by field.
+  let fromMirror = null
+  try { await applyChange(ctx.mount, { action: 'del', relPath: bad }) } catch (err) { fromMirror = err }
+  let fromBackend = null
+  try { pathFromMount(ctx.mirrorPath, bad) } catch (err) { fromBackend = err }
+
+  t.ok(fromMirror, 'the mirror refused it')
+  t.ok(fromBackend, 'and so did the backend')
+  t.is(fromMirror.code, ErrorCodes.EPATH)
+  t.is(fromMirror.code, fromBackend.code, 'one guard, one code')
+  t.is(fromMirror.message, fromBackend.message, 'and one message — the merge did not fork the contract')
 })

--- a/test/integration/foreign-synced-set.test.js
+++ b/test/integration/foreign-synced-set.test.js
@@ -107,3 +107,18 @@ test('REGRESSION (FIX-MIRROR-SET): a pre-existing user file at the natural name 
   t.is(fs.readFileSync(path.join(ctx.mirrorPath, 'report.pdf'), 'utf8'), 'THE USER OWN FILE', 'the user file is untouched')
   t.ok(fs.existsSync(path.join(ctx.mirrorPath, 'report (1).pdf')), 'the owner copy landed beside it as a sibling')
 })
+
+// The listing half of this lives in share-listing-batch.test.js (the renamed matrix dimension);
+// this is the half that proves the mirror really does mint the sibling and record the mapping.
+test('a pre-existing user file forces a sibling, and the mapping is recorded', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'report.pdf': 'owner-bytes' } })
+  fs.writeFileSync(path.join(ctx.mirrorPath, 'report.pdf'), 'the users own file')
+
+  await initialMaterializeScan(ctx.mount)
+
+  const mount = await getForeignMount(ctx.spaceId, ctx.share.id)
+  const localRel = mount.renamedPaths?.['report.pdf']
+  t.ok(localRel && localRel !== 'report.pdf', 'a sibling was minted: ' + localRel)
+  t.is(fs.readFileSync(path.join(ctx.mirrorPath, localRel), 'utf8'), 'owner-bytes', 'owner bytes landed there')
+  t.is(fs.readFileSync(path.join(ctx.mirrorPath, 'report.pdf'), 'utf8'), 'the users own file', "and the user's file is untouched")
+})

--- a/test/integration/preview-scan.test.js
+++ b/test/integration/preview-scan.test.js
@@ -214,3 +214,22 @@ test('foreign preview: emits scanning progress and an aborted signal throws PREV
     'an aborted preview rejects',
   )
 })
+
+// The destination count went through a private readdir copy of walkDisk until it was merged away.
+// These two pin the behaviour that copy carried and the shared walk must keep.
+test('foreign preview: an unreadable destination counts zero rather than failing', async (t) => {
+  const ctx = await setupSelfMirror(t)
+  const gone = path.join(ctx.mirrorPath, 'does-not-exist')
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, gone)
+  t.is(preview.existingAtDestination, 0, 'a missing destination is 0, not a throw')
+  t.is(preview.flow, 'mount-foreign-folder', 'and the dialog still gets a result')
+})
+
+test('foreign preview: ignored files do not inflate the destination count', async (t) => {
+  const ctx = await setupSelfMirror(t)
+  fs.writeFileSync(path.join(ctx.mirrorPath, 'real.txt'), 'x')
+  fs.writeFileSync(path.join(ctx.mirrorPath, '.DS_Store'), 'junk')
+  fs.writeFileSync(path.join(ctx.mirrorPath, 'half.mirall.part'), 'junk')
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, ctx.mirrorPath)
+  t.is(preview.existingAtDestination, 1, 'DEFAULT_IGNORE still applies through the shared walk')
+})

--- a/test/integration/share-listing-batch.test.js
+++ b/test/integration/share-listing-batch.test.js
@@ -187,12 +187,15 @@ const PENDING = { none: undefined, partial: { bytesTransferred: 5 }, error: { er
 
 const entryOf = (w) => ({ relPath: 'f.txt', size: 10, contentHash: w.hashed ? 'h1' : null, mtime: 7 })
 const claimedPathFor = (drivePath, rec) => rec?.localPath || '/downloads/' + path.basename(drivePath)
+// A pre-existing user file at the natural name forces the mirror onto a sibling, recorded in
+// mount.renamedPaths. The dimension the matrix was missing, and the one the bug lived in.
+const RENAMED_LEAF = 'f (1).txt'
 
 function baselineRow(w, mountPath) {
   const entry = entryOf(w)
   const out = { pruned: false }
   if (w.mirrored) {
-    const abs = pathFromMount(mountPath, entry.relPath)
+    const abs = pathFromMount(mountPath, w.renamed ? RENAMED_LEAF : entry.relPath)
     if (statSizeOrNull(abs) === entry.size) {
       const verified = !!entry.contentHash && VERIFIED[w.verified] === entry.contentHash
       return { ...out, row: { status: 'synced', localPath: abs, verified } }
@@ -254,7 +257,9 @@ function worldDeps(w, mountPath) {
     getLocalPublicKeyHex: () => 'me',
     isOwnerOnline: () => w.ownerOnline,
     getOwnedMount: async () => null,
-    getForeignMount: async () => (w.mirrored ? { enabled: true, mountPath } : null),
+    getForeignMount: async () => (w.mirrored
+      ? { enabled: true, mountPath, ...(w.renamed ? { renamedPaths: { 'f.txt': RENAMED_LEAF } } : {}) }
+      : null),
     listPendingForSpace: async () => (PENDING[w.pending] ? [{ ...PENDING[w.pending], filePath: drivePath }] : []),
     foreignFetchActive: () => w.fetchActive,
     overlayHasTransfer: () => w.active,
@@ -272,14 +277,16 @@ function matrix() {
   const cells = []
   for (const mirrored of [true, false]) {
     for (const sizeMatch of mirrored ? [true, false] : [false]) {
-      for (const fetchActive of mirrored ? [true, false] : [false]) {
-        for (const claim of mirrored ? ['none'] : Object.keys(CLAIMS)) {
-          for (const verified of Object.keys(VERIFIED)) {
-            for (const hashed of [true, false]) {
-              for (const ownerOnline of [true, false]) {
-                for (const pending of mirrored ? ['none'] : Object.keys(PENDING)) {
-                  for (const active of mirrored ? [false] : [true, false]) {
-                    cells.push({ mirrored, sizeMatch, fetchActive, claim, verified, hashed, ownerOnline, pending, active })
+      for (const renamed of mirrored ? [true, false] : [false]) {
+        for (const fetchActive of mirrored ? [true, false] : [false]) {
+          for (const claim of mirrored ? ['none'] : Object.keys(CLAIMS)) {
+            for (const verified of Object.keys(VERIFIED)) {
+              for (const hashed of [true, false]) {
+                for (const ownerOnline of [true, false]) {
+                  for (const pending of mirrored ? ['none'] : Object.keys(PENDING)) {
+                    for (const active of mirrored ? [false] : [true, false]) {
+                      cells.push({ mirrored, sizeMatch, renamed, fetchActive, claim, verified, hashed, ownerOnline, pending, active })
+                    }
                   }
                 }
               }
@@ -301,6 +308,9 @@ test('every row of the decision space matches the pre-batching rule', async (t) 
   fs.mkdirSync(present, { recursive: true })
   fs.mkdirSync(empty, { recursive: true })
   fs.writeFileSync(path.join(present, 'f.txt'), '0123456789')
+  // Same size as the natural name, or a renamed cell could never be a size match and the new
+  // dimension would prove nothing.
+  fs.writeFileSync(path.join(present, RENAMED_LEAF), '0123456789')
   t.teardown(() => { try { fs.rmSync(root, { recursive: true, force: true }) } catch {} })
 
   const cells = matrix()
@@ -328,4 +338,42 @@ test('every row of the decision space matches the pre-batching rule', async (t) 
   }
   t.is(mismatches, 0, 'every combination renders the same row and prunes the same claims')
   t.ok(prunesChecked > 0, 'the matrix actually exercises the pruning branches')
+})
+
+function mirrorDir(t, label, files) {
+  const root = path.join(os.tmpdir(), 'mirall-' + label + '-' + Date.now().toString(36))
+  fs.mkdirSync(root, { recursive: true })
+  for (const [name, body] of Object.entries(files)) fs.writeFileSync(path.join(root, name), body)
+  t.teardown(() => { try { fs.rmSync(root, { recursive: true, force: true }) } catch {} })
+  return root
+}
+
+// REGRESSION (FIX-MIRROR-RENAME: the mirror places a colliding entry at a sibling name and records
+// it in mount.renamedPaths, but the listing derived the local path from the owner key alone. It
+// therefore stat'd a path the mirror never wrote, and a fully-mirrored file rendered as 'remote' —
+// with a download button — for as long as the collision stood.)
+test("REGRESSION (FIX-MIRROR-RENAME): a collision-renamed mirror row is 'synced'", async (t) => {
+  const root = mirrorDir(t, 'renamed', {
+    'f.txt': 'THE USERS OWN FILE, a different length',
+    'f (1).txt': '0123456789',
+  })
+  const deps = countingDeps()
+  deps.getForeignMount = async () => ({ enabled: true, mountPath: root, renamedPaths: { 'f.txt': 'f (1).txt' } })
+
+  const entry = { relPath: 'f.txt', size: 10, contentHash: 'h1', mtime: 0 }
+  const res = await listOverlayShareFiles(SPACE, SHARE, backendFor([entry]), deps)
+
+  t.is(res.entries[0].status, 'synced', 'not remote — the bytes are on disk under the sibling name')
+  t.is(res.entries[0].localPath, path.join(root, 'f (1).txt'), 'and the row points at them')
+})
+
+test('an unrenamed mirror row is unaffected by the mapping lookup', async (t) => {
+  const root = mirrorDir(t, 'unrenamed', { 'f.txt': '0123456789' })
+  const deps = countingDeps()
+  // A mapping that exists but does not cover this entry — the fallback to the owner key.
+  deps.getForeignMount = async () => ({ enabled: true, mountPath: root, renamedPaths: { 'other.txt': 'other (1).txt' } })
+
+  const res = await listOverlayShareFiles(SPACE, SHARE, backendFor([{ relPath: 'f.txt', size: 10, contentHash: 'h1', mtime: 0 }]), deps)
+  t.is(res.entries[0].status, 'synced')
+  t.is(res.entries[0].localPath, path.join(root, 'f.txt'))
 })

--- a/test/unit/mirror-loop.test.js
+++ b/test/unit/mirror-loop.test.js
@@ -1,0 +1,179 @@
+import test from 'brittle'
+import { createMirrorLoops } from '../../src/shared/folders/mirror-loop.js'
+
+const deferred = () => {
+  let resolve
+  const promise = new Promise((r) => { resolve = r })
+  return { promise, resolve }
+}
+const settle = () => new Promise((r) => setImmediate(r))
+const NEVER = () => ({ intervalMs: () => 1e9 })
+
+test('a tick arriving mid-pass coalesces into exactly one follow-up', async (t) => {
+  let started = 0
+  const gate = deferred()
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { started++; await gate.promise } })
+
+  const first = loops.tick('k', {})
+  loops.tick('k', {})
+  loops.tick('k', {})
+  loops.tick('k', {})
+  t.is(started, 1, 'the three later requests joined the pass in flight')
+
+  gate.resolve()
+  await first
+  await settle()
+  t.is(started, 2, 'and produced exactly ONE follow-up, not three')
+})
+
+test('a request arriving mid-pass gets the pass in flight, not a fresh one', async (t) => {
+  const gate = deferred()
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { await gate.promise } })
+  const a = loops.tick('k', {})
+  const b = loops.tick('k', {})
+  t.is(a, b, 'the same promise — a caller that awaits observes the running pass')
+  gate.resolve()
+  await a
+})
+
+// The cancellation contract every long pass depends on.
+test('a stop invalidates the pass in flight without waiting for it', async (t) => {
+  const gate = deferred()
+  let sawStopped = null
+  const loops = createMirrorLoops({
+    ...NEVER(),
+    runPass: async (ctx) => { await gate.promise; sawStopped = loops.stopped('k', ctx.gen) },
+  })
+  const p = loops.tick('k', { gen: loops.generationOf('k') })
+  loops.stop('k')
+  gate.resolve()
+  await p
+  t.is(sawStopped, true, 'the pass can see it was cancelled and bail before writing')
+})
+
+test('the stop hook receives the key and its options', (t) => {
+  const seen = []
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => {}, onStop: (key, opts) => seen.push([key, opts]) })
+  loops.stop('k')
+  loops.stop('k', { discardPartial: true })
+  t.alike(seen, [['k', {}], ['k', { discardPartial: true }]], 'a pause and an unmount are distinguishable')
+})
+
+test('a stop does not clear the in-flight pass, so a bulk stop can await its tail', async (t) => {
+  const gate = deferred()
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { await gate.promise } })
+  const p = loops.tick('k', {})
+  loops.stop('k')
+  const bulk = loops.stopAll({ settleMs: 5000 })
+  gate.resolve()
+  await t.execution(bulk, 'the bulk stop waited for the tail it could see')
+  await p
+})
+
+test('stopAll returns at once when nothing is in flight', async (t) => {
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => {} })
+  loops.start('k', { spaceId: 's', shareId: 'sh' })
+  await t.execution(loops.stopAll({ settleMs: 5000 }))
+  t.is(loops.entries().length, 0, 'and the loop is disarmed')
+})
+
+// The wedge the mirror recovery exists for: a pass that never settles must not capture every
+// later tick.
+test('restart abandons a hung pass instead of coalescing onto it', async (t) => {
+  let started = 0
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { started++; await new Promise(() => {}) } })
+  loops.tick('k', {})
+  t.is(started, 1)
+  loops.tick('k', {})
+  t.is(started, 1, 'the hung pass captured it — this is the wedge')
+  loops.restart('k', { spaceId: 's', shareId: 'sh' })
+  t.is(started, 2, 'restart dropped the dead promise and armed a fresh pass')
+})
+
+test('a stale pass settling after a restart does not disturb the live one', async (t) => {
+  const first = deferred()
+  const second = deferred()
+  let n = 0
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { await (n++ === 0 ? first : second).promise } })
+  loops.tick('k', {})
+  loops.restart('k', { spaceId: 's', shareId: 'sh' })
+  first.resolve()
+  await settle()
+  loops.tick('k', {})
+  t.is(n, 2, 'the live pass still owns the key — the stale settle deleted nothing')
+  second.resolve()
+})
+
+test('the debounce collapses a burst into one delayed tick', async (t) => {
+  let started = 0
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { started++ } })
+  for (let i = 0; i < 5; i++) loops.debounce('k', {}, 10)
+  await new Promise((r) => setTimeout(r, 60))
+  t.is(started, 1)
+})
+
+test('a stop disarms a debounced tick that has not fired', async (t) => {
+  let started = 0
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { started++ } })
+  loops.debounce('k', {}, 20)
+  loops.stop('k')
+  await new Promise((r) => setTimeout(r, 60))
+  t.is(started, 0, 'a pause between the append and its tick cancels the tick')
+})
+
+test('keys are independent', async (t) => {
+  const seen = []
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async (ctx) => { seen.push(ctx.shareId) } })
+  await Promise.all([loops.tick('a', { shareId: 'a' }), loops.tick('b', { shareId: 'b' })])
+  t.alike(seen.sort(), ['a', 'b'])
+})
+
+test('a pass that rejects still releases the key', async (t) => {
+  let started = 0
+  const loops = createMirrorLoops({
+    ...NEVER(),
+    runPass: async () => { started++; throw new Error('boom') },
+    onError: () => {},
+  })
+  await loops.tick('k', {}).catch(() => {})
+  await loops.tick('k', {}).catch(() => {})
+  t.is(started, 2, 'a rejected pass is not a permanent wedge')
+})
+
+test('a pass that throws synchronously is still a rejected promise, not a throw', async (t) => {
+  const loops = createMirrorLoops({ ...NEVER(), runPass: () => { throw new Error('sync boom') }, onError: () => {} })
+  let caught = null
+  await t.execution(() => { loops.tick('k', {}).catch((e) => { caught = e }) }, 'the call itself does not throw')
+  await settle()
+  t.is(caught?.message, 'sync boom')
+  await loops.tick('k', {}).catch(() => {})
+  t.is(loops.liveness('k').startedAt, 0, 'and the key is released')
+})
+
+test('entries reports only mounts with a live loop', (t) => {
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => {} })
+  loops.start('s:a', { spaceId: 's', shareId: 'a' })
+  loops.start('s:b', { spaceId: 's', shareId: 'b' })
+  t.alike(loops.entries().map((e) => e.shareId).sort(), ['a', 'b'])
+  loops.stop('s:a')
+  t.alike(loops.entries().map((e) => e.shareId), ['b'], 'a stopped mount is not reported')
+})
+
+test('start is idempotent for a key that already has a loop', (t) => {
+  let armed = 0
+  const loops = createMirrorLoops({ intervalMs: () => { armed++; return 1e9 }, runPass: async () => {} })
+  loops.start('k', { spaceId: 's', shareId: 'sh' })
+  loops.start('k', { spaceId: 's', shareId: 'sh' })
+  t.is(armed, 1, 'a second start does not arm a second interval')
+  t.is(loops.entries().length, 1)
+})
+
+test('the generation advances once per stop', (t) => {
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => {} })
+  t.is(loops.generationOf('k'), 0, 'a key never stopped reads generation 0')
+  t.is(loops.stopped('k', 0), false)
+  loops.stop('k')
+  t.is(loops.generationOf('k'), 1)
+  t.is(loops.stopped('k', 0), true, 'a pass that captured 0 now knows to bail')
+  t.is(loops.stopped('k', 1), false, 'while a pass started after the stop keeps running')
+})

--- a/test/unit/mount-status-vocabulary.test.js
+++ b/test/unit/mount-status-vocabulary.test.js
@@ -3,6 +3,10 @@ import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
 import { OWNED_MOUNT_STATUS, FOREIGN_MOUNT_STATUS } from '../../src/shared/contract/statuses.js'
+import { ErrorCodes } from '../../src/shared/core/errors.js'
+import {
+  AUTO_PAUSE_STATUSES, statusForFaultCode, faultFromError, isAutoPauseStatus, mountFault, isMountFault,
+} from '../../src/shared/folders/mount-fault.js'
 
 // The mount status vocabularies were hand-written TypeScript unions until this shipped, and they
 // had already drifted: the mirror wrote 'paused-enospc', the owned union had never heard of it.
@@ -24,7 +28,9 @@ const WRITERS = [
   // Writes owned statuses directly (mount, relocate) and emits a mirror one, so leaving it out
   // made the promise above narrower than it reads.
   'worker/main.js',
-  'renderer/mountFault.js',
+  // The shared writer both roles now go through. renderer/mountFault.js and
+  // shared/folders/mount-fault.js re-export it and hold no literals of their own.
+  'shared/contract/mount-fault.js',
 ]
 
 const declared = new Set([...OWNED_MOUNT_STATUS, ...FOREIGN_MOUNT_STATUS])
@@ -42,4 +48,57 @@ test('the fault statuses both roles share are declared for both', (t) => {
   t.ok(FOREIGN_MOUNT_STATUS.includes('paused-enospc'))
   t.ok(FOREIGN_MOUNT_STATUS.includes('idle'), "and 'idle' stays mirror-only, which is why there are two")
   t.absent(OWNED_MOUNT_STATUS.includes('idle'))
+})
+
+// The promise the source scan could only approximate. Importable now that one bare-*-free module
+// owns the decision, so this asserts the writer's whole output range rather than its spelling.
+test('every status mount-fault.js can produce is declared for both roles', (t) => {
+  const produced = new Set([
+    ...AUTO_PAUSE_STATUSES,
+    statusForFaultCode(ErrorCodes.TRANSFER_DISK_FULL),
+    statusForFaultCode(ErrorCodes.TRANSFER_PERMISSION),
+    statusForFaultCode(null),
+  ])
+  t.ok(produced.size >= 3, 'the set is non-trivial (guards the assertion itself)')
+  for (const status of produced) {
+    t.ok(OWNED_MOUNT_STATUS.includes(status), `owned declares '${status}'`)
+    t.ok(FOREIGN_MOUNT_STATUS.includes(status), `foreign declares '${status}'`)
+  }
+})
+
+test('the errno split both roles depend on', (t) => {
+  t.is(faultFromError({ code: 'ENOSPC' }).status, 'paused-enospc')
+  t.is(faultFromError({ code: 'ENOSPC' }).code, ErrorCodes.TRANSFER_DISK_FULL)
+  t.is(faultFromError({ code: 'EACCES' }).status, 'paused-error')
+  t.is(faultFromError({ code: 'EPERM' }).status, 'paused-error')
+  t.is(faultFromError({ code: 'EROFS' }).status, 'paused-error')
+  t.is(faultFromError({ code: 'ENOENT' }), null, 'ENOENT is ambiguous — the caller must probe the path')
+  t.is(faultFromError({}), null)
+  t.is(faultFromError(null), null, 'and a non-error never pauses a mount')
+})
+
+// A user pause must never be auto-resumable; that distinction is the whole reason the set exists.
+test('a user pause is not an auto-pause', (t) => {
+  t.absent(isAutoPauseStatus('paused'))
+  t.absent(isAutoPauseStatus('active'))
+  t.absent(isAutoPauseStatus('scanning'))
+  t.absent(isAutoPauseStatus('idle'))
+  for (const s of ['paused-enospc', 'paused-error', 'mount-point-gone']) t.ok(isAutoPauseStatus(s))
+})
+
+test('the renderer fault reader names a reason even when none was recorded', (t) => {
+  t.alike(mountFault('paused-enospc', null), { status: 'paused-enospc', code: ErrorCodes.TRANSFER_DISK_FULL })
+  t.alike(mountFault('paused-error', ErrorCodes.TRANSFER_PERMISSION), { status: 'paused-error', code: ErrorCodes.TRANSFER_PERMISSION })
+  t.is(mountFault('paused-error', null).code, null, 'a plain error with no reason stays honest rather than guessing')
+  t.is(mountFault('mount-point-gone', null), null, 'a missing root is not a fault banner')
+  t.is(mountFault('paused', null), null)
+  t.absent(isMountFault('paused'))
+  t.ok(isMountFault('paused-error'))
+})
+
+// The layering constraint that makes one shared writer possible at all.
+test('mount-fault.js is loadable outside Bare', (t) => {
+  for (const f of ['shared/contract/mount-fault.js', 'shared/folders/mount-fault.js']) {
+    t.absent(/from '(bare-[a-z]+)'/.test(read(f)), f + ': no bare-* import — the renderer bundles the contract half')
+  }
 })

--- a/test/unit/pass-liveness.test.js
+++ b/test/unit/pass-liveness.test.js
@@ -1,0 +1,121 @@
+import test from 'brittle'
+import { createPassLiveness } from '../../src/shared/core/pass-liveness.js'
+
+// A controllable clock: the rule is about elapsed progress, so a real one makes the test a race.
+function clockAt (t0) {
+  let n = t0
+  return { now: () => n, advance: (ms) => { n += ms } }
+}
+
+test('an unknown key is healthy — nothing is in flight', (t) => {
+  const l = createPassLiveness()
+  t.is(l.verdict('missing', { now: 1e9, windowMs: 1000 }).ok, true)
+  t.is(l.peek('missing'), null)
+})
+
+test('a pass in flight and advancing stays healthy past the window', (t) => {
+  const c = clockAt(1000)
+  const l = createPassLiveness({ now: c.now })
+  l.started('k')
+  for (let i = 0; i < 10; i++) { c.advance(900); l.progress('k') }
+  t.is(l.verdict('k', { now: c.now(), windowMs: 1000 }).ok, true, 'ten windows of elapsed time, none of them stalled')
+})
+
+test('a pass in flight and NOT advancing is stalled once the window passes', (t) => {
+  const c = clockAt(1000)
+  const l = createPassLiveness({ now: c.now })
+  l.started('k')
+  c.advance(1000)
+  t.is(l.verdict('k', { now: c.now(), windowMs: 1000 }).ok, true, 'exactly at the bound is not yet stalled')
+  c.advance(1)
+  const v = l.verdict('k', { now: c.now(), windowMs: 1000 })
+  t.is(v.ok, false)
+  t.ok(/no progress for/.test(v.detail), 'and it says how long')
+})
+
+// The bug this shape exists to prevent: an abandoned pass's late callback re-arming a heartbeat.
+test('progress on an ended pass is a no-op', (t) => {
+  const c = clockAt(1000)
+  const l = createPassLiveness({ now: c.now })
+  l.started('k')
+  l.ended('k')
+  c.advance(5000)
+  l.progress('k')
+  t.is(l.peek('k').progressAt, 0, 'a late heartbeat did not resurrect the pass')
+  t.is(l.verdict('k', { now: c.now(), windowMs: 10 }).ok, true, 'and an ended pass is never stalled')
+})
+
+test('progress on an unknown key does not create one', (t) => {
+  const l = createPassLiveness()
+  l.progress('never-started')
+  t.is(l.peek('never-started'), null)
+})
+
+test('ended stamps a completion; started re-stamps rather than stacking', (t) => {
+  const c = clockAt(1000)
+  const l = createPassLiveness({ now: c.now })
+  l.started('k')
+  c.advance(50)
+  l.ended('k')
+  t.is(l.peek('k').completedAt, 1050)
+  c.advance(10)
+  l.started('k')
+  t.is(l.peek('k').startedAt, 1060)
+  t.is(l.peek('k').progressAt, 1060, 'a fresh pass starts its heartbeat at its start')
+})
+
+test('ended on an unknown key is a no-op', (t) => {
+  const l = createPassLiveness()
+  l.ended('nope')
+  t.is(l.peek('nope'), null)
+})
+
+// The clock never starts at 0: stallVerdict treats a falsy startedAt as "no pass in flight", so a
+// zero epoch would read every started key as idle.
+test('keys are independent, and forget/clear drop them', (t) => {
+  const c = clockAt(1000)
+  const l = createPassLiveness({ now: c.now })
+  l.started('a')
+  l.started('b')
+  c.advance(100)
+  l.progress('a')
+  t.is(l.verdict('a', { now: c.now(), windowMs: 50 }).ok, true)
+  t.is(l.verdict('b', { now: c.now(), windowMs: 50 }).ok, false, 'b stalled while a advanced')
+  l.forget('b')
+  t.is(l.peek('b'), null)
+  t.is(l.verdict('b', { now: c.now(), windowMs: 50 }).ok, true, 'a forgotten key reads healthy again')
+  l.clear()
+  t.is(l.peek('a'), null)
+})
+
+test('peek returns a copy', (t) => {
+  const l = createPassLiveness()
+  l.started('k')
+  l.peek('k').progressAt = 0
+  t.ok(l.peek('k').progressAt > 0, 'mutating the copy did not reach the heartbeat')
+})
+
+test('stalled() reports only the keys whose pass is in flight and not advancing', (t) => {
+  const c = clockAt(1000)
+  const l = createPassLiveness({ now: c.now })
+  l.started('advancing')
+  l.started('wedged')
+  l.started('finished')
+  l.ended('finished')
+
+  c.advance(5000)
+  l.progress('advancing')
+
+  const rows = l.stalled({ now: c.now(), windowMs: 1000 })
+  t.alike(rows.map((r) => r.key), ['wedged'], 'the settled and the advancing passes are not reported')
+  t.is(rows[0].ok, false)
+  t.ok(/no progress for/.test(rows[0].detail))
+})
+
+test('stalled() is empty when nothing is in flight', (t) => {
+  const l = createPassLiveness()
+  t.alike(l.stalled({ windowMs: 1 }), [])
+  l.started('k')
+  l.ended('k')
+  t.alike(l.stalled({ windowMs: 1 }), [], 'a completed pass is not a wedge')
+})

--- a/test/unit/paused-holders.test.js
+++ b/test/unit/paused-holders.test.js
@@ -1,0 +1,92 @@
+import test from 'brittle'
+import { createPausedHolders } from '../../src/shared/transfer/backends/overlay/paused-holders.js'
+
+function spy () {
+  const calls = []
+  return { fn: (h) => calls.push(h), calls }
+}
+
+test('a stop with no pause marker notifies nobody', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  t.is(p.stop('k'), false)
+  t.is(s.calls.length, 0)
+})
+
+// The whole reason the marker outlives the single-flight slot.
+test('a pause then a stop tells the holder we stopped', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  p.remember('k', 'hash-a')
+  t.is(p.stop('k'), true)
+  t.alike(s.calls, ['hash-a'])
+  t.is(p.stop('k'), false, 'and the marker is consumed, so a second stop is silent')
+})
+
+test('a resumed fetch supersedes the marker', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  p.remember('k', 'hash-a')
+  p.supersede('k')
+  t.is(p.stop('k'), false, 'the resumed fetch owns the holder relationship now')
+  t.is(s.calls.length, 0)
+})
+
+test('the newest pause wins for a key', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  p.remember('k', 'hash-a')
+  p.remember('k', 'hash-b')
+  p.stop('k')
+  t.alike(s.calls, ['hash-b'], 'never the stale hash')
+})
+
+// A pause with no live transfer still records the user's intent — it just has no holder to tell.
+test('a hash-less marker is still a marker', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  p.remember('k', null)
+  t.is(p.has('k'), true, 'the intent is recorded, which is what suppresses auto-resume')
+  t.is(p.peek('k'), null)
+  t.is(p.notify('k'), false, 'but there is nothing to notify')
+  t.is(s.calls.length, 0)
+})
+
+// The engine notifies BEFORE clearing its durable row and only supersedes after, so that a failed
+// clear cannot drop a marker whose absence would auto-resume a transfer the user paused.
+test('notify leaves the marker; supersede removes it', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  p.remember('k', 'hash-a')
+  t.is(p.notify('k'), true)
+  t.is(p.has('k'), true, 'still marked — the durable clear has not landed yet')
+  t.alike(s.calls, ['hash-a'])
+  p.supersede('k')
+  t.is(p.has('k'), false)
+})
+
+test('has() distinguishes an unmarked key from a hash-less one', (t) => {
+  const p = createPausedHolders({ notifyStopped: () => {} })
+  t.is(p.has('never'), false)
+  t.is(p.peek('never'), null)
+  p.remember('marked', null)
+  t.is(p.has('marked'), true, 'a null hash and no marker at all are different states')
+})
+
+test('a throwing notifier is contained', (t) => {
+  const p = createPausedHolders({ notifyStopped: () => { throw new Error('overlay is gone') } })
+  p.remember('k', 'h')
+  t.is(p.stop('k'), false, 'reports failure')
+  t.execution(() => p.stop('k'), 'and never propagates — a teardown must not fail on a notify')
+})
+
+test('keys are independent and clear drops all', (t) => {
+  const s = spy()
+  const p = createPausedHolders({ notifyStopped: s.fn })
+  p.remember('a', 'ha')
+  p.remember('b', 'hb')
+  p.stop('a')
+  t.is(p.peek('b'), 'hb')
+  p.clear()
+  t.is(p.has('b'), false)
+})

--- a/test/unit/preview-shape-parity.test.js
+++ b/test/unit/preview-shape-parity.test.js
@@ -1,0 +1,34 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (p) => readFileSync(path.resolve(here, '../../src', p), 'utf8')
+
+// Both previews feed one renderer component, and both used to hand-build their result object.
+// Source-scanned rather than imported: both modules import bare-fs/bare-path, so a Node runner
+// cannot load them. The promise is narrow but exactly the one that broke before — one flow's
+// contract fields drifting from the other's.
+for (const file of ['shared/folders/owned-preview.js', 'shared/folders/foreign-preview.js']) {
+  test(`${file} builds its result through the shared tally`, (t) => {
+    const src = read(file)
+    t.ok(/createPreviewTally/.test(src), 'it uses the shared accumulator')
+    t.absent(/perFileOmitted\s*:/.test(src), 'and does not hand-roll the contract fields')
+    t.absent(/toUpload\s*:/.test(src), 'nor the direction fields')
+    t.absent(/toDownload\s*:/.test(src))
+  })
+}
+
+// The layering rule from testing.md, pinned: these must stay Node-loadable, or the unit tests
+// above them silently belong to a different runner.
+for (const file of [
+  'shared/folders/preview-tally.js',
+  'shared/folders/preview-detail.js',
+  'shared/folders/path-keys.js',
+  'shared/transfer/partial-suffix.js',
+]) {
+  test(`${file} imports no bare-* module`, (t) => {
+    t.absent(/from '(bare-[a-z]+)'/.test(read(file)), 'stays unit-testable under Node')
+  })
+}

--- a/test/unit/preview-tally.test.js
+++ b/test/unit/preview-tally.test.js
@@ -1,0 +1,77 @@
+import test from 'brittle'
+import { createPreviewTally } from '../../src/shared/folders/preview-tally.js'
+import { PREVIEW_DETAIL_MAX_FILES } from '../../src/shared/folders/preview-detail.js'
+
+test('an empty tally is a well-formed result for either direction', (t) => {
+  const up = createPreviewTally().result('add-owned-folder', 'upload')
+  t.alike(
+    { ...up, perFile: up.perFile.length },
+    { flow: 'add-owned-folder', toUpload: 0, toDownload: 0, conflicts: 0, totalBytes: 0, perFile: 0, perFileOmitted: false },
+  )
+  const down = createPreviewTally().result('mount-foreign-folder', 'download')
+  t.is(down.toDownload, 0)
+  t.is(down.toUpload, 0, 'the unused direction is always 0, never undefined')
+})
+
+test('direction routes the one count onto the right field', (t) => {
+  const a = createPreviewTally()
+  a.add({ relPath: 'x', size: 5 })
+  t.alike([a.result('f', 'upload').toUpload, a.result('f', 'upload').toDownload], [1, 0])
+
+  const b = createPreviewTally()
+  b.add({ relPath: 'x', size: 5 })
+  t.alike([b.result('f', 'download').toUpload, b.result('f', 'download').toDownload], [0, 1])
+})
+
+test('conflicts and bytes accumulate; a non-conflict adds bytes only', (t) => {
+  const tally = createPreviewTally()
+  tally.add({ relPath: 'a', size: 10, conflict: true })
+  tally.add({ relPath: 'b', size: 5 })
+  const r = tally.result('f', 'download')
+  t.is(r.conflicts, 1)
+  t.is(r.totalBytes, 15)
+  t.is(r.toDownload, 2)
+})
+
+test('a size-less entry still counts', (t) => {
+  const tally = createPreviewTally()
+  tally.add({ relPath: 'a' })
+  const r = tally.result('f', 'upload')
+  t.is(r.toUpload, 1)
+  t.is(r.totalBytes, 0, 'and contributes no bytes rather than NaN')
+})
+
+// The cap policy is the thing the two dialogs must not fork on.
+test('per-file detail is omitted past the cap, and the flag says so', (t) => {
+  const tally = createPreviewTally()
+  for (let i = 0; i <= PREVIEW_DETAIL_MAX_FILES + 50; i++) tally.add({ relPath: 'f' + i, size: 1 })
+  const r = tally.result('f', 'download')
+  t.is(r.perFile.length, 0, 'detail is dropped wholesale, not truncated')
+  t.is(r.perFileOmitted, true)
+  t.ok(r.toDownload > PREVIEW_DETAIL_MAX_FILES, 'while the count stays honest')
+})
+
+test('exactly at the cap the detail is still included', (t) => {
+  const tally = createPreviewTally()
+  for (let i = 0; i < PREVIEW_DETAIL_MAX_FILES; i++) tally.add({ relPath: 'f' + i, size: 1 })
+  const r = tally.result('f', 'upload')
+  t.is(r.perFileOmitted, false)
+  t.is(r.perFile.length, PREVIEW_DETAIL_MAX_FILES)
+})
+
+test('extra fields ride through without colliding with the contract', (t) => {
+  const r = createPreviewTally().result('add-owned-folder', 'upload', { totalFiles: 7, overFileLimit: true })
+  t.is(r.totalFiles, 7)
+  t.is(r.overFileLimit, true)
+  t.is(r.flow, 'add-owned-folder')
+  t.is(r.toUpload, 0)
+})
+
+test('two tallies do not share state', (t) => {
+  const a = createPreviewTally()
+  const b = createPreviewTally()
+  a.add({ relPath: 'x', size: 9, conflict: true })
+  t.is(b.result('f', 'upload').toUpload, 0)
+  t.is(b.result('f', 'upload').conflicts, 0)
+  t.is(b.result('f', 'upload').totalBytes, 0)
+})


### PR DESCRIPTION
`foreign-folders.js` **1141 → 764 lines (−33%)**. It was the last folder module still carrying its own engine: the owner side had that cut out when the publish queue was extracted, while the mirror kept it inline through fourteen consecutive additive changes (ownership Set, convergence watermark, liveness probe, supervision contract, auto-pause). What remains is the mirror domain — the catalog passes, deletion safety, the integrity audit, owner-gone teardown.

## Read it in three commits

1. **Add the modules** — ten new files with unit tests, nothing importing them yet.
2. **Move the engine onto them** — the deletions here should match the additions above; that is how to check it is a genuine move.
3. **One bug fix**, kept separate because it changes behaviour.

## What is genuinely deleted, not re-homed

- `safeMaterializePath` was a byte-for-byte copy of `pathFromMount` (only the error message differed). Gone; the containment suite now asserts both sites raise one code *and* one message.
- `countFilesAtPath` re-implemented `walkDisk`, long-path normalisation and all — its own comment said so. Gone.
- `pausedHashes`: the download engine was migrated onto the shared markers too, so this is one implementation rather than two. `notify` and `supersede` stay separate primitives because the two producers order them differently on purpose — the engine must not drop a marker if its durable row clear fails.

## The bug (commit 3)

The mirror places an entry the user already has a file for under a sibling name, recorded in `mount.renamedPaths`. `share-listing` derived the local path from the owner key alone, so it stat'd a path the mirror never wrote — a fully-mirrored file rendered as `remote`, with a download button.

`share-listing-batch.test.js` already had a 500-cell conformance matrix with a `mirrored` dimension but no `renamed` one, which is exactly why this was invisible; `baselineRow` encoded the same bug. Both are fixed, so the matrix now covers it.

## Also fixed on the way

The owner side never reported pass liveness — a wedged diff read as healthy while the mirror's has been supervised since #171. `OwnedFolders.health()` now reports it. Reporting only: a wedged publish lane has no safe generic restart (an item mid-hash holds an fd), so the remedy is left to a follow-up.

## Layers

Unit + integration; flow and frontend for the P2P and UI surfaces.

- `typecheck`, `lint:ci`, `knip` at baseline
- `test:unit` **1754/1754** · `test:bare` **987/987** · `test:flow` **195/195**
- `test:fe` **7/7 targeted scenarios, 27 steps** — s6, s32, s42, s25, s127, s23, s24, chosen for the changed paths. `s127-folder-fault-strip` is the load-bearing one: it asserts the fault is named in plain language and survives a restart, which is what a wrong collapse of the four fault→status copies would have broken. jsx-a11y clean (runs inside `npm run build`).

Bug fix verified red-first. Two pre-existing assertions changed deliberately: `foreign-path-containment.test.js` matched the mirror's old error wording, and `mount-status-vocabulary.test.js`'s source scan now targets the shared writer.

## Not done, deliberately

- **The mirror is still not a download-engine channel.** `overlay-download.js` calls `pending-transfers` directly in ~15 places and the mirror has no pending rows, so that needs a row port first. The two `overlayHasTransfer` guards therefore stay, now with a comment naming why.
- **Re-export shims remain.** 22 test files and `worker/main.js` still import through `foreign-folders.js`; re-pointing them is a separate mechanical sweep.
- **No frontend scenario drives the collision case** — nothing holds a mirror open across a name collision. Pinned at the integration layer instead, where the derivation lives.