### PR TITLE
[fix] Two review follow-ups on the scan heartbeat and the fetch diag

### DIFF
--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -413,9 +413,11 @@ async function diffAndEnqueue(spaceId, shareId, { mountPath, ignore, deep, defer
   const specs = []
   const unchanged = []
   let deferred = 0
-  let seen = 0
   for (const [relPath, info] of onDisk) {
-    if (++seen % LIVENESS_EVERY === 0) passLiveness.progress(key)
+    // No beat in here, deliberately: this loop never awaits, so on the worker's single thread no
+    // probe can run between its iterations — only the stamps on either side of it are ever read. A
+    // heartbeat here cannot be observed, and one that cannot be observed makes the phase look
+    // covered. The beat that matters is in the ensureServable loop below, which does await.
     // A name no catalog key can carry (a '\' in a POSIX file name) is skipped, never a reason to
     // abort the whole diff.
     if (relKeyEscapes(relPath)) { log.warn('skipping file whose name cannot be a share key:', relPath); continue }
@@ -437,6 +439,13 @@ async function diffAndEnqueue(spaceId, shareId, { mountPath, ignore, deep, defer
   // advertising a hash the serve gate does not hold (a transient registerFile failure) must heal
   // on the next pass, not the next restart.
   for (const [relPath, prev, info] of unchanged) {
+    // Per file, like the walk's own callback: ensureServable is free only while the serve
+    // reference is present, and after a restart the serve map is empty — so every unchanged file
+    // pays a registerFile and this becomes the long pole of the whole pass on a large, fully
+    // synced share. LIVENESS_EVERY throttles the loops where the bookkeeping could itself become
+    // the cost; next to an await on real I/O a Map lookup is free, and throttling here could skip
+    // the entire window on a share with fewer files than the interval.
+    passLiveness.progress(key)
     try { await ensureServable(spaceId, shareId, relPath, pathFromMount(mountPath, relPath), prev.contentHash, info.size) } catch (err) {
       log.debug('ensure servable failed:', relPath, '-', err.message)
     }

--- a/src/shared/transfer/backends/overlay/fetch-run.js
+++ b/src/shared/transfer/backends/overlay/fetch-run.js
@@ -33,10 +33,18 @@ export async function runOverlayFetch (overlay, contentHash, {
     // and that TypeError would REPLACE the real fault — so a full disk would reach the caller as a
     // bug in this file instead of the ENOSPC that must pause the mount. The annotation is a
     // convenience; the fault is not.
+    let annotated = false
     try {
       err.attempted = attempted
       err.diag = diag
+      annotated = true
     } catch { log.debug('could not annotate a fetch rejection:', label, relPath) }
+    // Every caller reaches the diag through `err.diag`, so an annotation that could not land does
+    // not just lose the flag — it strands the diag, `diag?.finish('failed')` no-ops, and the
+    // `start:` line this fetch already logged never gets its terminal `INCOMPLETE … gave up`. That
+    // is precisely the frozen-rejection ENOSPC case above, i.e. the one where the give-up matters
+    // most. Nothing downstream can close it, so close it here.
+    if (!annotated) diag.finish('failed')
     throw err
   }
 }

--- a/test/integration/overlay-fetch-annotate.test.js
+++ b/test/integration/overlay-fetch-annotate.test.js
@@ -37,3 +37,38 @@ test('a primitive rejection survives too', async (t) => {
   const err = await rejectionOf('overlay said no')
   t.is(err, 'overlay said no', 'nothing in the instrumentation may swallow or rewrite it')
 })
+
+// Warnings, not the diag object: `INCOMPLETE … gave up` IS the artifact — the one line that closes
+// the `start:` line every fetch logs — and the diag exposes no readable state.
+function captureWarnings (t) {
+  const lines = []
+  const real = console.warn
+  console.warn = (...args) => lines.push(args.join(' '))
+  t.teardown(() => { console.warn = real })
+  return lines
+}
+
+// REGRESSION (FIX-FETCH-DIAG: when the annotation could not land, the diag was dropped rather than
+// settled. Every caller reaches it through `err.diag`, so `diag?.finish('failed')` no-opped and the
+// `start:` line this fetch had already logged never got its terminal `INCOMPLETE … gave up` —
+// losing the give-up record for exactly the frozen-rejection ENOSPC case the annotation guard was
+// added for.)
+test('REGRESSION (FIX-FETCH-DIAG): a rejection that cannot be annotated still closes its diag', async (t) => {
+  const warnings = captureWarnings(t)
+  const frozen = Object.freeze(Object.assign(new Error('no space left on device'), { code: 'ENOSPC' }))
+  const err = await rejectionOf(frozen)
+  t.is(err, frozen, 'the fault still reaches the caller unchanged')
+  t.ok(warnings.some((line) => line.includes('INCOMPLETE') && line.includes('a.txt')),
+    'and the give-up is on the record, because nothing downstream could have reached this diag')
+})
+
+// The other half of the rule, and the reason the fix is conditional rather than a finish() in the
+// catch: when the annotation DID land, the outcome is the caller's to choose. The mirror settles an
+// ECANCELLED as 'paused', which is normal control flow — pre-empting it here would turn every
+// pause and unmount into a logged give-up.
+test('an annotatable rejection is left for its caller to settle', async (t) => {
+  const warnings = captureWarnings(t)
+  const err = await rejectionOf(Object.assign(new Error('holder went away'), { code: 'ECANCELLED' }))
+  t.ok(err.diag, 'the caller got the diag')
+  t.alike(warnings, [], 'and this file did not decide the outcome on its behalf')
+})

--- a/test/unit/owner-pass-liveness-wiring.test.js
+++ b/test/unit/owner-pass-liveness-wiring.test.js
@@ -31,7 +31,7 @@ test('REGRESSION (FIX-OWNER-HEARTBEAT): every phase of a reconcile reports progr
   t.ok(beats(readBothSides) >= 3,
     `the read half beats after the walk, around the catalog settle and through the drain (found ${beats(readBothSides)})`)
   t.ok(beats(diffAndEnqueue) >= 2,
-    `the diff half beats on entry and through its loop (found ${beats(diffAndEnqueue)})`)
+    `the diff half beats on entry and inside the phase that awaits (found ${beats(diffAndEnqueue)})`)
 
   // The one that was there all along, and the reason the gap was invisible: on a share whose files
   // are the slow part it beats plenty, which is exactly the case nobody hits in a test.
@@ -43,4 +43,24 @@ test('the catalog drain beats on a bounded interval, not once per entry', (t) =>
   t.ok(/const LIVENESS_EVERY = \d+/.test(src), 'the interval is named')
   t.ok(/% LIVENESS_EVERY === 0\) passLiveness\.progress\(/.test(src),
     'so the bookkeeping cannot itself become the cost of the pass')
+})
+
+// REGRESSION (FIX-OWNER-HEARTBEAT-2: the beat added to the diff went into the loop over `onDisk`,
+// which is fully synchronous. On the worker's single thread nothing can run between that loop's
+// iterations, so only the stamps on either side of it are ever read and the beat was unobservable —
+// it made the phase look covered without covering anything. Meanwhile the one phase of the diff
+// that DOES yield got none: ensureServable is free only while the serve reference is present, and
+// after a restart the serve map is empty, so a large fully-synced share routes every unchanged file
+// through registerFile. Past the stall window that healthy pass reported as a folder scan that was
+// not advancing — the exact false verdict the heartbeat exists to prevent.
+//
+// Pinned by structure, not by a count: a count of beats cannot tell an observable one from a dead
+// one, which is how the first fix passed its own test.)
+test('REGRESSION (FIX-OWNER-HEARTBEAT-2): the phase that awaits per file is the one that beats', (t) => {
+  const loop = /for \(const \[relPath, prev, info\] of unchanged\) \{([\s\S]*?)\n  \}/.exec(src)
+  t.ok(loop, 'found the self-heal loop over unchanged files')
+  t.ok(/await ensureServable\(/.test(loop[1]),
+    'it awaits per file — which is what makes a beat inside it observable at all')
+  t.ok(/passLiveness\.progress\(key\)/.test(loop[1]),
+    'so it beats INSIDE the loop, not merely on either side of it')
 })


### PR DESCRIPTION
Review findings against `6622d2a`, already on staging. Separate branch — neither file is
touched by #183, so they merge independently.

- **The scan heartbeat beat in the wrong loop.** It sat in the diff over `onDisk`, which
  never awaits, so nothing could run between its iterations and the beat was unobservable.
  The phase that does yield had none: `ensureServable` is free only while the serve
  reference is present, and after a restart the serve map is empty, so a large fully-synced
  share routes every unchanged file through `registerFile` — past the stall window, and a
  healthy pass reported as a folder scan that was not advancing. Beat moved, per file
  rather than throttled: `LIVENESS_EVERY` guards loops where the bookkeeping could become
  the cost, and at 500 a share with fewer files would never beat at all.
- **A fetch diag the annotation could not reach was stranded.** Callers read `err.diag`, so
  when the assignment threw — the frozen ENOSPC the guard exists for — `finish()` no-opped
  and the `start:` line never got its terminal give-up. Closed here only when the
  annotation failed, so a caller settling an `ECANCELLED` as a pause still decides.

The existing `beats(diffAndEnqueue) >= 2` assertion passed on the broken code: a count
cannot tell an observable beat from a dead one. Replaced with a structural check — the loop
containing `await ensureServable` must contain the beat.

**Red-first, proven** by swapping each file back to its `HEAD` version: only the new test
fails in each file, and the file restores byte-identical.

**Verified**: typecheck; `lint:ci` 18 warnings / 0 errors; `test:node:core` 1835/1835;
`test:bare` 1024/1024; flow `foreign-mirror`, `foreign-mirror-progress`,
`loose-share-reconcile` 3/3.