### PR TITLE
[fix] Tell members when a folder download stalls

### DIFF
--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -633,7 +633,10 @@ function stopAllForeignLoops({ settleMs = 5000 } = {}) {
 export class ForeignMirrors extends Subsystem {
   constructor(name, deps) { super(name, deps); this.require('ipc'); this.units = new Map() }
   async _open() { initForeignFolders(this.deps.ipc) }
-  async _close() { await stopAllForeignLoops(); integritySeen.clear() }
+  // stopAllForeignLoops pauses rather than unmounts, so it is the one path that FILLS
+  // pausedHolders. Without the clear the hashes outlive the subsystem that recorded them, and a
+  // later open inherits markers for fetches belonging to a previous lifetime.
+  async _close() { await stopAllForeignLoops(); pausedHolders.clear(); integritySeen.clear() }
 
   // Counts, not identifiers: diagnostics:export is user-shareable and redacts peer keys and
   // topics, so space and share ids must not ride along. The probe names the mount in the worker

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -13,7 +13,7 @@ import { createCoalescingRunner } from '../core/coalescing-runner.js'
 import { createPassLiveness } from '../core/pass-liveness.js'
 import { getContentBackend, isUnsupportedShare } from '../transfer/content-backends.js'
 import { listOwnShare } from '../shares/share-catalog.js'
-import { ensureServable, setPendingPublishProbe } from '../transfer/backends/overlay/overlay-backend.js'
+import { ensureServable, setFolderPublishLane } from '../transfer/backends/overlay/overlay-backend.js'
 import { pathFromMount } from '../transfer/path-guard.js'
 import { makeKeyedCoalescer } from '../state/coalesce.js'
 import { walkDisk } from './walk-disk.js'
@@ -206,9 +206,15 @@ export function initOwnedFolders(_ipc, { settleScan = null, broadcastIndex = nul
   settleScanRef = settleScan
   broadcastIndexRef = broadcastIndex
   announceMs = indexAnnounceMs
-  // The presence sweep must never reclaim a path whose publish is queued or running. Installed
-  // here rather than by the service, which must not import the backend (import cycle).
-  setPendingPublishProbe((spaceId, shareId, relPath) => scheduler?.isPending(spaceId, shareId, relPath) ?? false)
+  // The backend's presence sweep proposes reclaims onto this lane rather than writing tombstones
+  // itself. Installed here rather than by the service, which must not import the backend.
+  setFolderPublishLane({
+    isPending: (spaceId, shareId, relPath) => scheduler?.isPending(spaceId, shareId, relPath) ?? false,
+    enqueueRetire: (spaceId, shareId, relPath) => sched().enqueue({ spaceId, shareId, relPath, op: OP.RETIRE, priority: PRIORITY.BULK }).settled,
+    // A bulk retire writes through the space's catalog batch, so the item settles before the
+    // tombstone is durable. An awaited sweep has to outlast the flush, not the enqueue.
+    settle: (spaceId) => settleCatalog(spaceId),
+  })
 }
 
 // Chokidar can drop `add` events when several files land in a new subfolder at once (macOS
@@ -504,7 +510,7 @@ export class OwnedFolders extends Subsystem {
   async _close() {
     stopping = true
     stopIndexAnnounce()
-    setPendingPublishProbe(null)
+    setFolderPublishLane(null)
     for (const timer of reconcileTimers.values()) clearTimeout(timer)
     reconcileTimers.clear()
     for (const signal of scanSignals.values()) signal.aborted = true

--- a/src/shared/folders/path-keys.js
+++ b/src/shared/folders/path-keys.js
@@ -26,6 +26,14 @@ export function driveKeyToSegments (key) {
   return key.split('/')
 }
 
+// Leaf name of a drive key or drive path. Distinct from `path.basename`, which
+// also honours the platform separator: a drive key is POSIX-shaped on every
+// platform, so a Windows `\` inside one is part of the name, not a separator.
+export function driveBaseName (key) {
+  if (typeof key !== 'string') return ''
+  return key.slice(key.lastIndexOf('/') + 1)
+}
+
 // ─── Windows long-path prefix ─────────────────────────────────────────────────
 // Strip a Windows extended-length / device prefix so two paths can be compared in
 // one namespace. Under Bare on Windows, `fs.readdir(root, { recursive: true })`

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -40,7 +40,9 @@ import { pathFromMount } from '../../path-guard.js'
 import { shareDecoKey } from '../../decoration-key.js'
 import { makeProgressTicker } from '../../progress-ticker.js'
 import { reuseDest } from '../../download-dest.js'
-import { supersedeDecision, republishDecision } from '../../supersede-decision.js'
+import { createOverlayChannel } from './overlay-channel.js'
+import { cancelSpaceOn, reconcileActiveSlots } from './overlay-consume.js'
+import { createPresenceSweeper } from '../../presence-sweeper.js'
 import { getPendingFor } from '../../pending-transfers.js'
 import { LOOSE_SHARE_ID, transferIdFor } from '../../transfer-id.js'
 import { getDownloadDir } from '../../../core/paths.js'
@@ -128,13 +130,14 @@ export function initContentBackendOverlay(ipc) {
   // every share in the space plus the loose channel, so an append names no single share.
   setOwnCatalogAppendHook((spaceId) => sharesRefresh.touch(spaceId, undefined))
 }
-export function resetContentBackendState() { ipcRef = null; setOwnCatalogAppendHook(null); sharesRefresh.reset(); peerPrepareBroadcast = null; pendingPublishProbe = null; presenceGone.clear(); publishesAborting = false }
+export function resetContentBackendState() { ipcRef = null; setOwnCatalogAppendHook(null); sharesRefresh.reset(); peerPrepareBroadcast = null; publishLane = null; folderSweeper.reset(); publishesAborting = false }
 export function abortInFlightPublishes() { publishesAborting = true }
 export function setSharePrepareBroadcast(fn) { peerPrepareBroadcast = fn }
-// Installed by owned-folders: (spaceId, shareId, relPath) → true while a publish for that path is
-// queued or running, so the presence sweep never reclaims a file whose publish has not started.
-let pendingPublishProbe = null
-export function setPendingPublishProbe(fn) { pendingPublishProbe = fn }
+// The owner's publish lane, installed by owned-folders — which owns the scheduler and imports this
+// module, so the edge cannot run the other way. `isPending` keeps the presence sweep off a path
+// whose publish has not started; `enqueueRetire` is how the sweep proposes a reclaim.
+let publishLane = null
+export function setFolderPublishLane(lane) { publishLane = lane }
 
 // Notified with (spaceId) whenever an owner's catalog appends, so a foreign mirror can
 // materialize the change promptly instead of waiting for its poll. (The catalog is the
@@ -493,29 +496,22 @@ async function reconcileActiveOverlayTransfers(spaceId, share) {
   const { keyHex, sck, encrypted, readable } = await resolvePeerCatalog(spaceId, share)
   if (!readable) return
   const prefix = '/' + share.name + '/'
-  for (const [transferId, slot] of engine().activeSlots()) {
-    if (slot.spaceId !== spaceId || slot.ownerPublicKey !== share.owner || !slot.pendingKey.startsWith(prefix)) continue
-    const relPath = slot.pendingKey.slice(prefix.length)
-    const inflightHash = slot.contentHash
-    const state = await getPeerEntryState(keyHex, share.id, relPath, { sck })
-    const decision = republishDecision(inflightHash, state, slot.sourceSeq)
-    // Tombstoned, or re-added with identical content → terminate; don't silently continue the
-    // old partial. A genuine content change falls through to the supersede below.
-    if (decision === 'drop') { await engine().dropRemoved(spaceId, slot.pendingKey, transferId).catch((err) => log.debug('overlay active drop-removed failed:', err.message)); continue }
-    // Mid-rehash: a new version is advertised, its hash not materialized yet. Park the transfer as
-    // 'preparing' (abort the doomed old-hash fetch, keep the row) — the setMaterializedHash append
-    // restarts it on the new content via runReconcile.
-    if (decision === 'pending') { engine().releaseForRepublish(transferId); continue }
-    if (decision !== 'restart' && supersedeDecision(inflightHash, state?.contentHash) !== 'restart') continue
-    engine().supersede(transferId, {
-      spaceId, pendingKey: slot.pendingKey, path: slot.pendingKey, relPath, shareId: share.id, ...catalogKeyField(keyHex, encrypted),
+  const relOf = (slot) => slot.pendingKey.slice(prefix.length)
+  await reconcileActiveSlots({
+    engine: engine(),
+    spaceId,
+    log,
+    ownsSlot: (slot) => slot.ownerPublicKey === share.owner && slot.pendingKey.startsWith(prefix),
+    entryStateFor: (slot) => getPeerEntryState(keyHex, share.id, relOf(slot), { sck }),
+    buildJob: (slot, state, transferId) => ({
+      spaceId, pendingKey: slot.pendingKey, path: slot.pendingKey, relPath: relOf(slot), shareId: share.id, ...catalogKeyField(keyHex, encrypted),
       folderName: folderLabel(share),
       transferId,
       contentHash: state.contentHash, size: state.size || 0, sourceSeq: state.seq,
-      ownerPublicKey: share.owner, verifyKey: share.id + '|' + relPath,
+      ownerPublicKey: share.owner, verifyKey: share.id + '|' + relOf(slot),
       finalPath: slot.finalPath,
-    }, inflightHash)
-  }
+    }),
+  })
 }
 
 async function peerEntry(spaceId, share, relPath) {
@@ -525,14 +521,9 @@ async function peerEntry(spaceId, share, relPath) {
 }
 
 // Non-mirrored overlay folder downloads run on the shared overlay consumer engine
-// (single-flight, real pause/resume, stop/cancel, auto-resume) — the same engine the
-// space-root loose path uses. This is the folder "channel": share-file-* event names
-// + the catalog/ownerKey/pending-key specifics. The pending row carries catalogKey so
-// reconnect-resume can re-look-up the entry without a share descriptor.
-// Folder-share progress is DECORATION on the unified 'transfer' channel, keyed shareId:relPath
-// (parity with the loose path's per-space path keys). The renderer merges it at render, gated on
-// the worker-derived status, so a lingering entry after a missed `done` stays invisible.
-const shareDeco = (job, p) => ipcRef?.emit('event:decoration', { channel: 'transfer', spaceId: job.spaceId, key: shareDecoKey(job.shareId, job.relPath), ...p })
+// (single-flight, real pause/resume, stop/cancel, auto-resume) — the same engine the space-root
+// loose path uses, driven by a channel built from the same factory. The pending row carries
+// catalogKey so reconnect-resume can re-look-up the entry without a share descriptor.
 
 // The label share:rename writes, carried on the job so the engine's audit row can name the folder
 // without a join — a row outlives the share it describes. Null when the owner's descriptor is
@@ -548,68 +539,52 @@ function engine() {
   return folderEngine
 }
 
-export const folderChannel = {
+async function resolveFolderPendingRow(spaceId, row) {
+  // Prefer the owner's CURRENT share record over the persisted row's key: when an owner
+  // migrates its catalog to SCK encryption the catalog key changes (plaintext to encrypted)
+  // and the plaintext core is purged, so a row-only resolve would open the dead core.
+  // Fall back to the row when the descriptor is unreadable (owner offline).
+  const share = await readPeerShareEntry(row.ownerKey, spaceId, row.shareId)
+  const { keyHex, sck, encrypted, readable } = await resolvePeerCatalog(spaceId, share || row)
+  if (!readable) return { removed: false, seq: undefined, job: null }
+  const state = await getPeerEntryState(keyHex, row.shareId, row.relPath, { sck })
+  if (state?.removed) return { removed: true, seq: undefined, job: null }
+  if (!state?.contentHash) return { removed: false, seq: state?.seq, job: null }
+  // Re-anchor to the space's CURRENT download folder: a row pinned before the user re-pointed the
+  // space would otherwise resume into the old one. A re-anchored row starts from zero — its bytes
+  // live in the old folder's partial, which the boot sweep reclaims.
+  const finalPath = reuseDest(row.finalPath, getDownloadDir(spaceId), path.basename(row.relPath))
+  return {
+    removed: false, seq: state.seq,
+    job: {
+      spaceId, pendingKey: row.filePath, path: row.filePath, relPath: row.relPath, shareId: row.shareId, ...catalogKeyField(keyHex, encrypted),
+      folderName: folderLabel(share),
+      transferId: transferIdFor(spaceId, row.shareId, row.relPath),
+      contentHash: state.contentHash, size: state.size || 0, sourceSeq: state.seq,
+      ownerPublicKey: row.ownerKey, verifyKey: row.shareId + '|' + row.relPath,
+      finalPath, prevBytes: finalPath === row.finalPath ? row.bytesTransferred : 0,
+    },
+  }
+}
+
+// Folder-share progress is DECORATION on the unified 'transfer' channel, keyed shareId:relPath
+// (parity with the loose path's per-space path keys). The renderer merges it at render, gated on
+// the worker-derived status, so a lingering entry after a missed `done` stays invisible.
+export const folderChannel = createOverlayChannel({
   diagLabel: 'overlay download',
   inPlace: false,
+  // A folder row surfaces its error inline in the file list (Resume retries), so only the codes no
+  // automatic retry can fix cross the wire as a toast + notification.
+  surfaceAllErrors: false,
+  updatedEvent: 'event:share-files-updated',
+  emit: (name, payload) => ipcRef?.emit(name, payload),
+  decoKeyFor: (job) => shareDecoKey(job.shareId, job.relPath),
+  decoKeyForRow: (row) => (row?.shareId && row?.relPath ? shareDecoKey(row.shareId, row.relPath) : null),
   ownsPendingRow: (row) => row.overlayShare === true,
   pendingExtra: (job) => ({ overlayShare: true, shareId: job.shareId, relPath: job.relPath, ...catalogKeyField(job.catalogKeyEnc || job.catalogKey, !!job.catalogKeyEnc) }),
-  emitProgress: (job, p) => shareDeco(job, { bytes: p.bytes, total: p.total, speed: p.speed, eta: p.eta }),
-  emitVerifying: (job, fraction) => shareDeco(job, { phase: 'verifying', verifyFraction: fraction, bytes: job.prevBytes || 0, total: job.size }),
-  // Folder rows surface errors via the list refresh (Resume retries); only the terminal
-  // failures cross the wire — disk-full, an integrity mismatch and an unreachable download
-  // folder need the user's attention (toast + notification) and no automatic retry can fix any
-  // of them. The membership of this set and the auto-resume suppression in overlay-download.js
-  // are the same judgement: a fault the user must clear before a retry can ever succeed.
-  emitError: (job, errorCode) => {
-    if (errorCode === ErrorCodes.TRANSFER_DISK_FULL || errorCode === ErrorCodes.TRANSFER_CHECKSUM
-      || errorCode === ErrorCodes.TRANSFER_DEST_UNAVAILABLE) {
-      ipcRef?.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode })
-    }
-    shareDeco(job, { done: true })
-  },
-  emitComplete: (job, localPath) => { ipcRef?.emit('event:transfer-complete', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, localPath }); shareDeco(job, { done: true }) },
-  // The cancel path has no job, but the pending row carries shareId/relPath (pendingExtra) —
-  // emit the terminal done frame so the entry can't resurrect a stale bar when the same key
-  // later re-derives 'downloading' (re-download, or a mirror fetch of the same file).
-  emitCancelled: (spaceId, transferId, pendingKey, row) => {
-    if (row?.shareId && row?.relPath) ipcRef?.emit('event:decoration', { channel: 'transfer', spaceId, key: shareDecoKey(row.shareId, row.relPath), done: true })
-  },
-  emitPaused: (job) => shareDeco(job, { done: true }),
-  emitDecorationDone: (job) => shareDeco(job, { done: true }),
   transferIdForRow: (spaceId, row) => transferIdFor(spaceId, row.shareId, row.relPath),
-  emitSuperseded: (job) => { ipcRef?.emit('event:transfer-superseded', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, fileName: path.basename(job.relPath) }); shareDeco(job, { bytes: 0, total: job.size, speed: 0, eta: null }) },
-  emitUpdated: (spaceId) => ipcRef?.emit('event:share-files-updated', { spaceId }),
-  resolvePendingRow: async (spaceId, row) => {
-    // Prefer the owner's CURRENT share record over the persisted row's key: when an owner
-    // migrates its catalog to SCK encryption the catalog key changes (plaintext→encrypted)
-    // and the plaintext core is purged, so a row-only resolve would open the dead core.
-    // Fall back to the row when the descriptor is unreadable (owner offline). Mirrors the
-    // loose path, which re-derives from the live member.
-    const share = await readPeerShareEntry(row.ownerKey, spaceId, row.shareId)
-    const { keyHex, sck, encrypted, readable } = await resolvePeerCatalog(spaceId, share || row)
-    if (!readable) return { removed: false, seq: undefined, job: null }
-    const state = await getPeerEntryState(keyHex, row.shareId, row.relPath, { sck })
-    if (state?.removed) return { removed: true, seq: undefined, job: null }
-    if (!state?.contentHash) return { removed: false, seq: state?.seq, job: null }
-    // Re-anchor to the space's CURRENT download folder: a row pinned before the user
-    // re-pointed the space would otherwise resume into the old one. A re-anchored row starts
-    // from zero — its bytes live in the old folder's partial, which the boot sweep reclaims.
-    const finalPath = reuseDest(row.finalPath, getDownloadDir(spaceId), path.basename(row.relPath))
-    return {
-      removed: false, seq: state.seq,
-      job: {
-        spaceId, pendingKey: row.filePath, path: row.filePath, relPath: row.relPath, shareId: row.shareId, ...catalogKeyField(keyHex, encrypted),
-        folderName: folderLabel(share),
-        transferId: transferIdFor(spaceId, row.shareId, row.relPath),
-        contentHash: state.contentHash, size: state.size || 0, sourceSeq: state.seq,
-        ownerPublicKey: row.ownerKey, verifyKey: row.shareId + '|' + row.relPath,
-        finalPath, prevBytes: finalPath === row.finalPath ? row.bytesTransferred : 0,
-      },
-    }
-  },
-  emitRemovedByOwner: (spaceId, pendingKey, row, transferId) =>
-    ipcRef?.emit('event:transfer-removed', { spaceId, transferId, path: pendingKey, fileName: path.basename(row?.relPath || pendingKey) }),
-}
+  resolvePendingRow: resolveFolderPendingRow,
+})
 
 // Consumer single-file download: fetch by contentHash straight from a holder and
 // write to the downloads folder. No second copy stored (reSeed:false). When the
@@ -640,17 +615,8 @@ export async function overlayRequestDownload(spaceId, share, relPath) {
 export const overlayPause = (transferId) => engine().pause(transferId)
 export const overlayCancel = (transferId) => engine().cancel(transferId)
 export const overlayCancelByKey = (spaceId, drivePath, transferId) => engine().cancelByKey(spaceId, drivePath, transferId)
-// Cancel + discard every in-flight overlay-folder download for a space (leave teardown):
-// the engine keeps fetching a started transfer even after its pending row is cleared, so
-// without this the partial is orphaned and a late completion re-writes purged meta rows.
 export async function overlayCancelSpace (spaceId) {
-  const ids = []
-  for (const [transferId, slot] of engine().activeSlots()) {
-    if (slot.spaceId === spaceId) ids.push(transferId)
-  }
-  // Per-id best-effort: cancel now throws when the row cannot be cleared, and the leave's own
-  // clearPendingForSpace purges the rows a beat later — one failed discard must not abort the leave.
-  await Promise.all(ids.map((id) => engine().cancel(id).catch((err) => log.warn('cancel on leave failed:', id, '-', err.message))))
+  await cancelSpaceOn(engine(), spaceId, log)
 }
 export const resumeOverlayForOwner = (ownerKey, spaceId) => engine().resumeForOwner(ownerKey, spaceId)
 export const overlayHasTransfer = (transferId) => engine().has(transferId)
@@ -706,12 +672,22 @@ export async function rehydrateOwnedFiles() {
   await forEachOwnedOverlayShare(rehydrateShare)
 }
 
-// Confirm-gone-twice (a path must be missing on two consecutive sweeps) so an
-// atomic-save window (editor rename-over / delete+recreate) doesn't transiently
-// tombstone a still-present file — which would cascade the deletion to every
-// mirror peer. Mirrors the loose sweep's sweepGone guard (loose-overlay.js).
-const presenceGone = new Set()
-const presenceGoneKey = (spaceId, shareId, relPath) => spaceId + '\0' + shareId + '\0' + relPath
+const folderSweeper = createPresenceSweeper({
+  keyOf: ({ spaceId, shareId }, entry) => spaceId + '\0' + shareId + '\0' + entry.relPath,
+  isPending: ({ spaceId, shareId }, entry) => !!publishLane?.isPending(spaceId, shareId, entry.relPath),
+  // Exact-name presence, like the retire executor: a following stat would keep a case-only
+  // rename's old key alive forever on a case-folding volume.
+  presentAt: ({ mountPath }, entry) => {
+    try { return fileExactlyPresent(pathFromMount(mountPath, entry.relPath)) } catch { return false }
+  },
+  // Onto the shared publish lane, exactly as the loose sweep retires: the runner re-confirms the
+  // file is really gone, the write joins the space's catalog batch, and the eviction rides with
+  // it. Writing the tombstone here instead skipped all three.
+  retire: ({ spaceId, shareId, retires }, entry) => {
+    const settled = publishLane?.enqueueRetire(spaceId, shareId, entry.relPath)
+    if (settled) retires.push(settled.catch((err) => log.debug('folder retire failed:', entry.relPath, '-', err.message)))
+  },
+})
 
 // Backstop: tombstone catalog entries whose source file vanished but whose
 // chokidar unlink event was missed. Mount-root guarded — a temporarily-
@@ -719,21 +695,12 @@ const presenceGoneKey = (spaceId, shareId, relPath) => spaceId + '\0' + shareId 
 export async function overlaySweepPresence() {
   await forEachOwnedOverlayShare(async (spaceId, shareId, mountPath) => {
     try { if (!fs.statSync(mountPath).isDirectory()) return } catch { return } // root gone → skip
-    let changed = false
+    const retires = []
     for await (const entry of listOwnShare(spaceId, shareId)) {
-      const key = presenceGoneKey(spaceId, shareId, entry.relPath)
-      if (pendingPublishProbe?.(spaceId, shareId, entry.relPath)) { presenceGone.delete(key); continue }
-      // Exact-name presence, like the retire executor: a following stat would keep a case-only
-      // rename's old key alive forever on a case-folding volume.
-      let exists = false
-      try { exists = fileExactlyPresent(pathFromMount(mountPath, entry.relPath)) } catch {}
-      if (exists) { presenceGone.delete(key); continue }
-      if (!presenceGone.has(key)) { presenceGone.add(key); continue } // arm; reclaim only on a 2nd consecutive miss
-      presenceGone.delete(key)
-      await catalogTombstone(spaceId, shareId, entry.relPath)
-      await evictIfUnreferenced(entry.contentHash, spaceId, shareId, entry.relPath)
-      changed = true
+      await folderSweeper.consider({ spaceId, shareId, mountPath, retires }, entry)
     }
-    if (changed) ipcRef?.emit('event:share-files-updated', { spaceId, shareId })
+    if (!retires.length) return
+    await Promise.all(retires)
+    await publishLane?.settle(spaceId)
   })
 }

--- a/src/shared/transfer/backends/overlay/overlay-channel.js
+++ b/src/shared/transfer/backends/overlay/overlay-channel.js
@@ -1,0 +1,82 @@
+// The consumer-side channel the download engine drives, built from the small set of facts that
+// actually differ between the loose pseudo-share and a folder share. Every member the engine calls
+// is derived here, so a policy that holds for one channel holds for both by construction. The two
+// hand-written bags this replaces had already drifted on the paused event and the error filter,
+// and nothing could have caught it: from the compiler's point of view they were unrelated objects.
+//
+// Imports nothing from `bare-*` (and nothing from the two modules that build channels), so it
+// loads under plain Node and unit-tests directly.
+import { driveBaseName } from '../../../folders/path-keys.js'
+import { ErrorCodes } from '../../../core/errors.js'
+
+// Codes that reach the user directly on a channel whose rows have a list to fall back on.
+// Everything else surfaces through the list refresh, where the row carries its own errorCode and
+// offers Resume. The membership of this set and the auto-resume suppression in overlay-download.js
+// are the same judgement: a fault the user must clear before a retry can ever succeed.
+const USER_FACING_ERRORS = new Set([
+  ErrorCodes.TRANSFER_DISK_FULL,
+  ErrorCodes.TRANSFER_CHECKSUM,
+  ErrorCodes.TRANSFER_DEST_UNAVAILABLE,
+])
+
+export function createOverlayChannel (d) {
+  // Decoration frames carry spaceId: a bare drive path is unique per space only — without the
+  // field two spaces downloading the same-named file would mix bytes in the renderer's per-key map.
+  const deco = (spaceId, key, patch) => {
+    if (key != null) d.emit('event:decoration', { channel: 'transfer', spaceId, key, ...patch })
+  }
+  const decoJob = (job, patch) => deco(job.spaceId, d.decoKeyFor(job), patch)
+
+  return {
+    diagLabel: d.diagLabel,
+    inPlace: d.inPlace,
+    ownsPendingRow: d.ownsPendingRow,
+    pendingExtra: d.pendingExtra,
+    transferIdForRow: d.transferIdForRow,
+    resolvePendingRow: d.resolvePendingRow,
+
+    // Progress is DECORATION (never status). Lifecycle events stay as signals for notifications;
+    // the row's status is re-derived from the listing.
+    emitProgress: (job, p) => decoJob(job, { bytes: p.bytes, total: p.total, speed: p.speed, eta: p.eta }),
+    emitVerifying: (job, fraction) => decoJob(job, { phase: 'verifying', verifyFraction: fraction, bytes: job.prevBytes || 0, total: job.size }),
+    emitDecorationDone: (job) => decoJob(job, { done: true }),
+    emitUpdated: (spaceId) => d.emit(d.updatedEvent, { spaceId }),
+
+    // `surfaceAllErrors` is the one asymmetry the two channels are allowed to keep, and it is a
+    // real one: a folder row surfaces its error inline in the file list, a loose row has no such
+    // list to fall back on.
+    emitError: (job, errorCode) => {
+      if (d.surfaceAllErrors || USER_FACING_ERRORS.has(errorCode)) {
+        d.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode })
+      }
+      decoJob(job, { done: true })
+    },
+
+    emitComplete: (job, localPath) => {
+      d.emit('event:transfer-complete', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, localPath })
+      decoJob(job, { done: true })
+    },
+
+    // `retrying` means the engine has an automatic retry armed for this row. The decoration still
+    // terminates (a stranded entry samples speed across the whole backoff), but the notification is
+    // withheld: 'event:transfer-paused' raises an OS notification, and one per attempt would turn a
+    // slow transfer into a stream of them.
+    emitPaused: (job, reason, opts) => {
+      if (!opts?.retrying) d.emit('event:transfer-paused', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, reason })
+      decoJob(job, { done: true })
+    },
+
+    emitSuperseded: (job) => {
+      d.emit('event:transfer-superseded', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, fileName: driveBaseName(job.relPath) })
+      decoJob(job, { bytes: 0, total: job.size, speed: 0, eta: null })
+    },
+
+    // The cancel path has no job, but the pending row carries what the key needs (pendingExtra) —
+    // emit the terminal done frame so the entry can't resurrect a stale bar when the same key
+    // later re-derives 'downloading'.
+    emitCancelled: (spaceId, transferId, pendingKey, row) => deco(spaceId, d.decoKeyForRow(row, pendingKey), { done: true }),
+
+    emitRemovedByOwner: (spaceId, pendingKey, row, transferId) =>
+      d.emit('event:transfer-removed', { spaceId, transferId, path: pendingKey, fileName: driveBaseName(row?.relPath || pendingKey) }),
+  }
+}

--- a/src/shared/transfer/backends/overlay/overlay-consume.js
+++ b/src/shared/transfer/backends/overlay/overlay-consume.js
@@ -1,0 +1,36 @@
+// Consumer-side operations both download channels drive against their own engine instance.
+import { activeSlotAction } from '../../supersede-decision.js'
+
+// Cancel + discard every in-flight download for a space (leave teardown): the engine keeps fetching
+// a started transfer even after its pending row is cleared, so without this the partial is orphaned
+// and a late completion re-writes purged meta rows.
+//
+// Per-id best-effort: cancel throws when the row cannot be cleared, and the leave's own
+// clearPendingForSpace purges the rows a beat later — one failed discard must not abort the leave.
+export async function cancelSpaceOn (engine, spaceId, log) {
+  const ids = []
+  for (const [transferId, slot] of engine.activeSlots()) {
+    if (slot.spaceId === spaceId) ids.push(transferId)
+  }
+  await Promise.all(ids.map((id) => engine.cancel(id).catch((err) => log.warn('cancel on leave failed:', id, '-', err.message))))
+}
+
+// Re-resolve every active slot this owner's catalog append could have invalidated, and apply the
+// one decision ladder to each. `entryStateFor(slot)` reads the owner's current entry for the slot's
+// path; `buildJob(slot, state)` produces the supersede job (null when it cannot be rebuilt).
+export async function reconcileActiveSlots ({ engine, spaceId, ownsSlot, entryStateFor, buildJob, log }) {
+  for (const [transferId, slot] of engine.activeSlots()) {
+    if (slot.spaceId !== spaceId || !ownsSlot(slot)) continue
+    const inflightHash = slot.contentHash
+    const state = await entryStateFor(slot)
+    const action = activeSlotAction(inflightHash, state, slot.sourceSeq)
+    if (action === 'drop') {
+      await engine.dropRemoved(spaceId, slot.pendingKey, transferId).catch((err) => log.debug('active drop-removed failed:', err.message))
+      continue
+    }
+    if (action === 'pending') { engine.releaseForRepublish(transferId); continue }
+    if (action !== 'restart') continue
+    const job = await buildJob(slot, state, transferId)
+    if (job) engine.supersede(transferId, job, inflightHash)
+  }
+}

--- a/src/shared/transfer/loose-overlay.js
+++ b/src/shared/transfer/loose-overlay.js
@@ -25,8 +25,10 @@ import { getPublishScheduler, registerPublishChannel } from '../folders/publish-
 import { OP, PRIORITY } from '../folders/work-item.js'
 import { fileStatPresent, statFacts } from '../folders/disk-presence.js'
 import { createLogger } from '../core/logger.js'
-import { supersedeDecision, republishDecision } from './supersede-decision.js'
 import { LOOSE_SHARE_ID, looseTransferIdFor } from './transfer-id.js'
+import { createOverlayChannel } from './backends/overlay/overlay-channel.js'
+import { cancelSpaceOn, reconcileActiveSlots } from './backends/overlay/overlay-consume.js'
+import { createPresenceSweeper } from './presence-sweeper.js'
 
 const log = createLogger('loose-overlay')
 
@@ -347,23 +349,17 @@ function ensureLooseCatalogWatch (spaceId, member, keyHex, sck) {
 async function reconcileActiveLooseTransfers (spaceId, member) {
   const { keyHex, sck, readable } = await resolvePeerCatalog(spaceId, member)
   if (!readable) return
-  for (const [transferId, slot] of engine().activeSlots()) {
-    if (slot.spaceId !== spaceId || slot.ownerPublicKey !== member.publicKey) continue
-    const drivePath = slot.pendingKey
-    const inflightHash = slot.contentHash
-    const state = await getPeerEntryState(keyHex, LOOSE_SHARE_ID, rel(drivePath), { sck })
-    const decision = republishDecision(inflightHash, state, slot.sourceSeq)
-    // Tombstoned, or re-added with identical content → terminate; don't silently continue the
-    // old partial. A genuine content change falls through to the supersede below.
-    if (decision === 'drop') { await engine().dropRemoved(spaceId, drivePath, transferId).catch((err) => log.debug('loose active drop-removed failed:', err.message)); continue }
-    // Mid-rehash: a new version is advertised, its hash not materialized yet. Park the transfer as
-    // 'preparing' (abort the doomed old-hash fetch, keep the row) — the setMaterializedHash append
-    // restarts it on the new content via runReconcile.
-    if (decision === 'pending') { engine().releaseForRepublish(transferId); continue }
-    if (decision !== 'restart' && supersedeDecision(inflightHash, state?.contentHash) !== 'restart') continue
-    const newJob = await buildLooseJob(spaceId, member, drivePath)
-    if (newJob) engine().supersede(transferId, { ...newJob, prevBytes: 0 }, inflightHash)
-  }
+  await reconcileActiveSlots({
+    engine: engine(),
+    spaceId,
+    log,
+    ownsSlot: (slot) => slot.ownerPublicKey === member.publicKey,
+    entryStateFor: (slot) => getPeerEntryState(keyHex, LOOSE_SHARE_ID, rel(slot.pendingKey), { sck }),
+    buildJob: async (slot) => {
+      const job = await buildLooseJob(spaceId, member, slot.pendingKey)
+      return job ? { ...job, prevBytes: 0 } : null
+    },
+  })
 }
 
 // Loose downloads run on the shared overlay consumer engine (single-flight, real
@@ -403,41 +399,32 @@ function engine() {
   return looseEngine
 }
 
-export const looseChannel = {
+async function resolveLoosePendingRow (spaceId, row) {
+  const space = await getSpace(spaceId)
+  const member = (space?.members || []).find((m) => m.publicKey === row.ownerKey)
+  if (!member) return { removed: false, seq: undefined, job: null }
+  const { keyHex, sck, readable } = await resolvePeerCatalog(spaceId, member, { space })
+  if (!readable) return { removed: false, seq: undefined, job: null }
+  const state = await getPeerEntryState(keyHex, LOOSE_SHARE_ID, row.relPath, { sck })
+  if (state?.removed) return { removed: true, seq: undefined, job: null }
+  const job = state?.contentHash ? await buildLooseJob(spaceId, member, drivePathOf(row.relPath), row, state) : null
+  return { removed: false, seq: state?.seq, job }
+}
+
+export const looseChannel = createOverlayChannel({
   diagLabel: 'loose download',
   inPlace: true,
+  // A loose row has no file list to surface an error inline in, so every code crosses the wire.
+  surfaceAllErrors: true,
+  updatedEvent: 'event:files-updated',
+  emit: (name, payload) => ipcRef?.emit(name, payload),
+  decoKeyFor: (job) => job.path,
+  decoKeyForRow: (_row, pendingKey) => pendingKey,
   ownsPendingRow: (row) => row.inPlace === true && row.shareId === LOOSE_SHARE_ID,
   pendingExtra: (job) => ({ shareId: LOOSE_SHARE_ID, relPath: job.relPath }),
-  // Progress is DECORATION (never status). Lifecycle events (complete/error/paused/superseded)
-  // remain as signals for notifications; the row's status is re-derived from files:list.
-  emitProgress: (job, p) => deco(job.spaceId, job.path, { bytes: p.bytes, total: p.total, speed: p.speed, eta: p.eta }),
-  emitVerifying: (job, fraction) => deco(job.spaceId, job.path, { phase: 'verifying', verifyFraction: fraction, bytes: job.prevBytes || 0, total: job.size }),
-  emitError: (job, errorCode) => { ipcRef?.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode }); deco(job.spaceId, job.path, { done: true }) },
-  emitComplete: (job, localPath) => { ipcRef?.emit('event:transfer-complete', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, localPath }); deco(job.spaceId, job.path, { done: true }) },
-  emitCancelled: (spaceId, transferId, pendingKey) => deco(spaceId, pendingKey, { done: true }),
-  emitSuperseded: (job) => { ipcRef?.emit('event:transfer-superseded', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, fileName: path.basename(job.relPath) }); deco(job.spaceId, job.path, { bytes: 0, total: job.size, speed: 0, eta: null }) },
-  // [mirall] FIX-BW9 — `retrying` means the engine has an automatic retry armed for this row.
-  // The decoration still terminates (a stranded entry samples speed across the whole backoff),
-  // but the notification is withheld: 'event:transfer-paused' raises an OS notification, and one
-  // per attempt would turn a slow transfer into a stream of them.
-  emitPaused: (job, reason, opts) => { if (!opts?.retrying) ipcRef?.emit('event:transfer-paused', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, reason }); deco(job.spaceId, job.path, { done: true }) },
-  emitDecorationDone: (job) => deco(job.spaceId, job.path, { done: true }),
-  emitUpdated: (spaceId) => ipcRef?.emit('event:files-updated', { spaceId }),
   transferIdForRow: (spaceId, row) => looseTransferIdFor(spaceId, row.relPath),
-  resolvePendingRow: async (spaceId, row) => {
-    const space = await getSpace(spaceId)
-    const member = (space?.members || []).find((m) => m.publicKey === row.ownerKey)
-    if (!member) return { removed: false, seq: undefined, job: null }
-    const { keyHex, sck, readable } = await resolvePeerCatalog(spaceId, member, { space })
-    if (!readable) return { removed: false, seq: undefined, job: null }
-    const state = await getPeerEntryState(keyHex, LOOSE_SHARE_ID, row.relPath, { sck })
-    if (state?.removed) return { removed: true, seq: undefined, job: null }
-    const job = state?.contentHash ? await buildLooseJob(spaceId, member, drivePathOf(row.relPath), row, state) : null
-    return { removed: false, seq: state?.seq, job }
-  },
-  emitRemovedByOwner: (spaceId, pendingKey, row, transferId) =>
-    ipcRef?.emit('event:transfer-removed', { spaceId, transferId, path: pendingKey, fileName: path.basename(row?.relPath || rel(pendingKey)) }),
-}
+  resolvePendingRow: resolveLoosePendingRow,
+})
 
 export function looseHasTransfer (transferId) { return engine().has(transferId) }
 export function looseTransferActive (spaceId, relPath) { return engine().has(looseTransferIdFor(spaceId, relPath)) }
@@ -468,17 +455,8 @@ export function looseCancelTransfer (transferId) { return engine().cancel(transf
 export function looseCancel (spaceId, drivePath) {
   return engine().cancelByKey(spaceId, drivePath, looseTransferIdFor(spaceId, rel(drivePath)))
 }
-// Cancel + discard every in-flight loose download for a space (leave teardown): the
-// engine keeps fetching a started transfer even after its pending row is cleared, so
-// without this the partial is orphaned and a late completion re-writes purged meta rows.
 export async function looseCancelSpace (spaceId) {
-  const ids = []
-  for (const [transferId, slot] of engine().activeSlots()) {
-    if (slot.spaceId === spaceId) ids.push(transferId)
-  }
-  // Per-id best-effort: cancel now throws when the row cannot be cleared, and the leave's own
-  // clearPendingForSpace purges the rows a beat later — one failed discard must not abort the leave.
-  await Promise.all(ids.map((id) => engine().cancel(id).catch((err) => log.warn('cancel on leave failed:', id, '-', err.message))))
+  await cancelSpaceOn(engine(), spaceId, log)
 }
 export function resumeLooseForOwner (ownerKey, spaceId) { return engine().resumeForOwner(ownerKey, spaceId) }
 
@@ -535,26 +513,30 @@ async function rehydrateLooseEntry (spaceId, e) {
 // and the retire executor confirms the same way, on the shared lane. Never touches an entry
 // whose publish is queued or running: disk presence decides only for settled entries. Each
 // space's failures stay its own; one failing retire never skips the spaces after it.
-const sweepGone = new Set()
-const goneKey = (spaceId, relPath) => spaceId + '\0' + relPath
+const looseSweeper = createPresenceSweeper({
+  keyOf: ({ spaceId }, e) => spaceId + '\0' + e.relPath,
+  isPending: ({ spaceId }, e) => getPublishScheduler().isPending(spaceId, LOOSE_SHARE_ID, e.relPath),
+  // No recorded source → a crash inside the tiny advertise→link window or a stranded entry from an
+  // older install (reverted by the boot rehydrate, not the sweep). The sweep only reclaims a
+  // RECORDED source that disappeared from disk.
+  presentAt: async ({ spaceId }, e) => {
+    const src = await getOwnedSourcePath(spaceId, drivePathOf(e.relPath))
+    return src ? fileStatPresent(src) : null
+  },
+  // Collected rather than awaited: the pass proposes every retire it finds and waits for them
+  // together at the end.
+  retire: ({ spaceId, retires }, e) => {
+    retires.push(enqueueLooseRetire(spaceId, e.relPath, PRIORITY.BULK)
+      .catch((err) => log.debug('loose retire failed:', e.relPath, '-', err.message)))
+  },
+})
 
 export async function sweepLoosePresence () {
   const retires = []
   for (const space of await listSpaces()) {
     try {
       for await (const e of listOwnShare(space.spaceId, LOOSE_SHARE_ID)) {
-        const key = goneKey(space.spaceId, e.relPath)
-        if (getPublishScheduler().isPending(space.spaceId, LOOSE_SHARE_ID, e.relPath)) { sweepGone.delete(key); continue }
-        // No recorded source → a crash inside the tiny advertise→link window or a stranded entry
-        // from an older install (reverted by the boot rehydrate, not the sweep). The sweep only
-        // reclaims a RECORDED source that disappeared from disk.
-        const src = await getOwnedSourcePath(space.spaceId, drivePathOf(e.relPath))
-        if (!src) { sweepGone.delete(key); continue }
-        if (fileStatPresent(src)) { sweepGone.delete(key); continue }
-        if (!sweepGone.has(key)) { sweepGone.add(key); continue }
-        sweepGone.delete(key)
-        retires.push(enqueueLooseRetire(space.spaceId, e.relPath, PRIORITY.BULK)
-          .catch((err) => log.debug('loose retire failed:', e.relPath, '-', err.message)))
+        await looseSweeper.consider({ spaceId: space.spaceId, retires }, e)
       }
     } catch (err) {
       log.debug('skip loose presence sweep for space', space.spaceId, '-', err.message)
@@ -566,5 +548,5 @@ export async function sweepLoosePresence () {
 export function resetLooseState () {
   ipcRef = null
   looseSources.clear()
-  sweepGone.clear()
+  looseSweeper.reset()
 }

--- a/src/shared/transfer/presence-sweeper.js
+++ b/src/shared/transfer/presence-sweeper.js
@@ -1,0 +1,27 @@
+// Confirm-gone-twice: a path must be missing on two consecutive sweeps before its catalog entry is
+// retired, so an atomic-save window (an editor's rename-over, a delete+recreate) cannot transiently
+// tombstone a still-present file — which would cascade the deletion to every mirror peer.
+//
+// One policy, one Set, both owned-content sweeps. Pure (no bare-* imports): the caller supplies the
+// key function, the in-flight probe, the presence probe and the retire.
+export function createPresenceSweeper ({ keyOf, isPending, presentAt, retire }) {
+  const gone = new Set()
+
+  return {
+    reset: () => gone.clear(),
+    size: () => gone.size,
+
+    // True when this entry was retired on THIS pass. `presentAt` returns null for an entry with no
+    // recorded source — not ours to reclaim — and a boolean otherwise.
+    async consider (ctx, entry) {
+      const key = keyOf(ctx, entry)
+      if (isPending(ctx, entry)) { gone.delete(key); return false }
+      const present = await presentAt(ctx, entry)
+      if (present !== false) { gone.delete(key); return false }
+      if (!gone.has(key)) { gone.add(key); return false }
+      gone.delete(key)
+      await retire(ctx, entry)
+      return true
+    },
+  }
+}

--- a/src/shared/transfer/supersede-decision.js
+++ b/src/shared/transfer/supersede-decision.js
@@ -36,3 +36,16 @@ export function republishDecision (inflightHash, state, sourceSeq) {
   if (inflightHash == null || state.contentHash === inflightHash) return 'drop'
   return 'restart'
 }
+
+// The whole ladder an active slot is put through when its owner's catalog appends: the
+// re-publish classification first, then the plain hash-change check for everything it left
+// as 'continue'. Both consumer channels reconcile their slots with this one rule.
+//
+//   'drop' | 'pending' — as republishDecision
+//   'restart'          — supersede the slot from byte 0
+//   'keep'             — nothing changed under this slot
+export function activeSlotAction (inflightHash, state, sourceSeq) {
+  const decision = republishDecision(inflightHash, state, sourceSeq)
+  if (decision !== 'continue') return decision
+  return supersedeDecision(inflightHash, state?.contentHash) === 'restart' ? 'restart' : 'keep'
+}

--- a/test/flow/folder-overlay-pause-resume.test.js
+++ b/test/flow/folder-overlay-pause-resume.test.js
@@ -166,3 +166,52 @@ test('REGRESSION (FIX-EDA-15: a manual folder pause survives an owner catalog ap
 
     A.kill()
   })
+
+// REGRESSION (FIX-PI1-1: a folder-share download that stalls raises no notification).
+//
+// The loose channel emitted event:transfer-paused; the folder channel's paused member only painted
+// a decoration, so the renderer's notification dispatcher could never fire for a file inside a
+// shared folder. The user saw a progress bar stop and nothing else. A data-polling assertion cannot
+// catch this — the list converges to 'paused' either way — so the event itself is the assertion.
+test('REGRESSION (FIX-PI1-1: an owner going offline mid-download raises the paused notification)',
+  { timeout: scaled(240000) }, async (t) => {
+    const bootstrap = await localTestnet(t)
+    const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: mkStoreDir(t), flags: FLAGS })
+    const B = await launchPeer(t, { bootstrap, displayName: 'Bob', downloads: mkTmpDir(t), flags: FLAGS })
+    const spaceId = await connectInSpace(t, A, B)
+    const aKey = (await A.request('profile:get')).publicKey
+
+    const share = await A.request('share:create', { spaceId, name: 'Vault', contentMode: 'overlay' })
+    const folder = mkTmpDir(t)
+    // Sized so the transfer outlasts the owner's exit: a file that lands first produces a
+    // completion, not a pause, and the wait below would then expire for the wrong reason.
+    const bytes = patternedBytes(256 * 1024 * 1024, 53)
+    fs.writeFileSync(path.join(folder, 'big.bin'), bytes)
+    const scanDone = A.waitFor('event:owned-folder-scan-completed', (m) => m.shareId === share.id)
+    await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })
+    await scanDone
+
+    await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+      (f) => Array.isArray(f?.entries) && f.entries.some((e) => e.relPath === 'big.bin' && e.status === 'remote'),
+      { ms: 60000 })
+
+    const flowing = new Promise((resolve) => {
+      B.on('event:decoration', (m) => {
+        if (m.channel !== 'transfer' || m.key !== share.id + ':big.bin' || m.done) return
+        if (m.bytes > 0) resolve()
+      })
+    })
+    let completed = false
+    B.on('event:transfer-complete', (m) => { if (m.path === '/Vault/big.bin') completed = true })
+
+    const notified = B.waitFor('event:transfer-paused', (m) => m.path === '/Vault/big.bin', 120000)
+    await B.request('share:read-file', { spaceId, ownerKey: aKey, shareId: share.id, relPath: 'big.bin' })
+    await flowing
+    t.absent(completed, 'the transfer is still mid-flight when the owner leaves')
+
+    A.kill()
+    const paused = await notified
+    t.ok(paused, 'the folder-share transfer raised the paused signal the notification dispatcher listens on')
+    t.is(paused.spaceId, spaceId, 'scoped to the space, so the notification can group by it')
+    t.ok(typeof paused.reason === 'string' && paused.reason.length > 0, 'and carries the reason the body is worded from')
+  })

--- a/test/integration/download-root-unavailable.test.js
+++ b/test/integration/download-root-unavailable.test.js
@@ -1,13 +1,13 @@
 import test from 'brittle'
 import fs from 'bare-fs'
 import path from 'bare-path'
-import url from 'bare-url'
 import { freshPeer } from '../helpers/store.js'
 import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
 import { initPendingTransfers, recordPending, getPendingFor } from '../../src/shared/transfer/pending-transfers.js'
 import { initDownloads } from '../../src/shared/transfer/files.js'
 import { ErrorCodes } from '../../src/shared/core/errors.js'
 import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
+import { createOverlayChannel } from '../../src/shared/transfer/backends/overlay/overlay-channel.js'
 
 // REGRESSION (FIX-DLDIR-2: a download folder that had been deleted, ejected, or replaced by a
 // file produced no message the user could act on).
@@ -194,16 +194,24 @@ test('a local-fs failure with the folder still present keeps its own classificat
 // are also emitted as event:transfer-error, which is what drives the toast, the OS notification,
 // and the banner's immediate re-probe. A dest-unavailable failure that stayed off the wire would
 // show the right words on the row and nothing anywhere else — the exact half-fix this pins
-// against. Asserted structurally because the gate lives in the channel, not the engine.
+// against. Behavioural now that the gate is one factory: build the folder channel and watch it.
 test('REGRESSION (FIX-DLDIR-2: the folder-share channel emits transfer-error for a gone folder)', (t) => {
-  const src = fs.readFileSync(
-    path.join(url.fileURLToPath(new URL('../../src/shared/transfer/backends/overlay/overlay-backend.js', import.meta.url))),
-    'utf8',
-  )
-  const gate = src.slice(src.indexOf('emitError: (job, errorCode)'), src.indexOf('emitComplete:'))
-  t.ok(gate.includes('ErrorCodes.TRANSFER_DEST_UNAVAILABLE'), 'the code is in the cross-the-wire set')
-  t.ok(gate.includes('ErrorCodes.TRANSFER_DISK_FULL'), 'alongside disk-full')
-  t.ok(gate.includes('ErrorCodes.TRANSFER_CHECKSUM'), 'and the integrity failure')
+  const emitted = []
+  const channel = createOverlayChannel({
+    diagLabel: 'test', inPlace: false, surfaceAllErrors: false, updatedEvent: 'event:share-files-updated',
+    emit: (name, payload) => emitted.push([name, payload]),
+    decoKeyFor: (job) => job.relPath, decoKeyForRow: () => null,
+  })
+  const job = { transferId: 't', spaceId: 'S', path: '/Vault/a.bin', relPath: 'a.bin', size: 1 }
+  const wired = (code) => {
+    emitted.length = 0
+    channel.emitError(job, code)
+    return emitted.some(([name]) => name === 'event:transfer-error')
+  }
+  t.ok(wired(ErrorCodes.TRANSFER_DEST_UNAVAILABLE), 'the code is in the cross-the-wire set')
+  t.ok(wired(ErrorCodes.TRANSFER_DISK_FULL), 'alongside disk-full')
+  t.ok(wired(ErrorCodes.TRANSFER_CHECKSUM), 'and the integrity failure')
+  t.absent(wired(ErrorCodes.DOWNLOAD_FAILED), 'and nothing else — a generic failure stays on the row')
 })
 
 // === Auto-resume suppression ===

--- a/test/integration/foreign-unmount-signals-stop.test.js
+++ b/test/integration/foreign-unmount-signals-stop.test.js
@@ -5,7 +5,9 @@ import { publishShare, generateShareId } from '../../src/shared/shares/shares.js
 import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
 import { saveForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
-import { runMaterializeTick, setForeignEnabled, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
+import { ForeignMirrors, runMaterializeTick, setForeignEnabled, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
+import { createLifecycle } from '../../src/shared/core/subsystem.js'
+import { createFakeIpc } from '../helpers/fake-ipc.js'
 import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
 import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
 
@@ -68,6 +70,8 @@ async function setupOverlayMirror (t, { relPath = 'big.bin', contentHash = 'a'.r
   return { spaceId, shareId, contentHash, spy }
 }
 
+const silentLog = { debug () {}, info () {}, warn () {}, error () {} }
+
 test('FIX-MIRROR-STOP: unmount after pause tells holders we stopped', async (t) => {
   const { spaceId, shareId, contentHash, spy } = await setupOverlayMirror(t)
 
@@ -106,4 +110,28 @@ test('FIX-MIRROR-STOP: unmounting an idle mirror sends no stray STOP', async (t)
   await unmountForeignFolder(spaceId, shareId)
   t.alike(spy.stopped, [], 'nothing was in flight or paused — nothing to stop')
   t.absent(spy.cancel, 'no fetch to cancel')
+})
+
+test('REGRESSION (FIX-PI7-3: a shutdown leaves no paused hash for the next lifetime)', async (t) => {
+  // stopAllForeignLoops pauses rather than unmounts, so a shutdown is the one path that FILLS the
+  // marker map — and _close cleared everything except that. A marker surviving it makes the next
+  // lifetime broadcast STOPPED for a fetch it never started.
+  const { spaceId, shareId, contentHash, spy } = await setupOverlayMirror(t)
+
+  const tickP = runMaterializeTick(spaceId, shareId)
+  await waitUntil(() => spy.startedHash === contentHash)
+
+  await setForeignEnabled(spaceId, shareId, false)
+  t.is(spy.cancel?.opts?.discardPartial, false, 'the pause kept the partial and remembered the hash')
+  t.alike(spy.stopped, [], 'and told the holder nothing yet')
+
+  const life = createLifecycle({ log: silentLog })
+  const mirrors = await life.start(new ForeignMirrors('mirrors-under-test', { ipc: createFakeIpc().ipc }))
+  mirrors.log = silentLog
+  await life.close()
+
+  await unmountForeignFolder(spaceId, shareId)
+  t.alike(spy.stopped, [], 'the closed subsystem took its markers with it — no STOP from a dead lifetime')
+
+  await tickP
 })

--- a/test/integration/overlay-backend.test.js
+++ b/test/integration/overlay-backend.test.js
@@ -5,7 +5,7 @@ import { freshPeer } from '../helpers/store.js'
 import { createSpace } from '../../src/shared/spaces/space.js'
 import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
 import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
-import { saveOwnedMount } from '../../src/shared/folders/mount-store.js'
+import { saveOwnedMount, patchOwnedMount } from '../../src/shared/folders/mount-store.js'
 import { initialPublishScan } from '../../src/shared/folders/owned-folders.js'
 import { getOwnEntry, ownCatalog } from '../../src/shared/shares/share-catalog.js'
 import { createCatalogBatch } from '../../src/shared/shares/catalog-writer.js'
@@ -135,6 +135,40 @@ test('REGRESSION (FIX: a folder file is not tombstoned on a single presence-swee
 
   await overlaySweepPresence()
   t.absent(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'), 'a second consecutive miss reclaims it')
+})
+
+test('REGRESSION (FIX-PI1-4: an owned-folder file gone from disk is retired through the publish lane)', async (t) => {
+  // The sweep used to write the tombstone itself, bypassing the lane the owner's every other
+  // publish and retire goes through — and with it the runner's own presence re-confirmation, the
+  // space's catalog batch, and the gates below. Index-paused is the one that discriminates: a
+  // direct write does not care about it, a lane item is skipped by it.
+  const ctx = await setup(t, { files: { 'a.txt': 'data' } })
+  const abs = path.join(ctx.mountPath, 'a.txt')
+  await overlayBackend.publishAdd(ctx.spaceId, ctx.share, 'a.txt', abs)
+
+  await patchOwnedMount(ctx.spaceId, ctx.share.id, { indexPaused: true })
+  fs.unlinkSync(abs)
+  await overlaySweepPresence()
+  await overlaySweepPresence()
+  t.ok(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'),
+    'a paused index publishes no deletions — the reclaim went through the lane and the lane declined it')
+
+  await patchOwnedMount(ctx.spaceId, ctx.share.id, { indexPaused: false })
+  await overlaySweepPresence()
+  await overlaySweepPresence()
+  t.absent(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'), 'and once the index resumes, the same lane retires it')
+})
+
+test('the presence sweep writes no catalog tombstone of its own', (t) => {
+  const src = fs.readFileSync(
+    path.join(new URL('../../src/shared/transfer/backends/overlay/overlay-backend.js', import.meta.url).pathname),
+    'utf8',
+  )
+  const start = src.indexOf('const folderSweeper =')
+  const sweep = src.slice(start, src.indexOf('\n}', src.indexOf('export async function overlaySweepPresence')))
+  t.ok(start > 0 && sweep.length > 200, 'the sweep was located — an empty slice would pass every assertion below')
+  t.absent(/catalogTombstone|evictIfUnreferenced/.test(sweep), 'the reclaim is proposed onto the lane, never written here')
+  t.ok(/enqueueRetire/.test(sweep), 'and the proposal is the lane call')
 })
 
 test('FIX: a folder file that reappears between sweeps (atomic save) is never tombstoned', async (t) => {

--- a/test/unit/loose-supersede-decision.test.js
+++ b/test/unit/loose-supersede-decision.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { supersedeDecision, isRepublished, republishDecision } from '../../src/shared/transfer/supersede-decision.js'
+import { supersedeDecision, isRepublished, republishDecision, activeSlotAction } from '../../src/shared/transfer/supersede-decision.js'
 
 // REGRESSION (FIX-REMOVE-1: a remove+re-add — even of identical content, even one never
 // observed as a tombstone — must terminate a download, not auto-resume). isRepublished is the
@@ -81,4 +81,23 @@ test('republishDecision: without a recorded hash, a materialized re-publish drop
   // We cannot prove the content changed, so the remove+re-add rule wins over an eager restart.
   t.is(republishDecision(undefined, { removed: false, seq: S2, contentHash: 'h2' }, S1), 'drop')
   t.is(republishDecision(null, { removed: false, seq: S2, contentHash: 'h2' }, S1), 'drop')
+})
+
+// activeSlotAction is the whole ladder both consumer channels put an active slot through when
+// their owner's catalog appends. Each used to spell it out inline, one `if` per rung.
+test('activeSlotAction: the re-publish verdicts pass straight through', (t) => {
+  t.is(activeSlotAction('h1', { removed: true }, S1), 'drop', 'tombstoned')
+  t.is(activeSlotAction('h1', { removed: false, seq: S2, contentHash: 'h1' }, S1), 'drop', 're-added identical')
+  t.is(activeSlotAction('h1', { removed: false, seq: S2, contentHash: null }, S1), 'pending', 'mid-rehash')
+  t.is(activeSlotAction('h1', { removed: false, seq: S2, contentHash: 'h2' }, S1), 'restart', 're-published new content')
+})
+
+test('activeSlotAction: a plain hash change with no re-publish still restarts', (t) => {
+  t.is(activeSlotAction('h1', { removed: false, seq: S1, contentHash: 'h2' }, S1), 'restart')
+})
+
+test('activeSlotAction: nothing to do is "keep", never a destructive default', (t) => {
+  t.is(activeSlotAction('h1', { removed: false, seq: S1, contentHash: 'h1' }, S1), 'keep', 'unchanged')
+  t.is(activeSlotAction('h1', { removed: false, seq: S1, contentHash: null }, S1), 'keep', 'hash not materialized, no re-publish')
+  t.is(activeSlotAction('h1', null, S1), 'keep', 'an unreadable head decides nothing')
 })

--- a/test/unit/overlay-channel.test.js
+++ b/test/unit/overlay-channel.test.js
@@ -1,0 +1,143 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { createOverlayChannel } from '../../src/shared/transfer/backends/overlay/overlay-channel.js'
+import { ErrorCodes } from '../../src/shared/core/errors.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const readSrc = (rel) => readFileSync(path.join(here, '..', '..', 'src', rel), 'utf8')
+
+const JOB = {
+  transferId: 'S|sh|a.bin', spaceId: 'S', path: '/Vault/a.bin', relPath: 'a.bin',
+  shareId: 'sh', size: 100, prevBytes: 10,
+}
+
+function build (kind, emit) {
+  const loose = kind === 'loose'
+  return createOverlayChannel({
+    diagLabel: loose ? 'loose download' : 'overlay download',
+    inPlace: loose,
+    surfaceAllErrors: loose,
+    updatedEvent: loose ? 'event:files-updated' : 'event:share-files-updated',
+    emit,
+    decoKeyFor: (job) => (loose ? job.path : job.shareId + ':' + job.relPath),
+    decoKeyForRow: (row, pendingKey) => (loose ? pendingKey : (row?.shareId ? row.shareId + ':' + row.relPath : null)),
+    ownsPendingRow: () => true,
+    pendingExtra: () => ({}),
+    transferIdForRow: () => 'id',
+    resolvePendingRow: async () => ({ removed: false, seq: undefined, job: null }),
+  })
+}
+
+function recorder () {
+  const out = []
+  return { out, emit: (name, payload) => out.push([name, payload]), names: () => out.map(([n]) => n) }
+}
+
+test('a paused folder transfer emits event:transfer-paused', (t) => {
+  const r = recorder()
+  build('folder', r.emit).emitPaused(JOB, 'offline')
+  t.ok(r.names().includes('event:transfer-paused'), 'the notification signal crosses the wire')
+  const [, payload] = r.out.find(([n]) => n === 'event:transfer-paused')
+  t.is(payload.reason, 'offline', 'carrying the reason the dispatcher words the body from')
+  t.is(payload.transferId, JOB.transferId, 'and the id the notification dedupes on')
+})
+
+test('REGRESSION (FIX-PI1-1: a retrying pause is decoration-only, on both kinds)', (t) => {
+  for (const kind of ['loose', 'folder']) {
+    const r = recorder()
+    build(kind, r.emit).emitPaused(JOB, 'interrupted', { retrying: true })
+    t.absent(r.names().includes('event:transfer-paused'), `${kind}: no notification per retry attempt`)
+    t.ok(r.out.some(([n, p]) => n === 'event:decoration' && p.done), `${kind}: the bar still terminates`)
+  }
+})
+
+test('a pause with no retry armed notifies on both kinds', (t) => {
+  for (const kind of ['loose', 'folder']) {
+    const r = recorder()
+    build(kind, r.emit).emitPaused(JOB, 'offline')
+    t.ok(r.names().includes('event:transfer-paused'), `${kind}: notifies`)
+  }
+})
+
+test('the error wire filter is the only behavioural difference between the kinds', (t) => {
+  const surfaced = (kind, code) => {
+    const r = recorder()
+    build(kind, r.emit).emitError(JOB, code)
+    return r.names().includes('event:transfer-error')
+  }
+  for (const code of [ErrorCodes.TRANSFER_DISK_FULL, ErrorCodes.TRANSFER_CHECKSUM, ErrorCodes.TRANSFER_DEST_UNAVAILABLE]) {
+    t.ok(surfaced('folder', code), `folder surfaces ${code}`)
+    t.ok(surfaced('loose', code), `loose surfaces ${code}`)
+  }
+  t.absent(surfaced('folder', ErrorCodes.DOWNLOAD_FAILED), 'a folder row keeps a generic failure inline')
+  t.ok(surfaced('loose', ErrorCodes.DOWNLOAD_FAILED), 'a loose row has no list to keep it in')
+
+  const events = (kind, drive) => {
+    const r = recorder()
+    drive(build(kind, r.emit))
+    return r.names()
+  }
+  const cases = {
+    progress: (c) => c.emitProgress(JOB, { bytes: 1, total: 2, speed: 3, eta: 4 }),
+    verifying: (c) => c.emitVerifying(JOB, 0.5),
+    complete: (c) => c.emitComplete(JOB, '/tmp/a.bin'),
+    paused: (c) => c.emitPaused(JOB, 'offline'),
+    superseded: (c) => c.emitSuperseded(JOB),
+    decorationDone: (c) => c.emitDecorationDone(JOB),
+    removedByOwner: (c) => c.emitRemovedByOwner('S', '/Vault/a.bin', { relPath: 'a.bin' }, 'id'),
+  }
+  for (const [name, drive] of Object.entries(cases)) {
+    t.alike(events('loose', drive), events('folder', drive), `${name} emits the same events on both kinds`)
+  }
+})
+
+test('every emit carries spaceId, and a decoration without a key is not emitted', (t) => {
+  const r = recorder()
+  const folder = build('folder', r.emit)
+  folder.emitProgress(JOB, { bytes: 1, total: 2, speed: 0, eta: null })
+  t.is(r.out[0][1].spaceId, 'S', 'a bare drive path is unique per space only')
+  t.is(r.out[0][1].key, 'sh:a.bin', 'keyed on the share axis')
+
+  r.out.length = 0
+  folder.emitCancelled('S', 'id', '/Vault/a.bin', null)
+  t.is(r.out.length, 0, 'a cancel whose row cannot name a key emits nothing')
+
+  r.out.length = 0
+  build('loose', r.emit).emitCancelled('S', 'id', '/a.bin', null)
+  t.is(r.out.length, 1, 'the loose key comes from the pending key, which is always there')
+})
+
+test('the superseded and removed events name the file, not the path', (t) => {
+  const r = recorder()
+  const channel = build('folder', r.emit)
+  channel.emitSuperseded({ ...JOB, relPath: 'nested/deep/a.bin' })
+  t.is(r.out.find(([n]) => n === 'event:transfer-superseded')[1].fileName, 'a.bin', 'a nested key still names the leaf')
+
+  r.out.length = 0
+  channel.emitRemovedByOwner('S', '/Vault/nested/a.bin', null, 'id')
+  t.is(r.out[0][1].fileName, 'a.bin', 'and so does a pending key with no row behind it')
+})
+
+test('neither module hand-writes a channel bag any more', (t) => {
+  for (const file of ['shared/transfer/loose-overlay.js', 'shared/transfer/backends/overlay/overlay-backend.js']) {
+    const src = readSrc(file)
+    t.absent(/^\s*emitProgress\s*:/m.test(src), `${file} declares no emit* members of its own`)
+    t.absent(/^\s*emitPaused\s*:/m.test(src), `${file} declares no paused emitter of its own`)
+    t.ok(/createOverlayChannel\(/.test(src), `${file} builds its channel from the factory`)
+  }
+})
+
+test('event:transfer-paused has exactly one emitter in src/', (t) => {
+  const files = ['shared/transfer/loose-overlay.js', 'shared/transfer/backends/overlay/overlay-backend.js',
+    'shared/transfer/backends/overlay/overlay-channel.js', 'shared/transfer/backends/overlay/overlay-download.js']
+  const emitters = files.filter((f) => /emit\(\s*'event:transfer-paused'/.test(readSrc(f)))
+  t.alike(emitters, ['shared/transfer/backends/overlay/overlay-channel.js'],
+    'the notification is raised in one place, so no channel can forget it')
+})
+
+test('the factory imports nothing that only loads under Bare', (t) => {
+  const src = readSrc('shared/transfer/backends/overlay/overlay-channel.js')
+  t.absent(/from '(bare-|node:)/.test(src), 'it stays loadable under plain Node, which is why this file can test it')
+})

--- a/test/unit/presence-sweeper.test.js
+++ b/test/unit/presence-sweeper.test.js
@@ -1,0 +1,78 @@
+import test from 'brittle'
+import { createPresenceSweeper } from '../../src/shared/transfer/presence-sweeper.js'
+
+function build ({ present = () => false, pending = () => false } = {}) {
+  const retired = []
+  const sweeper = createPresenceSweeper({
+    keyOf: (ctx, e) => ctx.spaceId + '\0' + e.relPath,
+    isPending: (ctx, e) => pending(ctx, e),
+    presentAt: async (ctx, e) => present(ctx, e),
+    retire: (ctx, e) => { retired.push(e.relPath) },
+  })
+  return { sweeper, retired }
+}
+
+const CTX = { spaceId: 'S' }
+const ENTRY = { relPath: 'a.txt' }
+
+test('a single miss only arms — the reclaim needs a second consecutive one', async (t) => {
+  const { sweeper, retired } = build()
+  t.absent(await sweeper.consider(CTX, ENTRY), 'first miss arms')
+  t.alike(retired, [], 'nothing retired yet')
+  t.ok(await sweeper.consider(CTX, ENTRY), 'second consecutive miss reclaims')
+  t.alike(retired, ['a.txt'], 'retired once')
+})
+
+test('REGRESSION (FIX-PI1-4: a file that returns between two passes is never retired)', async (t) => {
+  // An editor's atomic save (rename-over, delete+recreate) makes a healthy file briefly absent.
+  // Retiring on that single miss would tombstone it and cascade the deletion to every mirror peer.
+  let there = false
+  const { sweeper, retired } = build({ present: () => there })
+  await sweeper.consider(CTX, ENTRY)
+  there = true
+  t.absent(await sweeper.consider(CTX, ENTRY), 'presence disarms')
+  there = false
+  t.absent(await sweeper.consider(CTX, ENTRY), 'the next miss starts over rather than completing the old pair')
+  t.alike(retired, [], 'never retired')
+})
+
+test('an entry whose publish is queued is skipped, and its arming is dropped', async (t) => {
+  let pending = false
+  const { sweeper, retired } = build({ pending: () => pending })
+  await sweeper.consider(CTX, ENTRY)
+  t.is(sweeper.size(), 1, 'armed')
+  pending = true
+  t.absent(await sweeper.consider(CTX, ENTRY), 'skipped while its publish is in the queue')
+  t.is(sweeper.size(), 0, 'and disarmed — disk presence decides only for settled entries')
+  t.alike(retired, [])
+})
+
+test('an entry with no recorded source is never reclaimed, however many passes miss it', async (t) => {
+  const { sweeper, retired } = build({ present: () => null })
+  for (let i = 0; i < 5; i++) t.absent(await sweeper.consider(CTX, ENTRY), 'pass ' + i)
+  t.alike(retired, [], 'not ours to reclaim')
+})
+
+test('the arming is per key, so one gone file does not reclaim its neighbour', async (t) => {
+  const { sweeper, retired } = build()
+  await sweeper.consider(CTX, { relPath: 'a.txt' })
+  await sweeper.consider(CTX, { relPath: 'b.txt' })
+  t.alike(retired, [], 'both only armed')
+  await sweeper.consider(CTX, { relPath: 'a.txt' })
+  t.alike(retired, ['a.txt'], 'only the one that missed twice')
+})
+
+test('the same path in two spaces arms independently', async (t) => {
+  const { sweeper, retired } = build()
+  await sweeper.consider({ spaceId: 'S1' }, ENTRY)
+  t.absent(await sweeper.consider({ spaceId: 'S2' }, ENTRY), 'a miss in another space is not the second miss here')
+  t.alike(retired, [])
+})
+
+test('reset() forgets every arming', async (t) => {
+  const { sweeper, retired } = build()
+  await sweeper.consider(CTX, ENTRY)
+  sweeper.reset()
+  t.absent(await sweeper.consider(CTX, ENTRY), 'starts over')
+  t.alike(retired, [])
+})


### PR DESCRIPTION
## What & why

A folder-share download that stalled raised no notification. `event:transfer-paused`
had exactly one emitter — the loose channel — so the renderer's dispatcher could never
fire for a file inside a shared folder: the progress bar just stopped.

The cause is that the loose and folder download paths each hand-wrote their own channel
object, presence sweep and space-cancel, each carrying a comment promising to stay in sync
with its twin. Nothing enforced the promise, and they drifted.

Both channels are now built from one factory, so there is a single emitter and a policy
that holds for one channel holds for both by construction. Two further divergences close
with it:

- The folder presence sweep wrote catalog tombstones directly, bypassing the publish lane
  the loose sweep uses — and with it the runner's presence re-confirmation, the space's
  catalog batch, and the index-paused gate. It now retires through the lane.
- A shutdown pauses every mirror rather than unmounting it, making it the one path that
  fills the paused-holder map — and `ForeignMirrors._close` cleared everything except that.
  A marker surviving it makes the next lifetime tell a holder we stopped pulling content it
  never served us.

Three commits: the shared modules, the channel and sweep adoption (the behaviour change),
then the shutdown fix.

Rebased onto #177. That PR shipped `paused-holders.js`, which independently solved the
shared paused-hash problem this branch originally solved as `stop-notices.js`. The
duplicate is dropped in favour of the merged module — keeping both would recreate exactly
the divergence this PR exists to remove. What did not survive there is the shutdown clear,
which is the third commit.

## Coverage

Unit, Integration and Flow.

- Unit — the factory (Node-loadable by design: no `bare-*` imports), the sweep policy, and
  the slot-decision ladder. Includes a ratchet that neither module may hand-write emit
  members again, and that `event:transfer-paused` has one emitter in `src/`.
- Integration — the pause marker asserted independently of the hash it shares a map with;
  the folder sweep proven to go through the lane via the index-paused gate a direct write
  would ignore; a closed mirror subsystem proven to take its markers with it.
- Flow — an owner going offline mid-download must produce `event:transfer-paused` for a
  folder share. Asserted on the event, not on polled data: a data-polling test converges to
  `paused` either way and cannot see a missing IPC event.

Red-first verified by reverting each fix: the flow test fails with "saw 0
event:transfer-paused event(s)"; the shutdown test fails with "no STOP from a dead
lifetime".

Frontend and Accessibility — SKIP. No renderer, main or preload files change; the
user-visible surface is an OS notification.

## Ran locally

`test:fe` — not run, and not applicable: no renderer markup or flow changes. Dev axe and
VoiceOver likewise N/A for the same reason.

Known follow-up, deliberately out of scope: with folder rows now notifying, twenty paused
files means twenty notifications. Loose rows already behave that way, but folders are where
a user starts many downloads at once, so grouping is worth a look separately. Also noted
while working here: `cancelFetch` resolves through the protocol's async teardown and no
call site awaits it, so the `try/catch` guards around it cannot catch a rejection. Low
probability, unrelated to this change, left alone.
