### PR TITLE
[fix] Five follow-ups from the mirror-engine decomposition

### DIFF
--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -313,7 +313,7 @@ async function handleOverlayMirrorFetchError(mount, share, entry, err, diag) {
   // Order matters: a local I/O fault pauses the mount and is NOT a peer act. Auditing it would
   // blame a holder for our own full disk.
   if (await pauseMountForIoError(mount, err)) return
-  diag.finish('failed')
+  diag?.finish('failed')
   if (err?.code === 'EHASHMISMATCH') {
     log.warn('overlay mirror integrity failure — holder served bytes not matching the content hash:', entry.relPath)
     recordMirrorIntegrityFailure(mount, share, entry)
@@ -425,10 +425,14 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
       onTick: () => loops.noteProgress(streamKey),
     }))
   } catch (err) {
+    // The diag rides the rejection, and annotating a rejection is best-effort (runOverlayFetch says
+    // why) — so it can be absent. Dereferencing it blind would replace a real fault, an ENOSPC that
+    // must pause the mount included, with a TypeError out of this handler.
+    const failed = err?.diag ?? null
     // ECANCELLED is a deliberate pause/unmount abort (stopForeignLoop), not a
     // give-up: log it as a stop and keep whatever partial cancelFetch chose to keep.
-    if (err?.code === 'ECANCELLED') { err.diag.finish('paused'); return 'missing' }
-    await handleOverlayMirrorFetchError(mount, share, entry, err, err.diag)
+    if (err?.code === 'ECANCELLED') { failed?.finish('paused'); return 'missing' }
+    await handleOverlayMirrorFetchError(mount, share, entry, err, failed)
     return 'missing'
   } finally {
     activeOverlayFetches.delete(streamKey)

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -197,7 +197,7 @@ export async function applyChange(mount, change) {
 export async function initialMaterializeScan(mount) {
   const key = loopKey(mount.spaceId, mount.shareId)
   state.forgetConverged(key)
-  return await loops.adopt(key, runInitialMaterializeScan(mount))
+  return await loops.adopt(key, runInitialMaterializeScan(mount), { spaceId: mount.spaceId, shareId: mount.shareId })
 }
 
 async function runInitialMaterializeScan(mount) {

--- a/src/shared/folders/foreign-preview.js
+++ b/src/shared/folders/foreign-preview.js
@@ -10,7 +10,7 @@ import { isVerifiedUnchanged } from '../transfer/files.js'
 import { createPreviewTally } from './preview-tally.js'
 import { createLogger } from '../core/logger.js'
 import { mapLimit } from '../core/concurrency.js'
-import { AbortError, walkDisk } from './walk-disk.js'
+import { AbortError, countDiskFiles } from './walk-disk.js'
 
 const log = createLogger('foreign-preview')
 
@@ -73,7 +73,7 @@ export async function previewMaterializeScan(spaceId, ownerKey, shareId, mountPa
   const [existingAtDestination, entries] = await Promise.all([
     // Caught, not propagated: a preview of an unreadable destination reports zero rather than
     // failing the dialog the user is standing in front of.
-    walkDisk(mountPath, DEFAULT_IGNORE).then((w) => w.onDisk.size).catch(() => 0),
+    countDiskFiles(mountPath, DEFAULT_IGNORE).catch(() => 0),
     loadForeignListing(spaceId, ownerKey, shareId),
   ])
   checkAborted()

--- a/src/shared/folders/mirror-loop.js
+++ b/src/shared/folders/mirror-loop.js
@@ -26,7 +26,7 @@ export function createMirrorLoops ({ intervalMs, runPass, onStop = () => {}, onE
     if (inFlight.get(key) !== p) return
     inFlight.delete(key)
     liveness.ended(key)
-    if (dirty.delete(key) && ctx) tick(key, ctx).catch(onError)
+    if (dirty.delete(key)) tick(key, ctx).catch(onError)
   }
 
   function track (key, p, ctx) {
@@ -54,8 +54,12 @@ export function createMirrorLoops ({ intervalMs, runPass, onStop = () => {}, onE
 
   // Register a pass started outside `tick` (the unawaited boot scan) so the bulk stop has
   // something to await. It honours the generation itself; the stop can only wait for what it sees.
-  function adopt (key, promise) {
-    return track(key, promise, null)
+  //
+  // It takes the ctx for the same reason `tick` does: a request arriving while the boot scan runs
+  // sets the dirty flag, and without a ctx to run it with, that follow-up was consumed and dropped
+  // — so a resume landing during the initial materialize scan did nothing at all.
+  function adopt (key, promise, ctx) {
+    return track(key, promise, ctx)
   }
 
   function start (key, ctx) {

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -63,6 +63,10 @@ const SCAN_SETTLE_MS = 2000
 // A diff over a large tree is legitimately slow, so the wedge signal is a pass that stats no
 // file for this long — not one that merely takes a while.
 const RECONCILE_STALL_WINDOW_MS = 10 * 60 * 1000
+// How often a phase that iterates without touching the disk (the catalog drain, the diff) bumps the
+// pass heartbeat. Often enough that no phase can go quiet for the stall window, rare enough that the
+// bookkeeping is not itself the cost.
+const LIVENESS_EVERY = 500
 // Tracked on the PASS, not on the coalescing wrapper: a caller that joins a run in flight must
 // not re-stamp its heartbeat and make a stalled pass read as fresh.
 const passLiveness = createPassLiveness()
@@ -351,11 +355,19 @@ async function readBothSides(spaceId, shareId, mountPath, ignore) {
   scanSignals.set(key, signal)
   try {
     const walk = await walkDisk(mountPath, ignore, { signal, onProgress: () => passLiveness.progress(key) })
+    // Every phase after the walk beats too. The walk is the only one that reports per file, so a
+    // pass whose catalog side is the slow half — a large share, a flush window that just closed —
+    // used to go quiet for the whole stall window and be reported as wedged while it was working.
+    passLiveness.progress(key)
     // Commit the space batch first, or this read misses every hash materialized in the last flush
     // window and re-enqueues those files.
     await settleCatalog(spaceId)
+    passLiveness.progress(key)
     const known = new Map()
-    for await (const entry of listOwnShare(spaceId, shareId)) known.set(entry.relPath, entry)
+    for await (const entry of listOwnShare(spaceId, shareId)) {
+      known.set(entry.relPath, entry)
+      if (known.size % LIVENESS_EVERY === 0) passLiveness.progress(key)
+    }
     const bail = await bailIfAborted(spaceId, shareId, signal)
     return bail ? { bail } : { walk, known }
   } catch (err) {
@@ -370,6 +382,7 @@ async function readBothSides(spaceId, shareId, mountPath, ignore) {
 }
 
 async function diffAndEnqueue(spaceId, shareId, { mountPath, ignore, deep, deferFresh }) {
+  const key = spaceId + ':' + shareId
   const mount = await getOwnedMount(spaceId, shareId)
   if (!mount) throw new AppError(ErrorCodes.MOUNT_NOT_ON_DEVICE, 'Mount missing')
   // Before the walk rather than before the enqueue: the walk is the expensive half on a large tree.
@@ -394,12 +407,15 @@ async function diffAndEnqueue(spaceId, shareId, { mountPath, ignore, deep, defer
   const { walk, known, bail } = await readBothSides(spaceId, shareId, mountPath, ignore)
   if (bail) return bail
   const { onDisk, unreadable } = walk
+  passLiveness.progress(key)
 
   sched().beginShare(spaceId, shareId, onDisk.size)
   const specs = []
   const unchanged = []
   let deferred = 0
+  let seen = 0
   for (const [relPath, info] of onDisk) {
+    if (++seen % LIVENESS_EVERY === 0) passLiveness.progress(key)
     // A name no catalog key can carry (a '\' in a POSIX file name) is skipped, never a reason to
     // abort the whole diff.
     if (relKeyEscapes(relPath)) { log.warn('skipping file whose name cannot be a share key:', relPath); continue }

--- a/src/shared/folders/walk-disk.js
+++ b/src/shared/folders/walk-disk.js
@@ -14,6 +14,37 @@ export class AbortError extends Error {
   }
 }
 
+// One readdir entry -> its '/'-separated key relative to the root, or null when the entry must be
+// skipped: outside the root, unrepresentable, or ignored. Shared by the stat-ing walk and the
+// stat-free count below, so "already at the destination" counts exactly the files the walk sees.
+function entryKey(entry, root, cleanRoot, ignore) {
+  const dir = entry.parentPath ?? entry.path ?? root
+  const abs = path.join(dir, entry.name)
+  const rel = relToDriveKey(path.relative(cleanRoot, stripLongPathPrefix(abs)), path.sep)
+  if (!rel) return null
+  if (rel === '..' || rel.startsWith('../') || isAbsoluteDriveKey(rel)) {
+    log.warn('skipping file outside mount root:', abs, '→', rel)
+    return null
+  }
+  if (shouldIgnore(rel, ignore)) return null
+  return { abs, rel }
+}
+
+// How many files already sit at a destination — the count the mount preview reports. Stat-free on
+// purpose: it answers "how many", not "how big", and walkDisk's per-file statSync is a blocking
+// syscall on the worker's only thread, so paying it for a number nobody reads stalls the dialog the
+// user is standing in front of. It also counts a file the walk would set aside as unreadable, which
+// is still very much at the destination.
+export async function countDiskFiles(root, ignore) {
+  const cleanRoot = stripLongPathPrefix(root)
+  const entries = await fs.promises.readdir(root, { recursive: true, withFileTypes: true })
+  let count = 0
+  for (const entry of entries) {
+    if (entry.isFile() && entryKey(entry, root, cleanRoot, ignore)) count += 1
+  }
+  return count
+}
+
 // Returns { onDisk: Map<relKey, { size, mtime }>, unreadable: Set<relKey> }.
 // Stat-only — reads no file contents. `unreadable` holds paths that exist but
 // couldn't be stat'd; they are skipped, never reported as absent — callers must
@@ -35,15 +66,9 @@ export async function walkDisk(root, ignore, { onProgress = null, signal = null 
 
   for (const entry of files) {
     if (signal?.aborted) throw new AbortError()
-    const dir = entry.parentPath ?? entry.path ?? root
-    const abs = path.join(dir, entry.name)
-    const rel = relToDriveKey(path.relative(cleanRoot, stripLongPathPrefix(abs)), path.sep)
-    if (!rel) continue
-    if (rel === '..' || rel.startsWith('../') || isAbsoluteDriveKey(rel)) {
-      log.warn('skipping file outside mount root:', abs, '→', rel)
-      continue
-    }
-    if (shouldIgnore(rel, ignore)) continue
+    const key = entryKey(entry, root, cleanRoot, ignore)
+    if (!key) continue
+    const { abs, rel } = key
     let stat
     try { stat = fs.statSync(abs) } catch { unreadable.add(rel); continue }
     const info = { size: stat.size, mtime: stat.mtimeMs }

--- a/src/shared/transfer/backends/overlay/fetch-run.js
+++ b/src/shared/transfer/backends/overlay/fetch-run.js
@@ -9,6 +9,9 @@
 // still tell the two apart.
 import { makeProgressTicker } from '../../progress-ticker.js'
 import { makeFetchDiag } from './overlay-backend.js'
+import { createLogger } from '../../../core/logger.js'
+
+const log = createLogger('overlay-fetch')
 
 export async function runOverlayFetch (overlay, contentHash, {
   label, relPath, size = 0, destPath, reSeed = false, onProgress, onVerify, onTick,
@@ -26,8 +29,14 @@ export async function runOverlayFetch (overlay, contentHash, {
     })
     return { res, attempted, diag }
   } catch (err) {
-    err.attempted = attempted
-    err.diag = diag
+    // Best-effort: a frozen or primitive rejection makes these assignments throw in strict mode,
+    // and that TypeError would REPLACE the real fault — so a full disk would reach the caller as a
+    // bug in this file instead of the ENOSPC that must pause the mount. The annotation is a
+    // convenience; the fault is not.
+    try {
+      err.attempted = attempted
+      err.diag = diag
+    } catch { log.debug('could not annotate a fetch rejection:', label, relPath) }
     throw err
   }
 }

--- a/test/integration/disk-count.test.js
+++ b/test/integration/disk-count.test.js
@@ -1,0 +1,57 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import os from 'bare-os'
+import path from 'bare-path'
+import { countDiskFiles, walkDisk } from '../../src/shared/folders/walk-disk.js'
+import { DEFAULT_IGNORE } from '../../src/shared/folders/path-keys.js'
+
+const srcRoot = path.join(path.dirname(import.meta.url.replace(/^file:\/\//, '')), '..', '..', 'src')
+
+function tree (t) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'mirall-disk-count-'))
+  t.teardown(() => { try { fs.rmSync(root, { recursive: true, force: true }) } catch {} })
+  fs.mkdirSync(path.join(root, 'nested', 'deeper'), { recursive: true })
+  fs.writeFileSync(path.join(root, 'a.txt'), 'a')
+  fs.writeFileSync(path.join(root, 'nested', 'b.txt'), 'b')
+  fs.writeFileSync(path.join(root, 'nested', 'deeper', 'c.txt'), 'c')
+  return root
+}
+
+test('it counts every file the walk would see, and nothing else', async (t) => {
+  const root = tree(t)
+  fs.mkdirSync(path.join(root, 'empty-dir'))
+
+  t.is(await countDiskFiles(root, DEFAULT_IGNORE), 3, 'nested files counted, directories not')
+  const walk = await walkDisk(root, DEFAULT_IGNORE)
+  t.is(await countDiskFiles(root, DEFAULT_IGNORE), walk.onDisk.size,
+    'the two agree on a healthy tree — they share one key rule, so a file counted as already at the destination is a file the walk would sync')
+})
+
+test('it applies the ignore list, so hidden OS junk is not reported as user content', async (t) => {
+  const root = tree(t)
+  fs.writeFileSync(path.join(root, '.DS_Store'), 'junk')
+  fs.writeFileSync(path.join(root, 'nested', '.DS_Store'), 'junk')
+
+  t.is(await countDiskFiles(root, DEFAULT_IGNORE), 3,
+    'a folder the user has merely viewed does not report a phantom extra file')
+  t.is(await countDiskFiles(root, []), 5, 'and the ignore list is the caller\'s to choose')
+})
+
+test('an unreadable destination rejects rather than reporting a false zero', async (t) => {
+  await t.exception(() => countDiskFiles(path.join(os.tmpdir(), 'mirall-no-such-dir-' + Date.now()), DEFAULT_IGNORE))
+})
+
+// REGRESSION (FIX-PREVIEW-STAT: the mount preview's "already at the destination" count was moved
+// onto walkDisk, which stats every file. The preview runs on the worker's only thread while the
+// user waits in a dialog, and statSync is blocking — so a large destination folder stalled the
+// whole data layer to produce a number that needs no file metadata at all.)
+test('REGRESSION (FIX-PREVIEW-STAT): the count reads no file metadata', (t) => {
+  const src = fs.readFileSync(path.join(srcRoot, 'shared', 'folders', 'walk-disk.js'), 'utf8')
+  const from = src.indexOf('export async function countDiskFiles')
+  const body = src.slice(from, src.indexOf('\n}', from))
+  t.ok(from > 0, 'found the counter')
+  t.absent(/stat/i.test(body), 'it stats nothing — the count answers "how many", never "how big"')
+
+  const preview = fs.readFileSync(path.join(srcRoot, 'shared', 'folders', 'foreign-preview.js'), 'utf8')
+  t.absent(/walkDisk/.test(preview), 'and the mount preview does not reach for the stat-ing walk to get it')
+})

--- a/test/integration/overlay-fetch-annotate.test.js
+++ b/test/integration/overlay-fetch-annotate.test.js
@@ -1,0 +1,39 @@
+import test from 'brittle'
+import { runOverlayFetch } from '../../src/shared/transfer/backends/overlay/fetch-run.js'
+
+const ARGS = { label: 'test', relPath: 'a.txt', size: 4, destPath: '/tmp/mirall-fetch-diag-test' }
+
+const rejectingOverlay = (err) => ({ fetchFile: async () => { throw err } })
+
+// The rejection VALUE is the subject here, not merely that it rejected, so it is captured rather
+// than asserted through t.exception.
+async function rejectionOf (thrown) {
+  try {
+    await runOverlayFetch(rejectingOverlay(thrown), 'h'.repeat(64), ARGS)
+  } catch (err) { return err }
+  throw new Error('runOverlayFetch resolved — the fake overlay always rejects')
+}
+
+test('a rejection carries the attempt flag and the diag its caller settles', async (t) => {
+  const original = Object.assign(new Error('holder went away'), { code: 'ECANCELLED' })
+  const err = await rejectionOf(original)
+  t.is(err.code, 'ECANCELLED', 'the caller still sees its own fault')
+  t.is(err.attempted, false, 'annotated with whether a scheduler ever ran')
+  t.ok(err.diag, 'and with the diag, so the caller can settle the row it opened')
+})
+
+// REGRESSION (FIX-FETCH-ANNOTATE: the diag and the attempt flag were assigned onto the rejection
+// unguarded. ESM is always strict, so a frozen or primitive rejection made those assignments throw
+// a TypeError that REPLACED the real fault — a full disk would then reach the mirror as a bug in
+// the instrumentation instead of the ENOSPC that has to pause the mount.)
+test('REGRESSION (FIX-FETCH-ANNOTATE): a rejection that cannot be annotated still reaches its caller', async (t) => {
+  const frozen = Object.freeze(Object.assign(new Error('no space left on device'), { code: 'ENOSPC' }))
+  const err = await rejectionOf(frozen)
+  t.is(err, frozen, 'the original object, not a TypeError from this file')
+  t.is(err.code, 'ENOSPC', 'so the fault the mount must pause on survives')
+})
+
+test('a primitive rejection survives too', async (t) => {
+  const err = await rejectionOf('overlay said no')
+  t.is(err, 'overlay said no', 'nothing in the instrumentation may swallow or rewrite it')
+})

--- a/test/unit/contract-declarations.test.js
+++ b/test/unit/contract-declarations.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
 import { readFileSync, readdirSync, statSync } from 'fs'
-import { fileURLToPath } from 'url'
+import { fileURLToPath, pathToFileURL } from 'url'
 import path from 'path'
 import * as contract from '../../src/shared/contract/index.js'
 
@@ -36,6 +36,32 @@ test('REGRESSION (FIX-CONTRACT-DRIFT): every declared export exists at runtime',
 
   for (const name of declared) t.ok(name in contract, `${name} is declared but not exported at runtime`)
   for (const name of Object.keys(contract)) t.ok(declared.has(name), `${name} is exported but not declared`)
+})
+
+// index.js re-exports most of the package but not all of it, and the check above only reaches what
+// it re-exports — so mount-fault.d.ts declared a vocabulary nothing compared against its runtime,
+// while its own header said the opposite. Per FILE, against the module it declares: a fourth
+// AUTO_PAUSE_STATUSES entry would otherwise have reached the renderer's union silently.
+test('every declaration file matches the module it declares', async (t) => {
+  const files = readdirSync(dir).filter((f) => f.endsWith('.d.ts') && f !== 'index.d.ts')
+  t.ok(files.length >= 10, `found ${files.length} declaration files`)
+
+  for (const file of files) {
+    const dts = readFileSync(path.join(dir, file), 'utf8')
+    const mod = await import(pathToFileURL(path.join(dir, file.replace(/\.d\.ts$/, '.js'))).href)
+
+    const declared = [...dts.matchAll(/^export declare (?:const|function) ([A-Za-z_$][\w$]*)/gm)].map((m) => m[1])
+    for (const name of declared) t.ok(name in mod, `${file}: ${name} is declared but not exported at runtime`)
+    for (const name of Object.keys(mod)) t.ok(declared.includes(name), `${file}: ${name} is exported but not declared`)
+
+    // Tuples get an exact comparison for the same reason the status tuples do below: types.ts
+    // derives unions with (typeof X)[number], so a drifted tuple does not mistype a value — it
+    // changes which strings the renderer's exhaustive switches accept.
+    for (const m of dts.matchAll(/^export declare const ([A-Za-z_$][\w$]*): readonly \[([^\]]+)\]/gm)) {
+      const values = [...m[2].matchAll(/'([^']+)'/g)].map((x) => x[1])
+      t.alike(values, [...(mod[m[1]] ?? [])], `${file}: ${m[1]} declaration matches its implementation`)
+    }
+  }
 })
 
 test('every vocabulary is frozen', (t) => {

--- a/test/unit/mirror-loop.test.js
+++ b/test/unit/mirror-loop.test.js
@@ -26,6 +26,25 @@ test('a tick arriving mid-pass coalesces into exactly one follow-up', async (t) 
   t.is(started, 2, 'and produced exactly ONE follow-up, not three')
 })
 
+// REGRESSION (FIX-MIRROR-ADOPT: an adopted pass — the boot materialize scan — was tracked without a
+// ctx, and the settle read `dirty.delete(key) && ctx`. That CONSUMED the coalesced follow-up and
+// then dropped it, so a resume or a catalog change landing during the initial scan did nothing at
+// all and the mirror sat idle until the next poll interval.)
+test('REGRESSION (FIX-MIRROR-ADOPT): a tick arriving during an adopted pass still runs after it', async (t) => {
+  let started = 0
+  const gate = deferred()
+  const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { started++ } })
+
+  const adopted = loops.adopt('k', gate.promise, { spaceId: 'sp', shareId: 'sh' })
+  loops.tick('k', { spaceId: 'sp', shareId: 'sh' })
+  t.is(started, 0, 'the request joined the adopted pass rather than starting a second one')
+
+  gate.resolve()
+  await adopted
+  await settle()
+  t.is(started, 1, 'and ran once the adopted pass settled')
+})
+
 test('a request arriving mid-pass gets the pass in flight, not a fresh one', async (t) => {
   const gate = deferred()
   const loops = createMirrorLoops({ ...NEVER(), runPass: async () => { await gate.promise } })

--- a/test/unit/owner-pass-liveness-wiring.test.js
+++ b/test/unit/owner-pass-liveness-wiring.test.js
@@ -1,0 +1,46 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(path.join(here, '..', '..', 'src', 'shared', 'folders', 'owned-folders.js'), 'utf8')
+
+// owned-folders.js loads only under Bare and the heartbeat it keeps is module-private, so the wiring
+// is pinned by source the way the other *-wiring tests in this directory are. The RULE it pins is
+// behavioural: the supervisor reports a pass that has not advanced inside the stall window as
+// wedged, so every phase of a pass has to say it is still working — not just the one that happens
+// to iterate files.
+function bodyOf (name) {
+  const from = src.indexOf(`async function ${name}(`)
+  if (from < 0) return ''
+  const end = src.indexOf('\n}\n', from)
+  return src.slice(from, end < 0 ? src.length : end)
+}
+
+// REGRESSION (FIX-OWNER-HEARTBEAT: the owner-side pass bumped its heartbeat only from walkDisk's
+// per-file callback. The catalog settle, the catalog drain and the diff that follow it reported
+// nothing, so a large but perfectly healthy share went quiet for longer than the stall window and
+// diagnostics:export reported a folder scan that was not advancing.)
+test('REGRESSION (FIX-OWNER-HEARTBEAT): every phase of a reconcile reports progress, not just the walk', (t) => {
+  const readBothSides = bodyOf('readBothSides')
+  const diffAndEnqueue = bodyOf('diffAndEnqueue')
+  t.ok(readBothSides && diffAndEnqueue, 'found both halves of the pass')
+
+  const beats = (body) => [...body.matchAll(/passLiveness\.progress\(/g)].length
+  t.ok(beats(readBothSides) >= 3,
+    `the read half beats after the walk, around the catalog settle and through the drain (found ${beats(readBothSides)})`)
+  t.ok(beats(diffAndEnqueue) >= 2,
+    `the diff half beats on entry and through its loop (found ${beats(diffAndEnqueue)})`)
+
+  // The one that was there all along, and the reason the gap was invisible: on a share whose files
+  // are the slow part it beats plenty, which is exactly the case nobody hits in a test.
+  t.ok(/walkDisk\([^)]*onProgress: \(\) => passLiveness\.progress\(key\)/s.test(src),
+    'the walk still beats per file')
+})
+
+test('the catalog drain beats on a bounded interval, not once per entry', (t) => {
+  t.ok(/const LIVENESS_EVERY = \d+/.test(src), 'the interval is named')
+  t.ok(/% LIVENESS_EVERY === 0\) passLiveness\.progress\(/.test(src),
+    'so the bookkeeping cannot itself become the cost of the pass')
+})


### PR DESCRIPTION
Five defects found reviewing #177, all reproducing on `staging` and fixed here. One commit each.

- **Mirror preview stats every file.** The "already at the destination" count moved onto `walkDisk`, which stats what it enumerates — on the worker's only thread, while the user waits in a dialog. A shared `entryKey` keeps a stat-free counter and the walk on one key rule. Also stops under-counting files the walk sets aside as unreadable.
- **A fetch failure could be replaced by a TypeError.** `runOverlayFetch` assigned the diag onto the rejection unguarded; ESM is strict, so a frozen or primitive rejection threw instead — an ENOSPC reached the mirror as a bug in the instrumentation rather than the fault that must pause the mount.
- **A tick arriving during a mirror's boot scan was dropped.** The adopted pass was tracked without a context, and the settle consumed the coalesced follow-up before discarding it.
- **A healthy folder scan could report as wedged.** The heartbeat beat only from `walkDisk`'s per-file callback; the catalog settle, drain and diff reported nothing.
- **`mount-fault.d.ts` claimed a guard it did not have.** The declaration test only reached what `index.js` re-exports. Now every `.d.ts` in the contract package is compared against the module it declares.

## Testing

Layers: unit + integration. No flow test — none of these is P2P behaviour; the two that touch replicated paths are asserted where the defect lives. No frontend scenario: no rendered UI changes.

Four of the five carry a red-first regression test, each verified to fail against the pre-fix code. The owner-heartbeat fix is pinned by source in the style of the existing `*-wiring` tests — `owned-folders.js` loads only under Bare and the heartbeat is module-private, so its coverage is structural rather than behavioural.

Rebased onto `staging` (dbb1a99) and re-run there: typecheck, lint, comment-hygiene, `test:unit` 1807/1807, `test:bare` 1005/1005, `test:flow` 196/196.