### PR TITLE
Finish the query-store adoption, and give every timer an owner

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -301,3 +301,62 @@ Two consequences, both paid for once already:
    the double is more cooperative than the real code. When a test asserts on a fault class, drive at
    least one case with the real condition (a real 000 file), or a scenario built on an impossible
    lever will be the thing that finds out.
+
+
+## The query store's `loading` is not "still booting"
+
+`useQuery`'s `loading` is `entry.promise !== null || !settled` — it means *a read is in
+flight*, and it goes true again on every refetch of an already-settled entry. `app.tsx`
+gates its entire tree on the value `useProfile` returns, so returning the store's flag
+unmounted the whole tree on each re-read; that remounted all three `useProfile` call sites,
+each re-read `profile:get`, and the flag rose again. A real run issued ~13,900 rounds of
+every request in the app and never finished booting.
+
+Nothing below the frontend layer caught it: typecheck, lint, 1,862 unit, 1,028 integration
+and 199 flow tests were all green. A cross-component remount loop is invisible to every one
+of them.
+
+**The rule:** a boot or route gate asks "has an answer ever landed", not "is a read in
+flight" — `data !== undefined || error !== null`. Better, hand the decision to a pure
+projection that is never given `loading`, so the mistake cannot be expressed:
+`src/renderer/profileGate.js`, guarded by `test/unit/profile-gate.test.js`.
+
+
+## A hook that writes shared state amplifies by mount count
+
+Three worker-event subscriptions lived inside the hooks that read them, and every one of
+them wrote the query store: `useDownloadRootStatus` (two mounted consumers) pushed
+`downloads:roots-status`, `useSpaces` (**five** call sites, several mounted together) pushed
+`spaces:list` from `event:state` and re-read it on three membership events, plus a
+mount-time `refetchQuery` that abandoned the read `useQuery` had just issued.
+
+One worker event therefore wrote one entry N times. Each write is a NEW object, so the
+store's `prev.data === next.data` identity check fails and every subscriber re-renders a
+second, third and fourth time for a value that never changed; each event-driven refetch
+abandons the others' in-flight read. None of it is visible in a hook read in isolation —
+the amplification factor is "how many components happen to mount this today", which no
+test at the hook's own layer can see.
+
+**The rule:** a subscription that WRITES shared state is installed once for the app, next
+to the store (`installPushBridges` in `src/renderer/store/reconcile.ts`), never in a hook.
+A hook may subscribe for its own local state — a counter, a toast trigger — because that is
+per-consumer by design. Ratcheted by the `STORE_WRITERS` allowlist in
+`test/unit/renderer-reconcile-subscriptions.test.js`: a new writing site has to be justified
+there.
+
+
+## A guard's `if (handle) return` latches when the handle can die elsewhere
+
+`presenceTimer`, `convergenceTimer` and `announceTimer` are module bindings whose timers are
+owned by a subsystem's `this.timers`. `Subsystem.close()` clears the SET on every ending —
+including a failed `_open` and a `_close` that rejects, neither of which reaches the module's
+own stop function. The binding then still held a disarmed handle, `if (presenceTimer) return`
+read it as "already armed", and the heartbeat was off for the rest of the process: no error,
+no log, and to every peer we simply look offline.
+
+**The rule:** when the thing that clears a handle is not the thing that holds it, drop the
+handle before testing it — `liveHandle(timers, handle)` in `src/shared/core/timers.js`. The
+same asymmetry one level down is why an injected `schedule` must be guarded on the SET rather
+than on the subsystem pointer (`ownedScheduler`): a `_close` that rejects never reaches its
+own `subsystem = null`, so the pointer outlives the timers it points at, and arming against a
+closed set throws from inside a callback nothing catches.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -50,6 +50,45 @@ export const moduleLevelTimerRestrictions = [{
   message: 'No timer armed at import — nothing can clear it. Arm it inside a Subsystem _open through this.timers, or inside a function whose module holds a matching clear.',
 }]
 
+// The shape the rule above cannot see, and which slipped past it twelve times: a timer armed
+// INSIDE a function but held in a long-lived handle. The handle outlives every call, so nothing
+// scoped to a call can clear it — the same un-owned timer, wearing a function as a disguise.
+//
+// The storage is not the defect; arming from the GLOBAL is. A module still needs somewhere to keep
+// the handle it re-arms, so the rule targets the assignment: `x Timer = setTimeout(...)` is
+// un-owned, `x Timer = timers.setTimeout(...)` (or `this.timers.`) is owned, and only the first
+// matches. That also means the fix and the rule agree — the twelve migrated sites keep their
+// bindings and stop matching.
+//
+// The name pattern is the camelCase COMPOUND — `announceTimer`, `presenceBeat` — and deliberately
+// not a bare `timer`. A bare local handle inside a function is owned by that function, which
+// clears it on both exits; the compound names are the ones that belong to a module and outlive
+// every call. Three legitimate function-local `timer` variables in the data layer make that
+// distinction load-bearing rather than cosmetic.
+//
+// Known blind spot, stated rather than papered over: this is a naming heuristic, so a module-scope
+// handle called `pending` or `h` slips through. Its job is to stop the thirteenth, not to have
+// found the twelve, and a genuine exception is one inline disable with a reason written next to
+// it.
+const timerHandleMessage = 'This timer handle outlives the call that arms it — arm it through a Subsystem\'s `this.timers` (or a createTimers() the module\'s own reset closes), so one call clears every one of them.'
+export const moduleScopeTimerHandleRestrictions = [
+  {
+    selector: "AssignmentExpression[left.type='Identifier'][left.name=/[a-z0-9]Timer$|[a-z0-9]Beat$/][right.callee.name=/^set(Interval|Timeout)$/]",
+    message: timerHandleMessage,
+  },
+  // The same handle kept on an object rather than in a binding — `this.sweepTimer = setInterval(…)`
+  // is the most natural shape in a Subsystem-based codebase and outlives its call exactly as much.
+  // `this.timers.setTimeout(…)` is unaffected: a member callee has no `callee.name` to match.
+  {
+    selector: "AssignmentExpression[left.type='MemberExpression'][left.property.name=/[a-z0-9]Timer$|[a-z0-9]Beat$/][right.callee.name=/^set(Interval|Timeout)$/]",
+    message: timerHandleMessage,
+  },
+  {
+    selector: "Program > VariableDeclaration > VariableDeclarator[id.name=/[a-z0-9]Timer$|[a-z0-9]Beat$/][init.callee.name=/^set(Interval|Timeout)$/]",
+    message: timerHandleMessage,
+  },
+]
+
 // Mechanism invariant: chokidar's options are per-INSTANCE, not per-path, and its sharp edges —
 // native events never reach a network mount, an erroring watcher spins forever — were learned
 // once on the owned-folder watcher and never carried to the loose-file watcher, so a file shared
@@ -139,7 +178,7 @@ export default [
       'no-undef': 'error',
       ...unusedVars,
       ...complexityBudget,
-      'no-restricted-syntax': ['error', ...moduleLevelTimerRestrictions],
+      'no-restricted-syntax': ['error', ...moduleLevelTimerRestrictions, ...moduleScopeTimerHandleRestrictions],
     },
   },
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -86,7 +86,6 @@ export const byteFormatterSingleOwnerRestrictions = ['KB', 'MB', 'GB', 'TB', 'Ki
 // UNMOUNT_ONLY: the effect has [] deps and one in-flight read, so nothing can supersede it — the
 // only race is a write after unmount, which React tolerates.
 export const unmountOnlyAsyncEffects = Object.freeze({
-  'src/renderer/hooks/useProfile.ts': { effects: 1, why: 'One [] -deps read of the local profile; the live value afterwards arrives on event:profile-needed, not on a re-read.' },
   'src/renderer/hooks/useConnectionStatus.tsx': { effects: 1, why: 'The net.online probe has [] deps and one read; transitions arrive on onNetOnlineChange. (The other effect in this file carries a cleanup flag and is not exempt.)' },
   'src/renderer/screens/Account.tsx': { effects: 1, why: 'One [] -deps read of the identity-protection mode, which cannot change while the screen is open.' },
 })

--- a/src/renderer/hooks/useAuditLog.ts
+++ b/src/renderer/hooks/useAuditLog.ts
@@ -52,6 +52,9 @@ export function useAuditLog(filters: AuditFilters, kinds: string[] | null) {
     kinds: kinds && kinds.length ? kinds : null,
   }), [filters.spaceId, filters.categories, filters.actorKey, filters.search, filters.sinceDays, kinds])
 
+  // Deliberately outside the query store: the list ACCUMULATES pages behind a cursor, and the store
+  // holds one value per key with no way to append the next page to it. The runRef below is this
+  // hook's own sequence fence, doing what the store's would if it could hold this shape.
   const reload = useCallback(async () => {
     const run = ++runRef.current
     setLoading(true)

--- a/src/renderer/hooks/useDownloadRootStatus.ts
+++ b/src/renderer/hooks/useDownloadRootStatus.ts
@@ -2,8 +2,10 @@
 // network share, or replaced by a file. Drives the app-level banner and the Storage Settings
 // warning, so the user learns the folder is gone instead of reading "Transfer failed" on every
 // download that tries to land there.
-import { useCallback, useEffect, useState, useRef } from 'react'
-import { request, subscribe } from '../ipc.js'
+import { useCallback, useEffect, useState } from 'react'
+import { subscribe } from '../ipc.js'
+import { useQuery } from '../store/useQuery.js'
+import { refetchQuery } from '../store/query-store.js'
 
 interface RootsStatus {
   unavailable?: string[]
@@ -13,47 +15,37 @@ interface TransferErrorMessage {
   errorCode?: string
 }
 
+const NO_ROOTS: string[] = []
+
+const list = (res: RootsStatus | undefined) => (Array.isArray(res?.unavailable) ? res.unavailable : NO_ROOTS)
+
+// Scope-less: `event:download-roots-status` carries the whole answer, so the event PUSHES the value
+// into the entry rather than poking a re-read. The store's own no-clear-on-error policy is what the
+// hand-rolled version's empty catch was reaching for — a failed read keeps the last value on the
+// entry, so a worker that is not up yet cannot clear a banner that is currently correct.
+//
+// The pushing subscription itself is installDownloadRootsBridge's, not this hook's: two components
+// mount this, and a per-hook writer wrote the same entry twice per event with two distinct wrapper
+// objects — the second defeating the store's identity check and re-rendering everyone again.
 export function useDownloadRootStatus() {
-  const [unavailable, setUnavailable] = useState<string[]>([])
+  const { data } = useQuery<RootsStatus>('downloads:roots-status', {}, null)
   // Counts transfers that failed on an unreachable folder. The unavailable SET is unchanged by a
   // second failure against the same folder, so it alone cannot tell a consumer that the user just
   // hit the problem again — which is the one moment re-explaining a dismissed (or stack-evicted)
   // toast is warranted.
   const [faultSeq, setFaultSeq] = useState(0)
-  // A transfer failure re-probes on top of the mount read and the worker's own 60s push, so two
-  // probes overlap whenever a download fails during startup. The older verdict landing last would
-  // re-hide a banner the newer one had just raised.
-  const runRef = useRef(0)
 
   const refresh = useCallback(async () => {
-    const run = ++runRef.current
-    try {
-      const res = await request('downloads:roots-status') as RootsStatus
-      if (run !== runRef.current) return
-      setUnavailable(Array.isArray(res?.unavailable) ? res.unavailable : [])
-    } catch {
-      // A worker that isn't up yet is not evidence the folder is gone — leave the last
-      // known state alone rather than clearing a banner that is currently correct.
-    }
+    await refetchQuery<RootsStatus>('downloads:roots-status', {}, null).catch(() => undefined)
   }, [])
 
-  useEffect(() => {
-    void refresh()
-    const unsubs = [
-      subscribe<RootsStatus>('event:download-roots-status', (msg) => {
-        setUnavailable(Array.isArray(msg?.unavailable) ? msg.unavailable : [])
-      }),
-      // The worker probes on a 60s tick, so a download that just failed on a gone folder would
-      // otherwise sit behind a generic-looking error for up to a minute before the banner
-      // explains it. The failure itself is the signal to re-probe now.
-      subscribe<TransferErrorMessage>('event:transfer-error', (msg) => {
-        if (msg?.errorCode !== 'TRANSFER_DEST_UNAVAILABLE') return
-        setFaultSeq((n) => n + 1)
-        void refresh()
-      }),
-    ]
-    return () => { for (const off of unsubs) off() }
-  }, [refresh])
+  // Counting only — the re-probe this failure triggers is the bridge's. A counter is per-consumer
+  // state by design (the toast bridge re-explains itself, Storage settings does not), so this one
+  // subscription per mount writes nothing shared.
+  useEffect(() => subscribe<TransferErrorMessage>('event:transfer-error', (msg) => {
+    if (msg?.errorCode !== 'TRANSFER_DEST_UNAVAILABLE') return
+    setFaultSeq((n) => n + 1)
+  }), [])
 
-  return { unavailable, faultSeq, refresh }
+  return { unavailable: list(data), faultSeq, refresh }
 }

--- a/src/renderer/hooks/useFolderMount.ts
+++ b/src/renderer/hooks/useFolderMount.ts
@@ -1,77 +1,34 @@
-// Owned-folder mount state and RPC wrappers (validate/preview/mount); useOwnedMount refreshes on owned-folder-mount-status events.
-import { useState, useEffect } from 'react'
+// Owned-folder mount state and RPC wrappers (validate/preview/mount); useOwnedMount projects the
+// owned-folder:list-all entry the query store already holds.
+import { useMemo } from 'react'
 import { request, subscribe } from '../ipc.js'
-import type { OwnedFolderMount, MountValidationResult, ScanPreview, PreviewProgress, Share } from '../types.js'
+import { useQuery } from '../store/useQuery.js'
+import { ownedMountSettled, projectOwnedMount } from '../ownedMount.js'
+import { ANY_SHARES } from '../store/scopes.js'
+import type { OwnedMountRow, OwnedMountState } from '../ownedMount.js'
+import type { MountValidationResult, ScanPreview, PreviewProgress, Share, OwnedFolderMount } from '../types.js'
 
-interface MountStatusEvent {
-  spaceId: string
-  shareId: string
-  status: string
-  error?: string
-}
+export type { OwnedMountState } from '../ownedMount.js'
 
-// The badge projection of an owned mount's durable state: a live missing path wins, then
-// any persisted non-healthy status (paused-error / mount-point-gone survive a restart);
-// healthy states (active / scanning) render no badge. Shared by useOwnedMount and useShares
-// so SpaceView and FolderView cannot drift.
-export function unhealthyOwnedStatus(m: (OwnedFolderMount & { mountPointMissing?: boolean }) | null | undefined): string | null {
-  if (!m) return null
-  if (m.mountPointMissing) return 'mount-point-gone'
-  if (m.status && m.status !== 'active' && m.status !== 'scanning') return m.status
-  return null
-}
-
-// Level-triggered: every mount-status event for this share re-derives from
-// owned-folder:list-all (a live mountRootAvailable disk check plus the durable
-// mount.status) instead of latching msg.status — the same projection SpaceView gets
-// via useShares, but from a subscriber that is actually mounted while FolderView is open.
-export interface OwnedMountState {
-  status: string | null
-  lastError: string | null
-  /** The first read has landed. `status: null` means healthy only once this is true — before it,
-   *  it means "not read yet", and a caller that cannot tell them apart falls back to a frozen
-   *  navigation snapshot forever. */
-  loaded: boolean
-  indexPaused: boolean
-  /** The scan is walking the disk. It fills no queue, so nothing else can report that phase. */
-  scanning: boolean
-  mountPath: string | null
-}
-
-const NO_OWNED_MOUNT: OwnedMountState = { status: null, lastError: null, loaded: false, indexPaused: false, scanning: false, mountPath: null }
-
+// One read, one entry, one policy. This projects the SAME store entry useShares subscribes to, so
+// SpaceView's badge and FolderView's fault strip cannot disagree about a folder: they are two
+// projections of one value, not two reads of one worker. The hand-rolled second read this replaces
+// had no sequence fence, so two concurrent list-all reads resolved in arrival order — a slow
+// mount-point-gone read landing after a fast active one painted "Source folder is missing" over a
+// healthy, actively scanning folder, and it stayed until the next mount-status event.
+//
+// No event subscription: owned mount-status transitions are mapped to the shares scope worker-side,
+// so the one reconcile bridge invalidates this entry and the store refetches behind its fence.
 export function useOwnedMount(spaceId: string, shareId: string): OwnedMountState {
-  const [state, setState] = useState<OwnedMountState>(NO_OWNED_MOUNT)
-
-  useEffect(() => {
-    if (!spaceId || !shareId) return
-    let alive = true
-    const derive = () => {
-      request('owned-folder:list-all').then((mounts) => {
-        if (!alive) return
-        const rows = mounts as (OwnedFolderMount & { mountPointMissing?: boolean })[]
-        const m = rows.find((x) => x.spaceId === spaceId && x.shareId === shareId)
-        // Both from one read: the badge projection AND the durable intent behind it. The status
-        // alone cannot carry the pause — a scan settle overwrites it, and 'mount-point-gone'
-        // legitimately outranks it while the source is missing.
-        setState({
-          status: unhealthyOwnedStatus(m),
-          lastError: m?.lastError ?? null,
-          loaded: true,
-          indexPaused: !!m?.indexPaused,
-          scanning: m?.status === 'scanning',
-          mountPath: m?.mountPath ?? null,
-        })
-      }).catch(() => {})
-    }
-    derive()
-    const unsub = subscribe<MountStatusEvent>('event:owned-folder-mount-status', (msg) => {
-      if (msg.spaceId === spaceId && msg.shareId === shareId) derive()
-    })
-    return () => { alive = false; unsub() }
-  }, [spaceId, shareId])
-
-  return state
+  const enabled = Boolean(spaceId && shareId)
+  // Not `loading`: ownedMountSettled carries that reasoning, and not taking the flag at all is
+  // what makes the trap unrepresentable here.
+  const { data } = useQuery<OwnedMountRow[]>('owned-folder:list-all', {}, ANY_SHARES, { enabled })
+  const settled = ownedMountSettled(enabled, data)
+  return useMemo(
+    () => projectOwnedMount(data, spaceId, shareId, settled),
+    [data, spaceId, shareId, settled],
+  )
 }
 
 export async function validateOwnedMount(mountPath: string, shareId?: string): Promise<MountValidationResult> {

--- a/src/renderer/hooks/useForeignMount.ts
+++ b/src/renderer/hooks/useForeignMount.ts
@@ -1,45 +1,35 @@
-// Foreign (mirror) mount state and RPC wrappers (validate/preview/mount/enable/unmount); useForeignMount refreshes on foreign-folder-mount-status events.
-import { useState, useEffect, useCallback, useRef } from 'react'
+// Foreign (mirror) mount state and RPC wrappers (validate/preview/mount/enable/unmount);
+// useForeignMount reads the durable record through the query store.
+import { useMemo } from 'react'
 import { request, subscribe } from '../ipc.js'
+import { useQuery } from '../store/useQuery.js'
+import { sharesScope } from '../store/scopes.js'
 import type { ForeignFolderMount, MountValidationResult, ScanPreview, ForeignMountStatus, PreviewProgress } from '../types.js'
 
-interface MountStatusEvent {
-  spaceId: string
-  shareId: string
-  status: ForeignMountStatus
-  error?: string
-}
+// The scope foreign mount-status transitions actually carry: event:foreign-folder-mount-status is
+// mapped to the SHARES scope worker-side, not the mirrors one. The mount is still level-triggered
+// on every transition (paused states persist too), so the record can never go stale on a missed
+// recovery event — the difference is that the store, not this hook, owns the re-read.
 
+// The params are part of the entry key, so an unmounted mirror — shareId '' — is a DIFFERENT entry
+// rather than the same entry holding a stale value. That is what closes the bug the hand-rolled
+// version had: its early return left `mount` and `status` untouched, so FolderView went on
+// rendering a paused-enospc fault strip, Retry button and all, for a mount that had already been
+// unmounted. The same key separation is what stops share A's fault from painting under share B's
+// header when A's read resolves after the navigation.
 export function useForeignMount(spaceId: string, shareId: string) {
-  const [mount, setMount] = useState<ForeignFolderMount | null>(null)
-  const [status, setStatus] = useState<ForeignMountStatus | null>(null)
-  // Every mount-status transition re-fires refresh and a share switch re-runs the effect, so two
-  // reads are routinely in flight at once. Without a generation the older one can land last and
-  // paint the previous share's mount over the folder the user is actually looking at.
-  const runRef = useRef(0)
+  const enabled = Boolean(spaceId && shareId)
+  const scopes = useMemo(() => sharesScope(spaceId), [spaceId])
+  const { data } = useQuery<ForeignFolderMount | null>('foreign-folder:get', { spaceId, shareId }, scopes, { enabled })
 
-  const refresh = useCallback(async () => {
-    if (!spaceId || !shareId) return
-    const run = ++runRef.current
-    const m = (await request('foreign-folder:get', { spaceId, shareId })) as ForeignFolderMount | null
-    if (run !== runRef.current) return
-    setMount(m)
-    setStatus(m?.status ?? null)
-  }, [spaceId, shareId])
-
-  useEffect(() => {
-    void refresh()
-    const unsub = subscribe<MountStatusEvent>('event:foreign-folder-mount-status', (msg) => {
-      if (msg.spaceId !== spaceId || msg.shareId !== shareId) return
-      setStatus(msg.status)
-      // Re-read the durable record on EVERY transition (paused states persist too), so
-      // `mount` (enabled/status) can never go stale on a missed recovery event.
-      void refresh()
-    })
-    return unsub
-  }, [refresh, spaceId, shareId])
-
-  return { mount, status, refresh }
+  // No refresh escape hatch. The hand-rolled version exported one and nothing ever called it: the
+  // mutations that would need it (set-enabled, unmount) already emit a mount-status event, and that
+  // is the shares-scoped hint the store re-reads on.
+  //
+  // Not `data ?? null` unconditionally: a disabled entry has never been fetched, and its undefined
+  // must read as "no mount" rather than as whatever the last enabled render held.
+  const mount = enabled ? (data ?? null) : null
+  return { mount, status: (mount?.status ?? null) as ForeignMountStatus | null }
 }
 
 export async function validateForeignMount(mountPath: string, shareId?: string): Promise<MountValidationResult> {

--- a/src/renderer/hooks/usePeerDownloadDetail.ts
+++ b/src/renderer/hooks/usePeerDownloadDetail.ts
@@ -34,6 +34,9 @@ interface DetailSnapshot {
 // immediately); progress frames update live; the worker's ledger sweep pushes the
 // authoritative snapshot (empty included), so a missed "peer gone" frame self-corrects
 // without any renderer poll or silence-TTL guessing. Unmount calls detail-unsubscribe.
+// Deliberately outside the query store: this owns an explicit serving:detail-subscribe /
+// serving:detail-unsubscribe RPC pair, and a subscription with a teardown is not a query. The store
+// caches and refetches answers; it has no concept of telling the worker to stop producing them.
 export function usePeerDownloadDetail(spaceId: string, path: string): PeerDownloadPeer[] {
   const [peers, setPeers] = useState<PeerDownloadPeer[]>([])
   const samplersRef = useRef(new Map<string, SpeedSampler>())

--- a/src/renderer/hooks/usePeerDownloads.ts
+++ b/src/renderer/hooks/usePeerDownloads.ts
@@ -19,6 +19,11 @@ interface SummaryEvent {
 // expire "who is downloading" at the same time.
 export const SERVE_TTL_MS = 35000
 
+// Deliberately outside the query store. `serving:summary-list` is a SEED for the awareness feed
+// below, not a query: no scope invalidates it, no second consumer dedups with it, and its answer is
+// superseded by the first live frame — which is why the seed skips any row already seen live. The
+// guard flag below protects a Map mutation, not a fetched value overwriting a fresher one.
+//
 // Tier 1: the always-on summary of who is downloading each file WE serve in this
 // space (peer set + aggregate bytes). Cheap — one event per file, throttled on the
 // worker. Speed is derived here with the same SpeedSampler the download bar uses.

--- a/src/renderer/hooks/useProfile.ts
+++ b/src/renderer/hooks/useProfile.ts
@@ -1,36 +1,33 @@
 // Owns the local profile and the needs-setup flag; listens for event:profile-needed and saves via profile:set.
-import { useState, useEffect } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { request, subscribe } from '../ipc.js'
+import { useQuery } from '../store/useQuery.js'
+import { setQueryData } from '../store/query-store.js'
+import { projectProfile } from '../profileGate.js'
 import type { Profile } from '../types.js'
 
+// Three screens call this hook, so the hand-rolled read it replaces was three `profile:get` round
+// trips per session for one fact. Scope-less deliberately: the profile changes only when this app
+// writes it, and saveProfile pushes the new record into the entry rather than re-reading it.
+//
+// The store's `loading` is deliberately not read here — see profileGate.js for why gating the app
+// shell on it turns every re-read into a full remount of the tree.
 export function useProfile() {
-  const [profile, setProfile] = useState<Profile | null>(null)
-  const [needsSetup, setNeedsSetup] = useState(false)
-  const [loading, setLoading] = useState(true)
+  const { data, error } = useQuery<Profile | null>('profile:get', {}, null)
+  // The worker's own "there is no profile yet" signal, which is not a reconcile poke and has no
+  // scope: it announces a state the read cannot report, because it fires before a read would.
+  const [profileNeeded, setProfileNeeded] = useState(false)
 
-  useEffect(() => {
-    request('profile:get').then((p) => {
-      setProfile(p as Profile | null)
-      setNeedsSetup(!p)
-      setLoading(false)
-    }).catch(() => {
-      setNeedsSetup(true)
-      setLoading(false)
-    })
+  useEffect(() => subscribe('event:profile-needed', () => setProfileNeeded(true)), [])
 
-    const unsub = subscribe('event:profile-needed', () => {
-      setNeedsSetup(true)
-      setLoading(false)
-    })
-    return unsub
+  const saveProfile = useCallback(async ({ displayName, avatar }: { displayName: string; avatar: string | null }) => {
+    const updated = await request('profile:set', { displayName, avatar }) as Profile
+    // Pushed, not refetched: the worker just told us the new record, and every other consumer of
+    // this entry must see it in the same commit rather than one round trip later.
+    setQueryData<Profile | null>('profile:get', {}, updated)
+    setProfileNeeded(false)
+    return updated
   }, [])
 
-  async function saveProfile({ displayName, avatar }: { displayName: string; avatar: string | null }) {
-    const updated = await request('profile:set', { displayName, avatar }) as Profile
-    setProfile(updated)
-    setNeedsSetup(false)
-    return updated
-  }
-
-  return { profile, needsSetup, loading, saveProfile }
+  return { ...projectProfile({ data, error, profileNeeded }), saveProfile }
 }

--- a/src/renderer/hooks/useShares.ts
+++ b/src/renderer/hooks/useShares.ts
@@ -7,8 +7,10 @@ import { useCallback, useMemo } from 'react'
 import { request } from '../ipc.js'
 import { useQuery } from '../store/useQuery.js'
 import { invalidateKey, refetchQuery } from '../store/query-store.js'
-import { unhealthyOwnedStatus } from './useFolderMount.js'
-import type { Share, ShareRole, ForeignFolderMount, OwnedFolderMount } from '../types.js'
+import { unhealthyOwnedStatus } from '../ownedMount.js'
+import { ANY_SHARES, sharesScope } from '../store/scopes.js'
+import type { OwnedMountRow } from '../ownedMount.js'
+import type { Share, ShareRole, ForeignFolderMount } from '../types.js'
 
 // Dropped when a space leaves the roster, so re-joining the same id never renders the rows it held
 // before (the twin of pruneRosterCache / pruneMirrorCache, called from the same place).
@@ -28,16 +30,13 @@ export interface ShareWithRole extends Share {
   mirrorStatus?: string
 }
 
-type OwnedMountRow = OwnedFolderMount & { mountPointMissing?: boolean }
-
-const ANY_SHARES = [{ kind: 'shares' }]
 
 const NO_SHARES: Share[] = []
 const NO_FOREIGN: ForeignFolderMount[] = []
 const NO_OWNED: OwnedMountRow[] = []
 
 export function useShares(spaceId: string, myPublicKey: string | null) {
-  const shareScopes = useMemo(() => [{ kind: 'shares', spaceId }], [spaceId])
+  const shareScopes = useMemo(() => sharesScope(spaceId), [spaceId])
   const params = spaceId ? { spaceId } : {}
 
   // Share/mirror changes — including owned and foreign mount-status transitions, both mapped to the

--- a/src/renderer/hooks/useSpaces.ts
+++ b/src/renderer/hooks/useSpaces.ts
@@ -1,17 +1,14 @@
 // Owns the spaces list plus create/join/invite actions; refreshes on event:state, membership reconcile hints, and the grant/deny/divergence events.
 import { useEffect } from 'react'
-import { request, subscribe } from '../ipc.js'
+import { request } from '../ipc.js'
 import { useQuery } from '../store/useQuery.js'
-import { refetchQuery, setQueryData, invalidateKey } from '../store/query-store.js'
+import { refetchQuery, invalidateKey } from '../store/query-store.js'
+import { SPACES_SCOPES } from '../store/scopes.js'
 import { pruneRosterCache } from './useSpaceMembers.js'
 import { pruneMirrorCache } from './useSpaceMirrors.js'
 import { pruneSpaceCardState } from './useSpaceCardState.js'
 import { pruneShareCache } from './useShares.js'
 import type { Space } from '../types.js'
-
-// The list spans every space, so it is a wildcard view on the members and join-requests axes: any
-// hint of either kind re-derives it.
-const SPACES_SCOPES = [{ kind: 'members' }, { kind: 'join-requests' }]
 
 const SPACE_SCOPED_REQUESTS = ['members:online', 'space:pending-requests', 'space:storage-summary']
 
@@ -57,20 +54,11 @@ export function useSpaces() {
     await refetchQuery<Space[]>('spaces:list', {}, SPACES_SCOPES).catch(() => {})
   }
 
-  useEffect(() => {
-    refresh()
-    const unsub1 = subscribe('event:state', (msg) => {
-      // A push, not an answer to a fetch: it lands in the same entry so the two cannot disagree.
-      if (msg.spaces) setQueryData('spaces:list', {}, msg.spaces as Space[], SPACES_SCOPES)
-    })
-    // The reconcile subscription is gone: the store holds ONE for the whole app and invalidates by
-    // predicate. membership-granted/denied/divergence stay named events — they are one-shot
-    // user-level signals, not view pokes.
-    const unsub3 = subscribe('event:membership-granted', refresh)
-    const unsub4 = subscribe('event:membership-denied', refresh)
-    const unsub5 = subscribe('event:membership-creator-divergence', refresh)
-    return () => { unsub1(); unsub3(); unsub4(); unsub5() }
-  }, [])
+  // No subscriptions and no mount-time refresh. useQuery already fetches on mount, so refetchQuery
+  // here only abandoned that read to issue a second one — five times over, because five components
+  // call this hook and several are mounted together. The event:state push and the three membership
+  // re-reads moved to installPushBridges, which holds one subscription for the app; `refresh` stays
+  // for the mutations below, where one call really is one user action.
 
   async function createSpace(name: string, icon: string) {
     const space = await request('space:create', { name, icon }) as Space

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -7,7 +7,7 @@ import App from './app.js'
 import { request } from './ipc.js'
 import { configureQueryStore } from './store/query-store.js'
 import { configureMainStore, installMainPushBridge } from './store/main-store.js'
-import { installReconcileBridge } from './store/reconcile.js'
+import { installPushBridges, installReconcileBridge } from './store/reconcile.js'
 
 // Before the first render: both stores' transports, the single reconcile subscription every
 // worker-backed view re-derives from, and the one subscription per pushing main fact.
@@ -15,6 +15,7 @@ configureQueryStore({ request: (type, params, opts) => request(type, params, und
 configureMainStore(window.bridge)
 installMainPushBridge()
 installReconcileBridge()
+installPushBridges()
 
 if (__DEV__ && window.bridge?.isDev?.()) {
   void (async () => {

--- a/src/renderer/ownedMount.d.ts
+++ b/src/renderer/ownedMount.d.ts
@@ -1,0 +1,26 @@
+import type { OwnedFolderMount } from './types.js'
+
+export type OwnedMountRow = OwnedFolderMount & { mountPointMissing?: boolean }
+
+export interface OwnedMountState {
+  status: string | null
+  lastError: string | null
+  /** The first read has landed. `status: null` means healthy only once this is true — before it,
+   *  it means "not read yet", and a caller that cannot tell them apart falls back to a frozen
+   *  navigation snapshot forever. */
+  loaded: boolean
+  indexPaused: boolean
+  /** The scan is walking the disk. It fills no queue, so nothing else can report that phase. */
+  scanning: boolean
+  mountPath: string | null
+}
+
+export function unhealthyOwnedStatus(m: OwnedMountRow | null | undefined): string | null
+export function ownedMountSettled(enabled: boolean, rows: OwnedMountRow[] | undefined): boolean
+export function projectOwnedMount(
+  rows: OwnedMountRow[] | undefined,
+  spaceId: string,
+  shareId: string,
+  settled: boolean,
+): OwnedMountState
+export const NO_OWNED_MOUNT: OwnedMountState

--- a/src/renderer/ownedMount.js
+++ b/src/renderer/ownedMount.js
@@ -1,0 +1,52 @@
+// What FolderView and SpaceView each read out of the one `owned-folder:list-all` listing. Both
+// projections live here rather than in the hook so they are one declaration for two screens — and
+// so the precedence below is testable without React.
+
+// The badge projection of an owned mount's durable state: a live missing path wins, then any
+// persisted non-healthy status (paused-error / mount-point-gone survive a restart); healthy states
+// (active / scanning) render no badge.
+export function unhealthyOwnedStatus (m) {
+  if (!m) return null
+  if (m.mountPointMissing) return 'mount-point-gone'
+  if (m.status && m.status !== 'active' && m.status !== 'scanning') return m.status
+  return null
+}
+
+// Has an answer for this listing landed? Deliberately NOT given the store's `loading`: the store
+// settles an entry on an ERROR as well as on data, so a failed read reports loading:false with no
+// data — which the old expression read as "settled", i.e. as a healthy folder with no row. A
+// durably paused-error or mount-point-gone folder then painted with no fault strip at all, because
+// FolderView takes this projection outright once it says loaded. Undefined data is the unsettled
+// answer whatever the reason; a share that was simply never mounted still arrives as [].
+export function ownedMountSettled (enabled, rows) {
+  return Boolean(enabled) && rows !== undefined
+}
+
+// The full FolderView projection, over the listing rather than a per-share read.
+//
+// `settled` is the store's "a value has landed for this entry", which is NOT the same as "this
+// share has a row": a folder that was never mounted legitimately has no row, and reporting
+// loaded:false for it would pin FolderView to its frozen navigation snapshot forever. Settled with
+// no row is a healthy answer, not a missing one.
+//
+// Nothing here latches. Every field is read from the row on each call, so a share change re-derives
+// rather than carrying the previous folder's state into this one's header.
+export function projectOwnedMount (rows, spaceId, shareId, settled) {
+  if (!settled || !spaceId || !shareId) return NO_OWNED_MOUNT
+  const m = (rows || []).find((x) => x.spaceId === spaceId && x.shareId === shareId)
+  // Both from one row: the badge projection AND the durable intent behind it. The status alone
+  // cannot carry the pause — a scan settle overwrites it, and 'mount-point-gone' legitimately
+  // outranks it while the source is missing.
+  return {
+    status: unhealthyOwnedStatus(m),
+    lastError: m?.lastError ?? null,
+    loaded: true,
+    indexPaused: !!m?.indexPaused,
+    scanning: m?.status === 'scanning',
+    mountPath: m?.mountPath ?? null,
+  }
+}
+
+export const NO_OWNED_MOUNT = Object.freeze({
+  status: null, lastError: null, loaded: false, indexPaused: false, scanning: false, mountPath: null,
+})

--- a/src/renderer/profileGate.d.ts
+++ b/src/renderer/profileGate.d.ts
@@ -1,0 +1,16 @@
+import type { Profile } from './types.js'
+
+export interface ProfileGateInput {
+  data: Profile | null | undefined
+  error: Error | null
+  profileNeeded?: boolean
+}
+
+export interface ProfileGate {
+  profile: Profile | null
+  needsSetup: boolean
+  loading: boolean
+}
+
+export function profileSettled(input: { data: unknown; error: Error | null }): boolean
+export function projectProfile(input: ProfileGateInput): ProfileGate

--- a/src/renderer/profileGate.js
+++ b/src/renderer/profileGate.js
@@ -1,0 +1,30 @@
+// What the app shell decides from the local profile: show the boot screen, the onboarding screen,
+// or the app. Pure, so the precedence is testable without React.
+//
+// It deliberately does NOT take the query store's `loading`. That flag means "a read is in flight",
+// which is raised again by every refetch of an already-settled entry — and the shell gates its
+// WHOLE tree on it. Feeding it in unmounts the tree on each re-read, which remounts every hook,
+// which re-reads the profile, which raises the flag again. Boot has exactly one question: has an
+// answer ever landed. `settled` is that question, and once true it never goes back.
+
+// An answer landed, of either kind. A read that failed still settles: the shell must not sit on the
+// boot screen because the profile is unreadable.
+// `!= null` rather than `!== null`: this is a pure function over a snapshot, and a caller handing
+// it an absent `error` (rather than the store's explicit null) would otherwise settle boot with no
+// data at all — which reads as "no profile" and opens onboarding over an identity that exists.
+export function profileSettled ({ data, error }) {
+  return data !== undefined || error != null
+}
+
+export function projectProfile ({ data, error, profileNeeded = false }) {
+  const settled = profileSettled({ data, error })
+  return {
+    profile: data ?? null,
+    // A read that failed is treated as "no profile", as the hand-rolled version was: onboarding is
+    // the safe answer, because the alternative is a blank app over an unreadable identity.
+    needsSetup: profileNeeded || (settled && !data),
+    // The worker's profile-needed signal is itself an answer, so it ends boot on its own — it
+    // arrives before a read would.
+    loading: !profileNeeded && !settled,
+  }
+}

--- a/src/renderer/screens/ActivityLogSettings.tsx
+++ b/src/renderer/screens/ActivityLogSettings.tsx
@@ -1,6 +1,8 @@
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { request } from '../ipc.js'
+import { useQuery } from '../store/useQuery.js'
+import { refetchQuery, setQueryData } from '../store/query-store.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { RETENTION_CHOICES } from '../auditRetentionChoices.js'
 import type { AuditConfig, AuditEntry, AuditStats } from '../types.js'
@@ -27,33 +29,26 @@ export default function ActivityLogSettings({ onBack, onOpenLog }: ActivityLogSe
   const { t } = useTranslation()
   const errorText = useErrorText()
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
-  const [config, setConfig] = useState<AuditConfig | null>(null)
-  const [stats, setStats] = useState<AuditStats | null>(null)
+  // The same two store entries the Account screen reads, so the two screens cannot report
+  // different numbers for one log. Scope-less for the reason stated there: the audit scope would
+  // repaint these rows on every recorded event, and they are a summary, not a live counter.
+  const { data: config } = useQuery<AuditConfig>('audit:get-config', {}, null)
+  const { data: stats } = useQuery<AuditStats>('audit:stats', {}, null)
   const [busy, setBusy] = useState(false)
   const [status, setStatus] = useState<string | null>(null)
   const [confirmPurge, setConfirmPurge] = useState(false)
 
-  // The mount read and the post-purge read can overlap — purge is slow enough that a user can
-  // change retention while it runs — and the stats half of the older pair would then re-show the
-  // row count that was just deleted.
-  const runRef = useRef(0)
-
   const refresh = useCallback(async () => {
-    const run = ++runRef.current
-    const [nextConfig, nextStats] = await Promise.all([
-      request('audit:get-config') as Promise<AuditConfig>,
-      request('audit:stats') as Promise<AuditStats>,
+    await Promise.all([
+      refetchQuery<AuditConfig>('audit:get-config', {}, null),
+      refetchQuery<AuditStats>('audit:stats', {}, null),
     ])
-    if (run !== runRef.current) return
-    setConfig(nextConfig)
-    setStats(nextStats)
   }, [])
 
-  useEffect(() => { void refresh() }, [refresh])
-
   const patch = useCallback(async (next: Partial<AuditConfig>) => {
-    const applied = await request('audit:configure', next) as AuditConfig
-    setConfig(applied)
+    // The worker answers with the record it applied, so push it rather than re-reading: a refetch
+    // here would race the write it is meant to reflect.
+    setQueryData<AuditConfig>('audit:get-config', {}, await request('audit:configure', next) as AuditConfig)
   }, [])
 
   const handleExport = useCallback(async () => {

--- a/src/renderer/store/query-store.d.ts
+++ b/src/renderer/store/query-store.d.ts
@@ -15,6 +15,7 @@ export declare function keyOf (type: RequestName, params?: Record<string, unknow
 export declare function fetchQuery<T> (type: RequestName, params?: Record<string, unknown>, scopes?: ScopePattern | ScopePattern[] | null, opts?: { coalesceMs?: number }): Promise<T>
 export declare function invalidate (hint: ScopePattern): string[]
 export declare function subscribeKey (key: string, notify: () => void): () => void
+export declare const EMPTY_SNAPSHOT: QuerySnapshot<never>
 export declare function peek<T> (key: string): QuerySnapshot<T>
 export declare function refetchQuery<T> (type: RequestName, params?: Record<string, unknown>, scopes?: ScopePattern | ScopePattern[] | null): Promise<T>
 export declare function invalidateKey (shouldDrop: (key: string) => boolean): string[]

--- a/src/renderer/store/query-store.js
+++ b/src/renderer/store/query-store.js
@@ -62,7 +62,7 @@ function entryFor (key, scopes) {
 // An entry that has never resolved reports LOADING even before its fetch starts. The first render
 // happens before the effect that fetches, so reporting false there would paint the "nothing shared
 // yet" hero over a space whose content is still on its way.
-const EMPTY_SNAPSHOT = Object.freeze({ data: undefined, error: null, loading: true })
+export const EMPTY_SNAPSHOT = Object.freeze({ data: undefined, error: null, loading: true })
 
 function snapshotOf (entry) {
   const settled = entry.data !== undefined || entry.error !== null

--- a/src/renderer/store/reconcile.ts
+++ b/src/renderer/store/reconcile.ts
@@ -1,6 +1,13 @@
 import { subscribe } from '../ipc.js'
-import { invalidate } from './query-store.js'
+import { invalidate, refetchQuery, setQueryData } from './query-store.js'
+import { SPACES_SCOPES } from './scopes.js'
 import type { ScopePattern } from '../../shared/contract/scope.js'
+import type { RequestName } from '../../shared/contract/requests.js'
+
+// The app's worker-event → store subscriptions, each installed exactly once. A subscription that
+// WRITES the store belongs here rather than in a hook: a hook runs once per mounted consumer, so
+// the same event would write the same entry N times, and each write publishes a new object that
+// defeats the store's identity check and re-renders every subscriber again.
 
 // ONE reconcile subscription for the whole app. Nine hooks each held their own and each ran
 // scopeMatches; the store now does it once and invalidates by predicate.
@@ -8,4 +15,45 @@ export function installReconcileBridge(): () => void {
   return subscribe<{ scope?: ScopePattern }>('event:reconcile', (msg) => {
     if (msg.scope) invalidate(msg.scope)
   })
+}
+
+interface RootsStatus { unavailable?: string[] }
+
+const NO_ROOTS: string[] = []
+const list = (res: RootsStatus | undefined) => (Array.isArray(res?.unavailable) ? res.unavailable : NO_ROOTS)
+
+const reread = (type: RequestName, scopes: ScopePattern[] | null) => {
+  void refetchQuery(type, {}, scopes).catch(() => undefined)
+}
+
+// Every worker event that PUSHES a value into the store, or re-reads one, subscribed once for the
+// app. Two of these used to live in the hooks that read them, and both hooks have several mounted
+// consumers: useDownloadRootStatus two (Storage settings and the toast bridge), useSpaces five.
+// One event therefore wrote the same entry once per mount — each write publishing a new object
+// that defeats the store's identity check and re-renders every subscriber again — and each
+// membership signal fired N refetches that abandoned one another's in-flight read.
+export function installPushBridges(): () => void {
+  const unsubs = [
+    // The whole answer rides the event, so it is pushed rather than poked.
+    subscribe<RootsStatus>('event:download-roots-status', (msg) => {
+      setQueryData<RootsStatus>('downloads:roots-status', {}, { unavailable: list(msg) })
+    }),
+    // The worker probes download roots on a 60 s tick, so a download that just failed on a gone
+    // folder would otherwise sit behind a generic error for up to a minute. The failure itself is
+    // the signal to re-probe now.
+    subscribe<{ errorCode?: string }>('event:transfer-error', (msg) => {
+      if (msg?.errorCode !== 'TRANSFER_DEST_UNAVAILABLE') return
+      reread('downloads:roots-status', null)
+    }),
+    // A push, not an answer to a fetch: it lands in the same entry a read would fill, so the two
+    // cannot disagree.
+    subscribe<{ spaces?: unknown }>('event:state', (msg) => {
+      if (msg.spaces) setQueryData('spaces:list', {}, msg.spaces, SPACES_SCOPES)
+    }),
+    // One-shot user-level signals rather than view pokes, which is why they stay named events
+    // instead of riding event:reconcile.
+    ...['event:membership-granted', 'event:membership-denied', 'event:membership-creator-divergence']
+      .map((name) => subscribe(name, () => reread('spaces:list', SPACES_SCOPES))),
+  ]
+  return () => { for (const off of unsubs) off() }
 }

--- a/src/renderer/store/scopes.ts
+++ b/src/renderer/store/scopes.ts
@@ -1,0 +1,22 @@
+import type { ScopePattern } from '../../shared/contract/scope.js'
+
+// The view scopes more than one hook re-derives on, declared once.
+//
+// These are load-bearing rather than cosmetic: an entry keeps the scopes it was FIRST registered
+// with (entryFor only adopts them while the list is empty), so whichever hook mounts first decides
+// the invalidation set for the whole session. Three copies of the same constant meant a divergence
+// between them would surface as an entry that silently stops re-deriving — not as a type error.
+
+// `owned-folder:list-all` and `foreign-folder:list-all` take no parameters, so each is ONE entry
+// shared by every space. Pinning either to a spaceId would mean only the first space visited in the
+// session could ever invalidate it, and a mirror toggle in any later space would leave the badge
+// wrong until the user left and re-entered.
+export const ANY_SHARES: ScopePattern[] = [{ kind: 'shares' }]
+
+// `spaces:list` spans every space, so it is a WILDCARD view on the members and join-requests axes:
+// any hint of either kind re-derives it.
+export const SPACES_SCOPES: ScopePattern[] = [{ kind: 'members' }, { kind: 'join-requests' }]
+
+// The per-space form, for the reads that DO take a spaceId. Both mount-status events are mapped to
+// the shares scope worker-side, so this is what carries a mount transition to a view.
+export const sharesScope = (spaceId: string): ScopePattern[] => [{ kind: 'shares', spaceId }]

--- a/src/renderer/store/useQuery.ts
+++ b/src/renderer/store/useQuery.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useSyncExternalStore } from 'react'
-import { fetchQuery, keyOf, peek, subscribeKey } from './query-store.js'
+import { EMPTY_SNAPSHOT, fetchQuery, keyOf, peek, subscribeKey } from './query-store.js'
 import type { QuerySnapshot } from './query-store.js'
 import type { ScopePattern } from '../../shared/contract/scope.js'
 import type { RequestName } from '../../shared/contract/requests.js'
@@ -14,11 +14,19 @@ export function useQuery<T>(
   opts: { coalesceMs?: number; enabled?: boolean } = {},
 ): QuerySnapshot<T> {
   const key = keyOf(type, params)
-  const subscribe = useCallback((notify: () => void) => subscribeKey(key, notify), [key])
-  const snapshot = useCallback(() => peek<T>(key), [key])
+  const enabled = opts.enabled !== false
+  // A disabled hook does not fetch, and it must not SUBSCRIBE either. invalidate() refetches any
+  // entry with a subscriber, so a disabled consumer — FolderView holding useOwnedMount for a
+  // mirrored share — kept the shared listing hot and made every shares-scoped hint issue a full
+  // owned-folder:list-all (one live stat per owned mount) whose result it then discards. It also
+  // stopped subscribeKey minting a scope-less entry for a key nothing ever fetches.
+  const subscribe = useCallback(
+    (notify: () => void) => (enabled ? subscribeKey(key, notify) : () => {}),
+    [key, enabled],
+  )
+  const snapshot = useCallback(() => (enabled ? peek<T>(key) : EMPTY_SNAPSHOT as QuerySnapshot<T>), [key, enabled])
   const entry = useSyncExternalStore(subscribe, snapshot, snapshot)
 
-  const enabled = opts.enabled !== false
   useEffect(() => {
     // `enabled: false` is how a hook says "the ids are not ready yet". Without it a falsy spaceId
     // would send space:members with no spaceId, which the contract validator refuses — one

--- a/src/shared/audit/audit-runtime.js
+++ b/src/shared/audit/audit-runtime.js
@@ -26,11 +26,15 @@ export class AuditLog extends Subsystem {
     initNetworkWatch({
       emit: () => this.deps.ipc.emit('event:audit-updated', {}),
       peerDwellMs: this.deps.peerDwellMs ?? 0,
+      // The watch's dwell timeouts re-arm themselves, so they belong to this subsystem's set
+      // rather than to the call that happened to start them.
+      timers: this.timers,
     })
   }
 
-  // Symmetric with _open: the watch arms its own dwell timeouts, and the only other caller of
-  // resetNetworkWatch is destroySwarm — which boot({ swarm: false }) never reaches.
+  // Symmetric with _open: the watch arms its dwell timeouts through this subsystem's set, and the
+  // only other caller of resetNetworkWatch is destroySwarm — which boot({ swarm: false }) never
+  // reaches. This clears the two handles; the set itself is closed on every ending by the base.
   async _close() {
     resetNetworkWatch()
     await closeAuditLog()

--- a/src/shared/audit/network-watch.js
+++ b/src/shared/audit/network-watch.js
@@ -16,8 +16,18 @@ const log = createLogger('network-watch')
 
 let device = null
 let peers = null
+// The owning subsystem's timer set, handed in by initNetworkWatch. Both handles below re-arm
+// themselves, so they outlive every call that arms them and nothing scoped to a call can clear
+// them; owning them here means the AuditLog subsystem's close reaches them on every path,
+// including a failed _open, which ReadyResource ends without ever running _close.
+let timers = null
 let deviceTimer = null
 let peerTimer = null
+
+// Arming through a closed set THROWS, by design — a late continuation that still wants a timer is
+// a bug worth seeing. Both re-arm tails run from a timer callback, where a throw would escape into
+// the event loop, so they ask first rather than being surprised.
+function canArm() { return !!timers && !timers.closed }
 let emitUpdated = null
 let session = null
 let last = null
@@ -25,7 +35,8 @@ let degraded = false
 let running = false
 let pending = false
 
-export function initNetworkWatch({ emit = null, sessionId = null, dwellMs = 0, peerDwellMs = 0 } = {}) {
+export function initNetworkWatch({ emit = null, sessionId = null, dwellMs = 0, peerDwellMs = 0, timers: owner = null } = {}) {
+  timers = owner
   device = createEpisodeTracker(dwellMs ? { dwellMs } : {})
   peers = createPeerPresenceTracker(peerDwellMs ? { dwellMs: peerDwellMs } : {})
   emitUpdated = emit
@@ -37,8 +48,8 @@ export function initNetworkWatch({ emit = null, sessionId = null, dwellMs = 0, p
 }
 
 export function resetNetworkWatch() {
-  if (deviceTimer) { clearTimeout(deviceTimer); deviceTimer = null }
-  if (peerTimer) { clearTimeout(peerTimer); peerTimer = null }
+  if (deviceTimer) { timers?.clear(deviceTimer); deviceTimer = null }
+  if (peerTimer) { timers?.clear(peerTimer); peerTimer = null }
   device?.reset()
   peers?.reset()
   last = null
@@ -79,10 +90,9 @@ async function pumpDevice() {
     const persisted = await getNetworkState()
     const { row, next, waitMs } = device.step({ ...last, now: Date.now(), session, persisted })
 
-    if (deviceTimer) { clearTimeout(deviceTimer); deviceTimer = null }
-    if (waitMs != null) {
-      deviceTimer = setTimeout(() => { deviceTimer = null; void pumpDevice() }, waitMs + 50)
-      deviceTimer.unref?.()
+    if (deviceTimer) { timers?.clear(deviceTimer); deviceTimer = null }
+    if (waitMs != null && canArm()) {
+      deviceTimer = timers.setTimeout(() => { deviceTimer = null; void pumpDevice() }, waitMs + 50)
     }
     if (!row) return
 
@@ -135,7 +145,7 @@ export const peerLeft = guarded((publicKey, spaceId) => {
 // escape into the event loop as an uncaught exception. Each row is written in its own guard so one
 // failure cannot drop the rest — their episodes are already flagged recorded.
 const armPeerTimer = guarded(() => {
-  if (peerTimer) { clearTimeout(peerTimer); peerTimer = null }
+  if (peerTimer) { timers?.clear(peerTimer); peerTimer = null }
   const { rows, waitMs } = peers.step(Date.now())
   for (const row of rows) {
     try {
@@ -144,9 +154,8 @@ const armPeerTimer = guarded(() => {
       log.warn('peer row write failed:', err.message)
     }
   }
-  if (waitMs != null) {
-    peerTimer = setTimeout(() => { peerTimer = null; armPeerTimer() }, waitMs + 50)
-    peerTimer.unref?.()
+  if (waitMs != null && canArm()) {
+    peerTimer = timers.setTimeout(() => { peerTimer = null; armPeerTimer() }, waitMs + 50)
   }
 })
 

--- a/src/shared/core/ipc.js
+++ b/src/shared/core/ipc.js
@@ -24,8 +24,8 @@ const EMPTY = Buffer.alloc(0)
 // kind, and every hook that re-derives on a hint must have its poke sources mapped here.
 // event:member-joined is deliberately unmapped: it fires pre-persist; members-updated (post-persist)
 // is the poke. Owned/foreign mount-status both map to the shares scope (both persist a durable
-// mount.status the consumer re-derives); useOwnedMount keeps a named subscription for the transient
-// paused-error state, which owned-folder:get doesn't carry.
+// mount.status the consumer re-derives, and the listings they re-read carry lastError, so the
+// transient paused-error state arrives with them — neither consumer needs a named subscription).
 const POKE_SCOPE = {
   'event:files-updated': (p) => (p.spaceId ? Scope.files(p.spaceId) : null),
   'event:shares-updated': (p) => (p.spaceId ? Scope.shares(p.spaceId) : null),

--- a/src/shared/core/timers.js
+++ b/src/shared/core/timers.js
@@ -2,6 +2,31 @@
 // subsystem's periodic work cannot outlive it. Scheduling after close throws — a late
 // continuation that still wants a timer is the bug the flag exists to surface, not something
 // to swallow. Handles are opaque; clear() takes what set*() returned.
+// A handle whose owning set has CLOSED is dead: close() already disarmed it and clear() will not
+// find it in the set. A module that keeps its handle in a binding outliving the subsystem has to
+// drop it, because the usual `if (handle) return` guard reads a dead handle as "already armed" and
+// latches the work off for the rest of the process — the same shutdown-latch shape one level up
+// from the timer itself. Returns the handle only while its owner can still clear it.
+export function liveHandle(timers, handle) {
+  return timers && !timers.closed ? handle : null
+}
+
+// The schedule/clear pair to hand an injected scheduler (makeKeyedCoalescer's, say) when the owner
+// is a subsystem that may not exist yet and may already be closed. It DECLINES rather than throws:
+// arming against a closed set throws by design, and the callers here run inside a callback during
+// the post-close drain, where there is nothing to catch it. Guarded on the SET, not just the
+// pointer — a _close that rejects never reaches its `subsystem = null`, so the pointer stays live
+// while the base has already closed the timers underneath it.
+export function ownedScheduler(getTimers) {
+  return {
+    schedule: (fn, ms) => {
+      const timers = getTimers()
+      return timers && !timers.closed ? timers.setTimeout(fn, ms) : null
+    },
+    clear: (handle) => { if (handle) getTimers()?.clear(handle) },
+  }
+}
+
 export function createTimers() {
   const live = new Set()
   let closed = false

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -9,6 +9,7 @@ import { getOwnedMount, touchOwnedMountScan, findOwnedMountByShareId } from './m
 import { AppError, ErrorCodes, classifyLocalIoFault } from '../core/errors.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { liveHandle, ownedScheduler } from '../core/timers.js'
 import { createCoalescingRunner } from '../core/coalescing-runner.js'
 import { createPassLiveness } from '../core/pass-liveness.js'
 import { getContentBackend, isUnsupportedShare } from '../transfer/content-backends.js'
@@ -42,6 +43,13 @@ function sched() {
   if (!scheduler) throw new Error('owned-folders: not started')
   return scheduler
 }
+
+// The live subsystem, so the module-scope functions below can arm through ITS timer set. Every
+// handle they hold outlives the call that armed it, so nothing scoped to the call can clear it —
+// and _close alone is not enough: ReadyResource ends a FAILED _open by running close() without
+// ever calling _close, and a _close that rejects short-circuits the same way. Subsystem clears
+// `this.timers` on both of those paths as well as the ordinary one.
+let subsystem = null
 
 const reconcileTimers = new Map()
 // Diff passes currently reading a mount. A pause or a stop must reach the pass itself, not just the
@@ -138,23 +146,29 @@ function announceIndex(spaceId, shareId) {
 
 // Runs only while some share is scanning, and stops itself the moment none is.
 function armIndexAnnounce() {
-  if (announceTimer || announcing.size === 0) return
-  announceTimer = setInterval(() => {
+  // See startPresenceHeartbeat: a _close that rejects leaves this binding holding a handle its set
+  // has already disarmed, and the guard below would read that as "already armed" forever.
+  announceTimer = liveHandle(subsystem?.timers, announceTimer)
+  if (announceTimer || announcing.size === 0 || !subsystem || subsystem.timers.closed) return
+  announceTimer = subsystem.timers.setInterval(() => {
     for (const [key, at] of announcing) if (!announceIndex(at.spaceId, at.shareId)) announcing.delete(key)
-    if (announcing.size === 0) { clearInterval(announceTimer); announceTimer = null }
+    if (announcing.size === 0) stopIndexAnnounce()
   }, announceMs)
-  announceTimer.unref?.()
 }
 
 export function stopIndexAnnounce() {
-  if (announceTimer) clearInterval(announceTimer)
+  if (announceTimer) subsystem?.timers.clear(announceTimer)
   announceTimer = null
   announcing.clear()
 }
 
 const progress = makeKeyedCoalescer((spaceId, shareId) => {
-  // Tolerant: the publish service drains its executors AFTER this subsystem closes, and each
-  // settling item pokes progress on the way out.
+  // The publish service drains its executors AFTER this subsystem closes, and each settling item
+  // pokes progress on the way out. With no live subsystem there is no timer set to hold the window
+  // open, so every one of those pokes would fire on its own — turning one throttled frame per
+  // 500 ms into one broadcast per drained item, at shutdown, into a swarm being torn down. Nobody
+  // is left to act on index progress by then: the drain is silent.
+  if (!subsystem) return
   const status = scheduler?.statusFor(spaceId, shareId)
   if (!status) return
   ipcRef?.emit('event:owned-folder-index-progress', { spaceId, shareId, ...status })
@@ -164,7 +178,15 @@ const progress = makeKeyedCoalescer((spaceId, shareId) => {
   const key = spaceId + '|' + shareId
   if (status.adding > 0) { announcing.set(key, { spaceId, shareId }); armIndexAnnounce() }
   else announcing.delete(key)
-}, { intervalMs: 500, keyOf: (spaceId, shareId) => spaceId + '|' + shareId })
+}, {
+  intervalMs: 500,
+  keyOf: (spaceId, shareId) => spaceId + '|' + shareId,
+  // The coalescer's trailing timer is the same long-lived handle as the two above, one level down:
+  // it is held in the engine's own map and its only clear is progress.reset(), which a _close that
+  // rejects never reaches. Read lazily, because this is constructed at module load and the
+  // subsystem does not exist yet; before _open there is nothing to coalesce anyway.
+  ...ownedScheduler(() => subsystem?.timers),
+})
 
 registerPublishChannel('folder', {
   async resolve(item) {
@@ -224,11 +246,11 @@ export function initOwnedFolders(_ipc, { settleScan = null, broadcastIndex = nul
 // pass. The mount is re-read for the re-arm, so a share deleted or relocated meanwhile is not
 // chased with a stale path.
 function scheduleCatchupReconcile(mount, delayMs = POST_EVENT_RECONCILE_MS) {
-  if (stopping) return
+  if (stopping || !subsystem) return
   const { spaceId, shareId } = mount
   const key = spaceId + ':' + shareId
-  clearTimeout(reconcileTimers.get(key))
-  const timer = setTimeout(() => {
+  subsystem.timers.clear(reconcileTimers.get(key))
+  const timer = subsystem.timers.setTimeout(() => {
     reconcileTimers.delete(key)
     if (stopping) return
     const scan = periodicReconcile(spaceId, shareId, mount.mountPath, mount.ignore || DEFAULT_IGNORE, { deferFresh: true })
@@ -245,7 +267,6 @@ function scheduleCatchupReconcile(mount, delayMs = POST_EVENT_RECONCILE_MS) {
     if (settleScanRef) settleScanRef(scan, spaceId, shareId)
     else scan.catch((err) => log.debug('catch-up reconcile failed:', err.message))
   }, delayMs)
-  timer.unref?.()
   reconcileTimers.set(key, timer)
 }
 
@@ -505,7 +526,9 @@ export function cancelIndex(spaceId, shareId) {
 
 export function stopOwnedFolder(spaceId, shareId) {
   const key = spaceId + ':' + shareId
-  clearTimeout(reconcileTimers.get(key))
+  // Tolerant of a closed subsystem: this is a cleanup path that can legally run after it, and the
+  // set has already been emptied by then.
+  subsystem?.timers.clear(reconcileTimers.get(key))
   reconcileTimers.delete(key)
   clearShareGuards(shareId)
   // Tolerant on purpose: this is a cleanup path (leave, unmount, a test teardown) and can legally
@@ -520,6 +543,7 @@ export class OwnedFolders extends Subsystem {
   constructor(name, deps) { super(name, deps); this.require('ipc', 'publishService') }
 
   async _open() {
+    subsystem = this
     scheduler = this.deps.publishService.scheduler
     stopping = false
     initOwnedFolders(this.deps.ipc, {
@@ -532,7 +556,7 @@ export class OwnedFolders extends Subsystem {
     stopping = true
     stopIndexAnnounce()
     setFolderPublishLane(null)
-    for (const timer of reconcileTimers.values()) clearTimeout(timer)
+    for (const timer of reconcileTimers.values()) this.timers.clear(timer)
     reconcileTimers.clear()
     for (const signal of scanSignals.values()) signal.aborted = true
     scanSignals.clear()
@@ -550,6 +574,7 @@ export class OwnedFolders extends Subsystem {
     passFaults.clear()
     shareCache.clear()
     passLiveness.clear()
+    subsystem = null
   }
 
   // The mirror side has reported pass liveness since the supervision contract landed; the owner

--- a/src/shared/spaces/member-view.js
+++ b/src/shared/spaces/member-view.js
@@ -1,6 +1,6 @@
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
-import { openProfileBee, readMembershipRecord, readPeerRequests, readPeerDenials, getLocalPublicKeyHex } from './profile.js'
+import { openProfileBee, readMembershipRecord, readPeerRequests, readPeerDenials, getLocalPublicKeyHex, CAP_MEMBERSHIP_MANIFEST } from './profile.js'
 import { foldMembership } from './member-set.js'
 import { createDerivedView } from '../state/derived-view.js'
 import { getResourceCaps } from '../core/runtime-config.js'
@@ -126,6 +126,33 @@ export function createMemberView ({ spaceId, creatorKey, selfKey, onMembers, onE
   // displayName/membership append shares the same bee but must not trigger a share re-fetch.
   const shareRange = { gte: SHARE_PREFIX + spaceId + '/', lt: SHARE_PREFIX + spaceId + '/\xff' }
   const shareWatchers = new Map()
+
+  // The fold's read set expressed as watch ranges — one per read deriveMemberSet actually issues.
+  // Without them createDerivedView watches the WHOLE bee, and every profile write a peer makes
+  // wakes a full serial roster re-fold at one network-bounded readMembershipRecord per member.
+  // displayName, avatar, publicKey, invite/, drive/, loosecat*/, mirror/ and share/ are read by no
+  // part of this fold, and share/ is doubly wasteful because shareRange above already covers it.
+  // viewSignature does not save this: it suppresses the emit AFTER the fold has already run.
+  //
+  // This range set IS the membership convergence guarantee. A key family the fold reads but this
+  // set omits yields a view that is correct at fold time and then silently never re-folds when
+  // that key changes. It is enforced by test/integration/member-view-watch-range.test.js, which
+  // drives a write into each of these prefixes and asserts a re-fold, and into each excluded
+  // prefix and asserts none. The bounds mirror profile.js's read streams byte-for-byte, including
+  // the '0' upper bound (0x30, the byte after '/').
+  //
+  // The two exact-key ranges are exact on purpose. member/<spaceId> must NOT be a prefix range:
+  // member/<other> is another space's membership and must not wake this space's fold.
+  // caps/membership-manifest is written once and so almost never fires, but stays a wake reason in
+  // its own right — a peer publishing its manifest after we first folded it reads as "unknown /
+  // not replicated yet" until something re-folds.
+  const foldRanges = [
+    { gte: CAP_MEMBERSHIP_MANIFEST, lte: CAP_MEMBERSHIP_MANIFEST },
+    { gte: 'member/' + spaceId, lte: 'member/' + spaceId },
+    { gte: 'approved/' + spaceId + '/', lt: 'approved/' + spaceId + '0' },
+    { gte: 'request/' + spaceId + '/', lt: 'request/' + spaceId + '0' },
+    { gte: 'denied/' + spaceId + '/', lt: 'denied/' + spaceId + '0' },
+  ]
   let closed = false
   const follow = (key, bee) => {
     if (closed || key === self || follows.has(key)) return
@@ -188,6 +215,7 @@ export function createMemberView ({ spaceId, creatorKey, selfKey, onMembers, onE
     },
     onChange: emit,   // receives { members, considered, approved, requests, denied }
     onError,
+    ranges: foldRanges,
     debounceMs: getResourceCaps().deriveDebounceMs,
   })
 

--- a/src/shared/spaces/profile.js
+++ b/src/shared/spaces/profile.js
@@ -16,7 +16,7 @@ import { Subsystem } from '../core/subsystem.js'
 
 const log = createLogger('membership')
 
-const CAP_MEMBERSHIP_MANIFEST = 'caps/membership-manifest'
+export const CAP_MEMBERSHIP_MANIFEST = 'caps/membership-manifest'
 
 let profileBee
 let profileStore = -1

--- a/src/shared/state/coalesce.js
+++ b/src/shared/state/coalesce.js
@@ -13,7 +13,12 @@ export function makeKeyedCoalescer(fire, { intervalMs = 250, keyOf = (x) => Stri
         open.delete(key)
         if (state.pending) fire(...args)
       }, intervalMs)
-      state.timer?.unref?.()
+      // An injected schedule may decline — the owned timer sets return nothing once their owner has
+      // gone. Without a timer nothing would ever close the window, and every later poke for this
+      // key would be swallowed as "collapsed into a trailing fire" that can never happen. No
+      // window, no coalescing: each poke fires on its own, which is the safe degradation.
+      if (!state.timer) return
+      state.timer.unref?.()
       open.set(key, state)
     },
     flush(...args) {

--- a/src/shared/state/derived-view.js
+++ b/src/shared/state/derived-view.js
@@ -17,17 +17,34 @@
 //    keys too, e.g. avatar/displayName), or pass { gte, lt } to scope it. Over-firing is
 //    safe — the fold is deterministic and idempotent, so an extra recompute only costs
 //    a fold, never correctness.
+//  - `ranges` is the multi-family form of `range`, because hyperbee.watch takes ONE range and
+//    a fold whose read set spans disjoint key families would otherwise have to watch the whole
+//    bee. N ranges means N watchers per tracked bee, each holding a snapshot pair and diffing
+//    on every append — worth it only when a spurious wake costs more than the watchers do,
+//    which it does for any fold that reads over the network. Exclusive with `range`.
 
 import { createPassLiveness } from '../core/pass-liveness.js'
 
 // One fold at a time, so the keyed bookkeeping carries a single key.
 const FOLD = 'fold'
 
-export function createDerivedView ({ fold, onChange, range, onError, debounceMs = 0 } = {}) {
+export function createDerivedView ({ fold, onChange, range, ranges, onError, debounceMs = 0 } = {}) {
   if (typeof fold !== 'function') throw new Error('createDerivedView: fold is required')
   if (typeof onChange !== 'function') throw new Error('createDerivedView: onChange is required')
+  // Silently preferring one would hide a read set that is half-declared.
+  if (range !== undefined && ranges !== undefined) throw new Error('createDerivedView: pass range or ranges, not both')
+  // An empty array would open no watcher on any source: the view folds once at boot and then never
+  // re-derives, with no error and no log — a membership set frozen at whatever it was. `null` is
+  // the same mistake in the other direction, silently taking the whole-bee fallback this option
+  // exists to avoid. Both are a caller computing its key families and coming up empty.
+  if (ranges !== undefined && (!Array.isArray(ranges) || ranges.length === 0)) {
+    throw new Error('createDerivedView: ranges must be a non-empty array')
+  }
 
-  const watchers = new Map()   // sourceKey -> { watcher, loop }
+  // [undefined] is the whole-bee watch the single-range form gives, so a caller passing neither
+  // keeps exactly the previous behaviour.
+  const watchRanges = ranges ?? [range]
+  const watchers = new Map()   // sourceKey -> [{ watcher, loop }]
   let closed = false
   let scheduled = false        // a recompute is queued but not yet running
   let running = false          // a fold is in flight
@@ -106,11 +123,15 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
   // members are discovered; corestore dedups the underlying cores.
   function track (key, bee) {
     if (closed || watchers.has(key)) return
-    const watcher = bee.watch(range)
-    const loop = (async () => {
-      try { for await (const _ of watcher) recompute() } catch { /* watcher closed */ }
-    })()
-    watchers.set(key, { watcher, loop })
+    // One entry per source key holding ALL its watchers, so close() and tracking() stay keyed on
+    // the source and cannot half-release a bee.
+    watchers.set(key, watchRanges.map((r) => {
+      const watcher = bee.watch(r)
+      const loop = (async () => {
+        try { for await (const _ of watcher) recompute() } catch { /* watcher closed */ }
+      })()
+      return { watcher, loop }
+    }))
   }
 
   function tracking (key) { return watchers.has(key) }
@@ -123,8 +144,10 @@ export function createDerivedView ({ fold, onChange, range, onError, debounceMs 
     // resolves. Closing out from under it leaves those sessions open for the store to find.
     try { await inFlight } catch { /* the fold's own error path already reported */ }
     inFlight = null
-    for (const { watcher } of watchers.values()) {
-      try { await watcher.close() } catch { /* already gone */ }
+    for (const opened of watchers.values()) {
+      for (const { watcher } of opened) {
+        try { await watcher.close() } catch { /* already gone */ }
+      }
     }
     watchers.clear()
   }

--- a/src/shared/transfer/connectivity.js
+++ b/src/shared/transfer/connectivity.js
@@ -11,6 +11,7 @@ import os from 'bare-os'
 import crypto from 'hypercore-crypto'
 import idEncoding from 'hypercore-id-encoding'
 import { getUpgradeKey } from '../core/runtime-config.js'
+import { createTimers } from '../core/timers.js'
 import { refreshContentDiscoveries, getContentPlaneStatus } from './content-swarm.js'
 import { observeReachability } from '../audit/network-watch.js'
 import {
@@ -26,6 +27,13 @@ let getDroppedFrameCounters = () => ({})
 // Read at call time, not captured: initSwarm and destroySwarm reassign both handles.
 let getSwarm = () => null
 let getIpc = () => null
+
+// One owned set for all six timers below. They interlock — the dwell recheck schedules the status
+// emit, the liveness retry re-arms the liveness loop — so a bulk stop that reaches every one of
+// them is the point: a seventh timer armed through this set is stopped by resetConnectivity
+// without anyone remembering to add a line to it. There is no Subsystem here to hang them off, and
+// createTimers() is usable standalone; a lifecycle class for six timers would be apparatus.
+let timers = createTimers()
 
 export function initConnectivity(deps) {
   log = deps.log
@@ -275,7 +283,7 @@ function readInterfaceKind() {
 function startInterfaceWatch() {
   if (interfaceTimer) return
   interfaceKind = readInterfaceKind()
-  interfaceTimer = setInterval(() => {
+  interfaceTimer = timers.setInterval(() => {
     const next = readInterfaceKind()
     if (next === interfaceKind) return
     // A route reappearing is a fresh start for the probe, not a continuation.
@@ -283,7 +291,6 @@ function startInterfaceWatch() {
     interfaceKind = next
     scheduleStatusEmit()
   }, INTERFACE_POLL_MS)
-  interfaceTimer.unref?.()
 }
 
 const LIVENESS_INTERVAL_MS = 15000
@@ -340,11 +347,10 @@ let livenessRetryTimer = null
 
 function scheduleLivenessRetry() {
   if (livenessRetryTimer) return
-  livenessRetryTimer = setTimeout(() => {
+  livenessRetryTimer = timers.setTimeout(() => {
     livenessRetryTimer = null
     checkLiveness().catch((err) => log.debug('liveness retry failed:', err.message))
   }, LIVENESS_RETRY_MS)
-  livenessRetryTimer.unref?.()
 }
 
 // Lets a network transition the OS *did* notice trigger an immediate re-check instead of
@@ -356,20 +362,18 @@ export async function checkLivenessNow() {
 
 function startLivenessLoop() {
   if (livenessTimer) return
-  livenessTimer = setInterval(() => {
+  livenessTimer = timers.setInterval(() => {
     checkLiveness().catch((err) => log.debug('liveness check failed:', err.message))
   }, LIVENESS_INTERVAL_MS)
-  livenessTimer.unref?.()
 }
 
 function scheduleFirstCanaryProbe() {
   if (firstProbeTimer || spaceTopics.size > 0) return
-  firstProbeTimer = setTimeout(() => {
+  firstProbeTimer = timers.setTimeout(() => {
     firstProbeTimer = null
     if (spaceTopics.size > 0) return
     probeCanary(getUpgradeKey()).catch((err) => log.debug('first canary probe failed:', err.message))
   }, NAT_SETTLE_MS)
-  firstProbeTimer.unref?.()
 }
 
 export async function probeCanary(upgradeKey, { force = false } = {}) {
@@ -516,15 +520,14 @@ export function statusEqual(a, b) {
 let dwellTimer = null
 
 function armDwellRecheck(pending) {
-  if (dwellTimer) { clearTimeout(dwellTimer); dwellTimer = null }
+  if (dwellTimer) { timers.clear(dwellTimer); dwellTimer = null }
   if (!pending) return
-  dwellTimer = setTimeout(() => { dwellTimer = null; scheduleStatusEmit() }, BLOCKED_DWELL_MS / 2)
-  dwellTimer.unref?.()
+  dwellTimer = timers.setTimeout(() => { dwellTimer = null; scheduleStatusEmit() }, BLOCKED_DWELL_MS / 2)
 }
 
 export function scheduleStatusEmit() {
   if (statusEmitTimer) return
-  statusEmitTimer = setTimeout(() => {
+  statusEmitTimer = timers.setTimeout(() => {
     statusEmitTimer = null
     if (!getIpc()) return
     const next = getSwarmStatus()
@@ -583,12 +586,19 @@ export async function reconnectAll() {
 
 // What destroySwarm calls instead of clearing sixteen counters and six timers by hand.
 export function resetConnectivity() {
-  if (dwellTimer) { clearTimeout(dwellTimer); dwellTimer = null }
-  if (firstProbeTimer) { clearTimeout(firstProbeTimer); firstProbeTimer = null }
-  if (livenessTimer) { clearInterval(livenessTimer); livenessTimer = null }
-  if (interfaceTimer) { clearInterval(interfaceTimer); interfaceTimer = null }
-  if (livenessRetryTimer) { clearTimeout(livenessRetryTimer); livenessRetryTimer = null }
-  if (statusEmitTimer) { clearTimeout(statusEmitTimer); statusEmitTimer = null }
+  // The set, not the six handles: close() disarms every timer armed through it, including one added
+  // later that nobody thought to name here. The handles are still nulled, because the arm sites
+  // guard on them and a stale handle would block the re-arm after a restart. A fresh set replaces
+  // the closed one — destroySwarm and initSwarm cycle within one process, and arming through a
+  // closed set throws.
+  timers.close()
+  timers = createTimers()
+  dwellTimer = null
+  firstProbeTimer = null
+  livenessTimer = null
+  interfaceTimer = null
+  livenessRetryTimer = null
+  statusEmitTimer = null
   dhtReady = false
   readyAt = 0
   announced = false

--- a/src/shared/transfer/convergence-tick.js
+++ b/src/shared/transfer/convergence-tick.js
@@ -7,6 +7,7 @@
 // A converged, quiet swarm does no work in this module at all: each arm is gated on an observable
 // deficit, and the escalation to a discovery refresh is throttled and budgeted per space on top.
 import { getSpace } from '../spaces/space.js'
+import { liveHandle } from '../core/timers.js'
 import { getConvergenceConfig } from '../core/runtime-config.js'
 import { escalationDue, announceStatus } from './announce-ledger.js'
 import { refreshContentDiscoveries, contentPlaneHasPeer, getContentPlaneStatus } from './content-swarm.js'
@@ -33,6 +34,9 @@ export function initConvergenceTick(deps) {
   getIpc = deps.getIpc
 }
 
+// The owning subsystem's timer set, handed in when the tick starts. Same reason as the presence
+// heartbeat: a periodic interval outlives every call that could clear it.
+let timers = null
 let convergenceTimer = null
 let convergenceTicking = false          // re-entrancy guard: the tick is async, setInterval isn't
 const deficitTicks = new Map()          // spaceId → consecutive ticks with a roster deficit
@@ -199,11 +203,16 @@ export async function rescueStalledTransfers() {
   }
 }
 
-export function startConvergenceTick() {
+export function startConvergenceTick(owner = null) {
+  // See startPresenceHeartbeat: a handle from a closed set reads as "already armed" and would
+  // latch off stall rescue, roster-deficit escalation and every other arm of the re-drive.
+  convergenceTimer = liveHandle(timers, convergenceTimer)
   if (convergenceTimer) return
+  timers = owner ?? timers
+  if (!timers || timers.closed) return
   const { convergenceTickMs } = getConvergenceConfig()
   if (!convergenceTickMs) return
-  convergenceTimer = setInterval(() => {
+  convergenceTimer = timers.setInterval(() => {
     // The tick is async and setInterval doesn't await it — skip a fire that lands while the
     // previous run is still in flight, so overlapping runs can't double-send or double-count.
     if (convergenceTicking) return
@@ -212,14 +221,13 @@ export function startConvergenceTick() {
       .catch((err) => log.debug('convergence tick failed:', err.message))
       .finally(() => { convergenceTicking = false })
   }, convergenceTickMs)
-  convergenceTimer.unref?.()
 }
 
 // What destroySwarm calls: stop the timer and drop every counter, so a restarted swarm escalates
 // from a clean budget rather than inheriting the previous session's spent attempts.
 export function resetConvergenceTick() {
   if (convergenceTimer) {
-    clearInterval(convergenceTimer)
+    timers?.clear(convergenceTimer)
     convergenceTimer = null
   }
   convergenceTicking = false

--- a/src/shared/transfer/presence-broadcast.js
+++ b/src/shared/transfer/presence-broadcast.js
@@ -8,6 +8,7 @@
 // keeps swarm.js's public surface intact: it re-exports these names rather than wrapping them.
 import b4a from 'b4a'
 import { getProfileKey } from '../spaces/profile.js'
+import { liveHandle } from '../core/timers.js'
 import { LOOSE_SHARE_ID } from './transfer-id.js'
 import { shareDecoKey } from './decoration-key.js'
 import { peerSeen } from '../audit/network-watch.js'
@@ -17,6 +18,10 @@ import { connectedPeers, socketToPeers, spaceTopics, socketMsgHandlers } from '.
 let presence = null
 let membersPoke = null
 let log = null
+// The owning subsystem's timer set, handed in when the heartbeat starts. The handle is a periodic
+// interval that outlives every call, so nothing scoped to a call can clear it; owning it means the
+// Swarm subsystem's close reaches it on every path, including a failed _open.
+let timers = null
 let presenceTimer = null
 let getSwarm = () => null
 let getIpc = () => null
@@ -36,17 +41,22 @@ const PRESENCE_HEARTBEAT_MS = 5000
 // The interval lives with the timer variable, not with initSwarm: broadcastDeparture has to stop
 // the heartbeat before it sends (a beat landing after the departure re-marks us online on the
 // receiver and undoes it), and it can only stop a timer this module actually holds.
-export function startPresenceHeartbeat() {
+export function startPresenceHeartbeat(owner = null) {
+  // Drop a handle whose set has closed BEFORE the already-armed guard reads it: close() disarmed
+  // the interval but cannot reach this binding, so a stale handle here would latch the heartbeat
+  // off — and a module that never advertises presence again looks offline to every peer.
+  presenceTimer = liveHandle(timers, presenceTimer)
   if (presenceTimer) return
-  presenceTimer = setInterval(() => {
+  timers = owner ?? timers
+  if (!timers || timers.closed) return
+  presenceTimer = timers.setInterval(() => {
     try { broadcastPresence() } catch (err) { log.debug('presence heartbeat failed:', err.message) }
     presence.prune()
   }, PRESENCE_HEARTBEAT_MS)
-  presenceTimer.unref?.()
 }
 
 export function stopPresenceHeartbeat() {
-  if (presenceTimer) { clearInterval(presenceTimer); presenceTimer = null }
+  if (presenceTimer) { timers?.clear(presenceTimer); presenceTimer = null }
 }
 
 // Heartbeat: advertise our own liveness per space to the peers in it. The recipient leases
@@ -70,7 +80,7 @@ export function broadcastPresence() {
 export function broadcastDeparture() {
   // Stop our own heartbeat first: a heartbeat firing later in the shutdown teardown window would
   // re-mark us online on a receiver (mark after clear) and undo this departure.
-  if (presenceTimer) { clearInterval(presenceTimer); presenceTimer = null }
+  if (presenceTimer) { timers?.clear(presenceTimer); presenceTimer = null }
   if (!getSwarm() || socketMsgHandlers.size === 0) return
   const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
   for (const [spaceId, topicHex] of spaceTopics) {

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -129,6 +129,8 @@ function peerName(space, peerKey) {
 }
 
 let swarm
+// The live Swarm subsystem, so the module-scope starts below can arm through ITS timer set.
+let subsystem = null
 let ipcRef
 let overlayReconnectHook = null         // notified when an overlay-content owner (re)connects, so paused/interrupted overlay downloads (loose + folder) resume
 let membershipControlHandler = null     // membership:* frames (join request / grant / deny) routed to the worker
@@ -248,8 +250,12 @@ function initSwarm(_ipc) {
   noteBooted()
   log.info('initialized')
 
-  startPresenceHeartbeat()
-  startConvergenceTick()
+  // Both are periodic ticks that outlive the call arming them, so they hang off the Swarm
+  // subsystem's timer set — which the base closes on every ending, including a failed _open that
+  // never reaches _close. _open is initSwarm's only caller and sets the pointer first, so the
+  // fallback is defensive: an interval nobody can stop is one nobody should start.
+  startPresenceHeartbeat(subsystem?.timers ?? null)
+  startConvergenceTick(subsystem?.timers ?? null)
   attachSwarmWatchers()
 
 
@@ -1198,6 +1204,7 @@ export class Swarm extends Subsystem {
   }
 
   async _open() {
+    subsystem = this
     membershipControlHandler = this.deps.membershipControl
     stalledOwnersHook = this.deps.stalledOwners
     // Exclusive with the content plane: when it is on, the overlay channel rides the content
@@ -1216,6 +1223,7 @@ export class Swarm extends Subsystem {
     // audit rows the durable tier records, and those frames need a live connection.
     this.deps.overlayBackend.detach()
     await destroySwarm()
+    subsystem = null
   }
 
   get dht() { return getSwarmDht() }

--- a/test/frontend-layout/harness-bootstrap.ts
+++ b/test/frontend-layout/harness-bootstrap.ts
@@ -12,7 +12,8 @@
 // harnesses are local-only, so CI never catches the drift.
 import { request } from './../../src/renderer/ipc.js'
 import { configureQueryStore } from './../../src/renderer/store/query-store.js'
-import { installReconcileBridge } from './../../src/renderer/store/reconcile.js'
+import { installPushBridges, installReconcileBridge } from './../../src/renderer/store/reconcile.js'
 
 configureQueryStore({ request: (type, params, opts) => request(type, params, undefined, opts) })
 installReconcileBridge()
+installPushBridges()

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -128,6 +128,8 @@ import s127 from './scenarios/s127-folder-fault-strip.mjs'
 import s128 from './scenarios/s128-localized-errors.mjs'
 import s129 from './scenarios/s129-mirror-modal-folder-info.mjs'
 import s130 from './scenarios/s130-mirror-name-collision.mjs'
+import s131 from './scenarios/s131-mirror-fault-clears-on-unmount.mjs'
+import s132 from './scenarios/s132-activity-log-settings-parity.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -194,7 +196,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s131-mirror-fault-clears-on-unmount.mjs
+++ b/test/frontend/scenarios/s131-mirror-fault-clears-on-unmount.mjs
@@ -1,0 +1,77 @@
+import { mkdirSync, writeFileSync, chmodSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { allText, flatten } from '../tree.mjs'
+import { workDir } from '../paths.mjs'
+
+// REGRESSION (ADOPT-A1: the mirror's durable record was read by a hand-rolled effect with no
+// staleness guard AND an early return that did not clear. Unmounting the mirror flipped the share's
+// role off 'mirrored', which handed the hook an empty shareId — so it returned without touching
+// state and the fault strip went on rendering, Try again button and all, for a mount that no longer
+// existed. Pressing that button sent foreign-folder:set-enabled for a shareId with no record.)
+//
+// The unmount does not leave the screen: ScreenRouter flips the selected share's role to 'browse'
+// in place, so FolderView stays mounted with the same identity. That is precisely the case the
+// hand-rolled hook could not clear, and why this is a screen test rather than a unit one.
+//
+// The fault is induced the only way a mirror's can be: the mirror writes into its own directory, so
+// a directory it cannot write to fails the write and auto-pauses the mirror with paused-error.
+export default async function s131 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Reports')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'q1.txt'), 'numbers')
+
+  const mirrorDir = path.join(workDir('mirror-'), 'Reports')
+  mkdirSync(mirrorDir, { recursive: true })
+
+  try {
+    await r.ok('A shares a folder and B mirrors it', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Reports', 60000)
+      await B.waitText('Reports', 60000)
+      await B.mirrorShare(mirrorDir)
+      await B.openFolder('Reports')
+      await B.waitText('q1.txt', 60000)
+    })
+
+    await r.ok('a mirror that cannot write its own folder stops, and says so with a retry', async () => {
+      chmodSync(mirrorDir, 0o555)
+      writeFileSync(path.join(ownDir, 'q2.txt'), 'more numbers')
+      await waitFor(async () => /syncing stopped/i.test(allText(await B.snap())), 120000,
+        'the mirror fault strip names the stop')
+      const buttons = flatten(await B.snap()).filter((n) => n.role === 'button')
+      assert(buttons.some((b) => /^try again$/i.test(b.label)),
+        'the strip carries its verb, addressable by role and accessible name')
+      await B.shot('s131-mirror-fault', runDir)
+    })
+
+    await r.ok('unmounting the mirror clears the strip AND its retry, on the same screen', async () => {
+      chmodSync(mirrorDir, 0o755)   // so the unmount itself cannot fail on the permission
+      await B.unmountShare()
+      await waitFor(async () => {
+        const snap = await B.snap()
+        const noStrip = !/syncing stopped/i.test(allText(snap))
+        const noRetry = !flatten(snap).some((n) => n.role === 'button' && /^try again$/i.test(n.label))
+        return noStrip && noRetry
+      }, 60000, 'the fault strip and its Try again are both gone for a mount that no longer exists')
+      await B.shot('s131-unmounted', runDir)
+    })
+  } catch {} finally {
+    // Step 2 makes mirrorDir unwritable and step 3 restores it — but a failure in between (the
+    // 120 s fault-strip wait timing out, say) skips step 3 entirely, and the children of a 0o555
+    // directory cannot be unlinked. Without this, every failed run leaves its temp tree behind for
+    // good. Idempotent with step 3's own restore.
+    try { chmodSync(mirrorDir, 0o755) } catch {}
+  }
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/frontend/scenarios/s132-activity-log-settings-parity.mjs
+++ b/test/frontend/scenarios/s132-activity-log-settings-parity.mjs
@@ -1,0 +1,68 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { allText } from '../tree.mjs'
+import { workDir } from '../paths.mjs'
+
+// The Account screen and the Activity Log settings screen report the same two facts — how many
+// events are recorded, and whether recording is on. They used to read them twice: Account through
+// the query store, the settings screen through its own hand-rolled effect. Two reads of one fact
+// can disagree, which is the whole reason the store exists; they now share its two entries.
+//
+// Asserted as a string equality rather than a pair of regexes, because "they agree" is the claim.
+const eventsRecorded = (text) => (/(\d+) events? recorded/i.exec(text) ?? [])[1] ?? null
+
+export default async function s132 ({ runDir }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', slot: 0, total: 1 })
+
+  const ownDir = path.join(workDir('own-'), 'Reports')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'q1.txt'), 'numbers')
+
+  let fromAccount = null
+
+  try {
+    await r.ok('A does enough to record some activity', async () => {
+      await A.launch()
+      await A.createSpaceOnly('Aurora')
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Reports', 60000)
+    })
+
+    await r.ok('the Account screen reports a count', async () => {
+      await A.openAccount()
+      await waitFor(async () => eventsRecorded(allText(await A.snap())) !== null, 20000,
+        'the activity row carries the recorded count')
+      fromAccount = eventsRecorded(allText(await A.snap()))
+      assert(Number(fromAccount) > 0, 'and it is a real count, not a placeholder zero')
+      await A.shot('s132-account', runDir)
+    })
+
+    await r.ok('the Activity Log settings screen reports the same count', async () => {
+      await A.back()
+      await A.gotoSettings('Activity Log')
+      await A.waitText('Choose what Mirall records', 20000)
+      await waitFor(async () => eventsRecorded(allText(await A.snap())) !== null, 20000,
+        'the settings screen carries the recorded count too')
+      const fromSettings = eventsRecorded(allText(await A.snap()))
+      assert(fromSettings === fromAccount,
+        `both screens report one number for one log (account ${fromAccount}, settings ${fromSettings})`)
+      await A.shot('s132-settings', runDir)
+    })
+
+    await r.ok('turning recording off on one screen is what the other screen reports', async () => {
+      await A.click({ role: 'switch', name: 'Record activity' })
+      await waitFor(async () => await A.isChecked({ role: 'switch', name: 'Record activity' }) === false, 20000,
+        'the toggle settles off on the screen that owns it')
+      await A.back()
+      await A.openAccount()
+      await waitFor(async () => /recording is off/i.test(allText(await A.snap())), 20000,
+        'the Account row reads the pushed config rather than a copy it fetched separately')
+      await A.shot('s132-recording-off', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/integration/member-view-watch-range.test.js
+++ b/test/integration/member-view-watch-range.test.js
@@ -1,0 +1,178 @@
+import test from 'brittle'
+import b4a from 'b4a'
+import { freshPeerWithIdentity } from '../helpers/store.js'
+import { makePeer, replicate, waitFor } from '../helpers/peer-bee.js'
+import { getStore } from '../../src/shared/core/store.js'
+import { getLocalPublicKeyHex, markOwnMembership, markApproval } from '../../src/shared/spaces/profile.js'
+import { createMemberView } from '../../src/shared/spaces/member-view.js'
+
+// The member fold's watch ranges ARE its convergence guarantee, and a wrong one is silent: the view
+// is correct at fold time and then simply never re-folds. So this file is written as a closed
+// world — every key family the fold reads must wake it, and every family it does not read must
+// not. Checking only the first half would pass a range set that still watches the whole bee, which
+// is the defect this exists to catch.
+
+// The fold reads each roster peer through withPeerBee, which opens a FRESH core session per read
+// (profile.js openProfileBee → store.get). Counting the sessions opened against one peer's key is
+// therefore a direct count of folds that read it — and unlike onMembers, it is not suppressed by
+// viewSignature, which drops the emit only after the fold has already run.
+function countReadsOf (t, keyHex) {
+  const store = getStore()
+  const original = store.get.bind(store)
+  const state = { reads: 0 }
+  store.get = (arg, ...rest) => {
+    const key = b4a.isBuffer(arg) ? arg : arg?.key
+    if (key && b4a.toString(key, 'hex') === keyHex) state.reads += 1
+    return original(arg, ...rest)
+  }
+  t.teardown(() => { store.get = original })
+  return state
+}
+
+// deriveDebounceMs is 150; this leaves room for the debounced fold's reads to land. No scaled():
+// test/helpers/timing.js reads process.env, which Bare does not provide.
+const SETTLE_MS = 600
+
+// Quiet for a full settle window is what "did not wake" means; there is no negative event to await.
+const settle = () => new Promise((r) => setTimeout(r, SETTLE_MS))
+
+async function foldedRoster (t, spaceId) {
+  await freshPeerWithIdentity(t)
+  const creator = getLocalPublicKeyHex()
+  await markOwnMembership(spaceId)
+
+  const B = await makePeer(t)
+  await B.bee.put('member/' + spaceId, { active: true, ts: 1 })
+  await markApproval(spaceId, B.key)
+  replicate(getStore(), B.store, t)
+
+  let members = null
+  let shareAppends = 0
+  const mv = createMemberView({
+    spaceId,
+    creatorKey: creator,
+    selfKey: creator,
+    onMembers: (result) => { members = new Set(result.members) },
+    onBeeAppend: () => { shareAppends += 1 },
+  })
+  t.teardown(() => mv.close())
+
+  t.ok(await waitFor(() => members?.has(B.key)), 'the roster folded B in before the range assertions')
+  await settle()
+  return { creator, B, mv, appends: () => shareAppends }
+}
+
+test('every key family the member fold reads wakes a re-fold', async (t) => {
+  const S = 'space-wake'
+  const { B } = await foldedRoster(t, S)
+
+  // The approval target is a real replicated peer: an approval of a key with no bee anywhere makes
+  // every later fold spend a full peerReadTimeoutMs on it, which would swamp the settle window.
+  const C = await makePeer(t)
+  await C.bee.put('member/' + S, { active: true, ts: 1 })
+  replicate(getStore(), C.store, t)
+
+  const wakes = [
+    ['caps/membership-manifest', 1, 'the cap gate all three peer loaders read first'],
+    ['member/' + S, { active: true, ts: 2 }, 'own membership, the record the OR-Set folds'],
+    ['approved/' + S + '/' + C.key, { ts: 2 }, 'an approval — the OR-Set edge that grows the roster'],
+    ['request/' + S + '/joiner-1', { displayName: 'Joiner', ts: 2 }, 'a join request receipt'],
+    ['denied/' + S + '/joiner-2', { ts: 2 }, 'a denial'],
+  ]
+
+  const counter = countReadsOf(t, B.key)
+  for (const [key, value, why] of wakes) {
+    const before = counter.reads
+    await B.bee.put(key, value)
+    t.ok(await waitFor(() => counter.reads > before, 5000), `${key} woke the fold — ${why}`)
+    await settle()
+  }
+})
+
+test('no key family the member fold ignores wakes a re-fold', async (t) => {
+  const S = 'space-quiet'
+  const { B, appends } = await foldedRoster(t, S)
+
+  const quiet = [
+    ['displayName', 'Renamed', 'read by no part of the fold'],
+    ['avatar', 'data:image/png;base64,AAAA', 'the motivating case — a profile picture re-folded the whole roster'],
+    ['publicKey', 'abcd', 'written on every profile save, alongside avatar'],
+    ['invite/' + S + '/inv1', { ts: 1 }, 'invites are read by the invite listing, not the fold'],
+    ['drive/' + S, { key: 'ff' }, 'the space drive key'],
+    ['loosecat/' + S, { key: 'ee' }, 'the loose-file catalog key'],
+    ['mirror/' + S + '/sh1', { ts: 1 }, 'a mirror participation record'],
+    ['member/' + S + '-other', { active: true, ts: 1 }, 'ANOTHER space — a prefix range here would wake this fold'],
+    ['member/other-' + S, { active: true, ts: 1 }, 'another space sorting before this one'],
+  ]
+
+  const counter = countReadsOf(t, B.key)
+  for (const [key, value, why] of quiet) {
+    const before = counter.reads
+    await B.bee.put(key, value)
+    await settle()
+    t.is(counter.reads, before, `${key} did not wake the fold — ${why}`)
+  }
+
+  t.is(appends(), 0, 'and none of them reached the share watcher either')
+})
+
+// The fix. Before it, createMemberView passed no range at all, so createDerivedView watched the
+// whole bee and any profile write — an avatar most of all, since it is rewritten on every profile
+// save — triggered a full serial roster re-fold at one network-bounded read per member.
+test('REGRESSION (ADOPT-D1: an avatar append triggered a full serial roster re-fold)', async (t) => {
+  const S = 'space-avatar'
+  const { B } = await foldedRoster(t, S)
+  const counter = countReadsOf(t, B.key)
+
+  await B.bee.put('avatar', 'data:image/png;base64,' + 'A'.repeat(64))
+  await B.bee.put('displayName', 'Renamed')
+  await B.bee.put('publicKey', 'deadbeef')
+  await settle()
+
+  t.is(counter.reads, 0, 'the three keys a profile save rewrites cost zero roster reads')
+})
+
+test('a share append still wakes the share watcher and not the fold', async (t) => {
+  const S = 'space-share'
+  const { B, appends } = await foldedRoster(t, S)
+  const counter = countReadsOf(t, B.key)
+
+  await B.bee.put('share/' + S + '/sh1', { id: 'sh1', name: 'Docs' })
+
+  t.ok(await waitFor(() => appends() > 0, 5000), 'the share watcher fired')
+  await settle()
+  t.is(counter.reads, 0, 'and the membership fold stayed asleep — the two watches are independent')
+})
+
+test('close() releases every watcher on every tracked bee', async (t) => {
+  const S = 'space-close'
+  const creator = await (async () => {
+    await freshPeerWithIdentity(t)
+    const me = getLocalPublicKeyHex()
+    await markOwnMembership(S)
+    return me
+  })()
+
+  const B = await makePeer(t)
+  await B.bee.put('member/' + S, { active: true, ts: 1 })
+  await markApproval(S, B.key)
+  replicate(getStore(), B.store, t)
+
+  let members = null
+  const mv = createMemberView({
+    spaceId: S,
+    creatorKey: creator,
+    selfKey: creator,
+    onMembers: (result) => { members = new Set(result.members) },
+  })
+  t.ok(await waitFor(() => members?.has(B.key)), 'two bees are tracked, five watchers each')
+
+  await mv.close()
+
+  // A watcher left open keeps diffing every append forever; five ranges per bee is five chances to
+  // leak one, so the proof is that a post-close append reaches nothing.
+  const counter = countReadsOf(t, B.key)
+  await B.bee.put('member/' + S, { active: true, ts: 3 })
+  await settle()
+  t.is(counter.reads, 0, 'no watcher survived close()')
+})

--- a/test/integration/network-watch.test.js
+++ b/test/integration/network-watch.test.js
@@ -8,6 +8,12 @@ import { initAuditLog, flushAudit, queryAudit, purgeAudit, setAuditConfig, getNe
 import {
   initNetworkWatch, resetNetworkWatch, observeReachability, peerLost, peerLostMeta, peerSeen, peerLeft,
 } from '../../src/shared/audit/network-watch.js'
+import { createTimers } from '../../src/shared/core/timers.js'
+
+// The watch arms its dwell timeouts through the owning subsystem's set (AuditLog hands it
+// this.timers), so a test driving the module directly has to supply one too — without it the
+// re-arming tails have nothing to arm through and every dwell assertion below would wait forever.
+let watchTimers = null
 
 const DWELL = 60
 const META = { memberName: 'Anna Keller', spaceName: 'Design Team' }
@@ -26,6 +32,8 @@ async function boot (t, { session = 'run-1' } = {}) {
   const storage = tmpDir('store')
   t.teardown(() => {
     resetNetworkWatch()
+    watchTimers?.close()
+    watchTimers = null
     try { fs.rmSync(storage, { recursive: true, force: true }) } catch {}
   })
   initStore(storage)
@@ -33,7 +41,8 @@ async function boot (t, { session = 'run-1' } = {}) {
   await initAuditLog({ installId: 'install-under-test' })
   await setAuditConfig({ enabled: true, retentionDays: 90, maxEntries: 200000 })
   await purgeAudit()
-  initNetworkWatch({ sessionId: session, dwellMs: DWELL, peerDwellMs: DWELL })
+  watchTimers = createTimers()
+  initNetworkWatch({ sessionId: session, dwellMs: DWELL, peerDwellMs: DWELL, timers: watchTimers })
 }
 
 function observe (verdict, cause = null, since = Date.now()) {
@@ -197,7 +206,8 @@ test('relaunching on the same bad network is silent', async (t) => {
   await settle()
   t.is((await kinds()).filter((k) => k === 'network.blocked').length, 1)
 
-  initNetworkWatch({ sessionId: 'run-2', dwellMs: DWELL, peerDwellMs: DWELL })
+  watchTimers = createTimers()
+  initNetworkWatch({ sessionId: 'run-2', dwellMs: DWELL, peerDwellMs: DWELL, timers: watchTimers })
   observe('blocked', 'no-public-address')
   await settle()
   t.is((await kinds()).filter((k) => k === 'network.blocked').length, 1, 'the first launch already said so')
@@ -208,7 +218,8 @@ test('an outage spanning a restart recovers without inventing a duration', async
   observe('blocked', 'os-offline')
   await settle()
 
-  initNetworkWatch({ sessionId: 'run-2', dwellMs: DWELL, peerDwellMs: DWELL })
+  watchTimers = createTimers()
+  initNetworkWatch({ sessionId: 'run-2', dwellMs: DWELL, peerDwellMs: DWELL, timers: watchTimers })
   observe('healthy')
   await settle()
 

--- a/test/integration/timer-ownership.test.js
+++ b/test/integration/timer-ownership.test.js
@@ -1,0 +1,80 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { trackTimers } from '../helpers/timers.js'
+
+// The shim must wrap the globals BEFORE the modules load, so everything under test comes in through
+// a dynamic import (static ones are hoisted above it). Installed once for the file and restored
+// from the LAST test only: a per-test restore puts the natives back before the next test runs, and
+// every assertion after that reads a map nothing writes to any more.
+const timers = trackTimers()
+const { freshPeer } = await import('../helpers/store.js')
+const { createSpace } = await import('../../src/shared/spaces/space.js')
+const { publishShare, generateShareId } = await import('../../src/shared/shares/shares.js')
+const { getLocalPublicKeyHex } = await import('../../src/shared/spaces/profile.js')
+const { createOwnedMount } = await import('../../src/shared/folders/mount-store.js')
+const { onFsEvent } = await import('../../src/shared/folders/owned-folders.js')
+
+async function ownedShare (ctx) {
+  const space = await createSpace('Aurora')
+  const share = {
+    id: generateShareId(), type: 'owned-folder', name: 'Vault', contentMode: 'overlay',
+    owner: getLocalPublicKeyHex(), createdAt: Date.now(),
+  }
+  await publishShare(space.spaceId, share)
+  const mountPath = ctx.tmpDir('mount')
+  await createOwnedMount({ spaceId: space.spaceId, shareId: share.id, mountPath, ignore: [], createdAt: Date.now() })
+  return { space, share, mountPath }
+}
+
+// REGRESSION (ADOPT-B1: the owner's announce interval and its catch-up timeouts were held in
+// module-scope bindings and armed from the global. _close cleared them by hand, which covers the
+// ordinary ending and neither of the other two: ReadyResource finishes a FAILED _open by running
+// close() WITHOUT ever calling _close, and a _close that rejects short-circuits the same way. Both
+// left a periodic tick firing against a subsystem whose state had already been torn down. They now
+// arm through the subsystem's own timer set, which the base clears on all three.)
+//
+// Counted as timeouts AND intervals: the catch-up reconcile is a timeout, so an intervals-only
+// count — which is what the existing lifecycle guard takes — would report this file clean.
+//
+// One timeout is excluded, deliberately: the shutdown budget's own race in core/subsystem.js arms
+// one per subsystem and does not clear it on the winning branch, so a fast close leaves the loser
+// pending for the rest of the budget. It is unref'd and resolves a promise nobody is waiting on any
+// more, and it CANNOT be owned — a shutdown deadline that shutdown itself cancels is not a
+// deadline. Excluded by its arming site rather than by count, so a second un-owned timeout there
+// would still be seen.
+
+// The nearest frame below the shim, exactly as the tracker itself picks it — [1] is the shim's own
+// wrapper, not the caller.
+const armedBy = (e) => ((e.stack || '').split('\n').slice(1).find((l) => !l.includes('test/helpers/timers.js')) || '')
+const notTheShutdownBudget = (list) => list.filter((e) => !/core[/\\]subsystem\.js/.test(armedBy(e)))
+
+test('REGRESSION (ADOPT-B1): the owner side arms nothing a FAILING close can leave behind', async (t) => {
+  t.teardown(() => timers.restore())
+  const ctx = await freshPeer(t)
+  const { space, share, mountPath } = await ownedShare(ctx)
+
+  const abs = path.join(mountPath, 'a.txt')
+  fs.writeFileSync(abs, 'x')
+  await onFsEvent(space.spaceId, share.id, 'add', 'a.txt', abs)
+
+  // Non-vacuous by construction: if nothing was armed, the assertion after close would pass no
+  // matter what the subsystem did with its timers.
+  const before = timers.intervals().length + notTheShutdownBudget(timers.timeouts()).length
+  t.ok(before > 0, `the work under test armed something to begin with (${before})`)
+
+  // The ordinary path already cleared these by hand and is not what this proves. A _close that
+  // REJECTS short-circuits both `closed = true` and the 'close' emit, so every hand-written clear
+  // after the throw is unreachable — the same reachability a failed _open has, and the only
+  // difference between a timer the subsystem owns and one it merely remembers to stop. Rejecting
+  // BEFORE the body rather than after is what makes the two designs distinguishable at all.
+  const owned = ctx.root.ownedFolders
+  owned._close = async () => { throw new Error('close failed before teardown ran') }
+  // The composition root logs a failing close and carries on, so this does not reject.
+  await ctx.root.close()
+
+  const intervals = timers.intervals()
+  const timeouts = notTheShutdownBudget(timers.timeouts())
+  t.is(intervals.length, 0, 'no interval survived the failed close\n' + timers.describe(intervals))
+  t.is(timeouts.length, 0, 'and no timeout either\n' + timers.describe(timeouts))
+})

--- a/test/unit/derived-view.test.js
+++ b/test/unit/derived-view.test.js
@@ -316,3 +316,127 @@ test('noteProgress does nothing while no fold is in flight', async (t) => {
   t.is(view.health({ now: Date.now(), windowMs: 1000 }).ok, true)
   await view.close()
 })
+
+// A fake bee that records the range each watch() was opened with and how many were closed, so a
+// multi-range view can be asserted on watcher count rather than on behaviour it cannot fake.
+function recordingBee (log) {
+  return {
+    watch (range) {
+      log.opened.push(range)
+      let release
+      const until = new Promise((r) => { release = r })
+      return {
+        async * [Symbol.asyncIterator] () { await until },
+        async close () { log.closed += 1; release() },
+      }
+    },
+  }
+}
+
+test('ranges opens one watcher per range per tracked bee and close() releases all of them', async (t) => {
+  const log = { opened: [], closed: 0 }
+  const ranges = [
+    { gte: 'a/', lt: 'a0' },
+    { gte: 'b', lte: 'b' },
+    { gte: 'c/', lt: 'c0' },
+  ]
+  const view = createDerivedView({ fold: async () => null, onChange: () => {}, ranges })
+
+  view.track('peer', recordingBee(log))
+  t.is(log.opened.length, 3, 'one watcher per range')
+  t.alike(log.opened, ranges, 'each watcher got its own range, in order')
+  t.is(view.size(), 1, 'the source key counts once, not once per watcher')
+  t.ok(view.tracking('peer'))
+
+  view.track('peer', recordingBee(log))
+  t.is(log.opened.length, 3, 'track is still idempotent per source key')
+
+  await view.close()
+  t.is(log.closed, 3, 'close() released every watcher, not just the first')
+})
+
+test('range and no-range both still open exactly one watcher', async (t) => {
+  const single = { opened: [], closed: 0 }
+  const scoped = createDerivedView({ fold: async () => null, onChange: () => {}, range: { gte: 'a/', lt: 'a0' } })
+  scoped.track('peer', recordingBee(single))
+  t.is(single.opened.length, 1, 'the single-range form is unchanged')
+  t.alike(single.opened[0], { gte: 'a/', lt: 'a0' })
+  await scoped.close()
+  t.is(single.closed, 1)
+
+  const whole = { opened: [], closed: 0 }
+  const unscoped = createDerivedView({ fold: async () => null, onChange: () => {} })
+  unscoped.track('peer', recordingBee(whole))
+  t.is(whole.opened.length, 1, 'omitting both still watches the whole bee')
+  t.is(whole.opened[0], undefined, 'with an undefined range, as before')
+  await unscoped.close()
+  t.is(whole.closed, 1)
+})
+
+test('passing both range and ranges throws rather than silently preferring one', (t) => {
+  t.exception(
+    () => createDerivedView({ fold: async () => null, onChange: () => {}, range: { gte: 'a' }, ranges: [{ gte: 'b' }] }),
+    /pass range or ranges, not both/
+  )
+})
+
+// REGRESSION (REVIEW-8: `ranges ?? [range]` accepted an empty array, which opened NO watcher on any
+// source — the view folded once at boot and never re-derived, with no error and no log. A caller
+// deriving its key families and coming up empty gets a membership set frozen at whatever it was.
+// `null` is the same mistake in the other direction: it takes the ?? fallback and silently reverts
+// to the whole-bee watch the option exists to avoid.)
+test('REGRESSION (REVIEW-8): an empty or null range set is refused, not silently watched', async (t) => {
+  t.exception(
+    () => createDerivedView({ fold: async () => null, onChange: () => {}, ranges: [] }),
+    /ranges must be a non-empty array/,
+  )
+  t.exception(
+    () => createDerivedView({ fold: async () => null, onChange: () => {}, ranges: null }),
+    /ranges must be a non-empty array/,
+  )
+  // Omitting it entirely is still the whole-bee watch, which is what a caller passing neither means.
+  const whole = createDerivedView({ fold: async () => null, onChange: () => {} })
+  t.ok(whole, 'passing neither stays legal')
+  await whole.close()
+})
+
+test('a change inside any of several ranges schedules a fold', async (t) => {
+  let folds = 0
+  const emitters = []
+  const bee = {
+    watch () {
+      let push = null
+      const queue = []
+      emitters.push((v) => { if (push) { push(v); push = null } else queue.push(v) })
+      return {
+        async * [Symbol.asyncIterator] () {
+          for (;;) {
+            if (queue.length) { yield queue.shift(); continue }
+            const v = await new Promise((r) => { push = r })
+            if (v === null) return
+            yield v
+          }
+        },
+        async close () { if (push) { push(null); push = null } },
+      }
+    },
+  }
+  const view = createDerivedView({
+    fold: async () => { folds += 1 },
+    onChange: () => {},
+    ranges: [{ gte: 'a' }, { gte: 'b' }],
+  })
+  view.track('peer', bee)
+  await tick()
+  t.is(folds, 0, 'tracking alone does not fold')
+
+  emitters[1]([{}, {}])
+  await tick()
+  t.is(folds, 1, 'the second range woke the fold')
+
+  emitters[0]([{}, {}])
+  await tick()
+  t.is(folds, 2, 'the first range woke it independently')
+
+  await view.close()
+})

--- a/test/unit/keyed-coalescer.test.js
+++ b/test/unit/keyed-coalescer.test.js
@@ -86,3 +86,41 @@ test('keyed coalescer: reset clears every open window without firing', (t) => {
   c.poke('S1')
   t.alike(fired, ['S1', 'S2', 'S1'], 'a poke after reset opens a fresh leading edge')
 })
+
+// The injected schedule is how a caller hands the trailing timer to an owner that can stop it, and
+// an owner that has gone declines rather than arming something nothing will clear. The window must
+// then not open at all: a key left open with no timer swallows every later poke for it, which is a
+// far worse failure than the timer it was avoiding.
+test('a declined schedule fires every poke instead of opening a window nothing can close', (t) => {
+  const fired = []
+  const engine = makeKeyedCoalescer((x) => fired.push(x), {
+    intervalMs: 500,
+    schedule: () => null,
+    clear: () => {},
+  })
+
+  engine.poke('a')
+  engine.poke('a')
+  engine.poke('a')
+  t.alike(fired, ['a', 'a', 'a'], 'no window opened, so nothing was collapsed into a fire that never comes')
+})
+
+test('a granted schedule still coalesces, and the handle is the one the owner returned', (t) => {
+  const fired = []
+  const armed = []
+  const cleared = []
+  const handle = { owned: true }
+  const engine = makeKeyedCoalescer((x) => fired.push(x), {
+    intervalMs: 500,
+    schedule: (fn, ms) => { armed.push({ fn, ms }); return handle },
+    clear: (h) => cleared.push(h),
+  })
+
+  engine.poke('a')
+  engine.poke('a')
+  t.alike(fired, ['a'], 'the second poke collapsed into the open window')
+  t.is(armed.length, 1, 'one trailing timer, armed through the injected schedule')
+
+  engine.reset()
+  t.alike(cleared, [handle], 'and reset returned that same handle to the owner')
+})

--- a/test/unit/module-level-timers.test.js
+++ b/test/unit/module-level-timers.test.js
@@ -3,7 +3,7 @@ import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import { Linter } from 'eslint'
-import { moduleLevelTimerRestrictions } from '../../eslint.config.mjs'
+import { moduleLevelTimerRestrictions, moduleScopeTimerHandleRestrictions } from '../../eslint.config.mjs'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const roots = ['shared', 'worker'].map((d) => path.join(here, '..', '..', 'src', d))
@@ -21,6 +21,14 @@ function verify (linter, source, filename) {
     files: ['**/*.js'],
     languageOptions: { ecmaVersion: 2023, sourceType: 'module' },
     rules: { 'no-restricted-syntax': ['error', ...moduleLevelTimerRestrictions] },
+  }, filename)
+}
+
+function verifyHandles (linter, source, filename) {
+  return linter.verify(source, {
+    files: ['**/*.js'],
+    languageOptions: { ecmaVersion: 2023, sourceType: 'module' },
+    rules: { 'no-restricted-syntax': ['error', ...moduleScopeTimerHandleRestrictions] },
   }, filename)
 }
 
@@ -58,6 +66,49 @@ test('REGRESSION (LIFECYCLE-1c): no data-layer module arms a timer at module lev
 
   for (const file of roots.flatMap((r) => walk(r))) {
     const messages = verify(linter, readFileSync(file, 'utf8'), file)
+    t.alike(messages.map((m) => `${m.line}: ${m.message}`), [], path.relative(process.cwd(), file))
+  }
+})
+
+// The twelve sites the rule above could not see: a timer armed inside a function but held in a
+// binding that outlives the call, so nothing scoped to the call clears it. The worst of them sat
+// in a file whose own Subsystem was 368 lines below, with an unused `this.timers` on it.
+test('REGRESSION (ADOPT-B1): a long-lived timer handle is not armed from the global', (t) => {
+  const linter = new Linter()
+
+  for (const [label, src] of [
+    ['an interval assigned to a compound handle', 'let announceTimer = null\nfunction arm () { announceTimer = setInterval(() => {}, 1) }\n'],
+    ['a timeout assigned to a compound handle', 'let dwellTimer = null\nfunction arm () { dwellTimer = setTimeout(() => {}, 1) }\n'],
+    ['a re-arming tail', 'let peerTimer = null\nfunction arm () { peerTimer = setTimeout(() => { peerTimer = null; arm() }, 1) }\n'],
+    ['a heartbeat by that name', 'let presenceBeat = null\nfunction arm () { presenceBeat = setInterval(() => {}, 1) }\n'],
+    ['a module-scope declarator with an init', 'const idleTimer = setTimeout(() => {}, 1)\n'],
+    // REGRESSION (REVIEW-6: the selector matched an Identifier target only, so the most natural
+    // shape in a Subsystem-based codebase — a handle kept on `this` — slipped straight through the
+    // rule whose stated job is to stop the thirteenth.)
+    ['a handle kept on this', 'class C { arm () { this.sweepTimer = setInterval(() => {}, 1) } }\n'],
+    ['a handle kept on a module singleton', 'const state = {}\nfunction arm () { state.dwellTimer = setTimeout(() => {}, 1) }\n'],
+  ]) {
+    t.ok(verifyHandles(linter, src, 'bad.js').length > 0, label + ' is caught')
+  }
+
+  // The fix, and the shapes that must stay legal — otherwise the rule forces twelve inline
+  // disables and stops being a guard.
+  for (const [label, src] of [
+    ['arming through a module-owned set', 'let announceTimer = null\nfunction arm () { announceTimer = timers.setInterval(() => {}, 1) }\n'],
+    ['arming through a subsystem set', "class S { arm () { this.dwellTimer = this.timers.setTimeout(() => {}, 1) } }\n"],
+    ['arming through a current pointer', 'let idleTimer = null\nfunction arm () { idleTimer = current.timers.setTimeout(() => {}, 1) }\n'],
+    // A bare local handle is owned by its function, which clears it on both exits. Three of these
+    // exist in the data layer; flagging them would be a false positive on correct code.
+    ['a function-local bare handle', 'function race () { let timer = setTimeout(() => {}, 1); clearTimeout(timer) }\n'],
+    ['a promise delay', 'async function wait () { await new Promise((r) => { const t = setTimeout(r, 1); t.unref?.() }) }\n'],
+  ]) {
+    t.alike(verifyHandles(linter, src, 'ok.js'), [], label + ' stays legal')
+  }
+
+  // The ratchet: zero across the real tree, which is what makes the rule a floor rather than a
+  // wish. Both rules are run, so removing either is visible here.
+  for (const file of roots.flatMap((r) => walk(r))) {
+    const messages = verifyHandles(linter, readFileSync(file, 'utf8'), file)
     t.alike(messages.map((m) => `${m.line}: ${m.message}`), [], path.relative(process.cwd(), file))
   }
 })

--- a/test/unit/owned-mount-projection.test.js
+++ b/test/unit/owned-mount-projection.test.js
@@ -1,0 +1,88 @@
+import test from 'brittle'
+import { projectOwnedMount, ownedMountSettled, unhealthyOwnedStatus, NO_OWNED_MOUNT } from '../../src/renderer/ownedMount.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(here, '..', '..')
+
+const row = (over = {}) => ({ spaceId: 'sp1', shareId: 'sh1', status: 'active', mountPath: '/a', ...over })
+
+test('unhealthyOwnedStatus reports only the states that deserve a badge', (t) => {
+  t.is(unhealthyOwnedStatus(null), null, 'no row is not a fault')
+  t.is(unhealthyOwnedStatus(row()), null, 'active is healthy')
+  t.is(unhealthyOwnedStatus(row({ status: 'scanning' })), null, 'so is scanning')
+  t.is(unhealthyOwnedStatus(row({ status: 'paused-error' })), 'paused-error', 'a persisted fault shows')
+  t.is(
+    unhealthyOwnedStatus(row({ status: 'scanning', mountPointMissing: true })),
+    'mount-point-gone',
+    'a live missing path outranks the durable status',
+  )
+})
+
+test('an unsettled read is distinguishable from a share with no row', (t) => {
+  t.alike(projectOwnedMount(undefined, 'sp1', 'sh1', false), NO_OWNED_MOUNT, 'nothing read yet → loaded:false')
+  // The distinction FolderView depends on: loaded:false pins it to the frozen navigation snapshot,
+  // so reporting it for a folder that simply was never mounted would freeze that folder forever.
+  t.alike(
+    projectOwnedMount([], 'sp1', 'sh1', true),
+    { status: null, lastError: null, loaded: true, indexPaused: false, scanning: false, mountPath: null },
+    'settled with no row → loaded:true, healthy',
+  )
+})
+
+// REGRESSION (REVIEW-1: the hook derived `settled` from the store's `loading` —
+// `!(loading && data === undefined)`. The store settles an entry on an ERROR as well as on data, so
+// a FAILED owned-folder:list-all read reports loading:false with data undefined, and that
+// expression called it settled. projectOwnedMount then found no row for the share and returned the
+// healthy answer with loaded:true, which FolderView takes outright — so a folder durably
+// paused-error or mount-point-gone painted with no fault strip, no Try again and a null mountPath,
+// exactly when the worker was least able to correct it. The hand-rolled version this replaced left
+// loaded:false on a rejection and fell back to share.mountStatus.)
+test('REGRESSION (REVIEW-1): a failed read is not settled, so the fault strip survives it', (t) => {
+  t.absent(ownedMountSettled(true, undefined), 'no rows means no answer, whatever the reason')
+  t.ok(ownedMountSettled(true, []), 'an empty listing IS an answer — this share was never mounted')
+  t.ok(ownedMountSettled(true, [row()]), 'and so is a listing with rows')
+  t.absent(ownedMountSettled(false, [row()]), 'a disabled hook has no answer to give')
+
+  // The consequence, end to end: what FolderView receives when the read rejected.
+  t.alike(projectOwnedMount(undefined, 'sp1', 'sh1', ownedMountSettled(true, undefined)), NO_OWNED_MOUNT,
+    'loaded:false, so FolderView falls back to the share mount status it already had')
+})
+
+// The trap is a parameter the function does not have, as with profileGate. This pins that shape,
+// because the bug was one word in the caller.
+test('REGRESSION (REVIEW-1): the hook does not take the store loading flag', (t) => {
+  const src = readFileSync(path.join(root, 'src', 'renderer', 'hooks', 'useFolderMount.ts'), 'utf8')
+  const destructure = /const\s*\{([^}]*)\}\s*=\s*useQuery</.exec(src)
+  t.ok(destructure, 'useOwnedMount still reads the listing through the query store')
+  t.absent(/\bloading\b/.test(destructure[1]),
+    'and does not take `loading` off it — an error settles the entry with no data')
+})
+
+test('missing ids read as no mount, whatever the listing holds', (t) => {
+  t.alike(projectOwnedMount([row()], '', 'sh1', true), NO_OWNED_MOUNT, 'no spaceId')
+  t.alike(projectOwnedMount([row()], 'sp1', '', true), NO_OWNED_MOUNT, 'no shareId')
+})
+
+test('every field is read from the row, so nothing latches across a share change', (t) => {
+  const rows = [
+    row({ shareId: 'sh1', status: 'paused-error', lastError: 'ENOSPC', indexPaused: true }),
+    row({ shareId: 'sh2', status: 'scanning', mountPath: '/b' }),
+  ]
+
+  t.alike(projectOwnedMount(rows, 'sp1', 'sh1', true), {
+    status: 'paused-error', lastError: 'ENOSPC', loaded: true, indexPaused: true, scanning: false, mountPath: '/a',
+  })
+  // The same call for the sibling share carries none of sh1's state — the leak the hand-rolled
+  // hook had, where `loaded` and `status` survived a navigation because only the effect reset them.
+  t.alike(projectOwnedMount(rows, 'sp1', 'sh2', true), {
+    status: null, lastError: null, loaded: true, indexPaused: false, scanning: true, mountPath: '/b',
+  })
+})
+
+test('rows from another space are never matched', (t) => {
+  const rows = [row({ spaceId: 'sp2', status: 'paused-error' })]
+  t.is(projectOwnedMount(rows, 'sp1', 'sh1', true).status, null, 'same shareId, different space')
+})

--- a/test/unit/preload-parity.test.js
+++ b/test/unit/preload-parity.test.js
@@ -1,0 +1,103 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(here, '..', '..')
+const preloadPath = path.join(root, 'src', 'preload', 'preload.js')
+const dtsPath = path.join(root, 'src', 'renderer', 'global.d.ts')
+
+// The renderer's ONLY view of the preload bridge is global.d.ts, and nothing compares the two.
+// preload.js is plain JS outside tsconfig's include, so TypeScript checks every call site against a
+// declaration that could be describing a method the bridge does not have. The failure mode is not a
+// type error — it is `window.bridge.foo is not a function` at runtime, in a sandboxed renderer, on
+// whichever platform happens to reach that branch. That is the same hole
+// contract-declarations.test.js measured for the contract package, on a much bigger surface.
+//
+// The preload cannot import the contract package to close this structurally: it runs with
+// sandbox: true, which gives it a restricted require, and it ships unbundled. Bundling it is the
+// option that would; until someone takes it, this test is the substitute.
+//
+// Parsed, not imported: preload.js calls contextBridge.exposeInMainWorld at module scope and
+// requires('electron'), so it cannot be loaded under brittle-node. The key set is what matters and
+// it is unambiguous in the source.
+
+// Both extractors key on INDENTATION rather than on brace/paren depth: the values here are arrow
+// functions full of parens and strings that themselves contain braces, and a depth counter walks
+// straight into them. A top-level member of either surface sits at exactly two spaces; anything
+// nested sits deeper and is that member's own business.
+const atTopIndent = (body) => [...new Set(
+  [...body.matchAll(/^ {2}([A-Za-z_$][\w$]*)\s*[:(]/gm)].map((m) => m[1]),
+)].sort()
+
+// The object literal passed to exposeInMainWorld, bounded the same way as the interface below.
+// Slicing to end-of-file worked only because the call happens to be the last statement in the
+// file: anything appended after it — a second exposeInMainWorld, a helper object literal — would
+// have folded its keys into this surface. `\n})` closes the CALL and nothing inside it: a nested
+// object closes at `  },` and a multi-line arrow at `  }),`, both indented.
+function topLevelKeysOfExposedBridge (src) {
+  const open = src.indexOf("exposeInMainWorld('bridge', {")
+  if (open < 0) return []
+  const close = src.indexOf('\n})', open)
+  return atTopIndent(src.slice(open, close < 0 ? src.length : close))
+}
+
+// The body of `interface MirallBridge` — a call signature `name(...)` or a property `name:`.
+function membersOfMirallBridge (src) {
+  const open = src.indexOf('interface MirallBridge')
+  if (open < 0) return []
+  const close = src.indexOf('\n}', open)
+  return atTopIndent(src.slice(open, close < 0 ? src.length : close))
+}
+
+test('the preload bridge and global.d.ts declare the same members', (t) => {
+  const exposed = topLevelKeysOfExposedBridge(readFileSync(preloadPath, 'utf8'))
+  const declared = membersOfMirallBridge(readFileSync(dtsPath, 'utf8'))
+
+  t.ok(exposed.length > 40, `the extractor found a real surface (${exposed.length} keys)`)
+  t.is(exposed.length, declared.length, 'the surface has not silently grown or shrunk on one side')
+  t.alike(exposed, declared, 'every exposed key is declared, and every declared member is exposed')
+})
+
+// A regex that stops matching would make the test above vacuously green — two empty lists are
+// alike. These feed each extractor a fixture with a known shape and assert it reads it, and a
+// fixture with a member removed and assert the comparison notices.
+test('the extractors would actually catch a divergence', (t) => {
+  const preloadFixture = [
+    "const { contextBridge } = require('electron')",
+    "contextBridge.exposeInMainWorld('bridge', {",
+    '  alpha: () => 1,',
+    '  beta: (x) => ({ nested: x }),',
+    '  gamma: {',
+    '    subscribe: (fn) => fn,',
+    '  },',
+    '})',
+  ].join('\n')
+  t.alike(topLevelKeysOfExposedBridge(preloadFixture), ['alpha', 'beta', 'gamma'],
+    'top-indent keys only — the nested subscribe is gamma\'s business, not the bridge\'s')
+
+  // The bound, asserted: whatever follows the call is not part of the bridge. Without it the
+  // extractor reported `delta` and the parity comparison failed on a member nobody exposed.
+  const withTrailer = preloadFixture + '\n\nconst helpers = {\n  delta: () => 2,\n}\n'
+  t.alike(topLevelKeysOfExposedBridge(withTrailer), ['alpha', 'beta', 'gamma'],
+    'a statement appended after the call is not folded into the bridge surface')
+
+  const dtsFixture = [
+    'export interface MirallBridge {',
+    '  alpha(): number',
+    '  beta(x: string): { nested: string }',
+    '  gamma: {',
+    '    subscribe(fn: () => void): () => void',
+    '  }',
+    '}',
+  ].join('\n')
+  t.alike(membersOfMirallBridge(dtsFixture), ['alpha', 'beta', 'gamma'], 'and the same three on the declared side')
+
+  const dropped = dtsFixture.replace('  beta(x: string): { nested: string }\n', '')
+  t.alike(membersOfMirallBridge(dropped), ['alpha', 'gamma'], 'a removed declaration is seen as removed')
+  t.absent(
+    JSON.stringify(topLevelKeysOfExposedBridge(preloadFixture)) === JSON.stringify(membersOfMirallBridge(dropped)),
+    'so a one-sided change fails the comparison rather than passing on two empty lists',
+  )
+})

--- a/test/unit/presence-heartbeat-ownership.test.js
+++ b/test/unit/presence-heartbeat-ownership.test.js
@@ -2,6 +2,13 @@ import test from 'brittle'
 import {
   initPresenceBroadcast, startPresenceHeartbeat, stopPresenceHeartbeat, broadcastDeparture,
 } from '../../src/shared/transfer/presence-broadcast.js'
+import { createTimers } from '../../src/shared/core/timers.js'
+
+// The heartbeat arms through the owning subsystem's timer set (Swarm hands it this.timers), so a
+// test driving the module directly supplies one too — without an owner it declines to arm, which is
+// the point: an interval nobody can stop is one nobody should start. The set still reaches the
+// global setInterval underneath, so the shims below observe it exactly as before.
+const ownedTimers = (t) => { const set = createTimers(); t.teardown(() => set.close()); return set }
 
 // REGRESSION (SWARM-DECOMP-1: moving broadcastDeparture out of swarm.js left the heartbeat
 // interval behind. presence-broadcast declared its own presenceTimer, which nothing ever assigned,
@@ -30,7 +37,7 @@ test('REGRESSION (SWARM-DECOMP-1): the departure stops the heartbeat it races', 
     getIpc: () => null,
   })
 
-  startPresenceHeartbeat()
+  startPresenceHeartbeat(ownedTimers(t))
   t.is(started.length, 1, 'the heartbeat is armed by the module that holds the timer')
 
   broadcastDeparture()
@@ -42,6 +49,32 @@ test('REGRESSION (SWARM-DECOMP-1): the departure stops the heartbeat it races', 
   t.is(started.length, 2, 'and a later start arms a fresh one')
 })
 
+// REGRESSION (REVIEW-5: the already-armed guard ran BEFORE the owner was adopted, so a handle left
+// behind by a closed set could never be dropped. Subsystem.close() clears the set on every ending —
+// including a failed _open and a _close that rejects, neither of which reaches destroySwarm's
+// stopPresenceHeartbeat() — and the stale handle then latched the heartbeat off for good. A peer
+// that never hears another beat reads us as offline for the rest of the session.)
+test('REGRESSION (REVIEW-5): a heartbeat whose owner closed can be armed again', (t) => {
+  const realSet = globalThis.setInterval
+  const started = []
+  globalThis.setInterval = (fn, ms) => { const h = realSet(fn, ms); started.push(h); return h }
+  t.teardown(() => { globalThis.setInterval = realSet; stopPresenceHeartbeat() })
+
+  initPresenceBroadcast({ presence: { prune () {} }, membersPoke: null, log: { debug () {} }, getSwarm: () => null, getIpc: () => null })
+
+  const first = createTimers()
+  startPresenceHeartbeat(first)
+  t.is(started.length, 1, 'armed through the first owner')
+
+  // What Subsystem.close()'s finally does on EVERY ending, without any of the module's own stops
+  // having run — the one path a hand-written clear cannot reach.
+  first.close()
+
+  const second = ownedTimers(t)
+  startPresenceHeartbeat(second)
+  t.is(started.length, 2, 'the dead handle did not latch the heartbeat off')
+})
+
 test('starting the heartbeat twice arms one timer', (t) => {
   const realSet = globalThis.setInterval
   const started = []
@@ -49,7 +82,8 @@ test('starting the heartbeat twice arms one timer', (t) => {
   t.teardown(() => { globalThis.setInterval = realSet; stopPresenceHeartbeat() })
 
   initPresenceBroadcast({ presence: { prune () {} }, membersPoke: null, log: { debug () {} }, getSwarm: () => null, getIpc: () => null })
-  startPresenceHeartbeat()
-  startPresenceHeartbeat()
+  const set = ownedTimers(t)
+  startPresenceHeartbeat(set)
+  startPresenceHeartbeat(set)
   t.is(started.length, 1, 'a second start is a no-op, so a reconnect cannot double the beat rate')
 })

--- a/test/unit/profile-gate.test.js
+++ b/test/unit/profile-gate.test.js
@@ -1,0 +1,80 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { projectProfile, profileSettled } from '../../src/renderer/profileGate.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(here, '..', '..')
+
+const PROFILE = { displayName: 'Alice', avatar: null }
+const UNREAD = { data: undefined, error: null }
+
+test('boot ends on the first answer, of either kind', (t) => {
+  t.absent(profileSettled(UNREAD), 'nothing has landed yet')
+  t.ok(profileSettled({ data: null, error: null }), 'null IS an answer — there is no profile')
+  t.ok(profileSettled({ data: PROFILE, error: null }), 'so is a profile')
+  t.ok(profileSettled({ data: undefined, error: new Error('worker down') }), 'and so is a failure')
+})
+
+test('the three shell states', (t) => {
+  t.alike(projectProfile(UNREAD), { profile: null, needsSetup: false, loading: true },
+    'before any answer: the boot screen, and NOT onboarding')
+  t.alike(projectProfile({ data: null, error: null }), { profile: null, needsSetup: true, loading: false },
+    'no profile: onboarding')
+  t.alike(projectProfile({ data: PROFILE, error: null }), { profile: PROFILE, needsSetup: false, loading: false },
+    'a profile: the app')
+})
+
+test('an unreadable profile opens onboarding rather than stranding the app on boot', (t) => {
+  const gate = projectProfile({ data: undefined, error: new Error('worker unavailable') })
+  t.absent(gate.loading, 'boot is over — a failure is an answer')
+  t.ok(gate.needsSetup, 'and the safe answer is onboarding, not a blank app')
+})
+
+// REGRESSION (REVIEW-7: `error !== null` settles on an error of `undefined` — which is not an
+// error at all. The store's own snapshot uses null, so nothing hit it today, but the function is
+// pure, exported and typed `Error | null`: any caller handing it a partial snapshot settled boot
+// instantly with no data, and "settled and no data" is how the gate spells "no profile". The user
+// would meet onboarding over an identity that already exists.)
+test('REGRESSION (REVIEW-7): an absent error is not an answer', (t) => {
+  t.absent(profileSettled({ data: undefined, error: undefined }), 'nothing has landed')
+  const gate = projectProfile({ data: undefined, error: undefined })
+  t.ok(gate.loading, 'still booting')
+  t.absent(gate.needsSetup, 'and NOT offering to set up a profile that may well exist')
+})
+
+test('the worker profile-needed signal ends boot on its own', (t) => {
+  // It arrives before a read would, so waiting for one would hold the boot screen over a decision
+  // the worker has already made.
+  const gate = projectProfile({ ...UNREAD, profileNeeded: true })
+  t.absent(gate.loading, 'no longer booting')
+  t.ok(gate.needsSetup, 'onboarding')
+})
+
+// REGRESSION (ADOPT-A5: useProfile returned the query store's `loading`, which means "a read is in
+// flight" and is raised again by EVERY refetch of an already-settled entry. app.tsx gates its whole
+// tree on it, so each re-read unmounted the tree; that remounted all three useProfile call sites,
+// each of which re-read profile:get, which raised the flag again. Self-sustaining: a real run
+// issued ~13,900 rounds of every request in the app and never finished booting.)
+//
+// The projection is not given `loading` at all, so the trap is unrepresentable rather than merely
+// avoided. This asserts that shape directly, because a future edit could re-add the parameter.
+test('REGRESSION (ADOPT-A5): a read in flight over a settled profile does not re-enter boot', (t) => {
+  const settledGate = projectProfile({ data: PROFILE, error: null })
+  t.absent(settledGate.loading, 'settled')
+
+  // Whatever else the store reports mid-refetch, the entry still holds its value — and that is the
+  // only input the gate has.
+  const refetching = projectProfile({ data: PROFILE, error: null, loading: true, profileNeeded: false })
+  t.absent(refetching.loading, 'a refetch cannot put the shell back on the boot screen')
+  t.alike(refetching, settledGate, 'the projection ignores anything but the answer itself')
+})
+
+test('REGRESSION (ADOPT-A5): the hook does not read the store loading flag', (t) => {
+  const src = readFileSync(path.join(root, 'src', 'renderer', 'hooks', 'useProfile.ts'), 'utf8')
+  const destructure = /const\s*\{([^}]*)\}\s*=\s*useQuery</.exec(src)
+  t.ok(destructure, 'useProfile still reads the profile through the query store')
+  t.absent(/\bloading\b/.test(destructure[1]),
+    'and does not take `loading` off it — the shell gates its whole tree on that value')
+})

--- a/test/unit/query-store.test.js
+++ b/test/unit/query-store.test.js
@@ -449,3 +449,76 @@ test('a genuine failure on an abandoned read is still rethrown', async (t) => {
   pending[0].reject(new Error('worker exploded'))
   await t.exception(failing, /worker exploded/, 'not every error on a stale read is ours to swallow')
 })
+
+// The mechanism the two folder-status hooks were migrated onto. Both bugs were shapes the store
+// already forbids; what they lacked was a store. Asserted here on the store rather than on the
+// hooks, because the fence is what closes the whole class — not the two call sites that had it.
+test('ADOPT-A1: a read for one share cannot land in another share entry', async (t) => {
+  const tp = setup(t)
+  const params = (shareId) => ({ spaceId: 'sp1', shareId })
+
+  // The navigation: FolderView opens share A, then the user picks share B while A's read is in
+  // flight. Two different entries, because params are part of the key.
+  void fetchQuery('foreign-folder:get', params('A'), null)
+  void fetchQuery('foreign-folder:get', params('B'), null)
+  t.is(tp.count(), 2, 'two entries, two reads — not one entry racing itself')
+
+  tp.settle(1, { shareId: 'B', status: 'active' })
+  tp.settle(0, { shareId: 'A', status: 'paused-enospc' })   // A resolves LAST
+  await tick()
+
+  t.is(peek(keyOf('foreign-folder:get', params('B'))).data.status, 'active', "B keeps B's answer")
+  t.is(peek(keyOf('foreign-folder:get', params('A'))).data.status, 'paused-enospc', "and A keeps A's")
+})
+
+test('ADOPT-A1: an unmounted mirror reads as no mount, not as the last mount', async (t) => {
+  const tp = setup(t)
+  void fetchQuery('foreign-folder:get', { spaceId: 'sp1', shareId: 'sh1' }, null)
+  tp.settle(0, { shareId: 'sh1', status: 'paused-enospc' })
+  await tick()
+
+  // What the hook does once share.role leaves 'mirrored': the id is empty, so useQuery is disabled
+  // and reads a DIFFERENT (never-fetched) entry. The hand-rolled version returned early and left
+  // its state untouched, so the fault strip and its Retry button kept rendering.
+  const empty = peek(keyOf('foreign-folder:get', { spaceId: 'sp1', shareId: '' }))
+  t.is(empty.data, undefined, 'the empty-id entry holds nothing')
+  t.is(tp.count(), 1, 'and nothing was requested for it')
+})
+
+test('ADOPT-A2: a slow listing read cannot overwrite the fast one that superseded it', async (t) => {
+  const tp = setup(t)
+  const scopes = [{ kind: 'shares' }]
+  const rows = (status) => [{ spaceId: 'sp1', shareId: 'sh1', status }]
+
+  void fetchQuery('owned-folder:list-all', {}, scopes)
+  // The second mount-status event: refetchQuery abandons the first read rather than joining it,
+  // which is what the two hand-rolled derive() calls could not do — both passed their `alive`
+  // check and the later-RESOLVING one won, regardless of which was issued first.
+  void refetchQuery('owned-folder:list-all', {}, scopes)
+  t.is(tp.count(), 2, 'the second read did not join the first')
+
+  tp.settle(1, rows('active'))
+  tp.settle(0, rows('mount-point-gone'))   // the stat'd-a-stalled-mount read, landing last
+  await tick()
+
+  t.is(
+    peek(keyOf('owned-folder:list-all')).data[0].status,
+    'active',
+    'the newer read wins on issue order, not arrival order — no "Source folder is missing" over a healthy folder',
+  )
+  t.ok(tp.aborted.includes('owned-folder:list-all'), 'and the superseded read was actually cancelled')
+})
+
+test('ADOPT-A2: the paramless listing keeps its wildcard scope whichever hook mounts first', async (t) => {
+  const tp = setup(t)
+  // useOwnedMount and useShares read the SAME entry. An entry keeps the scopes it was first
+  // registered with, so if either narrowed them to a spaceId, only the first space visited in the
+  // session could ever invalidate it.
+  void fetchQuery('owned-folder:list-all', {}, [{ kind: 'shares' }])
+  void fetchQuery('owned-folder:list-all', {}, [{ kind: 'shares' }])
+  tp.settle(0, [])
+  await tick()
+
+  const touched = invalidate({ kind: 'shares', spaceId: 'a-space-never-visited-first' })
+  t.ok(touched.includes('owned-folder:list-all'), 'a hint for any space reaches the shared listing')
+})

--- a/test/unit/renderer-reconcile-subscriptions.test.js
+++ b/test/unit/renderer-reconcile-subscriptions.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
 import { Scope, scopeMatches } from '../../src/shared/contract/scope.js'
@@ -21,6 +21,11 @@ test('reconcile-driven hooks subscribe the reconcile channel, not the named poke
     'useMembers.ts': ['event:members-updated', 'event:member-left', 'event:member-avatar-updated',
       'event:member-join-request', 'event:join-requests-updated'],
     'useShares.ts': ['event:shares-updated', 'event:foreign-folder-mount-status', 'event:owned-folder-mount-status'],
+    // The two folder-status hooks. Both mount-status events map to the shares scope, so a named
+    // subscription here is the same fork off the level-triggered channel the listing hooks were
+    // moved away from — and it is how both of these carried a stale fault strip.
+    'useFolderMount.ts': ['event:owned-folder-mount-status'],
+    'useForeignMount.ts': ['event:foreign-folder-mount-status'],
     'useSpaces.ts': ['event:members-updated', 'event:member-left', 'event:member-avatar-updated',
       'event:member-join-request'],
     'useSpaceStorage.ts': ['event:share-files-updated', 'event:shares-updated'],
@@ -76,4 +81,56 @@ test('a files hint cannot invalidate a share-files view', (t) => {
     'kinds must be equal — a space-wide files poke never reaches a share-files view',
   )
   t.ok(scopeMatches(Scope.files('sp1'), Scope.files('sp1')), 'while it does reach a files view')
+})
+
+// Every renderer file that WRITES the query store, with the reason it may. The rule this ratchets
+// is about WHO holds the subscription, not about writing: a hook runs once per mounted consumer,
+// so a worker event subscribed from inside one writes the same entry once per mount. Each write
+// publishes a new object, which defeats the store's identity check and re-renders every subscriber
+// again, and each event-driven refetch abandons the others' in-flight read.
+const STORE_WRITERS = {
+  'store/reconcile.ts': 'the app-wide push bridges — one subscription each, installed once in main.tsx',
+  'hooks/useProfile.ts': 'post-mutation, so one call is one user action however many components are mounted',
+  'screens/ActivityLogSettings.tsx': 'post-mutation, same reason',
+}
+
+function walkRenderer (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) walkRenderer(p, out)
+    else if (/\.(ts|tsx|js)$/.test(name) && !name.endsWith('.d.ts')) out.push(p)
+  }
+  return out
+}
+
+// REGRESSION (REVIEW-4: useDownloadRootStatus subscribed event:download-roots-status from inside the
+// hook, and two components mount it — so one worker event wrote the entry twice. useSpaces was the
+// worse twin: it pushed spaces:list from event:state and re-read on three membership events, with
+// FIVE call sites and several mounted together, plus a mount-time refetchQuery that abandoned the
+// read useQuery had just issued. Both moved to installPushBridges.)
+test('REGRESSION (REVIEW-4): only the push bridges write the query store from a worker event', (t) => {
+  const rendererRoot = path.join(here, '..', '..', 'src', 'renderer')
+  const store = path.join(rendererRoot, 'store')
+  const writers = walkRenderer(rendererRoot)
+    // The store defines and declares it; the rule is about its CALLERS.
+    .filter((f) => path.dirname(f) !== store || path.basename(f) !== 'query-store.js')
+    .filter((f) => /setQueryData[<(]/.test(readFileSync(f, 'utf8')))
+    .map((f) => path.relative(rendererRoot, f).split(path.sep).join('/'))
+    .sort()
+
+  t.alike(writers, Object.keys(STORE_WRITERS).sort(),
+    'a new store writer needs a reason in STORE_WRITERS — and if it writes from a subscription, it belongs in the bridge')
+})
+
+// REGRESSION (REVIEW-3: useQuery called useSyncExternalStore outside its enabled check, so a
+// disabled consumer still subscribed the shared entry. invalidate() refetches any entry with a
+// subscriber, so FolderView holding useOwnedMount for a MIRRORED share — enabled:false, projecting
+// NO_OWNED_MOUNT whatever comes back — made every shares-scoped hint in any space issue a full
+// owned-folder:list-all, which runs a live stat per owned mount, and then discarded the result.)
+test('REGRESSION (REVIEW-3): a disabled useQuery holds no subscription on the shared entry', (t) => {
+  const src = readFileSync(path.join(here, '..', '..', 'src', 'renderer', 'store', 'useQuery.ts'), 'utf8')
+  t.ok(/enabled\s*\?\s*subscribeKey\(/.test(src),
+    'the subscription is gated on enabled, so an entry nobody is really watching is left stale')
+  t.ok(/enabled\s*\?\s*peek</.test(src),
+    'and the snapshot is too — a disabled hook reads the empty snapshot, not another view\'s data')
 })

--- a/test/unit/timer-handles.test.js
+++ b/test/unit/timer-handles.test.js
@@ -1,0 +1,50 @@
+import test from 'brittle'
+import { createTimers, liveHandle, ownedScheduler } from '../../src/shared/core/timers.js'
+
+// REGRESSION (REVIEW-5: three modules keep a long-lived timer handle in a binding that outlives the
+// subsystem owning the set — presenceTimer, convergenceTimer, announceTimer. Each guards its start
+// with `if (handle) return`, and Subsystem.close() clears the SET without being able to reach those
+// bindings. So after any ending the set closes on — a failed _open, a _close that rejects — the
+// binding still held a disarmed handle, the guard read it as "already armed", and the work was off
+// for the rest of the process with no error and no log.)
+test('REGRESSION (REVIEW-5): a handle whose owning set has closed reads as not armed', (t) => {
+  const set = createTimers()
+  const handle = set.setInterval(() => {}, 1000)
+
+  t.is(liveHandle(set, handle), handle, 'while the owner is open the handle stands')
+  set.close()
+  t.is(liveHandle(set, handle), null, 'once it closes the handle is dead, so the guard cannot latch')
+  t.is(liveHandle(null, handle), null, 'and no owner at all is the same answer')
+  t.is(liveHandle(createTimers(), null), null, 'nothing armed stays nothing armed')
+})
+
+// REGRESSION (REVIEW-2: the owner-side coalescer's injected schedule guarded only the SUBSYSTEM
+// POINTER — `subsystem?.timers.setTimeout(...) ?? null`. A _close that rejects never reaches its
+// `subsystem = null`, so the pointer stayed live while the base's finally had already closed the
+// timers underneath it. Arming against a closed set throws by design, and this one is called from
+// inside a coalescer callback during the post-close publish drain, where nothing catches it.)
+test('REGRESSION (REVIEW-2): an owned scheduler declines against a closed set instead of throwing', (t) => {
+  let set = createTimers()
+  const { schedule, clear } = ownedScheduler(() => set)
+
+  const handle = schedule(() => {}, 1000)
+  t.ok(handle, 'a live owner arms')
+  clear(handle)
+
+  // Exactly the state a rejecting _close leaves: the pointer is still there, the set is not.
+  set.close()
+  t.is(schedule(() => {}, 1000), null, 'a closed owner declines')
+  t.execution(() => clear(handle), 'and clearing against it is inert rather than an error')
+
+  set = null
+  t.is(schedule(() => {}, 1000), null, 'no owner at all declines too — this runs before _open')
+  t.execution(() => clear(handle), 'and clear stays safe with nothing to clear through')
+})
+
+// Non-vacuous by construction: if arming against a closed set did NOT throw, the guard above would
+// be measuring nothing.
+test('the timer set itself still refuses to arm after close', (t) => {
+  const set = createTimers()
+  set.close()
+  t.exception(() => set.setTimeout(() => {}, 1), /scheduling after close/)
+})


### PR DESCRIPTION
Four workstreams from `plan-finish-adoptions.md`, plus the fixes from an xhigh review of the branch.

**Renderer** — the last nine status hooks project query-store entries instead of hand-rolled reads. One value backs every view of a folder, so a slow `mount-point-gone` read can no longer land after a fast `active` one and paint a fault over a healthy folder. Boot and mount readiness ask "has an answer landed", never the store's in-flight flag: that flag rises again on every refetch, and gating a subtree on it is a remount loop (it cost a full boot hang, found only by the frontend suite). Subscriptions that *write* the store moved out of the hooks into `installPushBridges` — a hook runs once per mounted consumer, and `useSpaces` has five.

**Timers** — thirteen periodic handles were armed from the global and cleared by hand in `_close`. ReadyResource ends a failed `_open` without calling `_close`, and a rejecting `_close` short-circuits the same way, so both left a tick firing against torn-down state. They arm through a Subsystem's timer set now. A handle whose set has closed is dropped before the already-armed guard reads it, or that guard latches the work off for the process lifetime; an injected schedule declines against a closed set rather than throwing mid-drain. Lint catches the next one, including the `this.fooTimer =` shape.

**member-view** — the fold watched the whole bee per member and re-derived on file and catalog traffic it never reads. It watches the four key prefixes it actually folds; an empty or null range set is refused rather than silently opening no watcher.

The main-request contract this branch also built landed first as #185, so that commit is dropped — only its preload/`global.d.ts` parity test, which #185 has no equivalent of, is kept.

Gates: tsc · `lint:ci` · unit+raw 1921/1921 · flow 199/199 · integration 1042/1042.

Not yet run against this rebase: `test:fe s131 s132` and the manual a11y pass on the fault strip.