### PR TITLE
[fix] Three data-loss paths: boot sweep, mirror overwrite, mass deletion

### DIFF
--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -72,6 +72,12 @@ const DEFAULTED = {
   // Open peer catalogs kept cached. Each is a Hyperbee + Hypercore session with an append listener,
   // and every open core replicates to every socket. 0 = unbounded (the previous behaviour).
   peerCatalogCacheLimit: 64,
+  // Mirror deletion plausibility gate. The owner-online / non-empty / complete-listing gates
+  // establish that a listing is authoritative, not that it is plausible: a share shrinking 1000 ->
+  // 3 passed all three and unlinked 997 local files. Always honour up to `min` deletions so
+  // ordinary tidying is unaffected; above that never more than `ratio` of what the mirror owns.
+  minMirrorDeletions: 8,
+  maxMirrorDeletionRatio: 0.5,
   // Boot leftover-sweep plausibility cap. The sweep deletes cores irreversibly, so an implausibly
   // large target set is treated as evidence the classification is wrong, not as work to do. Always
   // allow `min`; above that never more than `ratio` of the store, and never more than `max`.
@@ -437,6 +443,8 @@ export function getResourceCaps() {
     avatarMaxBytes: c.maxAvatarBytes,
     deriveDebounceMs: c.deriveDebounceMs,
     foreignPollIntervalMs: c.foreignPollIntervalMs,
+    minMirrorDeletions: c.minMirrorDeletions,
+    maxMirrorDeletionRatio: c.maxMirrorDeletionRatio,
     minSweepPurgeCores: c.minSweepPurgeCores,
     maxSweepPurgeCores: c.maxSweepPurgeCores,
     maxSweepPurgeRatio: c.maxSweepPurgeRatio,

--- a/src/shared/core/runtime-config.js
+++ b/src/shared/core/runtime-config.js
@@ -72,6 +72,12 @@ const DEFAULTED = {
   // Open peer catalogs kept cached. Each is a Hyperbee + Hypercore session with an append listener,
   // and every open core replicates to every socket. 0 = unbounded (the previous behaviour).
   peerCatalogCacheLimit: 64,
+  // Boot leftover-sweep plausibility cap. The sweep deletes cores irreversibly, so an implausibly
+  // large target set is treated as evidence the classification is wrong, not as work to do. Always
+  // allow `min`; above that never more than `ratio` of the store, and never more than `max`.
+  minSweepPurgeCores: 8,
+  maxSweepPurgeCores: 64,
+  maxSweepPurgeRatio: 0.5,
   // Only topic-MATCHED identity frames charge this lane (the receiver resolves the topic
   // before charging). An honest connection sends one frame per shared space, we reciprocate
   // each, and a name change or ledger re-send can add a third inside one refill window — so
@@ -431,6 +437,9 @@ export function getResourceCaps() {
     avatarMaxBytes: c.maxAvatarBytes,
     deriveDebounceMs: c.deriveDebounceMs,
     foreignPollIntervalMs: c.foreignPollIntervalMs,
+    minSweepPurgeCores: c.minSweepPurgeCores,
+    maxSweepPurgeCores: c.maxSweepPurgeCores,
+    maxSweepPurgeRatio: c.maxSweepPurgeRatio,
     foreignFullWalkEvery: c.foreignFullWalkEvery,
   }
 }

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -363,7 +363,20 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   const localRelPath = await state.resolveLocalRelPath(mount, entry.relPath, entry.contentHash, hashOf, opts.synced || state.syncedSetFor(mount), opts.fresh)
   const abs = pathFromMount(mount.mountPath, localRelPath)
   let onDisk = null
-  try { onDisk = await fs.promises.stat(abs) } catch {}
+  // ENOENT is the only stat failure that means "nothing is there, the path is free to write".
+  // Every other one means something IS there that we could not read — and the fetch below renames
+  // over it regardless of whether we could stat it, since rename needs permission on the DIRECTORY,
+  // not the file. Swallowing them all made the preserve step fail open in exactly the case it
+  // exists for: an unreadable local file looked absent and was overwritten without a copy.
+  let unreadable = false
+  try {
+    onDisk = await fs.promises.stat(abs)
+  } catch (err) {
+    if (err?.code !== 'ENOENT') {
+      unreadable = true
+      log.debug('could not stat a mirror path before materializing:', entry.relPath, '-', err.message)
+    }
+  }
   // Retained past the checks below: it is the evidence the ancestor comparison needs, and hashing
   // a multi-GB file twice in one pass to re-derive it would undo FIX-MIRROR-REHASH.
   let diskHash = null
@@ -393,7 +406,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
     // Fall back to the LIVE generation rather than undefined: loops.stopped compares against it,
     // so an absent gen would read as 'stopped' and refuse every fetch. A caller without one still
     // gets the check it needs — a stop landing during the wait above.
-    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen: opts.gen ?? mirrorGen(streamKey), diskHash, localExists: !!onDisk?.isFile() })
+    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen: opts.gen ?? mirrorGen(streamKey), diskHash, localExists: !!onDisk || unreadable })
   } finally {
     releaseSlot()
   }

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -6,7 +6,7 @@
 // owner is provably online, so a lagged replica or a user's own files are never wiped.
 import fs from 'bare-fs'
 import path from 'bare-path'
-import { shouldHonorDeletions, relKeyEscapes, dropUnsafeEntries } from './path-keys.js'
+import { shouldHonorDeletions, relKeyEscapes, dropUnsafeEntries, conflictCopyName, driveKeyToSegments } from './path-keys.js'
 import { isOwnerOnline } from '../transfer/swarm.js'
 import { record } from '../audit/audit-log.js'
 import { createIntegritySeen } from './integrity-seen.js'
@@ -20,6 +20,7 @@ import { setMirrorState, tombstoneMirror } from './mirror-records.js'
 import { mountRootAvailable } from './owned-folders.js'
 import { AppError, ErrorCodes, classifyLocalIoFault } from '../core/errors.js'
 import { pathFromMount } from '../transfer/path-guard.js'
+import { PARTIAL_SUFFIX } from '../transfer/partial-suffix.js'
 import { faultFromError, statusForFaultCode, isAutoPauseStatus, STATUS_MOUNT_GONE } from './mount-fault.js'
 import { getContentBackend, hasContentBackend } from '../transfer/content-backends.js'
 import { getOverlay } from '../transfer/backends/overlay/overlay-instance.js'
@@ -30,12 +31,13 @@ import { claimFetch, dropFetchClaim, fetchClaimedBy } from '../transfer/backends
 import { createPausedHolders } from '../transfer/backends/overlay/paused-holders.js'
 import { shareDecoKey } from '../transfer/decoration-key.js'
 import { transferIdFor } from '../transfer/transfer-id.js'
-import { markVerified, isVerifiedUnchanged } from '../transfer/files.js'
+import { markVerified, isVerifiedUnchanged, getVerifiedHash } from '../transfer/files.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { mirrorVerdict } from './mirror-health.js'
 import { createMirrorLoops } from './mirror-loop.js'
 import { createMirrorState, localRelOf } from './mirror-state.js'
+import { classifyLocalCopy, mayOverwriteInPlace } from './mirror-ownership.js'
 import { shouldWalk } from './mirror-walk.js'
 
 const log = createLogger('foreign-folders')
@@ -302,6 +304,38 @@ function recordMirrorIntegrityFailure(mount, share, entry) {
   }).catch((err) => log.debug('mirror integrity audit failed:', err.message))
 }
 
+// A mirror is owner-authoritative: the owner's bytes belong at the natural name, and that is what
+// test/flow/mirror-local-edit.test.js pins. What was never intended is the other half of the old
+// behaviour — that the user's bytes were DESTROYED to get there, with no copy, no warning and no
+// audit row.
+//
+// So before the fetch renames over the local file, prove the file is one we delivered. The verified
+// record is that ancestor and `diskHash` is already computed, so the check costs one bee read on a
+// file that was going to be overwritten anyway. Anything we cannot vouch for is moved aside first;
+// the owner's version then lands at the canonical path exactly as before.
+async function preserveLocalEdit (mount, entry, verifyKey, diskHash, abs) {
+  const ancestorHash = await getVerifiedHash(mount.spaceId, verifyKey).catch(() => null)
+  if (mayOverwriteInPlace(classifyLocalCopy({ diskHash, ownerHash: entry.contentHash, ancestorHash }))) return
+
+  const segs = driveKeyToSegments(entry.relPath)
+  const leaf = segs.pop()
+  const dir = segs.join('/')
+  const isTaken = (name) => {
+    const candidate = pathFromMount(mount.mountPath, dir ? dir + '/' + name : name)
+    return fs.existsSync(candidate) || fs.existsSync(candidate + PARTIAL_SUFFIX)
+  }
+  const conflictRel = (dir ? dir + '/' : '') + conflictCopyName(leaf, isTaken)
+  try {
+    await fs.promises.rename(abs, pathFromMount(mount.mountPath, conflictRel))
+    log.warn('mirror conflict on', entry.relPath, '- the local copy was not the one we delivered; kept it as', conflictRel)
+  } catch (err) {
+    // Could not move it aside, so do not overwrite it either: leaving the mirror one file stale is
+    // recoverable on the next tick, and destroying the edit is not.
+    log.error('could not preserve a locally-edited mirror file — leaving it untouched:', entry.relPath, '-', err.message)
+    throw new AppError(ErrorCodes.TRANSFER_PERMISSION, 'could not preserve a local edit')
+  }
+}
+
 // Overlay share: the bytes never enter a drive, so the mirror fetches the file by
 // its content hash straight to the mount path (hash-verified by the overlay). No
 // ensureRemote/release handshake — the holder serves on demand, gated by the
@@ -330,12 +364,16 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   const abs = pathFromMount(mount.mountPath, localRelPath)
   let onDisk = null
   try { onDisk = await fs.promises.stat(abs) } catch {}
+  // Retained past the checks below: it is the evidence the ancestor comparison needs, and hashing
+  // a multi-GB file twice in one pass to re-derive it would undo FIX-MIRROR-REHASH.
+  let diskHash = null
   if (onDisk?.isFile() && entry.contentHash) {
     // Already-mirrored file: the verified record skips the full re-hash the poll
     // would otherwise run over every file each tick; only hash on a cache miss.
     if (await isVerifiedUnchanged(mount.spaceId, verifyKey, entry.contentHash, entry.size, onDisk)) return 'present'
     try {
-      if (await hashOf(abs) === entry.contentHash) {
+      diskHash = await hashOf(abs)
+      if (diskHash === entry.contentHash) {
         await markVerified(mount.spaceId, verifyKey, entry.contentHash)
         return 'present'
       }
@@ -355,7 +393,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
     // Fall back to the LIVE generation rather than undefined: loops.stopped compares against it,
     // so an absent gen would read as 'stopped' and refuse every fetch. A caller without one still
     // gets the check it needs — a stop landing during the wait above.
-    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen: opts.gen ?? mirrorGen(streamKey) })
+    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen: opts.gen ?? mirrorGen(streamKey), diskHash, localExists: !!onDisk?.isFile() })
   } finally {
     releaseSlot()
   }
@@ -385,7 +423,7 @@ async function acquireMirrorSlot(streamKey) {
 
 // The gated half of a materialize: everything past the slot owns a chunk scheduler, a watchdog,
 // an fd and a ticker.
-async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen }) {
+async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen, diskHash = null, localExists = false }) {
   // The wait for a slot is unbounded, so re-check the stop the catalog walk tests at every entry.
   if (mirrorStopped(streamKey, gen)) return 'missing'
   // Read AFTER the wait, not before it: the overlay can be torn down while a pass is parked.
@@ -406,6 +444,13 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   let diag = null
   // Everything from here is inside the try, so no throw between the claim and the fetch can leak it.
   try {
+    // Move a local edit aside before the fetch renames over it — here, past the gate, rather than
+    // in the caller: every early-out above (a claim the engine holds, a stop landing during the
+    // unbounded slot wait, the overlay torn down) would otherwise have moved the user's file and
+    // then not replaced it, leaving the canonical path empty until a later tick.
+    if (localExists) {
+      try { await preserveLocalEdit(mount, entry, verifyKey, diskHash, abs) } catch { return 'missing' }
+    }
     activeOverlayFetches.set(streamKey, { contentHash: entry.contentHash, relPath: entry.relPath, transferId })
     pausedHolders.supersede(streamKey)
     // The row just flipped to 'downloading' (foreignFetchActive) — poke the list re-derive.

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -551,6 +551,16 @@ async function initialMaterializeScanCatalog(mount, share) {
   return {}
 }
 
+// error, not warn: this is the mirror declining to delete the user's files on an implausible
+// listing, and it is the one line that explains a mirror that has stopped tracking deletions.
+// Nothing is forgotten from the synced set, so a later pass re-evaluates rather than losing the
+// fact. Quiet below the floor, where a withheld pass just means the owner was offline.
+function logWithheldDeletions (key, pending, syncedSize, minDeletions) {
+  if (pending <= minDeletions) return
+  log.error('withholding', pending, 'mirror deletions of', syncedSize,
+    'synced paths — the owner catalog shrank implausibly; keeping the local files:', key)
+}
+
 async function materializeOnceCatalog(mount, share) {
   const key = loopKey(mount.spaceId, mount.shareId)
   const gen = mirrorGen(key)
@@ -598,14 +608,22 @@ async function materializeOnceCatalog(mount, share) {
 
   if (mirrorStopped(key, gen)) return
 
+  // Resolved BEFORE the gate rather than inside the loop: the gate now weighs how MANY files a
+  // pass would remove, which cannot be known one key at a time.
+  const pendingDeletions = [...synced].filter((ownerKey) => !onDrive.has(ownerKey))
+  const caps = getResourceCaps()
   const honorDeletions = shouldHonorDeletions({
     ownerOnline: isOwnerOnline(mount.ownerKey),
     driveCount: onDrive.size,
     listingComplete: complete,
+    syncedCount: synced.size,
+    deletionCount: pendingDeletions.length,
+    minDeletions: caps.minMirrorDeletions,
+    maxDeletionRatio: caps.maxMirrorDeletionRatio,
   })
+  if (!honorDeletions) logWithheldDeletions(key, pendingDeletions.length, synced.size, caps.minMirrorDeletions)
   if (honorDeletions) {
-    for (const ownerKey of [...synced]) {
-      if (onDrive.has(ownerKey)) continue
+    for (const ownerKey of pendingDeletions) {
       if (relKeyEscapes(ownerKey)) {
         log.warn('refusing to honor a stored sync path that escapes the mount folder — skipping deletion:', ownerKey)
         state.forgetSynced(key, synced, ownerKey)

--- a/src/shared/folders/mirror-ownership.js
+++ b/src/shared/folders/mirror-ownership.js
@@ -1,0 +1,46 @@
+// Whose bytes are on disk? The one question the mirror never asked.
+//
+// The materialize path has always compared the local file against the owner's CURRENT content
+// hash. That answers "is this file up to date?" and nothing else — when it says no, the reason is
+// either that the owner moved on or that the user edited our copy, and those two need opposite
+// handling. Treating every mismatch as the first is what let a tick rename fetched bytes over a
+// user's edit.
+//
+// The evidence to separate them is the ANCESTOR: the hash the mirror itself last delivered for that
+// path, recorded by markVerified() on every landing and durable for the life of the mount. Disk ===
+// ancestor means our copy is untouched, so a difference from the owner is the owner's doing. Disk
+// !== ancestor means someone else wrote those bytes.
+//
+// Pure on purpose (same shape as supersede-decision.js / mount-fault.js): every branch here decides
+// whether a user's file may be destroyed, and that decision should be testable without a disk.
+
+export const LOCAL_COPY = {
+  // The local file already IS the owner's current content — nothing to fetch.
+  OWNER_CURRENT: 'owner-current',
+  // Exactly the bytes we last delivered, so the difference from the owner is the OWNER's edit.
+  OURS: 'ours',
+  // Neither the owner's current content nor what we delivered: the USER edited our copy.
+  DIVERGED: 'diverged',
+  // No ancestor on record, or the local file could not be read. Not proof of anything.
+  UNKNOWN: 'unknown',
+}
+
+export function classifyLocalCopy ({ diskHash = null, ownerHash = null, ancestorHash = null } = {}) {
+  // An unreadable local file is not an invitation to replace it.
+  if (!diskHash) return LOCAL_COPY.UNKNOWN
+  // Checked before the ancestor: when all three agree the file is current, and that is the more
+  // useful answer than "ours".
+  if (ownerHash && diskHash === ownerHash) return LOCAL_COPY.OWNER_CURRENT
+  if (!ancestorHash) return LOCAL_COPY.UNKNOWN
+  return diskHash === ancestorHash ? LOCAL_COPY.OURS : LOCAL_COPY.DIVERGED
+}
+
+// Only a copy we can PROVE is ours may be written over in place.
+//
+// UNKNOWN deliberately fails closed. A missing ancestor is an absence of evidence, not evidence of
+// ownership, and the two mistakes are not symmetric: a needless sibling is a file the user can
+// delete in a second, while a wrong overwrite is unrecoverable — there is no trash on this path and
+// no audit row to reconstruct from.
+export function mayOverwriteInPlace (verdict) {
+  return verdict === LOCAL_COPY.OURS || verdict === LOCAL_COPY.OWNER_CURRENT
+}

--- a/src/shared/folders/path-keys.js
+++ b/src/shared/folders/path-keys.js
@@ -208,6 +208,15 @@ export function nextFreeName (fileName, isTaken) {
   return candidate
 }
 
+// The name a mirrored file's LOCAL edit is moved aside to before the owner's version is written
+// back over the canonical path. A mirror is owner-authoritative — the owner's bytes belong at the
+// natural name — but that does not require destroying what the user wrote. Same shape as every
+// other file manager's conflict copy, and `nextFreeName` handles the second and third collision.
+export function conflictCopyName (fileName, isTaken) {
+  const { base, ext } = splitFileName(fileName)
+  return nextFreeName(`${base} (conflicted copy)${ext}`, isTaken)
+}
+
 // ─── mount path rejection rules ───────────────────────────────────────────────
 export const SYSTEM_FOLDERS = {
   darwin: ['/System', '/usr', '/bin', '/sbin', '/Library/Apple', '/private/var'],

--- a/src/shared/folders/path-keys.js
+++ b/src/shared/folders/path-keys.js
@@ -179,8 +179,28 @@ function matchPattern (input, pattern) {
 // out mid-tree returns a PARTIAL, non-empty list — indistinguishable from a real deletion unless
 // completeness is checked, and acting on it deletes files the owner still has. The likelihood of
 // such a drain grows with the file count, so the bigger the folder, the likelier the wrong delete.
-export function shouldHonorDeletions ({ ownerOnline, driveCount, listingComplete }) {
-  return !!ownerOnline && driveCount > 0 && !!listingComplete
+// The three gates above are TRUST gates: they establish that the listing is authoritative. None of
+// them establishes that it is PLAUSIBLE, and those are different questions. A share going from 1000
+// files to 3 passes all three, and the caller then unlinks 997 local files. At this layer a catalog
+// that legitimately shrank by 99% is indistinguishable from one read against a half-replicated
+// core — and only one of those two readings is recoverable, so the tie goes to keeping the files.
+//
+// `minDeletions` is a floor, not a ratio, so ordinary tidying (and a small mirror emptying out) is
+// never withheld. Above it, a pass may never remove more than `maxDeletionRatio` of what the mirror
+// owns. Both are parameters rather than a config read, so this stays a pure function the unit test
+// can drive with its own caps.
+//
+// Defaults keep an un-migrated caller on the old behaviour: passing no counts yields deletionCount
+// 0, which is under any floor. A guard that silently withheld everything the moment a caller forgot
+// an argument would be its own outage.
+export function shouldHonorDeletions ({
+  ownerOnline, driveCount, listingComplete,
+  syncedCount = 0, deletionCount = 0,
+  minDeletions = 8, maxDeletionRatio = 0.5,
+}) {
+  if (!ownerOnline || !(driveCount > 0) || !listingComplete) return false
+  if (deletionCount <= minDeletions) return true
+  return deletionCount <= Math.max(minDeletions, Math.floor(syncedCount * maxDeletionRatio))
 }
 
 // ─── collision-free download/copy naming ──────────────────────────────────────

--- a/src/shared/storage/leftover.js
+++ b/src/shared/storage/leftover.js
@@ -15,6 +15,9 @@ import { compactStore } from '../transfer/swarm.js'
 import { withReadTimeout } from '../core/with-timeout.js'
 import { mapLimit } from '../core/concurrency.js'
 import { classifyBeeKind } from './leftover-classify.js'
+import { decideSweep } from './sweep-decision.js'
+import { recordSweep } from './sweep-journal.js'
+import { getResourceCaps } from '../core/runtime-config.js'
 import { listContentKeys } from '../spaces/space-keys.js'
 
 const log = createLogger('leftover')
@@ -111,50 +114,75 @@ async function addMemberCores(wanted, member, spaceId) {
   for (const ck of await localPeerCatalogKeys(member.publicKey, spaceId)) wanted.add(dkOfKey(ck))
 }
 
-export async function buildWantedKeys() {
+const TIMED_OUT = Symbol('timed-out')
+
+// Every core current state still needs. A GAP means the set is INCOMPLETE — something that should
+// be in it is not — so "outside the set" no longer means "unneeded" and no category may be purged.
+// Each failure below used to log a warning (one did not even do that) and let the sweep proceed on
+// the shorter set, which is how a transient read failure became a permanent delete.
+export async function buildWantedKeys({ openSystemBee = null } = {}) {
   const wanted = new Set()
+  const gaps = []
+  const gap = (stage, detail) => {
+    gaps.push({ stage, detail: String(detail || '') })
+    log.warn('wanted-set gap:', stage, '-', detail)
+  }
 
   for (const { names, open } of WANTED_BEE_GROUPS) {
     for (const name of names) {
-      try { await addAndCloseBeeCore(wanted, open(name)) } catch (err) {
-        log.warn('wanted system bee failed:', name, err.message)
+      try { await addAndCloseBeeCore(wanted, (openSystemBee || open)(name)) } catch (err) {
+        gap('system-bee:' + name, err.message)
       }
     }
   }
+  // Was a bare `catch {}`. The most dangerous gap in this function: the live profile bee's own core,
+  // missing from `wanted`, classifies as 'profile' and is purged — the device's identity bee,
+  // deleted by the sweep that exists to protect it.
   const profile = getProfileBee()
   if (profile) {
-    try { await addBeeCore(wanted, profile) } catch {}
+    try { await addBeeCore(wanted, profile) } catch (err) { gap('profile-bee', err.message) }
+  } else {
+    gap('profile-bee', 'not open')
   }
 
   try {
     const { getOverlayLocalDiscoveryKeys } = await import('../transfer/backends/overlay/overlay-instance.js')
     for (const dk of await getOverlayLocalDiscoveryKeys()) wanted.add(dk)
   } catch (err) {
-    log.warn('wanted overlay cores failed:', err.message)
+    gap('overlay-cores', err.message)
   }
 
-  let unopenedDrive = false
+  // Deliberately NOT wrapped: a listSpaces() throw must propagate and fail the whole scan, which is
+  // already the correct outcome — purgeLeftovers never runs, so nothing is deleted.
   for (const space of await listSpaces()) {
     const drive = getDrive(space.spaceId)
     if (drive) {
-      await withReadTimeout(addLocalDriveCores(wanted, drive), INSPECT_MS, null)
-        .catch((err) => log.warn('wanted own drive failed:', space.spaceId, err.message))
+      // withReadTimeout RESOLVES the sentinel rather than rejecting, so the `.catch` below never
+      // sees a timeout. A drive whose read merely took too long silently contributed nothing to
+      // `wanted` and recorded nothing at all — the purest form of "couldn't read it just now"
+      // reaching the delete.
+      const res = await withReadTimeout(addLocalDriveCores(wanted, drive).then(() => true), INSPECT_MS, TIMED_OUT)
+        .catch((err) => { gap('own-drive:' + space.spaceId, err.message); return null })
+      if (res === TIMED_OUT) gap('own-drive:' + space.spaceId, 'read timed out after ' + INSPECT_MS + 'ms')
     } else if (space.status !== 'pending' && !space.leaving) {
-      // A listed space whose drive is not loaded — a boot open that failed and is being
-      // retried next boot (driveLoadError). Its cores are reachable only through the drive
-      // handle, so they cannot be added to the wanted set here; mark the scan unsafe instead
-      // of letting a sweep reclaim a drive the space still expects to use.
-      unopenedDrive = true
+      // A listed space whose drive is not loaded — a boot open that failed and is being retried
+      // next boot (driveLoadError). Its cores are reachable only through the drive handle, so they
+      // cannot be added here.
+      gap('unopened-drive:' + space.spaceId, 'drive not loaded this boot')
     }
     try { await addBeeCore(wanted, await ownCatalog(space.spaceId)) } catch (err) {
-      log.warn('wanted own catalog failed:', space.spaceId, err.message)
+      gap('own-catalog:' + space.spaceId, err.message)
     }
 
-    for (const member of (space.members || [])) await addMemberCores(wanted, member, space.spaceId)
+    // Wrapped where it never was: a throw here aborts the whole loop, so every space after this one
+    // contributes nothing to `wanted` while still being listed.
+    for (const member of (space.members || [])) {
+      try { await addMemberCores(wanted, member, space.spaceId) } catch (err) {
+        gap('member-cores:' + space.spaceId, err.message)
+      }
+    }
   }
-  // A drive we could not open is not in `wanted` and would scan as an orphan, so the caller is
-  // told to withhold the drive category rather than reclaim a space's own storage.
-  wanted.unopenedDrive = unopenedDrive
+  wanted.gaps = gaps
   return wanted
 }
 
@@ -272,12 +300,14 @@ async function inspectCore(store, dk) {
   return { kind: 'other', bytes: metaBytes }
 }
 
-export async function classifyLeftovers() {
+export async function classifyLeftovers(opts = {}) {
   const store = getStore()
-  const wanted = await buildWantedKeys()
+  const wanted = await buildWantedKeys(opts)
 
   const candidates = []
+  let totalCores = 0
   for await (const dk of store.list()) {
+    totalCores++
     const h = hex(dk)
     if (!wanted.has(h)) candidates.push(h)
   }
@@ -293,19 +323,23 @@ export async function classifyLeftovers() {
   for (const r of inspected) {
     if (r.kind === 'profile') profiles.push({ discoveryKeyHex: r.discoveryKeyHex, bytes: r.bytes })
     else if (r.kind === 'catalog') catalogs.push({ discoveryKeyHex: r.discoveryKeyHex, bytes: r.bytes })
-    // A drive only counts as an orphan when every space's own drive is loaded. If one failed to
-    // open this boot, its cores look unwanted while the space is still listed and expects to
-    // retry — reclaiming them would destroy the space's storage.
-    else if (r.kind === 'drive' && !wanted.unopenedDrive) orphanDrives.push({ metaDkHex: r.discoveryKeyHex, blobsDkHex: r.blobsDkHex, bytes: r.bytes })
+    // No longer filtered here by the unopened-drive flag: an unopened drive is now one gap among
+    // several, and a gap withholds EVERY category in purgeLeftovers. Filtering here would only hide
+    // the finding from the scan's own report, which is the one place it can be diagnosed.
+    else if (r.kind === 'drive') orphanDrives.push({ metaDkHex: r.discoveryKeyHex, blobsDkHex: r.blobsDkHex, bytes: r.bytes })
   }
-  if (wanted.unopenedDrive) log.warn('a space drive did not load this session — leaving orphan drives out of the reclaim scan')
+  if (wanted.gaps.length) log.warn('the wanted set is incomplete —', wanted.gaps.map((g) => g.stage).join(', '))
   const sum = (a) => a.reduce((n, r) => n + r.bytes, 0)
   return {
     profiles: { count: profiles.length, bytes: sum(profiles), keys: profiles },
     catalogs: { count: catalogs.length, bytes: sum(catalogs), keys: catalogs },
     orphanDrives: { count: orphanDrives.length, bytes: sum(orphanDrives), keys: orphanDrives },
     totalBytes: sum(profiles) + sum(catalogs) + sum(orphanDrives),
-    withheldDrives: !!wanted.unopenedDrive,
+    totalCores,
+    gaps: wanted.gaps,
+    scanComplete: wanted.gaps.length === 0,
+    // Retained for existing callers; now derived from the same one rule.
+    withheldDrives: wanted.gaps.length > 0,
   }
 }
 
@@ -324,27 +358,52 @@ function purgeTargets(scan, allowed) {
   return [...new Set(dks)]
 }
 
-export async function purgeLeftovers({ categories = PURGEABLE, onProgress, compact = true } = {}) {
+export async function purgeLeftovers({ categories = PURGEABLE, onProgress, compact = true, openSystemBee = null } = {}) {
   const store = getStore()
   const db = store.storage.db
-  const scan = await classifyLeftovers()
+  const scan = await classifyLeftovers({ openSystemBee })
   const allowed = categories.filter((c) => PURGEABLE.includes(c))
-  // Release any open probe handle for a drive about to be purged so its cores
-  // are not held open during the RocksDB delete.
+  const dks = purgeTargets(scan, allowed)
+
+  const decision = decideSweep({
+    gaps: scan.gaps,
+    targetCount: dks.length,
+    totalCores: scan.totalCores,
+    caps: getResourceCaps(),
+  })
+  if (!decision.allow) {
+    // error, not warn: this is the sweep declining to delete user data on incomplete or
+    // implausible evidence, and it is the one line that explains a boot that reclaimed nothing.
+    log.error('leftover sweep refused:', decision.reason, '- targets', dks.length, 'of',
+      scan.totalCores, 'cores, gaps:', scan.gaps.map((g) => g.stage).join(',') || 'none')
+    await recordSweep({
+      refused: decision.reason, targets: dks.length, totalCores: scan.totalCores,
+      gaps: scan.gaps, categories: allowed, purged: 0,
+    })
+    return { purged: 0, freedEstimate: 0, withheldDrives: true, refused: decision.reason }
+  }
+
+  // Released only once the sweep is known to be going ahead: closing them on a refused pass would
+  // drop the cache this module keeps so a scan and a later cleanup do not re-open the same drive.
   if (allowed.includes('orphanDrives')) {
     for (const d of scan.orphanDrives.keys) await closeProbe(d.metaDkHex)
   }
-  const dks = purgeTargets(scan, allowed)
   let purged = 0
+  const purgedDks = []
   for (const dkHex of dks) {
     if (onProgress) onProgress('purging', { done: purged, total: dks.length })
     try {
       await purgeCoreDk(store, db, dkHex)
       purged++
+      purgedDks.push(dkHex)
     } catch (err) {
       log.debug('leftover purge skip:', dkHex.slice(0, 12), err.message)
     }
   }
+  await recordSweep({
+    refused: null, targets: dks.length, totalCores: scan.totalCores,
+    gaps: [], categories: allowed, purged, purgedDks,
+  })
   // Tombstoning the cores is what makes the leave effective; the compaction only returns the
   // bytes. A boot-path caller passes compact:false rather than block startup on a full-range
   // pass — space-leave.js defers it for the same reason.
@@ -353,7 +412,7 @@ export async function purgeLeftovers({ categories = PURGEABLE, onProgress, compa
     await compactStore()
   }
   const freedEstimate = allowed.reduce((n, c) => n + (scan[c]?.bytes || 0), 0)
-  return { purged, freedEstimate, withheldDrives: scan.withheldDrives }
+  return { purged, freedEstimate, withheldDrives: scan.withheldDrives, refused: null }
 }
 
 // The cores a member brought with them: their profile bee, and the one catalog they advertise per

--- a/src/shared/storage/storage.js
+++ b/src/shared/storage/storage.js
@@ -104,7 +104,13 @@ export async function getSpaceCacheBytes(spaceId) {
 export async function cleanupOrphanedData() {
   const withDrives = await shouldReclaimOrphanDrives()
   const categories = withDrives ? ['profiles', 'catalogs', 'orphanDrives'] : ['profiles', 'catalogs']
-  const { purged, withheldDrives } = await purgeLeftovers({ categories, compact: false })
+  const { purged, withheldDrives, refused } = await purgeLeftovers({ categories, compact: false })
+  // A refused sweep looked at nothing, so it must not consume the one-shot orphan-drive pass below
+  // — that flag is the only chance this build ever gets to reclaim pre-overlay drive blobs.
+  if (refused) {
+    log.warn('leftover metadata cleanup skipped this boot:', refused)
+    return { purged: 0, refused }
+  }
   log.info('leftover metadata cleanup done, pruned', purged, 'cores')
   // A scan that withheld the drive category looked away on purpose — a space drive had not opened
   // — so spending the single pass here would strand those bytes for good. Retry on a later boot.
@@ -116,5 +122,5 @@ export async function cleanupOrphanedData() {
       try { await compactStore() } catch (err) { log.warn('reclaim compaction failed:', err.message) }
     }
   }
-  return { purged }
+  return { purged, refused: null }
 }

--- a/src/shared/storage/sweep-decision.js
+++ b/src/shared/storage/sweep-decision.js
@@ -1,0 +1,41 @@
+// Should this leftover sweep be allowed to delete anything?
+//
+// The sweep's deletes are irreversible RocksDB range deletes with no backup and no undo, decided
+// against a "wanted" set that is assembled best-effort from a dozen reads. Both guards here
+// therefore fail CLOSED: the cost of skipping a sweep is one boot's worth of unreclaimed
+// housekeeping bytes, and the cost of an unsafe sweep is the user's spaces.
+//
+// Pure — no store, no clock, no IO — so every branch is unit-testable, in the same shape as
+// supersede-decision.js / stall-verdict.js / mount-fault.js.
+
+export const SWEEP_REFUSAL = {
+  // The wanted set could not be built completely, so "not wanted" does not mean "not needed".
+  SCAN_INCOMPLETE: 'scan-incomplete',
+  OVER_ABSOLUTE_CAP: 'over-absolute-cap',
+  OVER_RATIO_CAP: 'over-ratio-cap',
+}
+
+export function decideSweep ({ gaps = [], targetCount = 0, totalCores = 0, caps = {} } = {}) {
+  const minCores = caps.minSweepPurgeCores ?? 8
+  const maxCores = caps.maxSweepPurgeCores ?? 64
+  const ratio = caps.maxSweepPurgeRatio ?? 0.5
+
+  // Nothing to delete outranks every other consideration: there is no risk to weigh, and refusing
+  // here would write a refusal row on every clean boot and bury the real ones.
+  if (targetCount === 0) return { allow: true, reason: null, limit: 0, gaps: [] }
+
+  // One rule, deliberately not per-category. Mapping each gap to the classifications it can reach
+  // ("an overlay gap only endangers file-index cores") is an inference that is true today and goes
+  // stale silently the next time a classification changes — the same shape as the defect this
+  // guard exists to fix.
+  if (gaps.length > 0) return { allow: false, reason: SWEEP_REFUSAL.SCAN_INCOMPLETE, limit: 0, gaps }
+
+  if (targetCount > maxCores) return { allow: false, reason: SWEEP_REFUSAL.OVER_ABSOLUTE_CAP, limit: maxCores, gaps }
+
+  // The floor is applied first so a fresh install is not held hostage by the ratio: a bare 50%
+  // rule would refuse an ordinary 3-core sweep of a 6-core store.
+  const ratioLimit = Math.max(minCores, Math.floor(totalCores * ratio))
+  if (targetCount > ratioLimit) return { allow: false, reason: SWEEP_REFUSAL.OVER_RATIO_CAP, limit: ratioLimit, gaps }
+
+  return { allow: true, reason: null, limit: Math.min(maxCores, ratioLimit), gaps: [] }
+}

--- a/src/shared/storage/sweep-journal.js
+++ b/src/shared/storage/sweep-journal.js
@@ -1,0 +1,58 @@
+// Forensic record of every leftover sweep: what it deleted, or why it refused to.
+//
+// The sweep is the only path in the app that destroys user data with no user action behind it, and
+// until now it left nothing behind but a log line that a release build discards. This is the record
+// that makes a boot where spaces went missing reconstructable.
+//
+// Kept in `reclaim-meta` — an existing LOCAL_BEE_NAMES bee (at-rest encrypted, already in the
+// sweep's own wanted set), so this adds no new core and therefore no new surface for the sweep to
+// be wrong about itself.
+//
+// Deliberately NOT an audit row: contract/audit-kinds.js excludes `storage.cleanup` as app
+// housekeeping rather than "which user did what in a space", and that decision stands. This answers
+// a different question — "what did the sweep do on boot N" — and is read through diagnostics:export.
+import { createLocalBee } from '../core/store.js'
+import { createLogger } from '../core/logger.js'
+
+const log = createLogger('sweep-journal')
+const PREFIX = 'purge/'
+const KEEP = 50
+
+// Zero-padded so the bee's lexicographic order is chronological, and counter-suffixed so two
+// sweeps inside one millisecond cannot collide on a key.
+let seq = 0
+const journalKey = (at) => PREFIX + String(at).padStart(16, '0') + '-' + String(seq++).padStart(4, '0')
+
+export async function recordSweep (entry) {
+  const bee = createLocalBee('reclaim-meta')
+  try {
+    await bee.ready()
+    await bee.put(journalKey(Date.now()), { at: Date.now(), ...entry })
+    const keys = []
+    for await (const node of bee.createReadStream({ gte: PREFIX, lt: PREFIX + '\xff' })) keys.push(node.key)
+    for (const key of keys.slice(0, Math.max(0, keys.length - KEEP))) await bee.del(key)
+  } catch (err) {
+    // Never throws. A journal failure must not be the thing that aborts a sweep — or, worse, that
+    // makes a caller retry one.
+    log.warn('could not record the sweep:', err.message)
+  } finally {
+    try { await bee.close() } catch {}
+  }
+}
+
+export async function listRecentSweeps (limit = 20) {
+  const bee = createLocalBee('reclaim-meta')
+  const out = []
+  try {
+    await bee.ready()
+    for await (const node of bee.createReadStream({ gte: PREFIX, lt: PREFIX + '\xff', reverse: true })) {
+      out.push(node.value)
+      if (out.length >= limit) break
+    }
+  } catch (err) {
+    log.warn('could not read the sweep journal:', err.message)
+  } finally {
+    try { await bee.close() } catch {}
+  }
+  return out
+}

--- a/src/shared/transfer/diagnostics.js
+++ b/src/shared/transfer/diagnostics.js
@@ -35,7 +35,7 @@ export function verdictHistoryFromAudit(entries = []) {
 // form, is the port 0, did it change, how many dials opened — is answerable without the
 // actual IP, the real keys, or space names.
 export function buildDiagnostics(ctx, redact = true) {
-  const { status, history, env, counters, peerSamples, requestFailures = {}, requestMetrics = {}, health = {} } = ctx
+  const { status, history, env, counters, peerSamples, requestFailures = {}, requestMetrics = {}, health = {}, sweeps = [] } = ctx
   const topicAlias = makeAliaser('t')
   const samples = peerSamples.map((peer) => ({
     peer: redact ? shortId(peer.publicKey) : peer.publicKey,
@@ -54,6 +54,18 @@ export function buildDiagnostics(ctx, redact = true) {
     system: { platform: env.platform, release: env.release, arch: env.arch },
 
     verdict: { current: status.reachability, history },
+
+    // The boot leftover sweep: what it deleted, or which gap made it refuse. Counts and gap STAGES
+    // only — a stage is a fixed label like 'own-catalog:<spaceId>', so the space id is aliased and
+    // the purged discovery keys are dropped entirely. This bundle is user-shareable.
+    sweeps: sweeps.map((row) => ({
+      at: row.at,
+      refused: row.refused || null,
+      targets: row.targets,
+      totalCores: row.totalCores,
+      purged: row.purged,
+      gaps: (row.gaps || []).map((g) => (redact ? String(g.stage).split(':')[0] : g.stage)),
+    })),
 
     network: {
       dhtReady: status.dhtReady,

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -140,6 +140,7 @@ import { spaceStorageSummary } from '../shared/storage/space-storage.js'
 import { forgetUnreferencedPeerCores } from '../shared/storage/leftover.js'
 import { sendFeedback } from '../shared/telemetry/feedback.js'
 import { getInstallId } from '../shared/telemetry/install-id.js'
+import { listRecentSweeps } from '../shared/storage/sweep-journal.js'
 import { deriveChannel } from '../shared/core/channel.js'
 import { buildDiagnostics, verdictHistoryFromAudit, VERDICT_KINDS } from '../shared/transfer/diagnostics.js'
 import {
@@ -1718,6 +1719,7 @@ ipc.handle('diagnostics:export', async (msg) => {
       arch: os.arch(),
     },
     counters: getDiagnosticCounters(),
+    sweeps: await listRecentSweeps(10),
     requestFailures: getRequestFailureCounters(),
     requestMetrics: getRequestMetrics(),
     health: health.snapshot({

--- a/test/integration/foreign-mirror-conflict.test.js
+++ b/test/integration/foreign-mirror-conflict.test.js
@@ -1,0 +1,120 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { setupSelfMirror } from '../helpers/owned.js'
+import { initialMaterializeScan, materializeCatalogFile } from '../../src/shared/folders/foreign-folders.js'
+import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
+import { getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { initDownloads } from '../../src/shared/transfer/files.js'
+
+// D2 — a mirror stays owner-authoritative, but a user's bytes are no longer destroyed to get there.
+//
+// test/flow/mirror-local-edit.test.js pins the doctrine: the owner's version belongs at the natural
+// name. That part is deliberate and unchanged here. What was never intended is the other half — the
+// old code renamed the fetched bytes straight over the local file, so an edit inside a mirrored
+// folder vanished on the next 30 s tick with no copy, no warning and no audit row.
+//
+// materializeOverlayFile had two "already correct?" tests and both compared the disk against
+// `entry.contentHash`, the OWNER's current hash. Failing both means only "this is not the owner's
+// current version" — equally true when the owner edited the file and when the user edited ours.
+//
+// The evidence to tell them apart was already durable: markVerified() records the hash the mirror
+// actually DELIVERED, per file, for the life of the mount. It was written on every landing and only
+// ever read back against the owner's hash — getVerifiedHash had no caller anywhere in src/.
+
+async function entryFor (ctx) {
+  const { entries: [entry] } = await overlayBackend.listPeerWithMeta(ctx.spaceId, ctx.share)
+  return entry
+}
+
+// Edit the mirrored copy the way a user would: new bytes, and an mtime after the verified record
+// so the fast-path cache correctly declines to vouch for it.
+function userEdits (abs, content) {
+  fs.writeFileSync(abs, content)
+  const future = new Date(Date.now() + 60000)
+  fs.utimesSync(abs, future, future)
+}
+
+test('REGRESSION (FIX-D2-1): a locally-edited mirror file is preserved, not destroyed', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'owner-bytes' } })
+  await initDownloads()
+  await initialMaterializeScan(ctx.mount)
+
+  const abs = path.join(ctx.mirrorPath, 'a.txt')
+  t.is(fs.readFileSync(abs, 'utf8'), 'owner-bytes', 'precondition: the mirror delivered the file')
+
+  userEdits(abs, 'my own edit')
+
+  // The owner has changed NOTHING, so the only difference on disk is the user's.
+  const cur = await getForeignMount(ctx.spaceId, ctx.share.id)
+  await materializeCatalogFile(cur, ctx.share, await entryFor(ctx))
+
+  // Owner-authoritative: the canonical path still ends up with the owner's bytes...
+  t.is(fs.readFileSync(abs, 'utf8'), 'owner-bytes', 'the owner version holds the natural name')
+  // ...but the user's edit was moved aside instead of being overwritten in place.
+  const conflict = path.join(ctx.mirrorPath, 'a (conflicted copy).txt')
+  t.ok(fs.existsSync(conflict), 'the local edit was preserved as a conflict copy')
+  t.is(fs.readFileSync(conflict, 'utf8'), 'my own edit', 'byte-exact')
+})
+
+test('REGRESSION (FIX-D2-2): the mirror converges on the owner version at the canonical path', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'owner-bytes' } })
+  await initDownloads()
+  await initialMaterializeScan(ctx.mount)
+
+  const abs = path.join(ctx.mirrorPath, 'a.txt')
+  userEdits(abs, 'my own edit')
+
+  const cur = await getForeignMount(ctx.spaceId, ctx.share.id)
+  await materializeCatalogFile(cur, ctx.share, await entryFor(ctx))
+
+  t.is(fs.readFileSync(abs, 'utf8'), 'owner-bytes', 'the mirror re-materialized the owner version')
+
+  // No rename mapping is minted: the mirror still owns the natural name, so nothing about its
+  // bookkeeping changes and an unmount/re-mount adopts the same path as before.
+  const after = await getForeignMount(ctx.spaceId, ctx.share.id)
+  t.absent(after.renamedPaths?.['a.txt'], 'the mirror kept owning the canonical path')
+})
+
+test('D2: repeated ticks do not pile up conflict copies', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'owner-bytes' } })
+  await initDownloads()
+  await initialMaterializeScan(ctx.mount)
+
+  const abs = path.join(ctx.mirrorPath, 'a.txt')
+  userEdits(abs, 'my own edit')
+
+  for (let i = 0; i < 3; i++) {
+    const cur = await getForeignMount(ctx.spaceId, ctx.share.id)
+    await materializeCatalogFile(cur, ctx.share, await entryFor(ctx))
+  }
+
+  t.absent(fs.existsSync(path.join(ctx.mirrorPath, 'a (conflicted copy) (1).txt')), 'only one conflict copy')
+  t.is(fs.readFileSync(abs, 'utf8'), 'owner-bytes', 'the canonical path settled on the owner version')
+  t.is(fs.readFileSync(path.join(ctx.mirrorPath, 'a (conflicted copy).txt'), 'utf8'), 'my own edit',
+    'and the single preserved edit is untouched by later ticks')
+})
+
+// The guard must not freeze normal syncing: an UNMODIFIED mirror copy is still ours, so an owner
+// edit overwrites it in place exactly as before. Without this the fix would trade data loss for a
+// mirror that never updates.
+test('D2: an owner edit still overwrites an untouched mirror copy in place', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'v1' } })
+  await initDownloads()
+  await initialMaterializeScan(ctx.mount)
+
+  const abs = path.join(ctx.mirrorPath, 'a.txt')
+  t.is(fs.readFileSync(abs, 'utf8'), 'v1', 'precondition: v1 mirrored')
+
+  // The owner republishes new bytes; the local copy is untouched.
+  fs.writeFileSync(path.join(ctx.mountPath, 'a.txt'), 'v2-from-owner')
+  const { initialPublishScan } = await import('../../src/shared/folders/owned-folders.js')
+  await initialPublishScan(ctx.spaceId, ctx.share.id, ctx.mountPath, [])
+
+  const cur = await getForeignMount(ctx.spaceId, ctx.share.id)
+  await materializeCatalogFile(cur, ctx.share, await entryFor(ctx))
+
+  t.is(fs.readFileSync(abs, 'utf8'), 'v2-from-owner', 'the owner update landed in place')
+  t.absent(fs.existsSync(path.join(ctx.mirrorPath, 'a (conflicted copy).txt')),
+    'no needless conflict copy for an ordinary update')
+})

--- a/test/integration/foreign-mirror-conflict.test.js
+++ b/test/integration/foreign-mirror-conflict.test.js
@@ -118,3 +118,34 @@ test('D2: an owner edit still overwrites an untouched mirror copy in place', asy
   t.absent(fs.existsSync(path.join(ctx.mirrorPath, 'a (conflicted copy).txt')),
     'no needless conflict copy for an ordinary update')
 })
+
+// REGRESSION (FIX-D2-3): the preserve step must not fail open on a path it cannot stat.
+//
+// The stat before the checks swallowed EVERY error, so anything present-but-unreadable read as
+// absent, `localExists` was false, and the fetch renamed over it without a copy — the same fail-open
+// shape the boot-sweep fix removed, reproduced inside the guard meant to prevent it. rename() needs
+// permission on the DIRECTORY, not the file, so an unstattable file is still perfectly destroyable.
+// A directory at the path exercises the same gate deterministically on every platform.
+test('REGRESSION (FIX-D2-3): a non-file at the mirror path is moved aside, not written over', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'owner-bytes' } })
+  await initDownloads()
+  // Mirror it first: a path the mirror has NOT synced is already handled by resolveLocalRelPath,
+  // which mints a sibling rather than touching a pre-existing file. The gap is on the synced path,
+  // where the resolver returns the natural name without reading the file at all.
+  await initialMaterializeScan(ctx.mount)
+
+  // The user replaces our file with a directory of their own.
+  const abs = path.join(ctx.mirrorPath, 'a.txt')
+  fs.unlinkSync(abs)
+  fs.mkdirSync(abs, { recursive: true })
+  fs.writeFileSync(path.join(abs, 'inner.txt'), 'user data inside a directory')
+
+  const cur = await getForeignMount(ctx.spaceId, ctx.share.id)
+  await materializeCatalogFile(cur, ctx.share, await entryFor(ctx))
+
+  const moved = path.join(ctx.mirrorPath, 'a (conflicted copy).txt')
+  t.ok(fs.existsSync(moved), 'the unvouchable directory was moved aside')
+  t.is(fs.readFileSync(path.join(moved, 'inner.txt'), 'utf8'), 'user data inside a directory',
+    'its contents survived intact')
+  t.is(fs.readFileSync(abs, 'utf8'), 'owner-bytes', 'and the owner version took the canonical path')
+})

--- a/test/integration/sweep-fail-closed.test.js
+++ b/test/integration/sweep-fail-closed.test.js
@@ -1,0 +1,140 @@
+import test from 'brittle'
+import b4a from 'b4a'
+import { freshPeer } from '../helpers/store.js'
+import { getStore, createBee, createLocalBee } from '../../src/shared/core/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { getProfileBee, getProfile } from '../../src/shared/spaces/profile.js'
+import { purgeLeftovers, classifyLeftovers } from '../../src/shared/storage/leftover.js'
+import { cleanupOrphanedData } from '../../src/shared/storage/storage.js'
+import { shouldReclaimOrphanDrives } from '../../src/shared/storage/legacy-orphan-drives.js'
+import { listRecentSweeps } from '../../src/shared/storage/sweep-journal.js'
+
+// D1 — the boot sweep must not delete on evidence it could not gather.
+//
+// cleanupOrphanedData hard-deletes every store core outside a "wanted" set, via a RocksDB range
+// delete with no backup and no undo. That set was built best-effort: six failure paths logged a
+// warning (one did not even do that) and let the sweep proceed on the shorter set. Only ONE of them
+// set a safety flag, and that flag withheld a single category — `profiles` and `catalogs` were
+// purged regardless. A transient read failure was therefore promoted to "the user no longer needs
+// this", permanently and silently.
+
+async function coreInStore (dkHex) {
+  for await (const dk of getStore().list()) {
+    if (b4a.toString(dk, 'hex') === dkHex) return true
+  }
+  return false
+}
+
+async function plantStray (name, key, value) {
+  const bee = createBee(name)
+  await bee.ready()
+  await bee.put(key, value)
+  const dk = b4a.toString(bee.core.discoveryKey, 'hex')
+  await bee.close()
+  return dk
+}
+
+// One system bee refuses to open. Anything can cause this — a lock held by a dying instance, disk
+// pressure, a half-written core — and none of it means the user's data is disposable.
+const failOpening = (name) => (n) => {
+  if (n === name) throw new Error('simulated transient open failure')
+  return createLocalBee(n)
+}
+
+test('REGRESSION (FIX-D1-1): a gap in the wanted set withholds every category', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+  const strayDk = await plantStray('past-peer-profile-sim', 'displayName', 'Ghost')
+  t.ok(await coreInStore(strayDk), 'precondition: the stray is present')
+
+  const res = await purgeLeftovers({ openSystemBee: failOpening('spaces-meta') })
+
+  t.is(res.purged, 0, 'nothing was purged on an incomplete scan')
+  t.is(res.refused, 'scan-incomplete')
+  t.ok(await coreInStore(strayDk), 'the stray survived — "unwanted" did not mean "unneeded"')
+})
+
+test('REGRESSION (FIX-D1-2): the device profile core survives a failed read of itself', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+  const profileDk = b4a.toString(getProfileBee().core.discoveryKey, 'hex')
+  // A target must exist, or the sweep is trivially allowed and proves nothing.
+  await plantStray('past-peer-profile-sim', 'displayName', 'Ghost')
+
+  // The profile bee is opened twice when building the set: once by name in WANTED_BEE_GROUPS and
+  // once as the live handle. Fail the first, and on staging the second's bare `catch {}` was the
+  // only thing between the device identity bee and a purge that classified it as a stray 'profile'.
+  const res = await purgeLeftovers({ openSystemBee: failOpening('profile') })
+
+  t.is(res.refused, 'scan-incomplete')
+  t.ok(await coreInStore(profileDk), 'the device profile core is still on disk')
+  t.ok(await getProfile(), 'and still readable')
+})
+
+test('REGRESSION (FIX-D1-3): an implausibly large target set is refused wholesale, not trimmed', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+
+  const strays = []
+  for (let i = 0; i < 25; i++) strays.push(await plantStray('stray-profile-' + i, 'displayName', 'Ghost ' + i))
+
+  const scan = await classifyLeftovers()
+  t.ok(scan.scanComplete, 'precondition: this scan is complete, so only the magnitude gate can refuse')
+
+  const res = await purgeLeftovers()
+  t.is(res.refused, 'over-ratio-cap', 'more than half the store is not a reclaim, it is a wipe')
+  t.is(res.purged, 0)
+  for (const dk of strays) t.ok(await coreInStore(dk), 'every target survived — a refusal is all-or-nothing')
+})
+
+test('D1: a complete scan with a plausible target set still reclaims', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+  const strayDk = await plantStray('past-peer-profile-sim', 'displayName', 'Ghost')
+
+  const res = await purgeLeftovers()
+  t.is(res.refused, null, 'a healthy sweep is not refused')
+  t.ok(res.purged >= 1)
+  t.absent(await coreInStore(strayDk), 'the stray was reclaimed — the guard did not disable the feature')
+})
+
+test('D1: the journal records what a sweep did, and why it refused', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+  const strayDk = await plantStray('past-peer-profile-sim', 'displayName', 'Ghost')
+
+  await purgeLeftovers()
+  const [done] = await listRecentSweeps(1)
+  t.is(done.refused, null, 'the successful pass is recorded')
+  t.ok(done.purgedDks.includes(strayDk), 'with the discovery keys it deleted')
+
+  await plantStray('another-past-peer', 'displayName', 'Ghost 2')
+  await purgeLeftovers({ openSystemBee: failOpening('spaces-meta') })
+  const [refused] = await listRecentSweeps(1)
+  t.is(refused.refused, 'scan-incomplete', 'the refusal is recorded too')
+  t.ok(refused.gaps.some((g) => g.stage === 'system-bee:spaces-meta'), 'naming the gap that caused it')
+})
+
+test('REGRESSION (FIX-D1-4): a refused sweep does not consume the one-shot orphan-drive pass', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+
+  // Booting the peer already ran one sweep, which consumed the flag. Put it back, because the
+  // property under test is what a REFUSED sweep does to it.
+  const flags = createLocalBee('app-migrations')
+  await flags.ready()
+  await flags.del('legacy-orphan-drive-reclaim-v1')
+  await flags.close()
+  t.ok(await shouldReclaimOrphanDrives(), 'precondition: the one-shot pass is owed again')
+
+  // Refuse through a real condition rather than a seam: cleanupOrphanedData takes no injection
+  // point, and an implausible target set reaches the same branch.
+  for (let i = 0; i < 25; i++) await plantStray('stray-profile-' + i, 'displayName', 'Ghost ' + i)
+
+  const { purged, refused } = await cleanupOrphanedData()
+  t.is(refused, 'over-ratio-cap', 'the boot sweep refused')
+  t.is(purged, 0)
+
+  t.ok(await shouldReclaimOrphanDrives(),
+    'the one-shot pass survives — a refused sweep looked at nothing, so it must not spend it')
+})

--- a/test/unit/mirror-ownership.test.js
+++ b/test/unit/mirror-ownership.test.js
@@ -1,0 +1,45 @@
+import test from 'brittle'
+import { classifyLocalCopy, mayOverwriteInPlace, LOCAL_COPY } from '../../src/shared/folders/mirror-ownership.js'
+
+const OWNER = 'o'.repeat(64)
+const OURS = 'a'.repeat(64)
+const USER = 'u'.repeat(64)
+
+test('the local copy is the owner current content', (t) => {
+  const v = classifyLocalCopy({ diskHash: OWNER, ownerHash: OWNER, ancestorHash: OURS })
+  t.is(v, LOCAL_COPY.OWNER_CURRENT)
+  t.ok(mayOverwriteInPlace(v))
+})
+
+test('the local copy is exactly what we delivered, so the owner moved on', (t) => {
+  const v = classifyLocalCopy({ diskHash: OURS, ownerHash: OWNER, ancestorHash: OURS })
+  t.is(v, LOCAL_COPY.OURS)
+  t.ok(mayOverwriteInPlace(v), 'an untouched mirror copy is ours to update in place')
+})
+
+test('REGRESSION (FIX-D2): a local copy that is neither is the user edit — never overwrite', (t) => {
+  const v = classifyLocalCopy({ diskHash: USER, ownerHash: OWNER, ancestorHash: OURS })
+  t.is(v, LOCAL_COPY.DIVERGED)
+  t.absent(mayOverwriteInPlace(v), 'this is the overwrite that destroyed user edits')
+})
+
+test('no ancestor on record proves nothing, so it fails closed', (t) => {
+  const v = classifyLocalCopy({ diskHash: USER, ownerHash: OWNER, ancestorHash: null })
+  t.is(v, LOCAL_COPY.UNKNOWN)
+  t.absent(mayOverwriteInPlace(v), 'absence of evidence is not evidence of ownership')
+})
+
+test('an unreadable local file is never overwritten', (t) => {
+  const v = classifyLocalCopy({ diskHash: null, ownerHash: OWNER, ancestorHash: OURS })
+  t.is(v, LOCAL_COPY.UNKNOWN)
+  t.absent(mayOverwriteInPlace(v))
+})
+
+test('owner-current outranks ours when all three agree', (t) => {
+  t.is(classifyLocalCopy({ diskHash: OWNER, ownerHash: OWNER, ancestorHash: OWNER }), LOCAL_COPY.OWNER_CURRENT)
+})
+
+test('an empty call does not throw and does not authorize an overwrite', (t) => {
+  t.is(classifyLocalCopy(), LOCAL_COPY.UNKNOWN)
+  t.absent(mayOverwriteInPlace(classifyLocalCopy()))
+})

--- a/test/unit/path-keys.test.js
+++ b/test/unit/path-keys.test.js
@@ -344,6 +344,38 @@ test('REGRESSION (MIR-23): content-backend serve path rejects the read PoC keys'
   t.absent(relKeyEscapes('reports/q3.pdf'), 'a legitimate advertised file is accepted')
 })
 
+// ── D3: mirror deletion MAGNITUDE gate ─────────────────────────────────────────
+// The three gates above ask "is this listing trustworthy?". None of them asks "is it
+// PLAUSIBLE?" — a share going 1000 -> 3 files passed every one of them and unlinked 997 local
+// files with no cap and no trash. A catalog that legitimately shrank by 99% is indistinguishable
+// at this layer from one read against a half-replicated core, and only one of those two readings
+// is recoverable.
+const CAPS = { minDeletions: 8, maxDeletionRatio: 0.5 }
+const gate = (over) => shouldHonorDeletions({ ownerOnline: true, driveCount: 3, listingComplete: true, ...CAPS, ...over })
+
+test('REGRESSION (FIX-D3-1): a mass deletion is refused even when every trust gate passes', (t) => {
+  t.absent(gate({ syncedCount: 1000, deletionCount: 997 }), '997 of 1000 -> implausible, withhold')
+  t.absent(gate({ syncedCount: 1000, deletionCount: 600 }), '600 of 1000 -> over half, withhold')
+})
+
+test('D3: ordinary deletions are unaffected by the magnitude gate', (t) => {
+  t.ok(gate({ syncedCount: 100, deletionCount: 3 }), '3 of 100 -> under the floor')
+  t.ok(gate({ syncedCount: 1000, deletionCount: 400 }), '400 of 1000 -> under half')
+  t.ok(gate({ syncedCount: 8, deletionCount: 8 }), 'a tiny mirror emptying is under the floor')
+  t.ok(gate({ syncedCount: 0, deletionCount: 0 }), 'nothing to delete')
+})
+
+test('D3: the trust gates still dominate the magnitude gate', (t) => {
+  t.absent(gate({ ownerOnline: false, syncedCount: 100, deletionCount: 1 }), 'offline outranks a plausible count')
+  t.absent(gate({ listingComplete: false, syncedCount: 100, deletionCount: 1 }), 'partial drain outranks it too')
+  t.absent(gate({ driveCount: 0, syncedCount: 100, deletionCount: 1 }), 'empty listing outranks it too')
+})
+
+test('D3: the gate defaults are safe when a caller supplies no counts', (t) => {
+  t.ok(shouldHonorDeletions({ ownerOnline: true, driveCount: 3, listingComplete: true }),
+    'an un-migrated caller keeps the old behaviour rather than silently withholding everything')
+})
+
 // D2: the name a mirrored file's local edit is moved aside to before the owner's version is
 // written back over the canonical path.
 test('conflictCopyName preserves the extension and steps aside on collision', (t) => {

--- a/test/unit/path-keys.test.js
+++ b/test/unit/path-keys.test.js
@@ -7,7 +7,7 @@ import {
   pathsOverlap, pathContains, overlapAllowed,
   DEFAULT_IGNORE, shouldIgnore,
   shouldHonorDeletions,
-  splitFileName, nextFreeName,
+  splitFileName, nextFreeName, conflictCopyName,
   systemRootViolation, personalRootViolation, isWindowsReservedName, firstWinReservedSegment, cloudSyncHint,
 } from '../../src/shared/folders/path-keys.js'
 
@@ -342,4 +342,18 @@ test('REGRESSION (MIR-23): content-backend serve path rejects the read PoC keys'
   t.ok(relKeyEscapes('../../../../etc/passwd'), 'the serve PoC read key is rejected')
   t.ok(relKeyEscapes('..\\..\\Windows\\System32\\drivers\\etc\\hosts'), 'Windows-separator traversal rejected')
   t.absent(relKeyEscapes('reports/q3.pdf'), 'a legitimate advertised file is accepted')
+})
+
+// D2: the name a mirrored file's local edit is moved aside to before the owner's version is
+// written back over the canonical path.
+test('conflictCopyName preserves the extension and steps aside on collision', (t) => {
+  const free = () => false
+  t.is(conflictCopyName('note.txt', free), 'note (conflicted copy).txt')
+  t.is(conflictCopyName('archive.tar.gz', free), 'archive.tar (conflicted copy).gz', 'splits like path.extname')
+  t.is(conflictCopyName('LICENSE', free), 'LICENSE (conflicted copy)', 'no extension, no stray dot')
+  t.is(conflictCopyName('.bashrc', free), '.bashrc (conflicted copy)', 'a dotfile is a name, not an extension')
+
+  const taken = new Set(['note (conflicted copy).txt'])
+  t.is(conflictCopyName('note.txt', (n) => taken.has(n)), 'note (conflicted copy) (1).txt',
+    'a second conflict does not clobber the first')
 })

--- a/test/unit/sweep-decision.test.js
+++ b/test/unit/sweep-decision.test.js
@@ -1,0 +1,48 @@
+import test from 'brittle'
+import { decideSweep, SWEEP_REFUSAL } from '../../src/shared/storage/sweep-decision.js'
+
+const caps = { minSweepPurgeCores: 8, maxSweepPurgeCores: 64, maxSweepPurgeRatio: 0.5 }
+const gap = [{ stage: 'own-catalog:s1', detail: 'no sck' }]
+
+test('a complete scan with a plausible target set is allowed', (t) => {
+  t.ok(decideSweep({ gaps: [], targetCount: 3, totalCores: 20, caps }).allow)
+})
+
+test('REGRESSION (FIX-D1): any gap refuses the sweep, however small the target set', (t) => {
+  const d = decideSweep({ gaps: gap, targetCount: 1, totalCores: 100, caps })
+  t.absent(d.allow, 'one unreadable core is enough to withhold every deletion')
+  t.is(d.reason, SWEEP_REFUSAL.SCAN_INCOMPLETE)
+  t.is(d.gaps.length, 1, 'the reason travels with the decision so the journal can record it')
+})
+
+test('an empty target set is allowed even with gaps — there is nothing to risk', (t) => {
+  t.ok(decideSweep({ gaps: gap, targetCount: 0, totalCores: 10, caps }).allow)
+})
+
+test('an implausibly large target set is refused outright, not trimmed', (t) => {
+  const d = decideSweep({ gaps: [], targetCount: 65, totalCores: 1000, caps })
+  t.absent(d.allow)
+  t.is(d.reason, SWEEP_REFUSAL.OVER_ABSOLUTE_CAP)
+})
+
+test('more than half the store is refused', (t) => {
+  const d = decideSweep({ gaps: [], targetCount: 12, totalCores: 20, caps })
+  t.absent(d.allow)
+  t.is(d.reason, SWEEP_REFUSAL.OVER_RATIO_CAP)
+  t.is(d.limit, 10, 'the limit it would have allowed is reported')
+})
+
+test('the floor beats the ratio on a small store', (t) => {
+  t.ok(decideSweep({ gaps: [], targetCount: 6, totalCores: 6, caps }).allow,
+    'a fresh install must still be able to reclaim a handful of strays')
+})
+
+test('the absolute cap is checked before the ratio', (t) => {
+  t.is(decideSweep({ gaps: [], targetCount: 100, totalCores: 1000, caps }).reason,
+    SWEEP_REFUSAL.OVER_ABSOLUTE_CAP, '100 is under half of 1000 but over the absolute ceiling')
+})
+
+test('defaults apply when no caps are supplied', (t) => {
+  t.absent(decideSweep({ gaps: [], targetCount: 65, totalCores: 1000 }).allow)
+  t.ok(decideSweep({ gaps: [], targetCount: 8, totalCores: 8 }).allow)
+})


### PR DESCRIPTION
Three paths that destroyed user data without a record. From the 2026-09-04 architecture review.

**Boot sweep deleted cores on evidence it failed to gather.** `cleanupOrphanedData` hard-deletes
every store core outside a "wanted" set. That set was built best-effort: six read failures logged a
warning (one was a bare `catch {}` on the device's own profile core) and let the sweep proceed on a
shorter set, while the single safety flag withheld only orphan drives. Any gap now withholds every
category, an implausible target set is refused outright, and each pass is journalled with its
reason. Two further gaps found while fixing: a `withReadTimeout` sentinel that resolves rather than
rejects, so a timed-out drive read recorded nothing at all; and an unguarded `addMemberCores` that
could abort the space loop and silently unwant every space after it.

**A mirror destroyed local edits to reach the owner version.** The doctrine is deliberate and pinned
by `test/flow/mirror-local-edit.test.js` — the owner's bytes belong at the canonical path — and it
is unchanged here. What was not intended is that the user's bytes were deleted to get there, with no
copy and no warning. `markVerified` already stored the hash the mirror delivered; comparing the file
against that ancestor separates an owner edit from a local one. Anything unvouchable is moved aside
to a conflict copy first.

**A shrinking catalog was honoured without limit.** The owner-online / non-empty / complete-listing
gates establish that a listing is authoritative, never that it is plausible: 1000 files to 3 passed
all three and unlinked 997 with no cap and no trash. Ordinary tidying is unaffected below a floor of
eight; above it a pass may not remove more than half of what the mirror owns.

Three commits, each independently verified. No renderer change, so no new audit kinds and no UI
surface — a conflict copy and a withheld deletion are visible in logs and `diagnostics:export`
only. Surfacing them in the UI is the follow-up.

Local: typecheck clean; lint 18 warnings / 0 errors (baseline 19); test:node:core 1841/1841;
test:bare clean; test:flow 196/196.