### PR TITLE
[fix] Bound every overlay fetch, and name who owns one

### DIFF
--- a/src/main/config-store.js
+++ b/src/main/config-store.js
@@ -27,7 +27,7 @@ function defaults() {
     // downloadConcurrency has no UI on purpose — it is an operator lever and the rollback path
     // for the shared fetch gate. 0 disables the cap entirely, so a UI would have to offer it as
     // a named "Unlimited" rather than a raw zero.
-    network: { downloadKBps: 0, uploadKBps: 0, relayMode: 'off', relays: [], downloadConcurrency: 3 },
+    network: { downloadKBps: 0, uploadKBps: 0, relayMode: 'off', relays: [], downloadConcurrency: 6 },
     storage: { cacheBudgetBytes: 0 },
     notifications: null,
     ui: { lastSeenVersion: null, feedbackEmail: '' },

--- a/src/main/config-store.js
+++ b/src/main/config-store.js
@@ -24,7 +24,10 @@ function defaults() {
     general: { minimizeToTray: true, openAtLogin: false, firstHideNoticeShown: false, appMenuAutoHide: false },
     downloads: { folder: null },
     // Shared group: bandwidth caps and relay configuration both live here.
-    network: { downloadKBps: 0, uploadKBps: 0, relayMode: 'off', relays: [] },
+    // downloadConcurrency has no UI on purpose — it is an operator lever and the rollback path
+    // for the shared fetch gate. 0 disables the cap entirely, so a UI would have to offer it as
+    // a named "Unlimited" rather than a raw zero.
+    network: { downloadKBps: 0, uploadKBps: 0, relayMode: 'off', relays: [], downloadConcurrency: 3 },
     storage: { cacheBudgetBytes: 0 },
     notifications: null,
     ui: { lastSeenVersion: null, feedbackEmail: '' },

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -719,6 +719,10 @@ function getWorker(specifier) {
     relayEnabled: readFeatureFlags().relay === true,
     relayMode: config().get('network.relayMode'),
     relays: config().get('network.relays'),
+    // Read at spawn only. getDownloadConcurrency() re-reads it per acquire, so a live push would
+    // take effect without a restart — but there is no setter by design, so a change means editing
+    // config.json and restarting.
+    downloadConcurrency: config().get('network.downloadConcurrency'),
     identityKEK: identityKEKHex,
   }
   worker.write(Buffer.from(JSON.stringify(bootstrap) + '\n'))

--- a/src/renderer/components/cards/ShareFileRow.tsx
+++ b/src/renderer/components/cards/ShareFileRow.tsx
@@ -122,6 +122,10 @@ function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadS
   const showPausedProgressBar = (isPausedInterrupted || isPausedOffline)
     && pausedBytes != null && pausedBytes > 0 && file.size > 0
   const action = fileRowAction({ status: file.status, manualControls, hasTransferId: !!transferId })
+  // The badge sits apart from the file name in the row, so on its own it announces a bare state
+  // with nothing tying it to what it describes. Naming it also makes the row's status assertable
+  // by one exact string instead of a whole-window word match.
+  const badgeName = (label: string) => t('file.rowStatusLabel', { name: displayName || file.relPath, status: label })
   const busyLabel = isPublishing ? t('status.publishing') : isPreparing ? t('file.preparing') : t('file.syncing')
 
   // Sender-side download indicator: who is currently pulling this file from us. Only
@@ -160,7 +164,7 @@ function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadS
             <DownloadProgressLane value={verifyPct} label={t('status.verifying')} showPct />
           </div>
           <div className="ml-5 mr-3 shrink-0 self-center items-center hidden @min-[480px]/row:flex">
-            <Badge label={t(badge.labelKey)} classes={badge.classes} />
+            <Badge label={t(badge.labelKey)} classes={badge.classes} srLabel={badgeName(t(badge.labelKey))} />
           </div>
         </>
       ) : showIndexProgressBar && file.progress ? (
@@ -174,7 +178,7 @@ function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadS
             />
           </div>
           <div className="ml-5 mr-3 shrink-0 self-center items-center hidden @min-[480px]/row:flex">
-            <Badge label={t(badge.labelKey)} classes={badge.classes} />
+            <Badge label={t(badge.labelKey)} classes={badge.classes} srLabel={badgeName(t(badge.labelKey))} />
           </div>
         </>
       ) : showDownloadProgressBar && file.progress ? (
@@ -189,7 +193,7 @@ function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadS
             />
           </div>
           <div className="ml-5 mr-3 shrink-0 self-center items-center hidden @min-[480px]/row:flex">
-            <Badge label={t(badge.labelKey)} classes={badge.classes} />
+            <Badge label={t(badge.labelKey)} classes={badge.classes} srLabel={badgeName(t(badge.labelKey))} />
           </div>
         </>
       ) : showPausedProgressBar && pausedBytes != null ? (
@@ -202,7 +206,7 @@ function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadS
             />
           </div>
           <div className="ml-5 mr-3 shrink-0 self-center items-center hidden @min-[480px]/row:flex">
-            <Badge label={t(badge.labelKey)} classes={badge.classes} />
+            <Badge label={t(badge.labelKey)} classes={badge.classes} srLabel={badgeName(t(badge.labelKey))} />
           </div>
         </>
       ) : indicatorActive && downloadSummary ? (
@@ -217,13 +221,13 @@ function ShareFileRow({ file, isOwn, manualControls, spaceId, members, downloadS
             />
           </div>
           <div className="ml-5 mr-3 shrink-0 self-center items-center hidden @min-[480px]/row:flex">
-            <Badge label={t('file.sending')} classes="bg-info text-accent" />
+            <Badge label={t('file.sending')} classes="bg-info text-accent" srLabel={badgeName(t('file.sending'))} />
           </div>
         </>
       ) : (
         <div className="shrink-0 ml-6 mr-3 flex items-center gap-2 self-center">
           {file.verified && <VerifiedCheck label={t('file.verified')} />}
-          <Badge label={t(badge.labelKey)} classes={badge.classes} />
+          <Badge label={t(badge.labelKey)} classes={badge.classes} srLabel={badgeName(t(badge.labelKey))} />
         </div>
       )}
       {/* Right edge is actions only; the verified badge is information and sits with

--- a/src/renderer/components/primitives/Badge.tsx
+++ b/src/renderer/components/primitives/Badge.tsx
@@ -2,11 +2,15 @@ interface BadgeProps {
   label: string
   classes: string
   className?: string
+  // The accessible name, for a badge whose visible word is ambiguous on its own. A file row's
+  // badge is the state of ONE file; without this it reads as an unattached "AVAILABLE".
+  srLabel?: string
 }
 
-export default function Badge({ label, classes, className }: BadgeProps) {
+export default function Badge({ label, classes, className, srLabel }: BadgeProps) {
   return (
     <span
+      aria-label={srLabel}
       className={`inline-flex items-center leading-none px-3 pt-[7px] pb-[5px] text-[10px] font-bold rounded-full uppercase tracking-wider border border-outline ${classes}${className ? ` ${className}` : ''}`}
     >
       {label}

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -323,7 +323,8 @@
     "sending": "Senden",
     "paused": "Pausiert",
     "downloadersPaused_one": "{{count}} pausiert",
-    "downloadersPaused_other": "{{count}} pausiert"
+    "downloadersPaused_other": "{{count}} pausiert",
+    "rowStatusLabel": "{{name}}: {{status}}"
   },
   "spaceCard": {
     "openSpace": "{{name}} öffnen",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -347,7 +347,8 @@
     "sending": "Sending",
     "paused": "Paused",
     "downloadersPaused_one": "{{count}} paused",
-    "downloadersPaused_other": "{{count}} paused"
+    "downloadersPaused_other": "{{count}} paused",
+    "rowStatusLabel": "{{name}}: {{status}}"
   },
   "spaceCard": {
     "openSpace": "Open {{name}}",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -323,7 +323,8 @@
     "sending": "Enviando",
     "paused": "En pausa",
     "downloadersPaused_one": "{{count}} en pausa",
-    "downloadersPaused_other": "{{count}} en pausa"
+    "downloadersPaused_other": "{{count}} en pausa",
+    "rowStatusLabel": "{{name}}: {{status}}"
   },
   "spaceCard": {
     "openSpace": "Abrir {{name}}",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -323,7 +323,8 @@
     "sending": "Envoi",
     "paused": "En pause",
     "downloadersPaused_one": "{{count}} en pause",
-    "downloadersPaused_other": "{{count}} en pause"
+    "downloadersPaused_other": "{{count}} en pause",
+    "rowStatusLabel": "{{name}}: {{status}}"
   },
   "spaceCard": {
     "openSpace": "Ouvrir {{name}}",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -323,7 +323,8 @@
     "sending": "Invio",
     "paused": "In pausa",
     "downloadersPaused_one": "{{count}} in pausa",
-    "downloadersPaused_other": "{{count}} in pausa"
+    "downloadersPaused_other": "{{count}} in pausa",
+    "rowStatusLabel": "{{name}}: {{status}}"
   },
   "spaceCard": {
     "openSpace": "Apri {{name}}",

--- a/src/shared/core/concurrency.js
+++ b/src/shared/core/concurrency.js
@@ -53,8 +53,11 @@ export function createSemaphore({ limit, expressLanes = 1 } = {}) {
   }
 
   return {
-    acquire({ express = false } = {}) {
-      const w = { express, released: false, resolve: null }
+    // `owner` tags the waiter so a drain can be scoped to one producer. One gate can be shared by
+    // subsystems that close at different times, and releasing all of them at the first close would
+    // start work the later ones are still guarding.
+    acquire({ express = false, owner = null } = {}) {
+      const w = { express, owner, released: false, resolve: null }
       if (roomFor(express)) return Promise.resolve(admit(w))
       return new Promise((resolve) => {
         w.resolve = resolve
@@ -62,10 +65,17 @@ export function createSemaphore({ limit, expressLanes = 1 } = {}) {
       })
     },
     stats: () => ({ held, queued: waiters.length, express: expressHeld }),
-    // Shutdown: hand every queued caller a no-op release so a parked acquire cannot hold close()
-    // past the stop deadline. They resume and find their own cancelled/stopping checks.
-    drain() {
-      while (waiters.length) waiters.shift().resolve(() => {})
+    // Shutdown: hand queued callers a no-op release so a parked acquire cannot hold close() past
+    // the stop deadline. They resume and find their own cancelled/stopping checks. No argument
+    // drains everyone; an owner drains only that producer and leaves the rest queued in order.
+    drain(owner) {
+      const keep = []
+      while (waiters.length) {
+        const w = waiters.shift()
+        if (owner == null || w.owner === owner) w.resolve(() => {})
+        else keep.push(w)
+      }
+      for (const w of keep) waiters.push(w)
     },
   }
 }

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -63,9 +63,12 @@ const DEFAULTED = {
   // 2 overlaps one file's reads with another's hashing, beyond that gains nothing. The scheduler
   // clamps to >= 1.
   publishConcurrency: 2,
-  // Concurrent overlay downloads. A reconnect can have hundreds of pending rows and each running
-  // fetch owns a chunk scheduler, a watchdog, an fd and a progress ticker. 0 disables the gate.
-  downloadConcurrency: 3,
+  // Concurrent overlay downloads across the WHOLE process — both engines and every mirror draw on
+  // one gate. A reconnect can have hundreds of pending rows and each running fetch owns a chunk
+  // scheduler, a watchdog, an fd and a progress ticker. 6, not 3: the cap used to be built per
+  // engine, so two engines meant six bulk slots, and 6 keeps that ceiling while bringing the
+  // mirrors — previously uncounted, one fetch each — inside it. 0 disables the gate.
+  downloadConcurrency: 6,
   // Open peer catalogs kept cached. Each is a Hyperbee + Hypercore session with an append listener,
   // and every open core replicates to every socket. 0 = unbounded (the previous behaviour).
   peerCatalogCacheLimit: 64,

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -36,13 +36,6 @@ import { createMirrorLoops } from './mirror-loop.js'
 import { createMirrorState, localRelOf } from './mirror-state.js'
 import { shouldWalk } from './mirror-walk.js'
 
-// Kept on this module so the worker and the existing tests keep their `./foreign-folders.js`
-// import path while the implementations live where they belong: the deletion gate in
-// `path-keys.js`, the preview in `foreign-preview.js`, and the on-disk path a renamed entry was
-// materialized as in `mirror-state.js` (share-listing must resolve it the way the engine wrote it).
-export { shouldHonorDeletions, localRelOf }
-export { previewMaterializeScan } from './foreign-preview.js'
-
 const log = createLogger('foreign-folders')
 
 // The loop engine. Everything mount-specific stays here; the interval, the one-pass-at-a-time

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -25,6 +25,7 @@ import { getContentBackend, hasContentBackend } from '../transfer/content-backen
 import { getOverlay } from '../transfer/backends/overlay/overlay-instance.js'
 import { overlayHashFile, setOverlayCatalogChangeHook, overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
 import { runOverlayFetch } from '../transfer/backends/overlay/fetch-run.js'
+import { acquireFetchSlot, drainFetchSlots, FETCH_OWNER_MIRROR } from '../transfer/backends/overlay/fetch-slots.js'
 import { createPausedHolders } from '../transfer/backends/overlay/paused-holders.js'
 import { shareDecoKey } from '../transfer/decoration-key.js'
 import { transferIdFor } from '../transfer/transfer-id.js'
@@ -345,6 +346,46 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   // decoration key and duplicate the bytes — skip; the next tick lands it after the
   // engine settles.
   if (overlayHasTransfer(transferIdFor(mount.spaceId, mount.shareId, entry.relPath))) return 'missing'
+  const streamKey = loopKey(mount.spaceId, mount.shareId)
+  const releaseSlot = await acquireMirrorSlot(streamKey)
+  try {
+    // Fall back to the LIVE generation rather than undefined: loops.stopped compares against it,
+    // so an absent gen would read as 'stopped' and refuse every fetch. A caller without one still
+    // gets the check it needs — a stop landing during the wait above.
+    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen: opts.gen ?? mirrorGen(streamKey) })
+  } finally {
+    releaseSlot()
+  }
+}
+
+// A parked pass is in flight as far as pass-liveness is concerned, so mirrorVerdict would condemn
+// it after pollInterval x STALL_FACTOR (10 minutes) and the Supervisor would restart it — churn
+// whose cause is a queue, not a wedge. Stamping progress either side of the wait is not enough:
+// the wait is unbounded and can outlast the window on its own. Heartbeat through it instead, so
+// the verdict measures the fetch rather than the queue. Before this gate the mirror never waited.
+//
+// Never express: a background materialize must not outrank a click. Taken BEFORE the in-flight
+// record, because cancelInflightFetch reads that record — a stop landing while this is parked
+// would ask the vendor layer to cancel a fetch that never started, and would tell the holder we
+// paused a transfer we never began.
+async function acquireMirrorSlot(streamKey) {
+  loops.noteProgress(streamKey)
+  const beat = setInterval(() => loops.noteProgress(streamKey), getResourceCaps().foreignPollIntervalMs)
+  beat.unref?.()
+  try {
+    return await acquireFetchSlot({ express: false, owner: FETCH_OWNER_MIRROR })
+  } finally {
+    clearInterval(beat)
+    loops.noteProgress(streamKey)
+  }
+}
+
+// The gated half of a materialize: everything past the slot owns a chunk scheduler, a watchdog,
+// an fd and a ticker.
+async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen }) {
+  // The wait for a slot is unbounded, so re-check the stop the catalog walk tests at every entry.
+  if (mirrorStopped(streamKey, gen)) return 'missing'
+  // Read AFTER the wait, not before it: the overlay can be torn down while a pass is parked.
   const overlay = getOverlay()
   if (!overlay) return 'missing'
   await fs.promises.mkdir(path.dirname(abs), { recursive: true })
@@ -352,16 +393,15 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   // bytes; ticker.pushTo diffs them.
   const total = entry.size || 0
   const decoKey = shareDecoKey(mount.shareId, entry.relPath)
-  const streamKey = loopKey(mount.spaceId, mount.shareId)
   let res
   let attempted = false
   let diag = null
-  activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath })
-  loops.noteProgress(streamKey)
-  pausedHolders.supersede(streamKey)
-  // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.
-  ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
+  // Everything from here is inside the try, so no throw between the claim and the fetch can leak it.
   try {
+    activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath })
+    pausedHolders.supersede(streamKey)
+    // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.
+    ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
     // The overlay scheduler reports CUMULATIVE bytes; the ticker diffs them into speed/ETA.
     ;({ res, attempted, diag } = await runOverlayFetch(overlay, entry.contentHash, {
       label: 'overlay mirror',
@@ -424,7 +464,7 @@ async function initialMaterializeScanCatalog(mount, share) {
     // wrote, or the owner's later delete of that file is never applied.
     state.recordSynced(key, synced, entry.relPath, fresh)
     try {
-      if (await materializeCatalogFile(mount, share, entry, { synced, fresh }) === 'missing') allPresent = false
+      if (await materializeCatalogFile(mount, share, entry, { synced, fresh, gen }) === 'missing') allPresent = false
     } catch (err) {
       allPresent = false
       log.debug('catalog initial materialize failed:', entry.relPath, '-', err.message)
@@ -498,7 +538,7 @@ async function materializeOnceCatalog(mount, share) {
     if (mirrorStopped(key, gen)) return
     state.recordSynced(key, synced, entry.relPath, fresh)
     try {
-      if (await materializeCatalogFile(mount, share, entry, { synced, fresh }) === 'missing') allPresent = false
+      if (await materializeCatalogFile(mount, share, entry, { synced, fresh, gen }) === 'missing') allPresent = false
     } catch (err) {
       allPresent = false
       log.debug('catalog materialize failed:', entry.relPath, '-', err.message)
@@ -629,7 +669,17 @@ export class ForeignMirrors extends Subsystem {
   // stopAllForeignLoops pauses rather than unmounts, so it is the one path that FILLS
   // pausedHolders. Without the clear the hashes outlive the subsystem that recorded them, and a
   // later open inherits markers for fetches belonging to a previous lifetime.
-  async _close() { await stopAllForeignLoops(); pausedHolders.clear(); integritySeen.clear() }
+  // The scoped drain comes first: a pass parked on the shared fetch gate cannot observe the
+  // generation bump stopAllForeignLoops relies on, and would hold the 1500 ms tier budget open
+  // until the 5000 ms settle timeout. Scoped to FETCH_OWNER_MIRROR because OverlayBackend closes
+  // AFTER us — an unscoped drain would release the two engines' backlog into an overlay that is
+  // still live, and those tasks pass their own hasOverlay() guard.
+  async _close() {
+    drainFetchSlots(FETCH_OWNER_MIRROR)
+    await stopAllForeignLoops()
+    pausedHolders.clear()
+    integritySeen.clear()
+  }
 
   // Counts, not identifiers: diagnostics:export is user-shareable and redacts peer keys and
   // topics, so space and share ids must not ride along. The probe names the mount in the worker

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -23,9 +23,10 @@ import { pathFromMount } from '../transfer/path-guard.js'
 import { faultFromError, statusForFaultCode, isAutoPauseStatus, STATUS_MOUNT_GONE } from './mount-fault.js'
 import { getContentBackend, hasContentBackend } from '../transfer/content-backends.js'
 import { getOverlay } from '../transfer/backends/overlay/overlay-instance.js'
-import { overlayHashFile, setOverlayCatalogChangeHook, overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
+import { overlayHashFile, setOverlayCatalogChangeHook } from '../transfer/backends/overlay/overlay-backend.js'
 import { runOverlayFetch } from '../transfer/backends/overlay/fetch-run.js'
 import { acquireFetchSlot, drainFetchSlots, FETCH_OWNER_MIRROR } from '../transfer/backends/overlay/fetch-slots.js'
+import { claimFetch, dropFetchClaim, fetchClaimedBy } from '../transfer/backends/overlay/fetch-claims.js'
 import { createPausedHolders } from '../transfer/backends/overlay/paused-holders.js'
 import { shareDecoKey } from '../transfer/decoration-key.js'
 import { transferIdFor } from '../transfer/transfer-id.js'
@@ -341,11 +342,13 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
     } catch (err) { log.debug('overlay hash skipped on disk:', err.message) }
   }
   if (!entry.contentHash) return 'missing'
-  // A manual download of the same file may already be in flight on the folder engine
-  // (mounted mid-download): fetching it here too would interleave two producers on one
-  // decoration key and duplicate the bytes — skip; the next tick lands it after the
-  // engine settles.
-  if (overlayHasTransfer(transferIdFor(mount.spaceId, mount.shareId, entry.relPath))) return 'missing'
+  // A manual download of the same file may already be in flight (mounted mid-download): fetching it
+  // here too would interleave two producers on one decoration key and duplicate the bytes. A cheap
+  // early-out so we do not queue for a slot to do it; the claim taken past the gate decides. Another
+  // OWNER only — our own overlapping pass (a tick racing an adopted initial scan) is serialised by
+  // activeOverlayFetches, and refusing it here would change what FIX-R09-2 pins.
+  const claimedBy = fetchClaimedBy(transferIdFor(mount.spaceId, mount.shareId, entry.relPath))
+  if (claimedBy && claimedBy !== FETCH_OWNER_MIRROR) return 'missing'
   const streamKey = loopKey(mount.spaceId, mount.shareId)
   const releaseSlot = await acquireMirrorSlot(streamKey)
   try {
@@ -393,12 +396,17 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   // bytes; ticker.pushTo diffs them.
   const total = entry.size || 0
   const decoKey = shareDecoKey(mount.shareId, entry.relPath)
+  // Taken past the gate, not before it: holding it while queued would make the engine attach to a
+  // fetch that has not started. Whoever holds it owns the decoration key until they release.
+  const transferId = transferIdFor(mount.spaceId, mount.shareId, entry.relPath)
+  const releaseClaim = claimFetch(transferId, FETCH_OWNER_MIRROR)
+  if (!releaseClaim) return 'missing'
   let res
   let attempted = false
   let diag = null
   // Everything from here is inside the try, so no throw between the claim and the fetch can leak it.
   try {
-    activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath })
+    activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath, transferId })
     pausedHolders.supersede(streamKey)
     // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.
     ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
@@ -424,14 +432,12 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
     return 'missing'
   } finally {
     activeOverlayFetches.delete(streamKey)
-    // Every settle (done/miss/error/pause) re-derives the row off the now-cleared fetch slot
-    // and terminally clears the row's decoration — unless a manual download of the same file
-    // started on the folder engine meanwhile (it now owns the decoration key; clearing it here
-    // would blank its live bar).
+    releaseClaim()
+    // Every settle (done/miss/error/pause) re-derives the row off the now-cleared fetch slot and
+    // terminally clears the row's decoration. No probe: the claim above means no other producer
+    // could have taken the key while we held it, so the decoration is ours to clear.
     ipcRef?.emit('event:share-files-updated', { spaceId: mount.spaceId, shareId: mount.shareId })
-    if (!overlayHasTransfer(transferIdFor(mount.spaceId, mount.shareId, entry.relPath))) {
-      ipcRef?.emit('event:decoration', { channel: 'transfer', spaceId: mount.spaceId, key: decoKey, done: true })
-    }
+    ipcRef?.emit('event:decoration', { channel: 'transfer', spaceId: mount.spaceId, key: decoKey, done: true })
   }
   // null = nothing fetched: a stall after a holder was asked is a give-up (WARN);
   // never reaching a holder is a benign retry-next-tick (debug).
@@ -644,6 +650,10 @@ function cancelInflightFetch(key, discardPartial) {
   if (inflight) {
     try { getOverlay()?.cancelFetch(inflight.contentHash, { discardPartial }) } catch {}
     activeOverlayFetches.delete(key)
+    // A cancelled pass may never settle at all — a wedged fetch is exactly what restartForeignLoop
+    // exists to recover — so the claim cannot wait for its finally, or the restart is refused by
+    // the dead claim of the pass it just gave up on.
+    dropFetchClaim(inflight.transferId)
     if (discardPartial) pausedHolders.supersede(key)
     else pausedHolders.remember(key, inflight.contentHash)
   } else if (discardPartial) {

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -25,10 +25,6 @@ import { registerPublishChannel, settleCatalog } from './publish-service.js'
 
 export { shouldIgnore, DEFAULT_IGNORE, mountRootAvailable }
 
-// Re-exported so the worker and the existing tests keep their `./owned-folders.js` import path;
-// the implementation lives in `owned-preview.js`.
-export { previewInitialPublishScan } from './owned-preview.js'
-
 const log = createLogger('owned-folders')
 
 let ipcRef = null

--- a/src/shared/shares/share-listing.js
+++ b/src/shared/shares/share-listing.js
@@ -17,7 +17,8 @@ import { getOwnedMount, getForeignMount } from '../folders/mount-store.js'
 import { listPendingForSpace } from '../transfer/pending-transfers.js'
 import { isOwnerOnline } from '../transfer/swarm.js'
 import { getLocalPublicKeyHex } from '../spaces/profile.js'
-import { foreignFetchActive, localRelOf } from '../folders/foreign-folders.js'
+import { foreignFetchActive } from '../folders/foreign-folders.js'
+import { localRelOf } from '../folders/mirror-state.js'
 import { overlayHasTransfer } from '../transfer/backends/overlay/overlay-backend.js'
 import {
   claimedPathFor,

--- a/src/shared/transfer/backends/overlay/fetch-claims.js
+++ b/src/shared/transfer/backends/overlay/fetch-claims.js
@@ -1,0 +1,62 @@
+// Who is fetching a given transferId right now, across every producer. The download engine's
+// registry answers only for its own instance, which is why the mirror had to probe it defensively
+// — and why the answer was wrong for the loose engine's rows anyway.
+//
+// An engine is registered as a PROBE rather than copied into a second map: its registry already has
+// exactly the lifetime of its fetch, and mirroring that into a claims map would mean clearing it at
+// each of start()'s bail sites. Only a producer with no registry of its own — the mirror — holds a
+// claim here, so there is one place that adds and one that removes — plus dropFetchClaim, for the
+// pass that is abandoned rather than finished.
+const held = new Map()
+const probes = new Map()
+
+export const FETCH_OWNER_MIRROR = 'mirror'
+
+export function registerFetchOwner(label, has) {
+  probes.set(label, has)
+}
+
+export function fetchClaimedBy(transferId) {
+  const claim = held.get(transferId)
+  if (claim) return claim.owner
+  for (const [label, has] of probes) {
+    if (has(transferId)) return label
+  }
+  return null
+}
+
+export const isFetchClaimed = (transferId) => fetchClaimedBy(transferId) !== null
+
+// Returns a release, or null when someone else already owns the file. The release is guarded on
+// the claim's own token rather than its owner label: a restart drops the claim of the pass it
+// abandons, and that pass may still run its finally afterwards — with a label guard it would then
+// free the claim the fresh pass had already taken.
+export function claimFetch(transferId, owner) {
+  const holder = fetchClaimedBy(transferId)
+  // Re-entrant for one owner. The question this registry answers is cross-producer — may the mirror
+  // fetch what an engine is already fetching — and a mirror's own overlapping passes (a poll tick
+  // and an adopted initial scan) are serialised by activeOverlayFetches, not by this. Refusing them
+  // here would change behaviour FIX-R09-2 pins, which is out of scope for the guard this replaces.
+  if (holder === owner) return () => {}
+  if (holder) return null
+  const token = {}
+  held.set(transferId, { owner, token })
+  return () => {
+    if (held.get(transferId)?.token === token) held.delete(transferId)
+  }
+}
+
+// A pass abandoned by a stop or a restart never reaches its finally, so whoever abandons it has to
+// drop the claim. Without this the restart that exists to un-wedge a mount is refused by the dead
+// claim of the very pass it gave up on, and that file is never fetched again this lifetime.
+export function dropFetchClaim(transferId) {
+  held.delete(transferId)
+}
+
+// Module state outlives the subsystem that fills it, so a leaked claim would block one transferId
+// for the life of the worker. Cleared with the rest of the overlay's per-lifetime state; the probes
+// go with it, since they close over engines this lifetime is about to drop.
+export function resetFetchClaims() {
+  held.clear()
+  probes.clear()
+}

--- a/src/shared/transfer/backends/overlay/fetch-slots.js
+++ b/src/shared/transfer/backends/overlay/fetch-slots.js
@@ -1,0 +1,30 @@
+// One gate for every overlay fetch in the process — both download engines and every mirror. The
+// limit bounds what an in-flight fetch owns (a chunk scheduler, a watchdog, an fd and a ticker),
+// and that cost is per fetch, not per producer. It used to live inside createOverlayDownloadEngine,
+// which is called once per channel, so the configured cap was silently doubled and the mirrors were
+// not counted against it at all.
+//
+// Named fetch-slots rather than admission: src/shared/transfer/ already has admission-gates.js and
+// deferred-admission.js, and both are about admitting PEERS.
+import { createSemaphore } from '../../../core/concurrency.js'
+import { getDownloadConcurrency } from '../../../core/runtime-config.js'
+
+// The mirror's waiter tag. ForeignMirrors closes before OverlayBackend, so its close must release
+// its own parked passes WITHOUT releasing the engines' backlog into a still-live overlay.
+export const FETCH_OWNER_MIRROR = 'mirror'
+
+// expressLanes: 2, not createSemaphore's default of 1. Two engines each carried one lane, so a
+// single shared gate would halve how many user-initiated fetches can jump a backlog.
+const build = () => createSemaphore({ limit: () => getDownloadConcurrency(), expressLanes: 2 })
+let gate = build()
+
+export const acquireFetchSlot = (opts) => gate.acquire(opts)
+export const drainFetchSlots = (owner) => gate.drain(owner)
+export const fetchSlotStats = () => gate.stats()
+
+// A per-instance semaphore died with the engine that owned it; a module singleton does not.
+// OverlayBackend builds fresh engines on every _open, so a slot whose release was lost would
+// shrink the cap for the life of the worker, across every later open.
+export function resetFetchSlots() {
+  gate = build()
+}

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -685,7 +685,15 @@ const folderSweeper = createPresenceSweeper({
   // it. Writing the tombstone here instead skipped all three.
   retire: ({ spaceId, shareId, retires }, entry) => {
     const settled = publishLane?.enqueueRetire(spaceId, shareId, entry.relPath)
-    if (settled) retires.push(settled.catch((err) => log.debug('folder retire failed:', entry.relPath, '-', err.message)))
+    // The lane's ticket RESOLVES with a settlement and never rejects — work-item.js's deferred has
+    // no reject path — so a .catch here could not fire, and a failed retire was dropped in silence.
+    // The loose twin may catch because settledWithTail rethrows for it; this one has to read the
+    // outcome. (A cancel is the user stopping it, not a failure.)
+    if (settled) {
+      retires.push(settled.then((s) => {
+        if (s?.outcome === 'failed') log.debug('folder retire failed:', entry.relPath, '-', s.error?.message || 'the publish runner refused it')
+      }))
+    }
   },
 })
 

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -21,6 +21,7 @@ import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js
 import { republishDecision } from '../../supersede-decision.js'
 import { makeKeyedCoalescer } from '../../../state/coalesce.js'
 import { acquireFetchSlot, drainFetchSlots, fetchSlotStats } from './fetch-slots.js'
+import { fetchClaimedBy } from './fetch-claims.js'
 import { ErrorCodes, classifyTransferError, isLocalDestFault } from '../../../core/errors.js'
 import { createLogger } from '../../../core/logger.js'
 
@@ -413,6 +414,23 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     pausedHashes.supersede(transferId) // a fresh start (resume) supersedes any paused marker
     const existing = registry.get(transferId)
     if (existing) return { transferId, finalPath: existing.finalPath }
+
+    // A producer with no registry of its own — the mirror — may already be fetching this content.
+    // Attach to it rather than starting a second fetch: both write the same decoration key, so the
+    // user sees the bar that is already moving. Refusing outright would leave a click with no
+    // feedback at all. The row is still recorded, so the next reconcile re-drives this destination
+    // once the claim frees (the mirror writes into the mount, not the download folder).
+    const holder = fetchClaimedBy(transferId)
+    if (holder) {
+      await recordPending(job.spaceId, job.pendingKey, {
+        total: job.size, inPlace: channel.inPlace, ownerKey: job.ownerPublicKey,
+        finalPath: job.finalPath, sourceSeq: job.sourceSeq, contentHash: job.contentHash,
+        bytesTransferred: job.prevBytes || 0, ...channel.pendingExtra(job),
+      })
+      log.debug('overlay download attached to an in-flight', holder, 'fetch:', job.relPath)
+      channel.emitUpdated(job.spaceId)
+      return { transferId, finalPath: job.finalPath }
+    }
 
     // Reserve the single-flight slot SYNCHRONOUSLY (before any await) so a duplicate
     // trigger can't start a second fetch that collides on the per-hash scheduler.

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -224,9 +224,9 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     pokeResume(job.ownerPublicKey, job.spaceId)
   }
 
-  // Give up on a retry without a fetch to settle it: the row must still land in a terminal
-  // paused state, or the transfer is left with no event at all — pre-fix, settleFailed always
-  // emitted one, and on the folder channel emitPaused IS the decoration terminator.
+  // Give up on a retry without a fetch to settle it: the row must still land in a terminal paused
+  // state, or the transfer is left with no event at all — emitPaused is what terminates the
+  // decoration, on either channel.
   function settleRetryAsPaused (job) {
     cancelStallRetry(job.transferId)
     channel.emitPaused?.(job, pauseReasonFor(job))
@@ -279,9 +279,9 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     if (!r.code) {
       diag.finish('no-holder')
       log.debug('overlay fetch interrupted — holder gone or throttled:', job.relPath, 'at', job.prevBytes || 0, 'bytes')
-      // `retrying` withholds the OS notification only — the paused emit still fires, because on
-      // the folder channel it is nothing BUT the terminal decoration frame, and withholding it
-      // strands a progress bar that then samples across the whole backoff.
+      // `retrying` withholds the OS notification only — the paused emit still fires, because it
+      // also terminates the decoration, and withholding it strands a progress bar that then
+      // samples speed across the whole backoff.
       const retrying = await scheduleStallRetry(job)
       channel.emitPaused?.(job, pauseReasonFor(job), { retrying })
       channel.emitUpdated(job.spaceId)
@@ -297,8 +297,6 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     failTerminal(job, code)
   }
 
-  // Resolve a finished fetch. Reads the LIVE slot, because a pause/cancel/supersede/republish
-  // may have landed while the bytes were in flight — the fetch's own result is only half the
   // The gated half of a download: everything past this point owns a chunk scheduler, a watchdog,
   // an fd and a ticker, which is what the admission limit exists to bound. start() has already
   // reserved the registry slot synchronously, so a queued job still reads as active and a second
@@ -337,7 +335,9 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     }
   }
 
-  // story, and which of these applies decides whether the slot is restarted or released.
+  // Resolve a finished fetch. Reads the LIVE slot, because a pause/cancel/supersede/republish may
+  // have landed while the bytes were in flight — the fetch's own result is only half the story, and
+  // which of these applies decides whether the slot is restarted or released.
   async function settleFetch (transferId, job, r, diag) {
     const s = registry.get(transferId)
     const wasPaused = s?.paused

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -20,8 +20,7 @@ import { recordTransferOutcome } from '../../transfer-audit.js'
 import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js'
 import { republishDecision } from '../../supersede-decision.js'
 import { makeKeyedCoalescer } from '../../../state/coalesce.js'
-import { createSemaphore } from '../../../core/concurrency.js'
-import { getDownloadConcurrency } from '../../../core/runtime-config.js'
+import { acquireFetchSlot, drainFetchSlots, fetchSlotStats } from './fetch-slots.js'
 import { ErrorCodes, classifyTransferError, isLocalDestFault } from '../../../core/errors.js'
 import { createLogger } from '../../../core/logger.js'
 
@@ -147,10 +146,6 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   // attempts that banked no new bytes, so a throttled holder (which always banks some) retries
   // indefinitely while a wedged one gives up.
   const stallRetries = new Map()
-  // Bounds how many fetches own a chunk scheduler, a watchdog, an fd and a ticker at once.
-  // A user-initiated job takes the express lane so a click never queues behind a reconnect backlog.
-  const admission = createSemaphore({ limit: () => getDownloadConcurrency() })
-
   const pauseReasonFor = (job) => reasonForOwnerOnline(ownerOnline(job.ownerPublicKey))
 
   function has (transferId) { return registry.has(transferId) }
@@ -298,11 +293,12 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   }
 
   // The gated half of a download: everything past this point owns a chunk scheduler, a watchdog,
-  // an fd and a ticker, which is what the admission limit exists to bound. start() has already
-  // reserved the registry slot synchronously, so a queued job still reads as active and a second
-  // trigger cannot start a duplicate fetch while this waits.
+  // an fd and a ticker, which is what the limit exists to bound — and that cost is per fetch, not
+  // per producer, which is why the gate is process-wide (fetch-slots.js) rather than built here.
+  // start() has already reserved the registry slot synchronously, so a queued job still reads as
+  // active and a second trigger cannot start a duplicate fetch while this waits.
   async function runFetchTask (slot, job, transferId) {
-    const releaseSlot = await admission.acquire({ express: !!job.express })
+    const releaseSlot = await acquireFetchSlot({ express: !!job.express })
     try {
       // The wait above is unbounded, so re-check every reason to abandon that the pre-fetch path
       // already checked — the same window recordPending guards against, only wider.
@@ -734,5 +730,5 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     if (pending) channel.emitRemovedByOwner?.(spaceId, pendingKey, pending, transferId)
   }
 
-  return { start, pause, clearPauseMarker, cancel, cancelByKey, resumeForOwner, reconcileOnAppend, dropRemoved, supersede, releaseForRepublish, has, activeSlots: () => registry.entries(), drainAdmission: () => admission.drain(), admissionStats: () => admission.stats(), _registry: registry, _stallRetries: stallRetries }
+  return { start, pause, clearPauseMarker, cancel, cancelByKey, resumeForOwner, reconcileOnAppend, dropRemoved, supersede, releaseForRepublish, has, activeSlots: () => registry.entries(), drainAdmission: () => drainFetchSlots(), admissionStats: fetchSlotStats, _registry: registry, _stallRetries: stallRetries }
 }

--- a/src/shared/transfer/backends/overlay/overlay-runtime.js
+++ b/src/shared/transfer/backends/overlay/overlay-runtime.js
@@ -7,6 +7,7 @@
 import { Subsystem } from '../../../core/subsystem.js'
 import { isOverlayEnabled, isInPlaceFilesEnabled } from '../../../core/runtime-config.js'
 import { createOverlayDownloadEngine } from './overlay-download.js'
+import { resetFetchSlots, drainFetchSlots } from './fetch-slots.js'
 import { drainTransferAudit } from '../../transfer-audit.js'
 import { initOverlay, teardownOverlay, attachOverlay, revokeServesForSpace, bumpServeEpoch } from './overlay-instance.js'
 import { serveIndex } from './overlay-serve-index.js'
@@ -45,6 +46,9 @@ export class OverlayBackend extends Subsystem {
     // (every entry point checks getOverlay()), and on the kill-switch build the alternative is an
     // engine() that throws out of files:list, space:leave and the transfer handlers.
     initLooseOverlay(this.deps.ipc)
+    // The gate is a module singleton, so unlike the engines it does not die with the previous
+    // lifetime: a slot whose release was lost would shrink the cap for every later open.
+    resetFetchSlots()
     this.folderEngine = createOverlayDownloadEngine(folderChannel)
     this.looseEngine = createOverlayDownloadEngine(looseChannel)
     setFolderEngine(this.folderEngine)
@@ -69,10 +73,10 @@ export class OverlayBackend extends Subsystem {
   async _close() {
     for (const timer of this.resumePending.values()) this.timers.clear(timer)
     this.resumePending.clear()
-    // Before the teardown: a download parked on the admission gate would otherwise hold its
-    // task past the stop deadline waiting for a slot nobody will release.
-    this.folderEngine?.drainAdmission()
-    this.looseEngine?.drainAdmission()
+    // Before the teardown: a download parked on the fetch gate would otherwise hold its task past
+    // the stop deadline waiting for a slot nobody will release. Unscoped — every producer is done
+    // by now, ForeignMirrors having already released its own waiters when it closed ahead of us.
+    drainFetchSlots()
     await teardownOverlay()
     // After the teardown, which settles the in-flight fetches that produce these rows, and before
     // the durable tier closes the audit bee: boot.js starts the audit log in `durable` and this

--- a/src/shared/transfer/backends/overlay/overlay-runtime.js
+++ b/src/shared/transfer/backends/overlay/overlay-runtime.js
@@ -8,6 +8,7 @@ import { Subsystem } from '../../../core/subsystem.js'
 import { isOverlayEnabled, isInPlaceFilesEnabled } from '../../../core/runtime-config.js'
 import { createOverlayDownloadEngine } from './overlay-download.js'
 import { resetFetchSlots, drainFetchSlots } from './fetch-slots.js'
+import { registerFetchOwner, resetFetchClaims } from './fetch-claims.js'
 import { drainTransferAudit } from '../../transfer-audit.js'
 import { initOverlay, teardownOverlay, attachOverlay, revokeServesForSpace, bumpServeEpoch } from './overlay-instance.js'
 import { serveIndex } from './overlay-serve-index.js'
@@ -53,6 +54,12 @@ export class OverlayBackend extends Subsystem {
     this.looseEngine = createOverlayDownloadEngine(looseChannel)
     setFolderEngine(this.folderEngine)
     setLooseEngine(this.looseEngine)
+    // Registered as probes, not copied: each engine's registry already has exactly the lifetime of
+    // its fetch. This is what lets the mirror ask "is ANYONE fetching this" instead of asking the
+    // folder engine alone, which is the wrong question for a loose row.
+    resetFetchClaims()
+    registerFetchOwner('folder', (transferId) => this.folderEngine.has(transferId))
+    registerFetchOwner('loose', (transferId) => this.looseEngine.has(transferId))
     if (isInPlaceFilesEnabled()) {
       rehydrateLooseFiles().catch((err) => this.log.debug('loose rehydrate failed:', err.message))
     }
@@ -85,6 +92,8 @@ export class OverlayBackend extends Subsystem {
     this.overlay = null
     setFolderEngine(null)
     setLooseEngine(null)
+    // Before the engines are dropped: the probes close over them.
+    resetFetchClaims()
     this.folderEngine = null
     this.looseEngine = null
     serveIndex.reset()

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -166,7 +166,6 @@ import { validateMountPath, validateDownloadFolderAgainstMounts } from '../share
 import {
   handleFsEventFromMain,
   initialPublishScan,
-  previewInitialPublishScan,
   stopOwnedFolder,
   DEFAULT_IGNORE,
   mountRootAvailable,
@@ -175,9 +174,10 @@ import {
 } from '../shared/folders/owned-folders.js'
 
 import { exceedsShareFileLimit, shareFileLimitMessage } from '../shared/folders/share-limits.js'
+import { previewInitialPublishScan } from '../shared/folders/owned-preview.js'
+import { previewMaterializeScan } from '../shared/folders/foreign-preview.js'
 import {
   initialMaterializeScan,
-  previewMaterializeScan,
   startForeignLoop,
   setForeignEnabled,
   unmountForeignFolder,

--- a/test/frontend/README.md
+++ b/test/frontend/README.md
@@ -86,6 +86,7 @@ These drive the real *filesystem → chokidar → publish → replicate → mate
 | s30 | `s30-delete-file-in-subfolder.mjs` | Owner deletes a nested file → only it leaves the mirror; its sibling is untouched. |
 | s31 | `s31-edit-and-readonly-revert.mjs` | Owner edit updates content on the mirror; **a local edit of a read-only mirror file is reverted** to the owner's version on the next sync. |
 | s32 | `s32-mirror-keeps-unrelated-file.mjs` | Mirroring into a folder that already holds the user's own file → it survives the initial scan **and** a later owner deletion (only synced files are removable). |
+| s130 | `s130-mirror-name-collision.mjs` | **FIX-MIRROR-RENAME (UI):** mirroring onto a folder holding a file at the *same* leaf name → the owner's copy lands at a sibling, and the folder still counts BOTH files as on-device. The row is asserted through the badge's accessible name, not a whole-window word match. |
 | s33 | `s33-copy-file.mjs` | Owner duplicates a file (same content, new path) → both copies publish and materialize. |
 | s34 | `s34-nested-initial-share.mjs` | Initial share of a realistic nested tree (files across several subfolders) → the whole tree replicates and materializes at the right depths. |
 | s35 | `s35-live-folder-refresh.mjs` | Peer has the FolderView open → an owner add/remove appears/disappears live, without re-navigating. |

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -127,6 +127,7 @@ import s126 from './scenarios/s126-activity-log-granted-actor.mjs'
 import s127 from './scenarios/s127-folder-fault-strip.mjs'
 import s128 from './scenarios/s128-localized-errors.mjs'
 import s129 from './scenarios/s129-mirror-modal-folder-info.mjs'
+import s130 from './scenarios/s130-mirror-name-collision.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -193,7 +194,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s130-mirror-name-collision.mjs
+++ b/test/frontend/scenarios/s130-mirror-name-collision.mjs
@@ -1,0 +1,66 @@
+import { mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { workDir } from '../paths.mjs'
+
+// The UI half of FIX-MIRROR-RENAME. Bob already has a file at the name the share uses, so the
+// mirror materializes the owner's copy under a sibling and leaves Bob's alone — and the folder view
+// must still report that row as on-device. share-listing derived the local path from the owner key
+// alone, so it stat'd a path the mirror never wrote: the header undercounted by one and the row
+// wore "Available" for a file already on disk.
+export default async function s130 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Vault')
+  const mirrorDir = workDir('mirror-')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'report.pdf'), 'ALICE OWNS THIS ONE')
+  writeFileSync(path.join(ownDir, 'plain.txt'), 'no collision here')
+  // The collision: Bob's own file at the same leaf name, with DIFFERENT bytes and length. The
+  // length matters — share-listing's synced test is statSizeOrNull(abs) === entry.size, so an
+  // equal-length decoy would make the pre-fix path accidentally correct.
+  writeFileSync(path.join(mirrorDir, 'report.pdf'), "BOB'S OWN FILE, a different length entirely")
+
+  try {
+    await r.ok('B mirrors into a folder that already holds a file at the share name', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      await A.addOwnedFolder(ownDir)
+      await B.waitText('Vault', 60000)
+      await B.mirrorShare(mirrorDir)
+      await waitFor(() => existsSync(path.join(mirrorDir, 'plain.txt')), 60000, 'the uncontested file materialized')
+    })
+
+    await r.ok("the owner's copy lands beside Bob's file, not over it", async () => {
+      const sibling = () => readdirSync(mirrorDir).find((f) => f !== 'report.pdf' && f.startsWith('report') && f.endsWith('.pdf'))
+      await waitFor(() => !!sibling(), 60000, 'a sibling was minted for the colliding name')
+      assert(readFileSync(path.join(mirrorDir, sibling()), 'utf8') === 'ALICE OWNS THIS ONE', "the sibling holds Alice's bytes")
+      assert(readFileSync(path.join(mirrorDir, 'report.pdf'), 'utf8').startsWith("BOB'S OWN FILE"), "Bob's file is untouched")
+    })
+
+    // The regression at the folder level. FolderStatsCard composes fileCount + ' · ' +
+    // onDeviceCount into ONE <p> and mirrorSync counts 'synced' rows, so before the fix a
+    // fully-materialized two-file mirror reported one.
+    await r.ok('the folder reports BOTH files as on the device', async () => {
+      await B.openFolder('Vault')
+      await B.waitText('2 on your device', 60000)
+      await B.shot('s130-B-collision-both-on-device', runDir)
+    })
+
+    // The same bug at the row level. Asserted through the badge's accessible name rather than the
+    // visible word: hasText is a case-folded whole-window substring, so a bare "Available" also
+    // matches status.unavailable ("Not available") and folder.unavailable ("Folder unavailable").
+    // The named form is exact and scoped to one row, and it names the OWNER's relPath — the row
+    // the bug mis-rendered.
+    await r.ok('the renamed row is badged as on-device, not merely available', async () => {
+      await B.waitText('report.pdf: On your device', 30000)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/integration/download-admission.test.js
+++ b/test/integration/download-admission.test.js
@@ -6,6 +6,7 @@ import { initPendingTransfers, recordPending } from '../../src/shared/transfer/p
 import { initDownloads } from '../../src/shared/transfer/files.js'
 import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { resetFetchSlots, drainFetchSlots, fetchSlotStats, FETCH_OWNER_MIRROR, acquireFetchSlot } from '../../src/shared/transfer/backends/overlay/fetch-slots.js'
 
 const SPACE = 'space1'
 const OWNER = 'ownerpub'
@@ -32,7 +33,10 @@ async function setup (t, concurrency) {
   await initOverlay()
   const prev = getRuntimeConfig()
   setRuntimeConfig({ ...prev, downloadConcurrency: concurrency })
-  t.teardown(async () => { setRuntimeConfig(prev); await teardownOverlay() })
+  // The gate is process-wide now, so each case has to start from an empty one — the per-engine
+  // semaphore it replaced died with the engine the previous test built.
+  resetFetchSlots()
+  t.teardown(async () => { setRuntimeConfig(prev); resetFetchSlots(); await teardownOverlay() })
   return ctx
 }
 
@@ -210,4 +214,62 @@ test('draining the gate at shutdown does not start a fetch into a torn-down over
 
   t.is(fetches.started.length, 1, 'the parked job abandoned instead of fetching')
   t.is(engine.admissionStats().queued, 0, 'and nothing is left holding close() open')
+})
+
+// The cap used to be built inside createOverlayDownloadEngine, so the two engines the overlay
+// backend constructs each got their own — a configured 3 was really 6, and no test could see it
+// because every case built one engine.
+test('the cap counts fetches across producers, not per engine', async (t) => {
+  const ctx = await setup(t, 2)
+  const folder = createOverlayDownloadEngine(testChannel())
+  const loose = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  await folder.start(makeJob(ctx, 1))
+  await loose.start(makeJob(ctx, 2))
+  t.ok(await until(() => fetches.started.length === 2), 'both engines got a slot')
+
+  await loose.start(makeJob(ctx, 3))
+  t.ok(await until(() => fetchSlotStats().queued === 1), 'the third is parked on the shared gate')
+  await settle()
+  t.is(fetches.peak, 2, 'two fetches at once across BOTH engines, not two each')
+
+  for (let i = 0; i < 20 && fetches.started.length < 3; i++) { fetches.releaseAll(); await settle() }
+  // A lower bound, not an equality: releasing a barrier settles the fetch, and a settle may re-drive
+  // its own job (a stall retry), which adds a SEQUENTIAL fetch. The invariant this test exists for
+  // is the peak — with a gate per engine it would be 4.
+  t.ok(fetches.started.length >= 3, 'the parked job ran once a slot freed')
+  t.is(fetches.peak, 2, 'and the peak never rose')
+  fetches.releaseAll()
+  await settle()
+})
+
+// Hazard 1, both halves. ForeignMirrors closes BEFORE OverlayBackend (boot.js starts the overlay
+// first), so a mirror parked on the shared gate has to be released by its own close — but an
+// unscoped drain would release the engines' backlog into an overlay that is still live, and those
+// tasks pass their own hasOverlay() guard and start real fetches during shutdown.
+test('draining the mirror at close does not release the engines into a live overlay', async (t) => {
+  const ctx = await setup(t, 1)
+  const engine = createOverlayDownloadEngine(testChannel())
+  const fetches = barrierFetch()
+
+  await engine.start(makeJob(ctx, 1))
+  t.ok(await until(() => fetches.started.length === 1), 'the first holds the only slot')
+  await engine.start(makeJob(ctx, 2))
+  let mirrorResumed = false
+  acquireFetchSlot({ owner: FETCH_OWNER_MIRROR }).then(() => { mirrorResumed = true })
+  t.ok(await until(() => fetchSlotStats().queued === 2), 'an engine job and a mirror pass are parked')
+
+  drainFetchSlots(FETCH_OWNER_MIRROR)
+  await sleep(300)
+
+  t.ok(mirrorResumed, 'the mirror was released so its close is not held to the settle timeout')
+  t.is(fetches.started.length, 1, 'the engine job did NOT start a fetch during shutdown')
+  // Not an exact count: the gate is process-wide, so engines built by earlier cases in this file
+  // can still put a job on it. The claim is that the engine's waiter was not released, which is
+  // what the assertion above measures and this one confirms it is still queued rather than dropped.
+  t.ok(fetchSlotStats().queued >= 1, 'it is still parked, for OverlayBackend._close to drain')
+
+  fetches.releaseAll()
+  await settle()
 })

--- a/test/integration/foreign-del-guard.test.js
+++ b/test/integration/foreign-del-guard.test.js
@@ -1,7 +1,8 @@
 import test from 'brittle'
 import fs from 'bare-fs'
 import path from 'bare-path'
-import { shouldHonorDeletions, initialMaterializeScan } from '../../src/shared/folders/foreign-folders.js'
+import { shouldHonorDeletions } from '../../src/shared/folders/path-keys.js'
+import { initialMaterializeScan } from '../../src/shared/folders/foreign-folders.js'
 import { getForeignMount } from '../../src/shared/folders/mount-store.js'
 import { setupSelfMirror } from '../helpers/owned.js'
 

--- a/test/integration/mirror-download-interleave.test.js
+++ b/test/integration/mirror-download-interleave.test.js
@@ -1,0 +1,216 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { setupSelfMirror } from '../helpers/owned.js'
+import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { createOverlayDownloadEngine } from '../../src/shared/transfer/backends/overlay/overlay-download.js'
+import {
+  materializeCatalogFile, runMaterializeTick, startForeignLoop, stopForeignLoop, restartForeignLoop, mirrorHealth,
+} from '../../src/shared/folders/foreign-folders.js'
+import {
+  claimFetch, fetchClaimedBy, registerFetchOwner, resetFetchClaims, FETCH_OWNER_MIRROR,
+} from '../../src/shared/transfer/backends/overlay/fetch-claims.js'
+import { resetFetchSlots, fetchSlotStats, acquireFetchSlot } from '../../src/shared/transfer/backends/overlay/fetch-slots.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { transferIdFor } from '../../src/shared/transfer/transfer-id.js'
+import { initPendingTransfers, listPendingForSpace } from '../../src/shared/transfer/pending-transfers.js'
+
+// REGRESSION: the mirror and the folder engine could both fetch one file and both write its
+// decoration key, so the mirror probed the FOLDER engine's registry defensively before every fetch
+// and again on every settle. That probe answered for one engine instance out of two and knew
+// nothing of a second mirror, which is why the two guards became one shared claim.
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+async function until (fn, ms = 10000) {
+  const deadline = Date.now() + ms
+  while (Date.now() < deadline) {
+    if (await fn()) return true
+    await sleep(10)
+  }
+  return false
+}
+
+async function mirrorCtx (t, opts = {}) {
+  const ctx = await setupSelfMirror(t, opts)
+  await initPendingTransfers()
+  const prev = getRuntimeConfig()
+  resetFetchSlots()
+  resetFetchClaims()
+  t.teardown(() => { setRuntimeConfig(prev); resetFetchSlots(); resetFetchClaims() })
+  return ctx
+}
+
+async function firstEntry (ctx) {
+  const { entries } = await (await import('../../src/shared/transfer/content-backends.js'))
+    .getContentBackend(ctx.share).listPeerWithMeta(ctx.spaceId, ctx.share)
+  return entries[0]
+}
+
+function testChannel (over = {}) {
+  return {
+    diagLabel: 'test download',
+    inPlace: false,
+    ownsPendingRow: (row) => row.overlayShare === true,
+    pendingExtra: (job) => ({ overlayShare: true, shareId: job.shareId, relPath: job.relPath }),
+    emitProgress: () => {}, emitError: () => {}, emitComplete: () => {}, emitCancelled: () => {},
+    emitSuperseded: () => {}, emitPaused: () => {}, emitUpdated: () => {}, emitDecorationDone: () => {},
+    transferIdForRow: (spaceId, row) => spaceId + '|' + row.shareId + '|' + row.relPath,
+    isOwnerOnline: () => true,
+    ...over,
+  }
+}
+
+test('a manual download and the mirror never both fetch one file', async (t) => {
+  const ctx = await mirrorCtx(t)
+  const entry = await firstEntry(ctx)
+  const transferId = transferIdFor(ctx.spaceId, ctx.share.id, entry.relPath)
+
+  // The engine got there first (the live direction: browse, download, then mirror the share).
+  const live = new Set([transferId])
+  registerFetchOwner('folder', (id) => live.has(id))
+
+  let fetched = 0
+  const overlay = getOverlay()
+  const realFetch = overlay.fetchFile
+  overlay.fetchFile = async (...args) => { fetched += 1; return await realFetch(...args) }
+  t.teardown(() => { overlay.fetchFile = realFetch })
+
+  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entry), 'missing', 'the mirror yields')
+  t.is(fetched, 0, 'and never reached the vendor layer')
+  t.absent(fs.existsSync(path.join(ctx.mirrorPath, entry.relPath)), 'no duplicate bytes landed')
+
+  live.delete(transferId)
+  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entry), 'present', 'the next tick lands it once the engine settles')
+  t.is(fetched, 1, 'exactly one fetch across both producers')
+})
+
+test('a start() against a held claim records the pending row and returns the live transfer', async (t) => {
+  const ctx = await mirrorCtx(t)
+  const entry = await firstEntry(ctx)
+  const transferId = transferIdFor(ctx.spaceId, ctx.share.id, entry.relPath)
+  claimFetch(transferId, FETCH_OWNER_MIRROR)
+
+  let started = 0
+  const overlay = getOverlay()
+  const realFetch = overlay.fetchFile
+  overlay.fetchFile = async (...args) => { started += 1; return await realFetch(...args) }
+  t.teardown(() => { overlay.fetchFile = realFetch })
+
+  const engine = createOverlayDownloadEngine(testChannel())
+  const finalPath = path.join(ctx.tmpDir('dl'), 'copy.bin')
+  const res = await engine.start({
+    spaceId: ctx.spaceId, pendingKey: '/dl/copy.bin', path: '/dl/copy.bin', relPath: entry.relPath,
+    shareId: ctx.share.id, transferId, contentHash: entry.contentHash, size: entry.size,
+    ownerPublicKey: ctx.share.owner, verifyKey: ctx.share.id + '|' + entry.relPath, finalPath,
+  })
+
+  // Refusing outright would leave the click with no transferId to follow and no bar — the failure
+  // this attach path exists to avoid.
+  t.is(res.transferId, transferId, 'the caller gets a transfer to follow')
+  t.is(started, 0, 'no second fetch was started')
+  t.absent(engine.has(transferId), 'and the engine did not reserve a registry slot')
+
+  const pending = await listPendingForSpace(ctx.spaceId)
+  t.ok(pending.some((row) => row.filePath === '/dl/copy.bin'), 'the intent is durable, so a later reconcile re-drives this destination')
+})
+
+// The deliberate third call site. share-listing asks "is the FOLDER engine fetching this" for a
+// browse row, which is a different question from "is anyone fetching this" — and a browse listing
+// has no mirror by construction. Pinned so a later sweep does not finish the job.
+test('a browse listing still reads isActive from the folder engine', (t) => {
+  const src = fs.readFileSync(new URL('../../src/shared/shares/share-listing.js', import.meta.url).pathname, 'utf8')
+  t.ok(/isActive: deps\.overlayHasTransfer\(transferId\)/.test(src), 'the browse row still probes the engine directly')
+  t.absent(/fetch-claims/.test(src), 'and does not ask the claim registry')
+})
+
+test('the mirror releases its claim and its slot on every exit path', async (t) => {
+  const ctx = await mirrorCtx(t, { files: { 'a.txt': 'aaa', 'b.txt': 'bbbb' } })
+  const entries = []
+  const backend = await import('../../src/shared/transfer/content-backends.js')
+  const listed = await backend.getContentBackend(ctx.share).listPeerWithMeta(ctx.spaceId, ctx.share)
+  entries.push(...listed.entries)
+
+  const overlay = getOverlay()
+  const realFetch = overlay.fetchFile
+
+  // done
+  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entries[0]), 'present')
+  t.is(fetchSlotStats().held, 0, 'slot released after a completed fetch')
+  t.is(fetchClaimedBy(transferIdFor(ctx.spaceId, ctx.share.id, entries[0].relPath)), null, 'claim released')
+
+  // miss (fetchFile resolves null)
+  overlay.fetchFile = async () => null
+  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entries[1]), 'missing')
+  t.is(fetchSlotStats().held, 0, 'slot released after a miss')
+  t.is(fetchClaimedBy(transferIdFor(ctx.spaceId, ctx.share.id, entries[1].relPath)), null, 'claim released after a miss')
+
+  // error
+  overlay.fetchFile = async () => { throw new Error('boom') }
+  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entries[1]), 'missing')
+  t.is(fetchSlotStats().held, 0, 'slot released after a throw')
+  t.is(fetchClaimedBy(transferIdFor(ctx.spaceId, ctx.share.id, entries[1].relPath)), null, 'claim released after a throw')
+
+  overlay.fetchFile = realFetch
+})
+
+// Hazard 3. A pass parked on the gate is 'in flight' as far as pass-liveness is concerned, and the
+// wait is unbounded — so stamping progress either side of it is not enough on its own. The
+// heartbeat is what keeps mirrorVerdict measuring the fetch instead of the queue.
+test('waiting for a slot counts as mirror progress', async (t) => {
+  const ctx = await mirrorCtx(t)
+  const prev = getRuntimeConfig()
+  // A 60 ms poll makes the stall window 60 x STALL_FACTOR (20) = 1.2 s of real time.
+  setRuntimeConfig({ ...prev, downloadConcurrency: 1, foreignPollIntervalMs: 60 })
+
+  const hog = await acquireFetchSlot({})
+  await startForeignLoop(ctx.mount)
+  t.teardown(() => stopForeignLoop(ctx.spaceId, ctx.share.id))
+
+  runMaterializeTick(ctx.spaceId, ctx.share.id).catch(() => {})
+  t.ok(await until(() => fetchSlotStats().queued === 1), 'the pass is parked behind the hogged slot')
+
+  // Past the window: without the heartbeat this reports stalled and the Supervisor restarts it.
+  await sleep(1500)
+  const [health] = mirrorHealth()
+  t.ok(health, 'the mirror is supervised')
+  t.ok(health.ok, 'a queued mirror is not a wedged one: ' + (health.detail || ''))
+
+  hog()
+  await settleTick()
+  async function settleTick () { await until(() => fetchSlotStats().queued === 0) }
+})
+
+// REGRESSION: the claim is released from the fetch's finally, which a WEDGED pass never reaches.
+// restartForeignLoop exists to recover exactly that mount, and it was refused by the dead claim of
+// the pass it had just abandoned — so the file was never fetched again this lifetime.
+test('a restart drops the abandoned pass claim so the mount can be recovered', async (t) => {
+  const ctx = await mirrorCtx(t)
+  const entry = await firstEntry(ctx)
+  const transferId = transferIdFor(ctx.spaceId, ctx.share.id, entry.relPath)
+
+  const overlay = getOverlay()
+  const realFetch = overlay.fetchFile
+  const realCancel = overlay.cancelFetch
+  let fetches = 0
+  // A fetch that never settles on its own, exactly like test/helpers/wedged-mirror.js: the test
+  // holds the rejecters and settles them in teardown, or stopForeignLoop awaits a dead promise.
+  const rejecters = []
+  overlay.fetchFile = () => { fetches += 1; return new Promise((_res, rej) => rejecters.push(rej)) }
+  overlay.cancelFetch = () => true
+  t.teardown(async () => {
+    for (const rej of rejecters.splice(0)) rej(Object.assign(new Error('cancelled'), { code: 'ECANCELLED' }))
+    await sleep(50)
+    overlay.fetchFile = realFetch
+    overlay.cancelFetch = realCancel
+  })
+
+  await startForeignLoop(ctx.mount)
+  t.teardown(() => stopForeignLoop(ctx.spaceId, ctx.share.id, { discardPartial: true }))
+  runMaterializeTick(ctx.spaceId, ctx.share.id).catch(() => {})
+  t.ok(await until(() => fetches === 1), 'the first pass wedged inside the fetch')
+  t.is(fetchClaimedBy(transferId), FETCH_OWNER_MIRROR, 'holding the claim')
+
+  await restartForeignLoop(ctx.spaceId, ctx.share.id)
+  t.ok(await until(() => fetches === 2), 'the restarted pass fetched instead of yielding to the zombie')
+})

--- a/test/integration/preview-scan.test.js
+++ b/test/integration/preview-scan.test.js
@@ -2,8 +2,9 @@ import test from 'brittle'
 import fs from 'bare-fs'
 import path from 'bare-path'
 import { setupOwnedShare, setupSelfMirror } from '../helpers/owned.js'
-import { initialPublishScan, previewInitialPublishScan } from '../../src/shared/folders/owned-folders.js'
-import { previewMaterializeScan } from '../../src/shared/folders/foreign-folders.js'
+import { initialPublishScan } from '../../src/shared/folders/owned-folders.js'
+import { previewInitialPublishScan } from '../../src/shared/folders/owned-preview.js'
+import { previewMaterializeScan } from '../../src/shared/folders/foreign-preview.js'
 import { overlayHashFile } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
 
 // The scan-preview dialogs are the user's last confirmation before bytes move.

--- a/test/integration/share-file-limit.test.js
+++ b/test/integration/share-file-limit.test.js
@@ -3,8 +3,9 @@ import fs from 'bare-fs'
 import path from 'bare-path'
 import { setupOwnedShare } from '../helpers/owned.js'
 import {
-  initialPublishScan, previewInitialPublishScan, periodicReconcile, onFsEvent, countFolderFiles,
+  initialPublishScan, periodicReconcile, onFsEvent, countFolderFiles,
 } from '../../src/shared/folders/owned-folders.js'
+import { previewInitialPublishScan } from '../../src/shared/folders/owned-preview.js'
 import { collectOwnShare } from '../../src/shared/shares/share-catalog.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 

--- a/test/unit/config-store.test.js
+++ b/test/unit/config-store.test.js
@@ -152,6 +152,31 @@ test('network defaults to unlimited and self-heals onto a config written before 
   t.is(reopened.get('appearance.theme'), 'dark', 'existing values preserved')
 })
 
+// The operator lever for the shared overlay fetch gate. It has no setter and no renderer surface,
+// so the only things that can break it are a missing default and a load that drops a hand-set
+// value — both of which this pins.
+test('the download concurrency default is carried, self-heals and survives a rewrite', (t) => {
+  const dir = tmpDir()
+  t.is(new ConfigStore(dir).load().get('network.downloadConcurrency'), 3, 'fresh config gets the default')
+
+  writeJson(path.join(dir, 'config.json'), { version: CONFIG_VERSION, network: { downloadKBps: 500 } })
+  const healed = new ConfigStore(dir).load()
+  t.is(healed.get('network.downloadConcurrency'), 3, 'a config written before the key existed gains it')
+  t.is(healed.get('network.downloadKBps'), 500, 'and keeps what that build did set')
+
+  // _migrate re-derives only the relay fields; a hand-set cap must not be reset on the next load,
+  // and the rollback value (0 = unlimited) must survive exactly, not be coerced to the default.
+  const store = new ConfigStore(dir).load()
+  store.set('network.downloadConcurrency', 0)
+  store.flush()
+  t.is(new ConfigStore(dir).load().get('network.downloadConcurrency'), 0, 'a hand-set 0 survives reload')
+})
+
+test('the download concurrency stays out of the renderer snapshot', (t) => {
+  const snap = new ConfigStore(tmpDir()).load().rendererSnapshot()
+  t.absent('downloadConcurrency' in snap.network, 'no UI by design — exposing it would need an "Unlimited" label for 0')
+})
+
 test('setBandwidth stores non-negative integers and ignores anything else', (t) => {
   const dir = tmpDir()
   const store = new ConfigStore(dir).load()
@@ -180,8 +205,9 @@ test('network survives a persist/reload round-trip', (t) => {
   const store = new ConfigStore(dir).load()
   store.setBandwidth({ downloadKBps: 2048, uploadKBps: 256 })
   store.flush()
-  // Bandwidth and relay share the `network` group, so the persisted block carries both.
-  t.alike(readConfig(dir).network, { downloadKBps: 2048, uploadKBps: 256, relayMode: 'off', relays: [] })
+  // Bandwidth, relay and the fetch-gate cap share the `network` group, so the persisted block
+  // carries all three.
+  t.alike(readConfig(dir).network, { downloadKBps: 2048, uploadKBps: 256, relayMode: 'off', relays: [], downloadConcurrency: 3 })
   const reopened = new ConfigStore(dir).load()
   t.is(reopened.get('network.downloadKBps'), 2048)
   t.is(reopened.get('network.uploadKBps'), 256)

--- a/test/unit/config-store.test.js
+++ b/test/unit/config-store.test.js
@@ -157,11 +157,11 @@ test('network defaults to unlimited and self-heals onto a config written before 
 // value — both of which this pins.
 test('the download concurrency default is carried, self-heals and survives a rewrite', (t) => {
   const dir = tmpDir()
-  t.is(new ConfigStore(dir).load().get('network.downloadConcurrency'), 3, 'fresh config gets the default')
+  t.is(new ConfigStore(dir).load().get('network.downloadConcurrency'), 6, 'fresh config gets the default')
 
   writeJson(path.join(dir, 'config.json'), { version: CONFIG_VERSION, network: { downloadKBps: 500 } })
   const healed = new ConfigStore(dir).load()
-  t.is(healed.get('network.downloadConcurrency'), 3, 'a config written before the key existed gains it')
+  t.is(healed.get('network.downloadConcurrency'), 6, 'a config written before the key existed gains it')
   t.is(healed.get('network.downloadKBps'), 500, 'and keeps what that build did set')
 
   // _migrate re-derives only the relay fields; a hand-set cap must not be reset on the next load,
@@ -207,7 +207,7 @@ test('network survives a persist/reload round-trip', (t) => {
   store.flush()
   // Bandwidth, relay and the fetch-gate cap share the `network` group, so the persisted block
   // carries all three.
-  t.alike(readConfig(dir).network, { downloadKBps: 2048, uploadKBps: 256, relayMode: 'off', relays: [], downloadConcurrency: 3 })
+  t.alike(readConfig(dir).network, { downloadKBps: 2048, uploadKBps: 256, relayMode: 'off', relays: [], downloadConcurrency: 6 })
   const reopened = new ConfigStore(dir).load()
   t.is(reopened.get('network.downloadKBps'), 2048)
   t.is(reopened.get('network.uploadKBps'), 256)

--- a/test/unit/download-concurrency-wiring.test.js
+++ b/test/unit/download-concurrency-wiring.test.js
@@ -1,0 +1,35 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (rel) => readFileSync(path.join(here, '..', '..', 'src', rel), 'utf8')
+
+// The defect this pins was never a wrong value: getDownloadConcurrency() read a key that main
+// never put in the bootstrap frame and config.json never carried, so a shipped build always ran
+// the hardcoded default and the documented rollback lever did not exist. Nothing fails when a
+// knob is wired at one end only, which is why it needs a source-level guard (the precedent is
+// worker-epipe-guard.test.js / foreign-resume-wiring.test.js).
+test('the bootstrap frame carries the configured download concurrency', (t) => {
+  const main = read('main/main.js')
+  const frame = main.match(/const bootstrap = \{[\s\S]*?\n  \}/)?.[0] || ''
+  t.ok(frame.length > 0, 'found the bootstrap frame literal')
+  t.ok(/downloadConcurrency: config\(\)\.get\('network\.downloadConcurrency'\)/.test(frame),
+    'the frame reads network.downloadConcurrency, or the setting is inert')
+})
+
+test('config.json defines the key the frame reads', (t) => {
+  t.ok(/network: \{[^}]*\bdownloadConcurrency\b/.test(read('main/config-store.js')),
+    'the network defaults carry downloadConcurrency')
+})
+
+test('the worker reads the frame into the runtime config', (t) => {
+  const worker = read('worker/main.js')
+  t.ok(/const bootstrap = await getBootstrapPromise\(\)\s*\n\s*setRuntimeConfig\(bootstrap\)/.test(worker),
+    'the frame is handed to setRuntimeConfig verbatim')
+  // buildConfig copies every key of DEFAULTED off the frame, so the value needs a default entry
+  // to be carried at all — without it the frame key is silently dropped.
+  t.ok(/\bdownloadConcurrency: \d+/.test(read('shared/core/runtime-config.js')),
+    'runtime-config declares the key in DEFAULTED')
+})

--- a/test/unit/fetch-claims.test.js
+++ b/test/unit/fetch-claims.test.js
@@ -1,0 +1,101 @@
+import test from 'brittle'
+import {
+  claimFetch, dropFetchClaim, fetchClaimedBy, isFetchClaimed, registerFetchOwner, resetFetchClaims, FETCH_OWNER_MIRROR,
+} from '../../src/shared/transfer/backends/overlay/fetch-claims.js'
+
+function fresh (t) {
+  resetFetchClaims()
+  t.teardown(() => resetFetchClaims())
+}
+
+const ID = 'space1|folder1|report.pdf'
+
+test('a second claim on the same transferId is refused', (t) => {
+  fresh(t)
+  t.ok(claimFetch(ID, FETCH_OWNER_MIRROR), 'the first claim is granted')
+  t.is(claimFetch(ID, 'other'), null, 'the second is refused')
+  t.is(fetchClaimedBy(ID), FETCH_OWNER_MIRROR, 'and the first owner still holds it')
+})
+
+test('releasing a claim frees it for the next producer', (t) => {
+  fresh(t)
+  const release = claimFetch(ID, FETCH_OWNER_MIRROR)
+  release()
+  t.absent(isFetchClaimed(ID), 'released')
+  t.ok(claimFetch(ID, 'other'), 'the next producer can take it')
+})
+
+// The release is handed out before the fetch runs and called from a finally, so an out-of-order
+// one is reachable: it must not free a claim that has since changed hands.
+test('a stale release does not free a claim the next producer took', (t) => {
+  fresh(t)
+  const stale = claimFetch(ID, FETCH_OWNER_MIRROR)
+  stale()
+  claimFetch(ID, 'other')
+  stale()
+  t.is(fetchClaimedBy(ID), 'other', 'the new owner survived the stale release')
+})
+
+// An engine is a probe, not a stored claim: its own registry already has exactly the lifetime of
+// its fetch, so copying it here would mean clearing it at each of start()'s bail sites.
+test('a registered engine answers for its own in-flight transfers', (t) => {
+  fresh(t)
+  const live = new Set([ID])
+  registerFetchOwner('folder', (id) => live.has(id))
+  t.is(fetchClaimedBy(ID), 'folder', 'the probe reports the engine as the owner')
+  t.is(claimFetch(ID, FETCH_OWNER_MIRROR), null, 'so the mirror cannot claim it')
+
+  live.delete(ID)
+  t.absent(isFetchClaimed(ID), 'the engine settled')
+  t.ok(claimFetch(ID, FETCH_OWNER_MIRROR), 'and the mirror may take it on its next tick')
+})
+
+test('an unrelated transferId is never claimed by a busy one', (t) => {
+  fresh(t)
+  claimFetch(ID, FETCH_OWNER_MIRROR)
+  t.absent(isFetchClaimed('space1|folder1|other.pdf'), 'claims are per transferId')
+})
+
+// REGRESSION: a wedged pass never reaches its finally, so a claim released only from there
+// outlives the pass — and restartForeignLoop, whose whole job is to recover that mount, was then
+// refused by the dead claim of the pass it had just given up on.
+// The registry answers a cross-producer question. A mirror's own overlapping passes are serialised
+// by activeOverlayFetches, so refusing them here would change behaviour FIX-R09-2 pins.
+test('the same owner may re-enter, and its second release is inert', (t) => {
+  fresh(t)
+  const first = claimFetch(ID, FETCH_OWNER_MIRROR)
+  const second = claimFetch(ID, FETCH_OWNER_MIRROR)
+  t.ok(second, 'a second pass by the same owner is admitted')
+
+  t.is(claimFetch(ID, 'folder'), null, 'a different owner is still refused')
+
+  second()
+  t.is(fetchClaimedBy(ID), FETCH_OWNER_MIRROR, 'the re-entrant release does not free the first holder')
+  first()
+  t.absent(isFetchClaimed(ID), 'the original holder still releases it')
+})
+
+test('a dropped claim frees the file for the pass that replaces it', (t) => {
+  fresh(t)
+  const abandoned = claimFetch(ID, FETCH_OWNER_MIRROR)
+  dropFetchClaim(ID)
+  const restarted = claimFetch(ID, FETCH_OWNER_MIRROR)
+  t.ok(restarted, 'the restarted pass can take the file')
+
+  // Both claims carry the same owner label, so the guard has to be the claim's own token: the
+  // zombie settling later must not free the live claim.
+  abandoned()
+  t.is(fetchClaimedBy(ID), FETCH_OWNER_MIRROR, 'the abandoned release did not free the new claim')
+  restarted()
+  t.absent(isFetchClaimed(ID), 'and the live one still releases normally')
+})
+
+test('resetFetchClaims drops both claims and probes from a previous lifetime', (t) => {
+  fresh(t)
+  registerFetchOwner('folder', () => true)
+  claimFetch(ID, FETCH_OWNER_MIRROR)
+
+  resetFetchClaims()
+  t.absent(isFetchClaimed(ID), 'a leaked claim would block one file for the life of the worker')
+  t.absent(isFetchClaimed('anything'), 'and a probe closes over an engine this lifetime dropped')
+})

--- a/test/unit/fetch-slots.test.js
+++ b/test/unit/fetch-slots.test.js
@@ -1,0 +1,64 @@
+import test from 'brittle'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { acquireFetchSlot, drainFetchSlots, fetchSlotStats, resetFetchSlots, FETCH_OWNER_MIRROR } from '../../src/shared/transfer/backends/overlay/fetch-slots.js'
+import * as reimported from '../../src/shared/transfer/backends/overlay/fetch-slots.js'
+
+function withCap (t, cap) {
+  const prev = getRuntimeConfig()
+  setRuntimeConfig({ ...prev, downloadConcurrency: cap })
+  t.teardown(() => { setRuntimeConfig(prev); resetFetchSlots() })
+  resetFetchSlots()
+}
+
+// The whole point of the module: the cap used to be built inside createOverlayDownloadEngine, which
+// is called once per channel, so two engines meant two independent gates and the mirror had none.
+// semaphore.test.js covers the accounting; this covers the thing a factory structurally cannot say.
+test('every importer draws from the same gate', async (t) => {
+  withCap(t, 1)
+  const held = await acquireFetchSlot({})
+  t.is(reimported.fetchSlotStats().held, 1, 'a second import observes the first import\'s slot')
+
+  let admitted = false
+  reimported.acquireFetchSlot({}).then(() => { admitted = true })
+  await new Promise((r) => setTimeout(r, 10))
+  t.absent(admitted, 'and is gated by it')
+  held()
+})
+
+test('the mirror can be drained without releasing the engines', async (t) => {
+  withCap(t, 1)
+  const held = await acquireFetchSlot({})
+  const mirror = acquireFetchSlot({ owner: FETCH_OWNER_MIRROR })
+  const engine = acquireFetchSlot({})
+  t.is(fetchSlotStats().queued, 2)
+
+  // ForeignMirrors closes before OverlayBackend, so its close must not release a download into an
+  // overlay that is still live.
+  drainFetchSlots(FETCH_OWNER_MIRROR)
+  await mirror
+  t.is(fetchSlotStats().queued, 1, 'the engine job is still parked')
+  held()
+  await engine
+})
+
+// OverlayBackend builds fresh engines on every _open. A per-instance semaphore died with them; a
+// module singleton would carry a lost slot into every later lifetime and shrink the cap for good.
+test('resetFetchSlots clears a held count from a previous lifetime', async (t) => {
+  withCap(t, 1)
+  await acquireFetchSlot({})
+  t.is(fetchSlotStats().held, 1, 'a slot is outstanding')
+
+  resetFetchSlots()
+  t.is(fetchSlotStats().held, 0, 'the new lifetime starts empty')
+  const next = await acquireFetchSlot({})
+  t.ok(next, 'and admits immediately rather than queueing behind the leak')
+  next()
+})
+
+test('the cap is read from the runtime config per acquire', async (t) => {
+  withCap(t, 0)
+  // 0 is the documented rollback path: it disables the gate rather than blocking everything.
+  const releases = await Promise.all([acquireFetchSlot({}), acquireFetchSlot({}), acquireFetchSlot({})])
+  t.is(fetchSlotStats().queued, 0, 'a cap of zero admits everything')
+  for (const rel of releases) rel()
+})

--- a/test/unit/folder-module-boundaries.test.js
+++ b/test/unit/folder-module-boundaries.test.js
@@ -1,0 +1,33 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (p) => readFileSync(path.resolve(here, '../../src', p), 'utf8')
+
+// The decomposition left these as re-exports so its own diff stayed on the move. Once the callers
+// were re-pointed the shims went, and this keeps them gone: a re-export is the cheap way to undo a
+// decomposition one import at a time, and nothing else fails when one grows back.
+test('the folder engines no longer re-export what moved out of them', (t) => {
+  const foreign = read('shared/folders/foreign-folders.js')
+  t.absent(/export \{[^}]*\blocalRelOf\b/.test(foreign), 'localRelOf comes from mirror-state.js')
+  t.absent(/export \{ previewMaterializeScan \}/.test(foreign), 'the preview comes from foreign-preview.js')
+  t.absent(/export \{[^}]*\bshouldHonorDeletions\b/.test(foreign), 'the deletion gate comes from path-keys.js')
+
+  const owned = read('shared/folders/owned-folders.js')
+  t.absent(/export \{ previewInitialPublishScan \}/.test(owned), 'the preview comes from owned-preview.js')
+})
+
+// The four that predate the decomposition and are deliberately NOT swept, asserted so the test
+// above reads as a decision rather than an oversight. Matching the export STATEMENT matters: a
+// bare substring check also matches owned-folders.js's import of the same names from path-keys.js,
+// and would stay green with the re-export deleted.
+test('the pre-existing owned-folders re-exports are left in place on purpose', (t) => {
+  const owned = read('shared/folders/owned-folders.js')
+  for (const name of ['shouldIgnore', 'DEFAULT_IGNORE', 'mountRootAvailable']) {
+    t.ok(new RegExp(`export \\{[^}]*\\b${name}\\b[^}]*\\}(?!\\s*from)`).test(owned),
+      `${name} still re-exported — it predates this work and has worker consumers`)
+  }
+  t.ok(/export \{ walkDisk \}/.test(owned), 'walkDisk still re-exported')
+})

--- a/test/unit/presence-sweeper.test.js
+++ b/test/unit/presence-sweeper.test.js
@@ -1,5 +1,8 @@
 import test from 'brittle'
 import { createPresenceSweeper } from '../../src/shared/transfer/presence-sweeper.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import nodePath from 'path'
 
 function build ({ present = () => false, pending = () => false } = {}) {
   const retired = []
@@ -75,4 +78,23 @@ test('reset() forgets every arming', async (t) => {
   sweeper.reset()
   t.absent(await sweeper.consider(CTX, ENTRY), 'starts over')
   t.alike(retired, [])
+})
+
+// REGRESSION: both call sites collect their retire promises the same way, but they do not settle the
+// same way. The loose one goes through settledWithTail, which rethrows, so .catch is meaningful
+// there. The folder one pushes the publish lane's raw ticket, and that deferred (work-item.js) is
+// built with a resolve and no reject — so its copied .catch could never fire and a failed retire
+// vanished with no log at all. The failure has to be read off the settlement outcome.
+test('the folder retire reads its settlement instead of catching a rejection that cannot happen', (t) => {
+  const here = nodePath.dirname(fileURLToPath(import.meta.url))
+  const read = (rel) => readFileSync(nodePath.resolve(here, '../../src', rel), 'utf8')
+
+  const deferredSrc = read('shared/folders/work-item.js')
+  t.absent(/new Promise\(\(resolve, reject\)/.test(deferredSrc), 'the lane ticket still has no reject path')
+
+  const backend = read('shared/transfer/backends/overlay/overlay-backend.js')
+  const retire = backend.match(/retire: \(\{ spaceId, shareId, retires \}[\s\S]*?\n  \},/)?.[0] || ''
+  t.ok(retire.length > 0, 'found the folder sweep retire')
+  t.absent(/settled\.catch\(/.test(retire), 'no catch on a promise that never rejects')
+  t.ok(/outcome === 'failed'/.test(retire), 'a failed retire is read off the outcome and logged')
 })

--- a/test/unit/semaphore.test.js
+++ b/test/unit/semaphore.test.js
@@ -105,6 +105,58 @@ test('drain resolves every queued waiter and their releases are inert', async (t
   t.is(sem.stats().held, 1, 'the drained releases did not decrement the real holder')
 })
 
+// One gate is now shared by subsystems that close at different times (the mirror closes before the
+// overlay backend), so a close must be able to release its OWN parked callers without releasing
+// work the later subsystem is still guarding.
+test('drain(owner) releases only that owner and leaves the rest queued in order', async (t) => {
+  const sem = createSemaphore({ limit: 1, expressLanes: 0 })
+  await sem.acquire()
+  const mine = sem.acquire({ owner: 'mirror' })
+  const theirs = [sem.acquire({ owner: 'folder' }), sem.acquire({ owner: 'folder' })]
+  t.is(sem.stats().queued, 3)
+
+  sem.drain('mirror')
+  const release = await mine
+  t.is(sem.stats().queued, 2, 'only the mirror waiter was released')
+  release()
+  t.is(sem.stats().held, 1, 'and its release is inert')
+
+  let order = []
+  theirs[0].then(() => order.push(0))
+  theirs[1].then(() => order.push(1))
+  sem.drain()
+  await Promise.all(theirs)
+  t.alike(order, [0, 1], 'the survivors kept their acquire order across the scoped drain')
+})
+
+test('an untagged drain still releases an owner-tagged waiter', async (t) => {
+  const sem = createSemaphore({ limit: 1, expressLanes: 0 })
+  await sem.acquire()
+  const parked = sem.acquire({ owner: 'mirror' })
+  sem.drain()
+  await parked
+  t.is(sem.stats().queued, 0, 'no argument means everyone, tagged or not')
+})
+
+// Two engines each carried one express lane, so the shared gate has to carry two or a click on a
+// loose file would queue behind a click on a folder file.
+test('expressLanes: 2 admits two express acquires over a saturated limit', async (t) => {
+  const sem = createSemaphore({ limit: 1, expressLanes: 2 })
+  await sem.acquire()
+  t.is(sem.stats().held, 1, 'the single bulk slot is taken')
+
+  const admitted = []
+  sem.acquire({ express: true }).then(() => admitted.push('a'))
+  sem.acquire({ express: true }).then(() => admitted.push('b'))
+  await tick()
+  t.is(admitted.length, 2, 'both express lanes are available')
+
+  let third = false
+  sem.acquire({ express: true }).then(() => { third = true })
+  await tick()
+  t.absent(third, 'and the third express caller waits')
+})
+
 test('releasing twice does not double-decrement', async (t) => {
   const sem = createSemaphore({ limit: 2, expressLanes: 0 })
   const a = await sem.acquire()


### PR DESCRIPTION
Follow-on to #177, plus three defects it left behind.

**Commits, in order**
- `[fix] Report a folder retire that silently failed` — the sweep caught a rejection its publish-lane ticket cannot raise (that deferred has no reject path), so a failed retire was dropped with no log. Also unsplices a `settleFetch` comment #177 pasted into `runFetchTask` mid-sentence.
- `[chore] Import the folder helpers from where they live` — retires the decomposition's re-export shims (5 files), with a ratchet.
- `[fix] Let the download concurrency be configured` — `getDownloadConcurrency` read a key `config.json` never carried and the bootstrap frame never sent, so the documented rollback lever did not exist. No UI.
- `[fix] Count every overlay fetch against one gate` — the cap was built inside the engine factory, which runs once per channel: a configured 3 meant 3 per engine, and mirrors were uncounted entirely (`8 + N`). One process-wide gate, default 6 to hold the old two-engine ceiling.
- `[fix] Let one claim decide who fetches a file` — replaces the mirror's two `overlayHasTransfer` probes, which answered for one engine out of two. A manual download of a file already in flight now attaches instead of doing nothing.
- `[fix] Name a file row's status badge for screen readers` — the badge announced a bare state untied to its file.
- `[test] Drive the mirror name collision through the UI` — s130.

**Deliberately not done:** the mirror does not get pending rows (P8, won't-do — one bee row per mirrored file reintroduces the write amplification #113 removed). `share-listing.js` keeps `overlayHasTransfer`: a browse row asks a different question and has no mirror by construction.

**Local:** build, `lint:ci`, `test:unit` (1803), `test:bare` (998) green post-rebase. `test:flow` was 196/196 pre-rebase; the post-rebase run was contended by another suite on the same machine, so CI is the arbiter. `test:fe s130` and the VoiceOver spot-check have not been run.