### PR TITLE
[fix] Make the safety guards measure the property, not the spelling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,16 +58,58 @@ jobs:
         run: |
           files="$(node test/flow-shard.mjs ${{ matrix.shard }} 6)"
           echo "Shard ${{ matrix.shard }}/6:"; echo "$files" | tr ' ' '\n'
+          mkdir -p flake-report/logs
           # Run each file independently so one file's crash can't abort the rest,
           # then retry ONLY the failed files once (a whole-shard retry wasted minutes).
+          # The FIRST attempt's output is kept for anything that failed: a flake that only
+          # reproduces in CI cannot be diagnosed after the fact from a ::warning, and the
+          # warning text itself used to point at diagnostics nothing was saving.
           failed=""
           for f in $files; do
-            npx brittle-node "$f" || failed="$failed $f"
+            log="flake-report/logs/$(echo "$f" | tr '/' '_').log"
+            if npx brittle-node "$f" >"$log" 2>&1; then rm -f "$log"; else cat "$log"; failed="$failed $f"; fi
           done
+          entries=""
+          status=0
           if [ -n "$failed" ]; then
-            echo "::warning title=Flow shard ${{ matrix.shard }} flaked::retried$failed (a pass-on-retry is a residual flake — see the failed attempt's timeout diagnostics)"
-            for f in $failed; do npx brittle-node "$f" || exit 1; done
+            echo "::warning title=Flow shard ${{ matrix.shard }} flaked::retried$failed (a pass-on-retry is a residual flake — the failed attempt's output is in the flake-report artifact)"
+            for f in $failed; do
+              if npx brittle-node "$f"; then passed=true; else passed=false; status=1; fi
+              entries="$entries{\"file\":\"$f\",\"attempts\":2,\"passedOnRetry\":$passed},"
+            done
           fi
+          printf '{"shard":%s,"files":[%s]}\n' "${{ matrix.shard }}" "${entries%,}" > flake-report/flake-${{ matrix.shard }}.json
+          { echo "### Flow shard ${{ matrix.shard }}/6"; if [ -z "$failed" ]; then echo "No retries."; else echo "Retried:$failed"; fi; } >> "$GITHUB_STEP_SUMMARY"
+          exit $status
+      - name: Upload flake report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: flake-report-${{ matrix.shard }}
+          path: flake-report
+          if-no-files-found: ignore
+
+  # A pass-on-retry used to leave a ::warning and nothing else: annotation-only, nothing aggregates
+  # it, so nobody could tell an improving suite from a decaying one. This is the gate for
+  # FLAKINESS, deliberately separate from the shard jobs so a genuine hard failure stays an
+  # immediate shard red and can never be mistaken for a budget overrun.
+  flake-ledger:
+    runs-on: ubuntu-latest
+    needs: flow
+    if: always()
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '24.20.0'
+      - uses: actions/download-artifact@v7
+        continue-on-error: true
+        with:
+          pattern: flake-report-*
+          path: flake-reports
+          merge-multiple: true
+      - name: Flake budget
+        run: node scripts/flake-ledger.mjs flake-reports test/flow-flake-budget.json
 
   # Tier 2/3 in-process tests of the real bare-* modules. brittle-bare shells
   # out to a `bare` binary on PATH (provided by the bare-runtime devDep).

--- a/eslint-rules/no-unguarded-async-effect.js
+++ b/eslint-rules/no-unguarded-async-effect.js
@@ -1,0 +1,266 @@
+// An effect that writes React state after an await is a race by default: React does not cancel the
+// continuation, so a response issued for the PREVIOUS deps can land after a newer one and win. The
+// renderer already has the correct answer — store/query-store.js carries a per-entry `seq` and an
+// AbortController, and useQuery/useMainQuery inherit both — so a hook that reaches past it owes the
+// same guarantee by hand, or an entry in the exemption table with a reason.
+//
+// This is a RULE and not a `no-restricted-syntax` selector (the shape the rest of eslint.config.mjs
+// uses) because the property is not a syntactic shape. It needs three things esquery cannot do:
+// reachability from an async boundary to a setter, scope resolution of `setX` to a useState
+// binding, and one hop of call-graph following into a useCallback. The predecessor guard was a
+// regex for `let cancelled = false`, which measured a spelling — it saw four of the eleven
+// hand-rolled guards in the tree and, more to the point, could never see a site with no guard at
+// all, which is the only thing that is actually forbidden.
+
+const EFFECT_HOOKS = new Set(['useEffect', 'useLayoutEffect'])
+const CONTINUATIONS = new Set(['then', 'catch', 'finally'])
+// A function handed to one of these is a fresh event context, not the continuation of the await
+// above it, so it does not inherit post-async position.
+const DEFERRED = new Set(['subscribe', 'addEventListener', 'on', 'once', 'setTimeout', 'setInterval', 'requestAnimationFrame', 'requestIdleCallback', 'queueMicrotask'])
+// Reads that carry supersession themselves.
+const GUARDED_READS = new Set(['useQuery', 'useMainQuery', 'usePrefs', 'fetchQuery'])
+const FUNCTION_TYPES = new Set(['ArrowFunctionExpression', 'FunctionExpression', 'FunctionDeclaration'])
+
+function isFunction (node) {
+  return !!node && FUNCTION_TYPES.has(node.type)
+}
+
+function calleeName (callee) {
+  if (!callee) return null
+  if (callee.type === 'Identifier') return callee.name
+  if (callee.type === 'MemberExpression' && !callee.computed && callee.property.type === 'Identifier') {
+    return callee.property.name
+  }
+  return null
+}
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    docs: { description: 'Require a supersession guard on any effect that writes state after an async boundary' },
+    schema: [{
+      type: 'object',
+      properties: { allow: { type: 'array', items: { type: 'string' } } },
+      additionalProperties: false,
+    }],
+  },
+
+  create (context) {
+    // eslint's job here is to keep CI and the editor quiet about the effects that are already
+    // reasoned about; the ratchet that decides WHICH those are lives in
+    // test/unit/renderer-stale-guard-ratchet.test.js, which drives this rule with no allowances at
+    // all and compares the full report set against the table. A file-level allowance cannot hide a
+    // new violation from that test.
+    const allow = (context.options[0] && context.options[0].allow) || []
+    const filename = context.filename.split('\\').join('/')
+    if (allow.some((suffix) => filename.endsWith(suffix))) return {}
+
+    const sourceCode = context.sourceCode
+    const keys = sourceCode.visitorKeys
+
+    function children (node) {
+      const out = []
+      for (const key of keys[node.type] || []) {
+        const child = node[key]
+        if (Array.isArray(child)) { for (const c of child) if (c && typeof c.type === 'string') out.push(c) } else if (child && typeof child.type === 'string') out.push(child)
+      }
+      return out
+    }
+
+    function walk (node, visit) {
+      visit(node)
+      for (const child of children(node)) walk(child, visit)
+    }
+
+    function lookup (name, at) {
+      for (let scope = sourceCode.getScope(at); scope; scope = scope.upper) {
+        const variable = scope.set.get(name)
+        if (variable) return variable
+      }
+      return null
+    }
+
+    // `setWrapperRef` in components/primitives/Modal.tsx is an ordinary function, not a setter. The
+    // name is no evidence of anything; the binding is.
+    function isStateSetter (node) {
+      if (!node || node.type !== 'Identifier') return false
+      const variable = lookup(node.name, node)
+      const def = variable && variable.defs[0]
+      if (!def || def.type !== 'Variable') return false
+      const declarator = def.node
+      if (!declarator.id || declarator.id.type !== 'ArrayPattern') return false
+      if (declarator.id.elements[1] !== def.name) return false
+      const hook = declarator.init && declarator.init.type === 'CallExpression' && calleeName(declarator.init.callee)
+      return hook === 'useState' || hook === 'useReducer'
+    }
+
+    // One hop, deliberately: the three out-of-order defects this rule was written for all put the
+    // async work in a `const refresh = useCallback(async …)` that the effect merely invokes, so a
+    // rule that only walks the effect body misses exactly the highest-risk class. Two hops is the
+    // known residual.
+    function resolveCalledFunction (callee) {
+      if (!callee || callee.type !== 'Identifier') return null
+      const variable = lookup(callee.name, callee)
+      const def = variable && variable.defs[0]
+      if (!def) return null
+      if (def.type === 'FunctionName') return def.node
+      if (def.type !== 'Variable') return null
+      const init = def.node.init
+      if (isFunction(init)) return init
+      if (init && init.type === 'CallExpression' && calleeName(init.callee) === 'useCallback' && isFunction(init.arguments[0])) {
+        return init.arguments[0]
+      }
+      return null
+    }
+
+    function ownAwaitStart (fn) {
+      let first = Infinity
+      const visit = (node) => {
+        if (node !== fn && isFunction(node)) return
+        if (node.type === 'AwaitExpression' || node.type === 'ForOfStatement' && node.await) {
+          first = Math.min(first, node.range[0])
+        }
+        for (const child of children(node)) visit(child)
+      }
+      visit(fn)
+      return first
+    }
+
+    // Three acceptors, all name-blind: a flag flipped in the cleanup closure, a ref compared against
+    // a captured generation, or an abort signal. Renaming `cancelled` to `alive` — which is what
+    // four hooks in this tree already did — changes nothing here.
+    function hasGuardEvidence (region, effectFn) {
+      const cleanups = []
+      walk(effectFn, (node) => {
+        if (node.type !== 'ReturnStatement' || !node.argument) return
+        if (isFunction(node.argument)) cleanups.push(node.argument)
+        else {
+          const resolved = resolveCalledFunction(node.argument)
+          if (resolved) cleanups.push(resolved)
+        }
+      })
+
+      const booleanFlags = new Set()
+      const clearedInCleanup = new Set()
+      const readAsCondition = new Set()
+      let generation = false
+      let abort = false
+      let guardedRead = false
+
+      const noteConditionReads = (node) => {
+        walk(node, (n) => { if (n.type === 'Identifier') readAsCondition.add(n.name) })
+      }
+
+      for (const fn of region) {
+        walk(fn, (node) => {
+          if (node.type === 'VariableDeclarator' && node.id.type === 'Identifier' && node.init &&
+              node.init.type === 'Literal' && typeof node.init.value === 'boolean') {
+            booleanFlags.add(node.id.name)
+          }
+          if (node.type === 'IfStatement') noteConditionReads(node.test)
+          if (node.type === 'ConditionalExpression') noteConditionReads(node.test)
+          if (node.type === 'LogicalExpression') noteConditionReads(node)
+          if (node.type === 'UnaryExpression' && node.operator === '!') noteConditionReads(node.argument)
+          if ((node.type === 'BinaryExpression') && (node.operator === '===' || node.operator === '!==')) {
+            const touchesCurrent = [node.left, node.right].some((side) =>
+              side.type === 'MemberExpression' && !side.computed && side.property.type === 'Identifier' && side.property.name === 'current')
+            if (touchesCurrent) generation = true
+          }
+          if (node.type === 'NewExpression' && calleeName(node.callee) === 'AbortController') abort = true
+          if (node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier' && node.property.name === 'signal') abort = true
+          if (node.type === 'CallExpression') {
+            const name = calleeName(node.callee)
+            if (name === 'abort') abort = true
+            if (GUARDED_READS.has(name)) guardedRead = true
+          }
+        })
+      }
+
+      for (const cleanup of cleanups) {
+        walk(cleanup, (node) => {
+          if (node.type !== 'AssignmentExpression' || node.operator !== '=') return
+          if (node.left.type === 'Identifier' && node.right.type === 'Literal' && typeof node.right.value === 'boolean') {
+            clearedInCleanup.add(node.left.name)
+          }
+        })
+      }
+
+      const flag = [...booleanFlags].some((name) => clearedInCleanup.has(name) && readAsCondition.has(name))
+      return flag || generation || abort || guardedRead
+    }
+
+    function postAsyncSetters (region) {
+      const setters = new Set()
+
+      const visit = (node, post, firstAwait) => {
+        const here = post || node.range[0] > firstAwait
+
+        if (node.type === 'CallExpression') {
+          if (here && isStateSetter(node.callee)) setters.add(node.callee.name)
+          if (CONTINUATIONS.has(calleeName(node.callee))) {
+            for (const arg of node.arguments) if (isStateSetter(arg)) setters.add(arg.name)
+          }
+        }
+
+        for (const child of children(node)) {
+          if (!isFunction(child)) { visit(child, here, firstAwait); continue }
+          const parentCallee = node.type === 'CallExpression' ? calleeName(node.callee) : null
+          const childPost = CONTINUATIONS.has(parentCallee) ? true
+            : DEFERRED.has(parentCallee) ? false
+              : here
+          visit(child, childPost, ownAwaitStart(child))
+        }
+      }
+
+      for (const fn of region) visit(fn, false, ownAwaitStart(fn))
+      return [...setters]
+    }
+
+    // A function registered as an event handler is not part of the effect's own read path — what it
+    // does when the user clicks is a different question from what the effect does when its deps
+    // change. Following into one would report SpaceView's add-folder command as an effect race.
+    function deferredHandlers (root) {
+      const handlers = new Set()
+      walk(root, (node) => {
+        if (node.type !== 'CallExpression' || !DEFERRED.has(calleeName(node.callee))) return
+        for (const arg of node.arguments) {
+          if (isFunction(arg)) handlers.add(arg)
+          else {
+            const resolved = resolveCalledFunction(arg)
+            if (resolved) handlers.add(resolved)
+          }
+        }
+      })
+      return handlers
+    }
+
+    return {
+      CallExpression (node) {
+        if (!EFFECT_HOOKS.has(calleeName(node.callee))) return
+        const effectFn = node.arguments[0]
+        if (!isFunction(effectFn)) return
+
+        const handlers = deferredHandlers(effectFn)
+        const region = [effectFn]
+        const collect = (n) => {
+          if (n !== effectFn && handlers.has(n)) return
+          if (n.type === 'CallExpression') {
+            const target = resolveCalledFunction(n.callee)
+            if (target && !region.includes(target)) region.push(target)
+          }
+          for (const child of children(n)) collect(child)
+        }
+        collect(effectFn)
+
+        const setters = postAsyncSetters(region)
+        if (!setters.length) return
+        if (hasGuardEvidence(region, effectFn)) return
+
+        context.report({
+          node: node.callee,
+          message: `This effect writes ${setters.sort().join(', ')} after an async boundary with nothing to tell a superseded response from a current one. Read through useQuery/useMainQuery, or carry a generation ref or a cleanup flag.`,
+        })
+      },
+    }
+  },
+}

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -30,16 +30,23 @@ export const rendererStatusRestrictions = [
 ]
 
 // Lifecycle invariant: a timer armed at module level runs at import, so no close() can ever
-// reach it. Every periodic or deferred call belongs inside a Subsystem's _open, armed through
-// `this.timers`, so it dies with the subsystem. Exported so
-// test/unit/module-level-timers.test.js enforces the same grammar through eslint's parser.
+// reach it. Exported so test/unit/module-level-timers.test.js enforces the same grammar through
+// eslint's parser.
+//
+// This is the import-time corner of the lifecycle rule, and only that. The message used to say
+// "arm it in a Subsystem _open so close() can clear it", which reads as a promise that every
+// periodic call dies with its subsystem — a property no selector can decide, since three of the
+// eleven module-scoped handles in the data layer belong to module singletons that are not
+// Subsystems at all. The broad property is measured where it is actually observable: at runtime, in
+// test/integration/timer-lifecycle.test.js, with test/unit/module-scoped-timer-handles.test.js as
+// the decidable static companion.
 export const moduleLevelTimerRestrictions = [{
   // `:not(:function *)` alone is the whole rule: it matches a set*() call that has no function
   // ancestor, i.e. one that runs at import. Scoping it to top-level statement types instead would
   // miss every nesting a module-level timer can hide in — a top-level `if`, `try`, bare block,
   // labelled block, `for`/`while`, `switch` case, or a class static field or static block.
   selector: "CallExpression[callee.name=/^set(Interval|Timeout)$/]:not(:function *)",
-  message: 'No module-level timers — arm it in a Subsystem _open so close() can clear it.',
+  message: 'No timer armed at import — nothing can clear it. Arm it inside a Subsystem _open through this.timers, or inside a function whose module holds a matching clear.',
 }]
 
 // Mechanism invariant: chokidar's options are per-INSTANCE, not per-path, and its sharp edges —

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -62,6 +62,20 @@ export const chokidarSingleOwnerRestrictions = [
   { selector: "ImportDeclaration[source.value='chokidar']", message: chokidarMessage },
 ]
 
+// Presentation invariant: one byte size means one string. src/renderer/formatSize.js owns the
+// decimal (SI) ladder because the divisor and the labels have to agree — a binary 1024 divisor
+// under KB/MB/GB labels reads ~7-10% below what the OS shows for the same file. auditRow.js grew a
+// second ladder that did exactly that, so the Activity Log printed every size ~7.4% low while
+// every other screen printed it right, and a unit test pinned the wrong numbers. A unit-ladder
+// array literal is the shape a re-implementation always takes; naming the array differently
+// changes nothing here. Exported so test/unit/byte-formatter-single-owner.test.js enforces the
+// same grammar through eslint's parser.
+const byteLadderMessage = 'Only src/renderer/formatSize.js may declare a byte-unit ladder — call formatSize so the divisor and the labels stay in one place.'
+export const byteFormatterSingleOwnerRestrictions = ['KB', 'MB', 'GB', 'TB', 'KiB', 'MiB', 'GiB', 'TiB'].map((unit) => ({
+  selector: `ArrayExpression > Literal[value='${unit}']`,
+  message: byteLadderMessage,
+}))
+
 export default [
   // Vendored hyper-overlay v2 subset — third-party code kept re-diffable
   // against upstream (PROVENANCE.md), so our complexity/style rules don't apply.
@@ -82,7 +96,7 @@ export default [
       'jsx-a11y/no-autofocus': 'off',
       'jsx-a11y/label-has-associated-control': ['error', { depth: 3 }],
       'jsx-a11y/no-noninteractive-tabindex': ['error', { roles: ['tabpanel', 'region'] }],
-      'no-restricted-syntax': ['error', ...rendererStatusRestrictions],
+      'no-restricted-syntax': ['error', ...rendererStatusRestrictions, ...byteFormatterSingleOwnerRestrictions],
       ...complexityBudget,
     },
   },
@@ -125,5 +139,12 @@ export default [
   {
     files: ['src/main/watch-host.js'],
     rules: { 'no-restricted-syntax': 'off' },
+  },
+
+  // The one module the byte-ladder rule exists to protect. The renderer's status invariant still
+  // applies to it, so only the ladder restriction is dropped.
+  {
+    files: ['src/renderer/formatSize.js'],
+    rules: { 'no-restricted-syntax': ['error', ...rendererStatusRestrictions] },
   },
 ]

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,6 +1,7 @@
 import tseslint from 'typescript-eslint'
 import jsxA11y from 'eslint-plugin-jsx-a11y'
 import globals from 'globals'
+import noUnguardedAsyncEffect from './eslint-rules/no-unguarded-async-effect.js'
 
 // Complexity/size budget applied to every source area. These are WARNINGS, not errors: they
 // surface the existing hotspots (see the Stage-1 worklist) and flag any NEW oversized function
@@ -76,6 +77,26 @@ export const byteFormatterSingleOwnerRestrictions = ['KB', 'MB', 'GB', 'TB', 'Ki
   message: byteLadderMessage,
 }))
 
+// Stale-response invariant, split into two tables because the two cases are not the same risk and
+// must not share a number. The predecessor guard grepped for `let cancelled = false` and counted
+// four files: it missed six hand-rolled guards spelled `alive`/`active`/`sawFrame`/`runRef`, and —
+// the point — it could never see an effect with no guard at all, which is the only thing actually
+// forbidden. Six such effects were live while it reported the property covered.
+//
+// UNMOUNT_ONLY: the effect has [] deps and one in-flight read, so nothing can supersede it — the
+// only race is a write after unmount, which React tolerates.
+export const unmountOnlyAsyncEffects = Object.freeze({
+  'src/renderer/hooks/useProfile.ts': { effects: 1, why: 'One [] -deps read of the local profile; the live value afterwards arrives on event:profile-needed, not on a re-read.' },
+  'src/renderer/hooks/useConnectionStatus.tsx': { effects: 1, why: 'The net.online probe has [] deps and one read; transitions arrive on onNetOnlineChange. (The other effect in this file carries a cleanup flag and is not exempt.)' },
+  'src/renderer/screens/Account.tsx': { effects: 1, why: 'One [] -deps read of the identity-protection mode, which cannot change while the screen is open.' },
+})
+
+// OUT_OF_ORDER must stay EMPTY. An effect that re-fires — on a dep change or from a subscription —
+// can have two reads in flight, and the older one can win. That is wrong data on screen, not a
+// warning in a console. Allowlisting one of these would repeat the mistake this whole guard exists
+// to undo: a green test standing over a live defect.
+export const outOfOrderAsyncEffects = Object.freeze({})
+
 export default [
   // Vendored hyper-overlay v2 subset — third-party code kept re-diffable
   // against upstream (PROVENANCE.md), so our complexity/style rules don't apply.
@@ -90,13 +111,16 @@ export default [
       parserOptions: { ecmaFeatures: { jsx: true } },
       globals: { ...globals.browser, __DEV__: 'readonly' },
     },
-    plugins: { 'jsx-a11y': jsxA11y },
+    plugins: { 'jsx-a11y': jsxA11y, local: { rules: { 'no-unguarded-async-effect': noUnguardedAsyncEffect } } },
     rules: {
       ...jsxA11y.flatConfigs.recommended.rules,
       'jsx-a11y/no-autofocus': 'off',
       'jsx-a11y/label-has-associated-control': ['error', { depth: 3 }],
       'jsx-a11y/no-noninteractive-tabindex': ['error', { roles: ['tabpanel', 'region'] }],
       'no-restricted-syntax': ['error', ...rendererStatusRestrictions, ...byteFormatterSingleOwnerRestrictions],
+      'local/no-unguarded-async-effect': ['error', {
+        allow: [...Object.keys(unmountOnlyAsyncEffects), ...Object.keys(outOfOrderAsyncEffects)],
+      }],
       ...complexityBudget,
     },
   },

--- a/forge.config.js
+++ b/forge.config.js
@@ -140,6 +140,7 @@ let packagerConfig = {
     /\/\.github($|\/)/,
     /^\/test($|\/)/,
     /^\/scripts($|\/)/,
+    /^\/eslint-rules($|\/)/,
     // src/renderer is bundled into assets/dist by esbuild; the .tsx sources
     // don't ship. src/{main,preload,worker,shared} are part of the runtime
     // and must stay.

--- a/scripts/flake-ledger.mjs
+++ b/scripts/flake-ledger.mjs
@@ -1,0 +1,72 @@
+// Turns a pass-on-retry from an annotation nobody counts into a countable, attributable fact with a
+// budget over it.
+//
+// The flow shards retry a failed file once and go green if the retry passes. That is the right call
+// for a real 6-shard P2P suite on a 2-vCPU runner — verified-known flakiness exists independently
+// of any diff, so failing on the first flake would turn CI into a re-run lottery. What was wrong is
+// that the only trace was a `::warning`: annotation-only, nothing aggregates it, so "is this suite
+// getting flakier" was unanswerable and the failed attempt's output — which the warning text itself
+// pointed at — was thrown away.
+//
+// Honest limit: this measures ONE run. A file that flakes 30% of the time passes a maxTotal of 1
+// most runs. It makes flakes countable and attributable, which is the precondition for a cross-run
+// rate; it is not itself a rate.
+import { readFileSync, readdirSync, existsSync } from 'fs'
+import path from 'path'
+
+// Two rules, and they have to agree with each other. `maxTotal` is the aggregate ceiling for one
+// run and is the gate: exceed it and the ledger is red. `perFile` names the files KNOWN to flake,
+// each with its own cap and reason, so a repeat offender cannot hide inside the aggregate. A file
+// absent from `perFile` is not forbidden from flaking — it is reported by name so it becomes a
+// candidate for the table — because a per-file budget of zero plus an aggregate budget of one
+// contradict each other, and the contradiction would resolve as "red on arrival", which is exactly
+// what trains people to re-run instead of look.
+export function evaluateLedger (reports, budget) {
+  const flaked = []
+  for (const report of reports) {
+    for (const entry of report.files || []) {
+      if (entry.passedOnRetry) flaked.push({ shard: report.shard, file: entry.file, attempts: entry.attempts })
+    }
+  }
+
+  const perFile = budget.perFile || {}
+  const counts = new Map()
+  for (const { file } of flaked) counts.set(file, (counts.get(file) || 0) + 1)
+
+  const unbudgeted = [...counts.keys()].filter((file) => !(file in perFile)).sort()
+  const over = [...counts.entries()].filter(([file, n]) => file in perFile && n > perFile[file].max)
+    .map(([file, n]) => `${file} flaked ${n}x, budget ${perFile[file].max}`).sort()
+  const total = flaked.length
+  const overTotal = total > budget.maxTotal
+
+  return { ok: !overTotal && over.length === 0, total, maxTotal: budget.maxTotal, flaked, unbudgeted, over, overTotal }
+}
+
+export function describeLedger (verdict) {
+  const lines = [`Flow flakes this run: ${verdict.total} (budget ${verdict.maxTotal})`]
+  for (const f of verdict.flaked) lines.push(`  shard ${f.shard}: ${f.file} passed on attempt ${f.attempts}`)
+  if (verdict.overTotal) lines.push(`FAIL: ${verdict.total} pass-on-retry exceeds the budget of ${verdict.maxTotal}`)
+  for (const file of verdict.unbudgeted) lines.push(`NEW: ${file} flaked and is not named in test/flow-flake-budget.json`)
+  for (const line of verdict.over) lines.push(`FAIL: ${line}`)
+  if (verdict.ok && verdict.total === 0) lines.push('No retries. The suite passed on first attempt everywhere.')
+  return lines.join('\n')
+}
+
+export function readReports (dir) {
+  if (!existsSync(dir)) return []
+  return readdirSync(dir).filter((n) => /^flake-\d+\.json$/.test(n))
+    .map((n) => JSON.parse(readFileSync(path.join(dir, n), 'utf8')))
+}
+
+if (process.argv[1] && process.argv[1].endsWith('flake-ledger.mjs')) {
+  const [dir = 'flake-reports', budgetPath = 'test/flow-flake-budget.json'] = process.argv.slice(2)
+  const reports = readReports(dir)
+  const verdict = evaluateLedger(reports, JSON.parse(readFileSync(budgetPath, 'utf8')))
+  const text = describeLedger(verdict)
+  console.log(text)
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    const { appendFileSync } = await import('fs')
+    appendFileSync(process.env.GITHUB_STEP_SUMMARY, `### Flow flake ledger\n\n\`\`\`\n${text}\n\`\`\`\n`)
+  }
+  if (!verdict.ok) process.exit(1)
+}

--- a/src/renderer/auditRow.d.ts
+++ b/src/renderer/auditRow.d.ts
@@ -42,9 +42,9 @@ export const FIELD_SENTINEL: string
 export const SENTENCE_FIELDS: string[]
 export function sentinelValues(): SentenceValues
 export function splitSentence(rendered: string, values: SentenceValues): SentenceSegment[]
-export function formatBytes(bytes: number): string | null
-export function formatCount(n: number): string | null
-export function metaParts(entry: AuditEntry): MetaPart[]
+export function formatBytes(bytes: number, locale?: string): string | null
+export function formatCount(n: number, locale?: string): string | null
+export function metaParts(entry: AuditEntry, locale?: string): MetaPart[]
 export function dayKey(ts: number, now?: number): string
 export function groupByDay(entries: AuditEntry[], now?: number): DayGroup[]
 

--- a/src/renderer/auditRow.js
+++ b/src/renderer/auditRow.js
@@ -4,6 +4,7 @@
 // Every field it reads is snapshotted in the record itself — nothing here joins against live
 // state, because a row routinely outlives the space, share or peer it describes.
 import { formatDuration } from './connectivity.js'
+import { formatSize } from './formatSize.js'
 
 // Which participant a row is "about". `actorLabelKey` distinguishes the three cases the copy
 // has to handle: you did it, a named peer did it, or the app did it on its own.
@@ -144,22 +145,15 @@ export function splitSentence(rendered, values) {
   return segments
 }
 
-const BYTES_UNITS = ['B', 'KB', 'MB', 'GB', 'TB']
-
-export function formatBytes(bytes) {
+// One byte size means one string everywhere. This used to carry its own decimal-labelled,
+// binary-divided ladder, so the Activity Log read ~7.4% below every other screen for the same file.
+export function formatBytes(bytes, locale) {
   if (!Number.isFinite(bytes) || bytes < 0) return null
-  let value = bytes
-  let unit = 0
-  while (value >= 1024 && unit < BYTES_UNITS.length - 1) {
-    value /= 1024
-    unit++
-  }
-  const rounded = value >= 100 || unit === 0 ? Math.round(value) : Math.round(value * 10) / 10
-  return rounded + ' ' + BYTES_UNITS[unit]
+  return formatSize(bytes, locale)
 }
 
-export function formatCount(n) {
-  return Number.isFinite(n) ? n.toLocaleString() : null
+export function formatCount(n, locale) {
+  return Number.isFinite(n) ? n.toLocaleString(locale) : null
 }
 
 // Closed set, like DENIAL_REASONS: a cause written by a newer version renders nothing rather than a
@@ -182,7 +176,7 @@ function formatClock(ts) {
 // the kind carries. Returns STRUCTURED parts — `{ key, values }` for anything that needs
 // translating, `{ text }` for a value that is already a proper noun or a formatted number. It used
 // to return finished strings, which is how a hard-coded English ' files' shipped to five locales.
-export function metaParts(entry) {
+export function metaParts(entry, locale) {
   const parts = []
   if (entry.space?.name) parts.push({ text: entry.space.name })
   const subject = entry.subject || {}
@@ -190,13 +184,13 @@ export function metaParts(entry) {
   // as text and needs no catalogue entry; null on a loose file, which renders no segment.
   if (typeof subject.folder === 'string' && subject.folder) parts.push({ text: subject.folder })
   if (Number.isFinite(subject.fileCount)) {
-    const files = formatCount(subject.fileCount)
+    const files = formatCount(subject.fileCount, locale)
     if (files !== null) {
       parts.push({ key: 'activityLog.metaFiles', values: { count: subject.fileCount, formatted: files } })
     }
   }
   if (Number.isFinite(subject.bytes)) {
-    const size = formatBytes(subject.bytes)
+    const size = formatBytes(subject.bytes, locale)
     if (size) parts.push({ text: size })
   }
   if (typeof subject.mountPath === 'string' && subject.mountPath) parts.push({ text: subject.mountPath })

--- a/src/renderer/hooks/useDownloadRootStatus.ts
+++ b/src/renderer/hooks/useDownloadRootStatus.ts
@@ -2,7 +2,7 @@
 // network share, or replaced by a file. Drives the app-level banner and the Storage Settings
 // warning, so the user learns the folder is gone instead of reading "Transfer failed" on every
 // download that tries to land there.
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useState, useRef } from 'react'
 import { request, subscribe } from '../ipc.js'
 
 interface RootsStatus {
@@ -20,10 +20,16 @@ export function useDownloadRootStatus() {
   // hit the problem again — which is the one moment re-explaining a dismissed (or stack-evicted)
   // toast is warranted.
   const [faultSeq, setFaultSeq] = useState(0)
+  // A transfer failure re-probes on top of the mount read and the worker's own 60s push, so two
+  // probes overlap whenever a download fails during startup. The older verdict landing last would
+  // re-hide a banner the newer one had just raised.
+  const runRef = useRef(0)
 
   const refresh = useCallback(async () => {
+    const run = ++runRef.current
     try {
       const res = await request('downloads:roots-status') as RootsStatus
+      if (run !== runRef.current) return
       setUnavailable(Array.isArray(res?.unavailable) ? res.unavailable : [])
     } catch {
       // A worker that isn't up yet is not evidence the folder is gone — leave the last

--- a/src/renderer/hooks/useForeignMount.ts
+++ b/src/renderer/hooks/useForeignMount.ts
@@ -1,5 +1,5 @@
 // Foreign (mirror) mount state and RPC wrappers (validate/preview/mount/enable/unmount); useForeignMount refreshes on foreign-folder-mount-status events.
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { request, subscribe } from '../ipc.js'
 import type { ForeignFolderMount, MountValidationResult, ScanPreview, ForeignMountStatus, PreviewProgress } from '../types.js'
 
@@ -13,22 +13,28 @@ interface MountStatusEvent {
 export function useForeignMount(spaceId: string, shareId: string) {
   const [mount, setMount] = useState<ForeignFolderMount | null>(null)
   const [status, setStatus] = useState<ForeignMountStatus | null>(null)
+  // Every mount-status transition re-fires refresh and a share switch re-runs the effect, so two
+  // reads are routinely in flight at once. Without a generation the older one can land last and
+  // paint the previous share's mount over the folder the user is actually looking at.
+  const runRef = useRef(0)
 
   const refresh = useCallback(async () => {
     if (!spaceId || !shareId) return
+    const run = ++runRef.current
     const m = (await request('foreign-folder:get', { spaceId, shareId })) as ForeignFolderMount | null
+    if (run !== runRef.current) return
     setMount(m)
     setStatus(m?.status ?? null)
   }, [spaceId, shareId])
 
   useEffect(() => {
-    refresh()
+    void refresh()
     const unsub = subscribe<MountStatusEvent>('event:foreign-folder-mount-status', (msg) => {
       if (msg.spaceId !== spaceId || msg.shareId !== shareId) return
       setStatus(msg.status)
       // Re-read the durable record on EVERY transition (paused states persist too), so
       // `mount` (enabled/status) can never go stale on a missed recovery event.
-      refresh()
+      void refresh()
     })
     return unsub
   }, [refresh, spaceId, shareId])

--- a/src/renderer/screens/ActivityLog.tsx
+++ b/src/renderer/screens/ActivityLog.tsx
@@ -40,13 +40,13 @@ function selectItems(
 }
 
 function AuditRow({ entry }: { entry: AuditEntry }) {
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
   const badge = rowBadge(entry)
   // The reason trails the row's own context (space, totals): "DENIED" says something was refused,
   // this says what a reader should do about it — nothing, if we simply had no verified identity yet.
   const reasonKey = denialReasonKey(entry)
   const meta = [
-    ...metaParts(entry).map((part) => (part.key ? t(part.key, part.values) : part.text)),
+    ...metaParts(entry, i18n.language).map((part) => (part.key ? t(part.key, part.values) : part.text)),
     ...(reasonKey ? [t(reasonKey)] : []),
   ].join(' · ')
   const avatar = avatarKind(entry)

--- a/src/renderer/screens/ActivityLogSettings.tsx
+++ b/src/renderer/screens/ActivityLogSettings.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { request } from '../ipc.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
@@ -33,11 +33,18 @@ export default function ActivityLogSettings({ onBack, onOpenLog }: ActivityLogSe
   const [status, setStatus] = useState<string | null>(null)
   const [confirmPurge, setConfirmPurge] = useState(false)
 
+  // The mount read and the post-purge read can overlap — purge is slow enough that a user can
+  // change retention while it runs — and the stats half of the older pair would then re-show the
+  // row count that was just deleted.
+  const runRef = useRef(0)
+
   const refresh = useCallback(async () => {
+    const run = ++runRef.current
     const [nextConfig, nextStats] = await Promise.all([
       request('audit:get-config') as Promise<AuditConfig>,
       request('audit:stats') as Promise<AuditStats>,
     ])
+    if (run !== runRef.current) return
     setConfig(nextConfig)
     setStats(nextStats)
   }, [])

--- a/src/shared/contract/events.js
+++ b/src/shared/contract/events.js
@@ -1,5 +1,8 @@
-// Every event the worker pushes to the renderer. Emitted names are the source of truth: this list
-// is generated from them, and the taxonomy test fails if an emit site appears that is not here.
+// Every event the worker pushes to the renderer. Emitted names are the source of truth. Nothing in
+// production imports this file: its teeth are test/unit/contract-declarations.test.js, which parses
+// every emit site, every renderer subscription and this list and asserts all three name the same
+// set. The header used to claim the taxonomy test enforced it, which was never true — the taxonomy
+// test compares against its own map — and the two had already drifted by one name.
 export const EVENTS = Object.freeze({
   AUDIT_UPDATED: 'event:audit-updated',
   AWARENESS: 'event:awareness',
@@ -25,6 +28,7 @@ export const EVENTS = Object.freeze({
   OWNED_FOLDER_PREVIEW_PROGRESS: 'event:owned-folder-preview-progress',
   OWNED_FOLDER_SCAN_COMPLETED: 'event:owned-folder-scan-completed',
   PROFILE_NEEDED: 'event:profile-needed',
+  RECONCILE: 'event:reconcile',
   SHARE_FILES_UPDATED: 'event:share-files-updated',
   SHARE_INDEX_PROGRESS: 'event:share-index-progress',
   SHARES_UPDATED: 'event:shares-updated',

--- a/src/shared/core/subsystem.js
+++ b/src/shared/core/subsystem.js
@@ -100,10 +100,15 @@ export function createLifecycle({ log }) {
           else if (left <= 0) log.warn(subsystem.name, 'close skipped — shutdown budget spent')
           else {
             const timedOut = Symbol('timeout')
+            // Cleared on the way out: the loser of the race stays armed for the rest of the budget
+            // otherwise, so a clean shutdown ends with one pending timeout per subsystem — armed by
+            // the very code whose job was to make sure nothing was.
+            let budget = null
             const race = await Promise.race([
               subsystem.close().then(() => null),
-              new Promise((resolve) => { const t = setTimeout(() => resolve(timedOut), left); t.unref?.() }),
+              new Promise((resolve) => { budget = setTimeout(() => resolve(timedOut), left); budget.unref?.() }),
             ])
+            clearTimeout(budget)
             if (race === timedOut) log.warn(subsystem.name, 'close exceeded the shutdown budget — abandoned')
           }
         } catch (err) { log.warn(subsystem.name, 'close failed:', err.message) }

--- a/test/flow-flake-budget.json
+++ b/test/flow-flake-budget.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Pass-on-retry budget for one CI run. maxTotal is the gate: the aggregate only goes down. perFile names the files known to flake, each with a max and a reason, so a repeat offender cannot hide inside the aggregate; a file not listed here is reported by name in the run summary as a candidate for the table. Sized against the suite as it actually behaves today — a budget of zero would be red on arrival and would train people to re-run rather than to look.",
+  "maxTotal": 1,
+  "perFile": {}
+}

--- a/test/frontend/scenarios/s125-activity-log-folder-download.mjs
+++ b/test/frontend/scenarios/s125-activity-log-folder-download.mjs
@@ -17,7 +17,11 @@ export default async function s125 ({ runDir, bootstrap }) {
 
   const ownDir = path.join(workDir('own-'), 'Brand Assets')
   mkdirSync(ownDir, { recursive: true })
-  writeFileSync(path.join(ownDir, 'logo.txt'), 'the mark'.repeat(64))
+  // 10,000 bytes exactly, chosen so the meta line's size DISCRIMINATES: the Activity Log used to
+  // carry its own ladder that divided by 1024 under decimal KB/MB/GB labels, and at this size that
+  // reads '9.8 KB' where every other screen reads '10 KB'. At the previous 512 bytes both
+  // formatters printed the same string, so the row could not have caught it.
+  writeFileSync(path.join(ownDir, 'logo.txt'), 'the mark'.repeat(1250))
 
   try {
     await r.ok('A shares "Brand Assets"; B sees it', async () => {
@@ -57,6 +61,10 @@ export default async function s125 ({ runDir, bootstrap }) {
       assert(
         nodes.some((n) => n.startsWith('Aurora · Brand Assets')),
         'and its meta line names the space AND the folder — without the folder a folder row reads exactly like a loose one'
+      )
+      assert(
+        nodes.some((n) => n.startsWith('Aurora · Brand Assets · 10 KB')),
+        'and the size agrees with every other screen — 9.8 KB here would mean the log kept its own 1024 divisor under decimal labels'
       )
     })
 

--- a/test/helpers/ast-scan.js
+++ b/test/helpers/ast-scan.js
@@ -1,0 +1,58 @@
+// Shared parse-and-walk primitives for the guards that assert a property over real source. They
+// exist because the guards they replaced matched text: a leading dot, a quote style, an identifier
+// name. A parser has no opinion about punctuation, so the same invariant holds however the code is
+// spelled.
+import tseslint from 'typescript-eslint'
+
+export function parseSource (source, filePath) {
+  return tseslint.parser.parseForESLint(source, {
+    filePath,
+    range: true,
+    loc: true,
+    sourceType: 'module',
+    // `foo<T>()` and `<div/>` are the same two characters, so TS resolves the ambiguity by file
+    // extension and so must this.
+    ecmaFeatures: { jsx: filePath.endsWith('.tsx') },
+  })
+}
+
+export function forEachNode (node, visitorKeys, visit) {
+  if (!node || typeof node.type !== 'string') return
+  visit(node)
+  for (const key of visitorKeys[node.type] || []) {
+    const child = node[key]
+    if (Array.isArray(child)) for (const c of child) forEachNode(c, visitorKeys, visit)
+    else forEachNode(child, visitorKeys, visit)
+  }
+}
+
+// A string the reader can see in full at the call site: a plain literal, or a template with no
+// interpolation. A name assembled at runtime is not a declaration and is not treated as one.
+export function staticString (node) {
+  if (!node) return null
+  if (node.type === 'Literal' && typeof node.value === 'string') return node.value
+  if (node.type === 'TemplateLiteral' && node.expressions.length === 0 && node.quasis.length === 1) {
+    return node.quasis[0].value.cooked
+  }
+  return null
+}
+
+export function calleeName (callee) {
+  if (!callee) return null
+  if (callee.type === 'Identifier') return callee.name
+  if (callee.type === 'MemberExpression') {
+    if (callee.computed) return staticString(callee.property)
+    return callee.property.type === 'Identifier' ? callee.property.name : null
+  }
+  return null
+}
+
+// Every Identifier node mapped to the variable it resolves to, so a guard can ask "is this binding
+// module-scoped" instead of "does this name look module-scoped".
+export function resolutionMap (scopeManager) {
+  const resolved = new Map()
+  for (const scope of scopeManager.scopes) {
+    for (const ref of scope.references) if (ref.resolved) resolved.set(ref.identifier, ref.resolved)
+  }
+  return resolved
+}

--- a/test/helpers/emit-sites.js
+++ b/test/helpers/emit-sites.js
@@ -1,0 +1,28 @@
+// Finds the event names a source file actually emits or subscribes to, by parsing it rather than by
+// matching text. The guard this replaces used /\.emit\('(event:[a-z-]+)'/ — it required a leading
+// dot and single quotes, so `emit('event:reconcile', …)` in src/shared/state/hints.js (where `emit`
+// is a bare parameter) was invisible, and that one name is the fan-in point for the entire
+// level-triggered reconcile channel.
+import { parseSource, forEachNode, staticString, calleeName } from './ast-scan.js'
+
+function namesCalledOn (source, filePath, fn) {
+  const { ast, visitorKeys } = parseSource(source, filePath)
+  const found = new Set()
+  forEachNode(ast, visitorKeys, (node) => {
+    if (node.type !== 'CallExpression') return
+    if (calleeName(node.callee) !== fn) return
+    const name = staticString(node.arguments[0])
+    if (name && name.startsWith('event:')) found.add(name)
+  })
+  return found
+}
+
+// Total over emit syntax: `emit(…)`, `x.emit(…)`, `x?.emit(…)`, `x['emit'](…)`, single or double
+// quotes, backticks.
+export function emitSites (source, filePath) {
+  return namesCalledOn(source, filePath, 'emit')
+}
+
+export function subscribeSites (source, filePath) {
+  return namesCalledOn(source, filePath, 'subscribe')
+}

--- a/test/integration/timer-lifecycle.test.js
+++ b/test/integration/timer-lifecycle.test.js
@@ -1,0 +1,63 @@
+import test from 'brittle'
+import { trackTimers } from '../helpers/timers.js'
+
+// The shim must wrap the globals BEFORE the modules load, so everything under test comes in through
+// a dynamic import (static ones are hoisted above it).
+const timers = trackTimers()
+const { freshPeer } = await import('../helpers/store.js')
+const { initConvergenceTick, startConvergenceTick, resetConvergenceTick } = await import('../../src/shared/transfer/convergence-tick.js')
+const { initPresenceBroadcast, startPresenceHeartbeat, stopPresenceHeartbeat } = await import('../../src/shared/transfer/presence-broadcast.js')
+const { initConnectivity, scheduleStatusEmit, resetConnectivity } = await import('../../src/shared/transfer/connectivity.js')
+const { initNetworkWatch, observeReachability, resetNetworkWatch } = await import('../../src/shared/audit/network-watch.js')
+
+const silent = { debug () {}, info () {}, warn () {}, error () {} }
+const noSwarm = () => null
+
+// Eleven timer handles in the data layer live in module-scoped variables, armed inside a function
+// with a bare setInterval/setTimeout. That is legal under eslint.config.mjs's
+// moduleLevelTimerRestrictions, which forbids only a timer armed at IMPORT, and
+// test/unit/module-scoped-timer-handles.test.js proves each has a matching clear in its own module.
+// Neither can decide the property the lint MESSAGE used to imply — that a periodic call dies with
+// the thing that armed it — because three of the owners are module singletons, not Subsystems, and
+// deciding it statically needs interprocedural reachability. Measured directly instead: arm every
+// handle these modules publish a way to arm, run the reset set destroySwarm() runs, and count what
+// survives.
+//
+// Residual, stated so it is not later mistaken for more: this proves each module's reset disarms
+// everything that module arms. That destroySwarm() is itself reached on the way out is covered at
+// the root level by lifecycle-restart.test.js's LIFECYCLE-1a.
+test('no timer armed by a module-scoped handle survives the swarm teardown', async (t) => {
+  t.teardown(() => timers.restore())
+  const ctx = await freshPeer(t)
+
+  initConvergenceTick({ log: silent, sendSingleHandshake () {}, getStalledOwners: noSwarm, getSwarm: noSwarm, getIpc: noSwarm })
+  initPresenceBroadcast({ presence: { prune () {}, clearAll () {} }, membersPoke () {}, log: silent, getSwarm: noSwarm, getIpc: noSwarm })
+  initConnectivity({ log: silent, diag: silent, dhtVersion: '0', getDroppedFrameCounters: () => ({}), getSwarm: noSwarm, getIpc: noSwarm })
+  initNetworkWatch({ emit: null, sessionId: 'timer-lifecycle', dwellMs: 60000, peerDwellMs: 60000 })
+
+  startConvergenceTick()
+  startPresenceHeartbeat()
+  scheduleStatusEmit()
+  observeReachability({ verdict: 'blocked', cause: 'dht-unreachable', confidence: 'measured', evidence: null })
+
+  // A teardown assertion over an empty set proves nothing, so the arms are the first subject.
+  await new Promise((resolve) => setTimeout(resolve, 50))
+  const armedIntervals = timers.intervals().length
+  const armedTimeouts = timers.timeouts().length
+  t.ok(armedIntervals >= 2, `the periodic handles are armed (${armedIntervals} interval(s))`)
+  t.ok(armedTimeouts >= 1, `the deferred handles are armed (${armedTimeouts} timeout(s))`)
+
+  // Exactly what destroySwarm() calls, in its order, then the composition root itself — the
+  // subsystems booted by boot() arm their own timers through src/shared/core/timers.js and those
+  // are the root's to end.
+  resetConnectivity()
+  resetNetworkWatch()
+  stopPresenceHeartbeat()
+  resetConvergenceTick()
+  await ctx.root.close()
+
+  const intervals = timers.intervals()
+  const timeouts = timers.timeouts()
+  t.is(intervals.length, 0, 'no interval survives the teardown\n' + timers.describe(intervals))
+  t.is(timeouts.length, 0, 'no timeout survives the teardown\n' + timers.describe(timeouts))
+})

--- a/test/unit/audit-row.test.js
+++ b/test/unit/audit-row.test.js
@@ -4,6 +4,7 @@ import {
   groupByDay, isSystemRow, metaParts, rowBadge, sentenceKey, sentenceValues,
   splitSentence, sentinelValues, systemIcon, emptyStateFor, FIELD_SENTINEL, SENTENCE_FIELDS,
 } from '../../src/renderer/auditRow.js'
+import { formatSize } from '../../src/renderer/formatSize.js'
 
 const row = (over = {}) => ({
   v: 1, seq: 1, ts: Date.now(), tzOffset: 0,
@@ -107,11 +108,25 @@ test('sentence key and values come only from the row', (t) => {
 
 test('byte and count formatting', (t) => {
   t.is(formatBytes(0), '0 B')
-  t.is(formatBytes(1024), '1 KB')
-  t.is(formatBytes(1536), '1.5 KB')
-  t.is(formatBytes(13314398617), '12.4 GB')
+  t.is(formatBytes(1000, 'en'), '1 KB')
+  t.is(formatBytes(1500, 'en'), '1.5 KB')
+  t.is(formatBytes(13314398617, 'en'), '13.3 GB')
   t.is(formatBytes(-1), null)
   t.is(formatCount(5180), (5180).toLocaleString())
+  t.is(formatCount(5180, 'de'), (5180).toLocaleString('de'))
+})
+
+// REGRESSION (FIX-BYTES-1: the Activity Log divided by 1024 under decimal KB/MB/GB labels, so
+// every size it printed sat ~7.4% below the same file on the folder screen — and the assertions
+// above pinned the wrong numbers, so CI defended the discrepancy. The assertion is deliberately a
+// comparison against formatSize rather than a literal: a second literal ladder is how the first
+// one got written.)
+test('REGRESSION (FIX-BYTES-1): the Activity Log agrees with every other screen', (t) => {
+  const ladder = [0, 1, 999, 1000, 1024, 1536, 999999, 1000000, 13314398617, 676209262264, 1e15, 1e18]
+  for (const bytes of ladder) {
+    t.is(formatBytes(bytes, 'en'), formatSize(bytes, 'en'), `${bytes} reads the same on both screens`)
+  }
+  t.is(formatBytes(2411724, 'de'), formatSize(2411724, 'de'), 'and under a non-English locale too')
 })
 
 test('meta line leads with the space and folds in the aggregate totals', (t) => {

--- a/test/unit/byte-formatter-single-owner.test.js
+++ b/test/unit/byte-formatter-single-owner.test.js
@@ -1,0 +1,57 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { Linter } from 'eslint'
+import tseslint from 'typescript-eslint'
+import { byteFormatterSingleOwnerRestrictions } from '../../eslint.config.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const rendererDir = path.join(here, '..', '..', 'src', 'renderer')
+const OWNER = path.join(rendererDir, 'formatSize.js')
+
+function walk (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) walk(p, out)
+    else if (/\.(js|ts|tsx)$/.test(name)) out.push(p)
+  }
+  return out
+}
+
+function verify (linter, source, filename) {
+  return linter.verify(source, {
+    files: ['**/*.{js,ts,tsx}'],
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaFeatures: { jsx: true } } },
+    rules: { 'no-restricted-syntax': ['error', ...byteFormatterSingleOwnerRestrictions] },
+  }, filename)
+    // Renderer files carry inline eslint-disable comments for jsx-a11y rules this minimal Linter
+    // does not register, and eslint reports each one as a "rule not found" message. Only this
+    // rule's own verdict is the subject here.
+    .filter((m) => m.ruleId === 'no-restricted-syntax')
+}
+
+// REGRESSION (FIX-BYTES-2: auditRow.js carried a second byte ladder — decimal labels over a binary
+// divisor — so the Activity Log read ~7.4% below every other screen for the same file, and
+// test/unit/audit-row.test.js pinned the wrong numbers. Deleting that ladder fixes today's
+// discrepancy; this rule is what stops the NEXT one, in any spelling: it matches the SHAPE of a
+// unit ladder, an array literal carrying a byte-unit element, not a variable called BYTES_UNITS.)
+test('REGRESSION (FIX-BYTES-2): src/renderer/formatSize.js is the only module that declares a byte ladder', (t) => {
+  const linter = new Linter()
+
+  t.ok(verify(linter, "const U = ['B', 'KB', 'MB', 'GB', 'TB']\n", 'control.js').length > 0, 'a decimal ladder is caught')
+  t.ok(verify(linter, 'const U = ["B", "KB", "MB"]\n', 'control2.js').length > 0, 'quote style does not matter')
+  t.ok(verify(linter, "const U = ['bytes', 'KiB', 'MiB', 'GiB']\n", 'control3.js').length > 0, 'a binary ladder is caught too')
+  t.ok(verify(linter, "const anything = ['GB']\n", 'control4.js').length > 0, 'renaming the array changes nothing')
+  t.alike(verify(linter, "const s = formatSize(bytes, locale)\n", 'ok.js'), [], 'calling the owner is the supported door')
+  t.alike(verify(linter, 'const PRESET_KBPS = [0, 1024, 5120, 25600]\n', 'ok2.js'), [], 'a numeric rate ladder stays legal')
+  t.alike(verify(linter, "const speed = size + ' KB/s'\n", 'ok3.js'), [], 'a bandwidth label stays legal')
+  t.alike(verify(linter, "const unit = 'KB'\n", 'ok4.js'), [], 'a lone unit string outside an array stays legal')
+
+  const files = walk(rendererDir).filter((f) => f !== OWNER)
+  t.ok(files.length > 0, 'src/renderer was actually walked')
+  for (const file of files) {
+    t.alike(verify(linter, readFileSync(file, 'utf8'), file).map((m) => `${m.line}: ${m.message}`), [], path.relative(process.cwd(), file))
+  }
+  t.ok(/const UNITS = \['B', 'KB'/.test(readFileSync(OWNER, 'utf8')), 'and formatSize.js is where the ladder actually lives')
+})

--- a/test/unit/contract-declarations.test.js
+++ b/test/unit/contract-declarations.test.js
@@ -3,6 +3,7 @@ import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath, pathToFileURL } from 'url'
 import path from 'path'
 import * as contract from '../../src/shared/contract/index.js'
+import { emitSites, subscribeSites } from '../helpers/emit-sites.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const dir = path.join(here, '..', '..', 'src', 'shared', 'contract')
@@ -109,28 +110,76 @@ test('the renderer derives its status unions instead of re-listing them', (t) =>
   }
 })
 
-// The EVENTS list claimed to be guarded and was not. Rather than soften the comment, this is the
-// guard: an emit site the contract does not know is drift, and the list is only useful if it is
-// complete.
-test('every event the worker emits is declared in the contract', (t) => {
-  const src = path.join(dir, '..', '..')
-  const files = []
-  const walkAll = (d) => {
-    for (const name of readdirSync(d)) {
-      const p = path.join(d, name)
-      if (statSync(p).isDirectory()) { if (name !== 'vendor' && name !== 'contract') walkAll(p) }
-      else if (name.endsWith('.js')) files.push(p)
+// REGRESSION (FIX-EVENTS-1: this guard matched the TEXT /\.emit\('(event:[a-z-]+)'/ — a leading
+// dot and single quotes. src/shared/state/hints.js calls `emit('event:reconcile', …)` on a bare
+// parameter, so the one missing punctuation mark hid the fan-in point of the entire
+// level-triggered reconcile channel, and the contract reported itself complete. The scan now
+// parses; quote style, optional chaining and the receiver's shape cannot hide a site.
+//
+// Three directions, because a one-way guard only measures half a contract: an undeclared emit is
+// drift, a declared name nobody emits is dead vocabulary, and a renderer subscribed to a name
+// nothing emits waits forever. The last one is what would have caught event:reconcile from the
+// other end.
+const DATA_LAYER = ['shared', 'worker', 'main']
+
+function walkSrc (dir, pattern, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) { if (name !== 'vendor' && name !== 'contract') walkSrc(p, pattern, out) }
+    else if (pattern.test(name)) out.push(p)
+  }
+  return out
+}
+
+function collect (dirs, pattern, scan) {
+  const found = new Map()
+  for (const d of dirs) {
+    for (const f of walkSrc(path.join(dir, '..', '..', d), pattern)) {
+      for (const name of scan(readFileSync(f, 'utf8'), f)) {
+        if (!found.has(name)) found.set(name, [])
+        found.get(name).push(path.relative(process.cwd(), f))
+      }
     }
   }
-  walkAll(path.join(src, 'shared'))
-  walkAll(path.join(src, 'worker'))
+  return found
+}
 
-  const emitted = new Set()
-  for (const f of files) {
-    for (const m of readFileSync(f, 'utf8').matchAll(/\.emit\('(event:[a-z-]+)'/g)) emitted.add(m[1])
-  }
-  const undeclared = [...emitted].filter((e) => !contract.EVENT_NAMES.includes(e)).sort()
+test('REGRESSION (FIX-EVENTS-1): a bare emit() is seen by the contract guard', (t) => {
+  const seen = (src) => [...emitSites(src, 'fixture.js')]
+  t.alike(seen("emit('event:x', {})"), ['event:x'], 'a bare emit on a parameter is seen')
+  t.alike(seen('bus.emit("event:y", {})'), ['event:y'], 'double quotes are seen')
+  t.alike(seen('bus?.emit(`event:z`, {})'), ['event:z'], 'optional chaining and a template are seen')
+  t.alike(seen("this.ipc.emit('event:w')"), ['event:w'], 'a nested receiver is seen')
+  t.alike(seen("bus['emit']('event:v')"), ['event:v'], 'a computed member is seen')
+  t.alike(seen("emit(name, {})"), [], 'a name assembled at runtime is not a declaration')
+  t.alike(seen("emit('not-an-event')"), [], 'a non-event call is not collected')
+  t.alike(seen('const emit = 1'), [], 'a mention that is not a call is not collected')
+})
+
+test('every event the worker emits is declared in the contract', (t) => {
+  const emitted = collect(DATA_LAYER, /\.js$/, emitSites)
+  t.ok(emitted.size > 10, 'the data layer was actually walked')
+  const undeclared = [...emitted.keys()].filter((e) => !contract.EVENT_NAMES.includes(e)).sort()
+    .map((e) => `${e} (${emitted.get(e).join(', ')})`)
   t.alike(undeclared, [], 'events emitted but absent from the contract')
+})
+
+// The reverse direction, which was never measured. Empty today; a name that stops being emitted
+// should lose its contract row in the same commit, not linger as vocabulary nothing speaks.
+test('every declared event is emitted somewhere', (t) => {
+  const emitted = collect(DATA_LAYER, /\.js$/, emitSites)
+  const dead = contract.EVENT_NAMES.filter((e) => !emitted.has(e)).sort()
+  t.alike(dead, [], 'events declared in the contract that nothing emits')
+})
+
+// The renderer imports no leaf of the contract, so nothing else relates what it listens for to
+// what the worker sends. A subscription to a name nothing emits is a screen that never updates.
+test('every renderer subscription names a declared event', (t) => {
+  const subscribed = collect(['renderer'], /\.(js|ts|tsx)$/, subscribeSites)
+  t.ok(subscribed.size > 10, 'src/renderer was actually walked')
+  const unknown = [...subscribed.keys()].filter((e) => !contract.EVENT_NAMES.includes(e)).sort()
+    .map((e) => `${e} (${subscribed.get(e).join(', ')})`)
+  t.alike(unknown, [], 'the renderer waits for an event the contract does not declare')
 })
 
 // The RequestName union is what makes request() type-safe; declared as Record<string, …> it would

--- a/test/unit/event-taxonomy.test.js
+++ b/test/unit/event-taxonomy.test.js
@@ -3,6 +3,7 @@ import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import { scopeForEvent } from '../../src/shared/core/ipc.js'
+import { EVENT_NAMES } from '../../src/shared/contract/events.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const SRC = path.join(here, '..', '..', 'src')
@@ -62,6 +63,14 @@ const TAXONOMY = {
   'event:foreign-folder-preview-progress': 'signal',
   'event:state': 'snapshot',
 }
+
+// The two artifacts describe the same vocabulary from two angles — the contract says what exists,
+// the taxonomy says which channel it belongs to — and nothing related them, so they had already
+// drifted by one name (event:reconcile was classified here and missing from the contract) for as
+// long as the contract's own header claimed this test enforced it.
+test('the taxonomy and the contract declare the same events', (t) => {
+  t.alike(Object.keys(TAXONOMY).sort(), [...EVENT_NAMES].sort(), 'every declared event is classified and vice versa')
+})
 
 test('every emitted worker event is classified in the EDA taxonomy', (t) => {
   const emitted = new Set()

--- a/test/unit/flow-flake-ledger.test.js
+++ b/test/unit/flow-flake-ledger.test.js
@@ -1,0 +1,61 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { evaluateLedger, describeLedger } from '../../scripts/flake-ledger.mjs'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const budgetPath = path.join(here, '..', 'flow-flake-budget.json')
+const shard = (n, files) => ({ shard: n, files })
+
+// A pass-on-retry used to leave a `::warning` and nothing else. An annotation is not a measurement:
+// nothing aggregates it, so "is this suite getting flakier" had no answer, and the failed attempt's
+// output — which the warning text itself told you to read — was never saved anywhere. These are the
+// ledger's rules, exercised on fixtures so the gate is proven without spending a CI run on it.
+test('the flake ledger fails a run that exceeds its budget', (t) => {
+  const budget = { maxTotal: 1, perFile: {} }
+
+  t.ok(evaluateLedger([shard(1, [])], budget).ok, 'a clean run passes')
+  t.is(evaluateLedger([shard(1, [])], budget).total, 0, 'and counts nothing')
+
+  const one = evaluateLedger([shard(3, [{ file: 'test/flow/a.test.js', attempts: 2, passedOnRetry: true }])], budget)
+  t.ok(one.ok, 'a single flake is within the budget')
+  t.is(one.total, 1, 'and is counted')
+  t.alike(one.unbudgeted, ['test/flow/a.test.js'], 'and is named, so it can become a table entry')
+
+  const two = evaluateLedger([
+    shard(3, [{ file: 'test/flow/a.test.js', attempts: 2, passedOnRetry: true }]),
+    shard(5, [{ file: 'test/flow/b.test.js', attempts: 2, passedOnRetry: true }]),
+  ], budget)
+  t.absent(two.ok, 'two flakes in one run exceed a budget of one')
+  t.ok(two.overTotal, 'and the aggregate is what failed')
+  t.ok(describeLedger(two).includes('FAIL: 2 pass-on-retry exceeds'), 'the summary says which rule failed')
+
+  // A hard failure is the shard job's business, never the ledger's: the two must not be
+  // confusable, or a broken change reads as a flaky suite.
+  const hard = evaluateLedger([shard(2, [{ file: 'test/flow/c.test.js', attempts: 2, passedOnRetry: false }])], budget)
+  t.ok(hard.ok, 'a file that failed BOTH attempts is not a flake')
+  t.is(hard.total, 0, 'and is not counted as one')
+
+  const named = { maxTotal: 3, perFile: { 'test/flow/a.test.js': { max: 1, why: 'known hyperdht bind race under a 2-vCPU runner' } } }
+  t.ok(evaluateLedger([shard(1, [{ file: 'test/flow/a.test.js', attempts: 2, passedOnRetry: true }])], named).ok,
+    'a named offender may flake up to its own cap')
+  const repeat = evaluateLedger([
+    shard(1, [{ file: 'test/flow/a.test.js', attempts: 2, passedOnRetry: true }]),
+    shard(2, [{ file: 'test/flow/a.test.js', attempts: 2, passedOnRetry: true }]),
+  ], named)
+  t.absent(repeat.ok, 'a repeat offender cannot hide inside the aggregate')
+  t.alike(repeat.over, ['test/flow/a.test.js flaked 2x, budget 1'], 'and the ledger names it')
+})
+
+// The committed budget is the ratchet. A number nobody can read the reason for is a snapshot.
+test('the committed flake budget is well formed', (t) => {
+  const budget = JSON.parse(readFileSync(budgetPath, 'utf8'))
+  t.is(typeof budget.maxTotal, 'number', 'the aggregate ceiling is a number')
+  t.ok(budget.maxTotal >= 0, 'and not negative')
+  t.ok(budget._comment.length > 100, 'the file explains what the numbers mean and which way they move')
+  for (const [file, entry] of Object.entries(budget.perFile)) {
+    t.is(typeof entry.max, 'number', `${file} caps its flakes`)
+    t.ok(typeof entry.why === 'string' && entry.why.length > 20, `${file} says why it is listed`)
+  }
+})

--- a/test/unit/module-scoped-timer-handles.test.js
+++ b/test/unit/module-scoped-timer-handles.test.js
@@ -1,0 +1,81 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { parseSource, forEachNode, calleeName, resolutionMap } from '../helpers/ast-scan.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(here, '..', '..')
+
+const ARM = new Set(['setInterval', 'setTimeout'])
+const DISARM = new Set(['clearInterval', 'clearTimeout'])
+
+function walk (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) { if (name !== 'vendor') walk(p, out) } else if (name.endsWith('.js')) out.push(p)
+  }
+  return out
+}
+
+// A handle held in a module-scoped variable and armed inside a function is legal under
+// eslint.config.mjs's moduleLevelTimerRestrictions, which only forbids a timer armed at IMPORT.
+// This is the next question that rule cannot ask: whether the module that armed it holds anything
+// that can disarm it. A handle nothing can ever clear is a leak by construction — no reachability
+// analysis needed to say so.
+function uncleared (source, filePath) {
+  const { ast, visitorKeys, scopeManager } = parseSource(source, filePath)
+  const resolved = resolutionMap(scopeManager)
+  const armed = new Map()
+  const cleared = new Set()
+
+  forEachNode(ast, visitorKeys, (node) => {
+    // A BARE set*() only. `this.timers.setTimeout(…)` is the Subsystem facility that owns the
+    // ending itself (src/shared/core/timers.js), which is the shape the lint message asks for.
+    if (node.type === 'AssignmentExpression' && node.operator === '=' && node.left.type === 'Identifier' &&
+        node.right && node.right.type === 'CallExpression' &&
+        node.right.callee.type === 'Identifier' && ARM.has(node.right.callee.name)) {
+      const variable = resolved.get(node.left)
+      if (variable && variable.scope.type === 'module') {
+        armed.set(variable, (armed.get(variable) || []).concat(node.loc.start.line))
+      }
+    }
+    if (node.type === 'CallExpression' && DISARM.has(calleeName(node.callee))) {
+      const arg = node.arguments[0]
+      if (arg && arg.type === 'Identifier') {
+        const variable = resolved.get(arg)
+        if (variable) cleared.add(variable)
+      }
+    }
+  })
+
+  return [...armed].filter(([variable]) => !cleared.has(variable))
+    .map(([variable, lines]) => `${variable.name} (armed at ${lines.join(', ')})`)
+}
+
+// The companion to test/unit/module-level-timers.test.js, which proves the IMPORT-TIME property and
+// is correct about it. What neither can prove — and what the lint message used to imply — is that a
+// handle's reset is actually CALLED before the process that armed it goes away: three of the owners
+// are module singletons, not Subsystems, so that needs a call graph across modules. The runtime
+// proof of the broad property is test/integration/timer-lifecycle.test.js. This is the decidable
+// corner, stated as exactly that.
+test('every module-scoped timer handle has a matching clear in its own module', (t) => {
+  t.alike(uncleared('let h\nfunction f () { h = setInterval(tick, 1000) }\n', 'control.js'),
+    ['h (armed at 2)'], 'a module-scoped interval with no clear is caught')
+  t.alike(uncleared('let h\nfunction f () { h = setTimeout(tick, 1000) }\n', 'control2.js'),
+    ['h (armed at 2)'], 'and a module-scoped timeout')
+  t.alike(uncleared('let handle\nfunction arm () { handle = setInterval(tick, 1) }\nfunction reset () { clearInterval(handle) }\n', 'ok.js'),
+    [], 'a matching clear in the same module is the supported shape')
+  t.alike(uncleared('function f () { let h = setTimeout(tick, 1) }\n', 'ok2.js'),
+    [], 'a function-scoped handle dies with the call')
+  t.alike(uncleared('async function f () { await new Promise((r) => setTimeout(r, 5)) }\n', 'ok3.js'),
+    [], 'a one-shot delay holds no handle at all')
+  t.alike(uncleared('let h\nfunction f (current) { h = current.timers.setTimeout(tick, 1) }\n', 'ok4.js'),
+    [], 'the Subsystem timer facility owns its own ending')
+
+  const files = [...walk(path.join(root, 'src', 'shared')), ...walk(path.join(root, 'src', 'worker'))]
+  t.ok(files.length > 0, 'the data layer was actually walked')
+  for (const file of files) {
+    t.alike(uncleared(readFileSync(file, 'utf8'), file), [], path.relative(root, file))
+  }
+})

--- a/test/unit/renderer-stale-guard-ratchet.test.js
+++ b/test/unit/renderer-stale-guard-ratchet.test.js
@@ -2,6 +2,10 @@ import test from 'brittle'
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
+import { Linter } from 'eslint'
+import tseslint from 'typescript-eslint'
+import noUnguardedAsyncEffect from '../../eslint-rules/no-unguarded-async-effect.js'
+import { unmountOnlyAsyncEffects, outOfOrderAsyncEffects } from '../../eslint.config.mjs'
 import { MAIN_QUERIES, MAIN_QUERY_NAMES } from '../../src/renderer/store/main-queries.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
@@ -11,60 +15,112 @@ function walk (dir, out = []) {
   for (const name of readdirSync(dir)) {
     const p = path.join(dir, name)
     if (statSync(p).isDirectory()) walk(p, out)
-    else if (/\.(ts|tsx)$/.test(name)) out.push(p)
+    // `.js` matters: src/renderer/store/* is the sanctioned implementation of this property and the
+    // predecessor guard never scanned it, so nothing checked that the answer stayed the answer.
+    else if (/\.(js|ts|tsx)$/.test(name)) out.push(p)
   }
   return out
 }
 
-// The four sites where the hand-rolled guard is DELIBERATE, each justified in a comment at the
-// site:
-//   AddFolderShareModal / MirrorFolderModal — point-in-time filesystem probes; a cached verdict
-//     would answer for a path the user has since changed.
-//   FilenameTitle — not a query at all; it guards a document.fonts.ready continuation.
-//   useConnectionStatus — a single provider mounted once with an event feed; cache, dedup and
-//     abort all buy nothing.
-const ALLOWED = Object.freeze({
-  'src/renderer/components/modals/AddFolderShareModal.tsx': 1,
-  'src/renderer/components/modals/MirrorFolderModal.tsx': 1,
-  'src/renderer/components/widgets/FilenameTitle.tsx': 1,
-  'src/renderer/hooks/useConnectionStatus.tsx': 1,
-})
-
-function guardSites () {
-  const found = {}
-  for (const f of walk(path.join(root, 'src', 'renderer'))) {
-    const hits = readFileSync(f, 'utf8').match(/let cancelled = false/g)
-    if (hits) found[path.relative(root, f)] = hits.length
-  }
-  return found
+// Driven with NO allowances — the `allow` option in eslint.config.mjs only keeps CI and the editor
+// quiet about the files below, and cannot hide anything from this scan.
+function verify (linter, source, filename) {
+  return linter.verify(source, {
+    files: ['**/*.{js,ts,tsx}'],
+    languageOptions: { parser: tseslint.parser, parserOptions: { ecmaFeatures: { jsx: true } } },
+    plugins: { local: { rules: { 'no-unguarded-async-effect': noUnguardedAsyncEffect } } },
+    rules: { 'local/no-unguarded-async-effect': 'error' },
+  }, filename).filter((m) => m.ruleId === 'local/no-unguarded-async-effect')
 }
 
-// A ratchet, not a snapshot: the four below are decisions with reasons written at the site.
-// Nothing may be ADDED without someone noticing, and removing one is a change to that file's
-// reason, which belongs in its own commit together with this table.
-test('REGRESSION (FIX-R04-2): the hand-rolled stale-response guard only shrinks', (t) => {
-  const found = guardSites()
+const wrap = (body, hooks = 'const [x, setX] = useState(null)') => `
+function Component ({ dep }) {
+  ${hooks}
+  ${body}
+  return x
+}
+`
 
-  const unexpected = Object.keys(found).filter((f) => !(f in ALLOWED))
-  t.alike(unexpected, [], 'a new hand-rolled cancel flag was introduced — use useQuery/useMainQuery')
+// REGRESSION (FIX-STALE-2: the predecessor guard matched the TEXT `let cancelled = false` and
+// counted at most four files. Six more hand-rolled guards were spelled `alive`, `active`,
+// `sawFrame` or `runRef` and were invisible to it; six effects had no guard at all and were
+// invisible to it by construction, because absence has no spelling. It reported the property
+// covered while three of those six could paint a superseded response over current state.
+//
+// These fixtures are the grammar itself: what must be caught, and — the half a widened regex could
+// never express — what must stay legal.)
+test('REGRESSION (FIX-STALE-2): an async effect that writes state names its supersession strategy', (t) => {
+  const linter = new Linter()
+  const caught = (body, hooks) => verify(linter, wrap(body, hooks), 'fixture.tsx').length > 0
+  const legal = (body, hooks) => verify(linter, wrap(body, hooks), 'fixture.tsx').map((m) => m.message)
 
-  for (const [file, cap] of Object.entries(ALLOWED)) {
-    t.ok((found[file] ?? 0) <= cap, `${file} has at most ${cap} justified guard(s)`)
-  }
+  t.ok(caught('useEffect(() => { read().then(setX) }, [dep])'), 'a bare .then(setX) is caught')
+  t.ok(caught('useEffect(() => { async function run () { const v = await read(); setX(v) } void run() }, [dep])'),
+    'an await followed by a setter is caught')
+  t.ok(caught(
+    'useEffect(() => { void refresh() }, [refresh])',
+    'const [x, setX] = useState(null)\n  const refresh = useCallback(async () => { const v = await read(); setX(v) }, [dep])',
+  ), 'async work inside a useCallback the effect calls is caught — the shape all three live defects took')
 
-  const total = Object.values(found).reduce((a, b) => a + b, 0)
-  t.ok(total <= 4, `at most four justified guards remain (found ${total})`)
+  t.alike(legal('useEffect(() => { let cancelled = false; read().then((v) => { if (cancelled) return; setX(v) }); return () => { cancelled = true } }, [dep])'),
+    [], 'a cleanup flag spelled `cancelled` is legal')
+  t.alike(legal('useEffect(() => { let alive = true; read().then((v) => { if (!alive) return; setX(v) }); return () => { alive = false } }, [dep])'),
+    [], 'the same flag spelled `alive` is equally legal — the guard is recognised by structure')
+  t.alike(legal('useEffect(() => { let active = true; read().then((v) => { if (!active) return; setX(v) }); return () => { active = false } }, [dep])'),
+    [], 'and spelled `active`')
+  t.alike(legal(
+    'useEffect(() => { const run = ++runRef.current; read().then((v) => { if (run !== runRef.current) return; setX(v) }) }, [dep])',
+    'const [x, setX] = useState(null)\n  const runRef = useRef(0)',
+  ), [], 'a generation ref is legal')
+  t.alike(legal('useEffect(() => { const c = new AbortController(); read(c.signal).then(setX); return () => c.abort() }, [dep])'),
+    [], 'an abort signal is legal')
+  t.alike(legal('useEffect(() => { fetchQuery("x").then(setX) }, [dep])'),
+    [], 'reading through the store, which owns seq and abort, is legal')
+  t.alike(legal('useEffect(() => { async function run () { setX(true); await read() } void run() }, [dep])'),
+    [], 'a setter BEFORE the await is not a race')
+  t.alike(legal('useEffect(() => { async function run () { await read(); subscribe("event:x", (m) => setX(m)) } void run() }, [dep])'),
+    [], 'an event handler registered after an await is a fresh context, not a continuation')
+  t.alike(legal(
+    'useEffect(() => { read().then((el) => setWrapperRef(el)) }, [dep])',
+    'const [x, setX] = useState(null)\n  function setWrapperRef (el) { holder = el }',
+  ), [], 'a plain function whose name merely starts with `set` is not a setter — the binding decides, not the spelling')
 })
 
-// The allowlist is only honest if each entry SAYS why. A file that keeps its flag without a reason
-// is indistinguishable from one nobody got round to migrating.
-test('every allowed guard carries its justification at the site', (t) => {
-  for (const file of Object.keys(ALLOWED)) {
-    const src = readFileSync(path.join(root, file), 'utf8')
-    const idx = src.indexOf('let cancelled = false')
-    t.ok(idx > 0, `${file} still has the guard the allowlist exempts`)
-    const preamble = src.slice(Math.max(0, idx - 700), idx)
-    t.ok(/\/\//.test(preamble), `${file} explains the guard in a comment above it`)
+// A ratchet, not a snapshot: the table lives in eslint.config.mjs so the rule and this scan cannot
+// disagree about what is exempt, and every entry states its reason there.
+test('the renderer has no unguarded async effect outside the exemption table', (t) => {
+  const linter = new Linter()
+  const found = {}
+  for (const f of walk(path.join(root, 'src', 'renderer'))) {
+    const messages = verify(linter, readFileSync(f, 'utf8'), f)
+    if (messages.length) found[path.relative(root, f).split(path.sep).join('/')] = messages.length
+  }
+
+  const table = { ...outOfOrderAsyncEffects, ...unmountOnlyAsyncEffects }
+  const unexpected = Object.keys(found).filter((f) => !(f in table)).sort()
+  t.alike(unexpected, [], 'a new unguarded async effect was introduced — read through useQuery/useMainQuery, or carry a generation ref')
+
+  for (const [file, entry] of Object.entries(table)) {
+    t.ok((found[file] ?? 0) <= entry.effects, `${file} has at most ${entry.effects} exempt effect(s)`)
+  }
+
+  const stale = Object.keys(table).filter((f) => !(f in found)).sort()
+  t.alike(stale, [], 'an exemption outlived the effect it excused — delete the row')
+})
+
+// OUT_OF_ORDER is the whole point of splitting the table. An effect that re-fires can have two
+// reads in flight, and the older one winning is wrong data on screen; there is no reason that makes
+// that acceptable, so the list has no legal contents.
+test('no out-of-order async effect is exempted', (t) => {
+  t.alike(Object.keys(outOfOrderAsyncEffects), [], 'an out-of-order race was allowlisted instead of fixed')
+})
+
+// An exemption is only honest if it SAYS why. A file listed without a reason is indistinguishable
+// from one nobody got round to migrating.
+test('every exemption states its reason', (t) => {
+  for (const [file, entry] of Object.entries({ ...outOfOrderAsyncEffects, ...unmountOnlyAsyncEffects })) {
+    t.is(typeof entry.effects, 'number', `${file} caps how many effects it exempts`)
+    t.ok(typeof entry.why === 'string' && entry.why.length > 40, `${file} explains why it is exempt`)
   }
 })
 


### PR DESCRIPTION
Five guards each claimed a safety property; four tested a spelling — a regex over
identifier names, quote styles or call syntax — and reported "covered" while the
hole stayed open. Plan: `plan-guards-measure-property.md`.

One commit per guard.

**What the guards were hiding**
- The Activity Log divided by 1024 under decimal KB/MB/GB labels, so every size read
  ~7.4% below the same file elsewhere. A unit test pinned the wrong numbers.
- Six effects wrote React state after an await with no supersession guard; three could
  land out of order and paint a superseded read over current state. The ratchet grepped
  for `let cancelled = false`, which cannot see an effect with no guard at all.
- `event:reconcile` — the fan-in point for the whole reconcile channel — was undeclared,
  because the scan required a leading dot and single quotes.
- Subsystem close armed one shutdown-budget timeout per subsystem and never cleared the
  loser of the race. Found by the new runtime timer check on its first run.

**Deviations from the plan** (reasons in the plan's review section)
- The flake budget's two rules contradicted each other; `maxTotal` is now the gate and
  `perFile` names known offenders.
- No `src/renderer/store/**` exemption: it is scanned and reports nothing.
- Exemption tables live in `eslint.config.mjs` so the rule and the ratchet cannot disagree;
  the ratchet drives the rule with no allowances.

**Not delivered**: a hook-level two-in-flight-reads test (T3) — needs a React renderer the
repo does not have.

**Verified**: typecheck; `lint:ci` 18 warnings / 0 errors (ceiling unchanged at 28);
`test:node:core` 1845/1845; `test:bare` 1023/1023 against a 1022 baseline on pristine
staging; flow shutdown subset 3 files; `test:fe s125 s25 s109 s115 s6 s71` 6/6.
`s125`'s fixture was 512 bytes — below the ladder's first step, so it could not have
caught this bug; it is now 10,000 and asserts the size.