### PR TITLE
[feat] Rebuild the hover palette for buttons and controls

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -57,7 +57,8 @@ each key color (`-container`, `-fixed`, `-fixed-dim`, `-fixed-variant`,
 
 | Token | Hex | Role |
 |---|---|---|
-| `primary` / `accent` | `#33253b` | Twilight plum. Headings, primary buttons, key text. (`accent` == `primary` in light mode.) |
+| `accent` | `#33253b` | Twilight plum as **ink** — headings, key text, link-ish emphasis |
+| `primary` / `-hover` | `#42304a` / `#52405b` | Twilight plum as **fill** — the primary button, resting dark and lightening on hover. Off the ramp floor on purpose: see Buttons |
 | `on-primary` | `#ffffff` | Text/icon on primary |
 | `secondary` | `#904d00` | Burnt amber — focus rings, links, secondary emphasis |
 | `secondary-container` | `#fd9c42` | Signature orange (the "Mirall dot") |
@@ -68,6 +69,7 @@ each key color (`-container`, `-fixed`, `-fixed-dim`, `-fixed-variant`,
 | `surface-container-low` | `#f5f3ef` | Section/setting cards; **folder cards at rest (light)**; file cards at rest (dark) |
 | `surface-container` | `#efeeea` | |
 | `surface-container-high` | `#eae8e4` | Neutral chips, toggle track, icon tiles |
+| `surface-control` / `-hover` | `#eae8e4` / `#dcdad6` | **Every filled neutral control** — secondary buttons, ActionMenu triggers, PathRow, filter chips (dark: `#434955` / `#4f5561`) |
 | `surface-container-highest` | `#e4e2de` | **Card hover lift** (folder & file rows); avatar fallback, "remote" badge |
 | `progress-track` | `#d0cec9` | Progress-bar tracks and the peer-dropdown divider — see the note below |
 | `on-surface` | `#1b1c1a` | Primary body text (near-black; **never** `#000`) |
@@ -86,8 +88,8 @@ each key color (`-container`, `-fixed`, `-fixed-dim`, `-fixed-variant`,
 | `warning` / `on-warning` | `#fcd34d` / `#1b1c1a` | The yellow "needs attention" state — paused / folder missing on disk. **Solid chips only** |
 | `warning-container` / `on-warning-container` | `#fdefc6` / `#6d4c00` (dark: `#4e4229` / `#fbe3a4`) | The tinted warning *surface* — the read-only notice, the work strip's paused band |
 | `error` | `#ba1a1a` | Hard error text/icon |
-| `error-container` / `on-error-container` | `#ffdad6` / `#93000a` | Danger button rest, error toast/badge |
-| `error-container-hover` | `#f5c8c4` | Danger button hover |
+| `error-container` / `on-error-container` | `#f6c8c4` / `#93000a` | Danger button rest, error toast/badge, destructive row hover |
+| `error-container-hover` | `#e8bab6` | Danger button hover (dark: `#7c3f43`) — see the hover-token table under Buttons |
 | `icon-tile` / `on-icon-tile` | `#fec78a` / `#0a4742` | Reserved icon-tile pair (defined; most tiles render on `surface-container-high`) |
 
 ### Dark theme
@@ -100,9 +102,10 @@ mockup): `surface` `#282c34`, `surface-container-lowest` `#21252b`,
 `surface-container-low` `#2e3239`, `surface-container` `#2e323a`,
 `surface-container-high` `#5c6068`, `surface-container-highest` `#393f4a`,
 `progress-track` `#4a5160`. **The ramp is not monotonic by name in dark** — `surface-container-high` (`#5c6068`) is
-markedly *lighter* than `-highest` (`#393f4a`); this is why secondary buttons use
-`dark:bg-surface-container-highest` deliberately (and `dark:hover:bg-surface-container-high`,
-a step *lighter* on hover). The `icon-tile` pair (`#fec78a` / `#0a4742`) is **not
+markedly *lighter* than `-highest` (`#393f4a`), which is why the subtle icon triggers hover to
+`-high` and the card rows lift to `-highest`, both a step *lighter*, and why secondary buttons no
+longer borrow from this ramp at all: they sit on `surface-control` (`#434955`), a token of their
+own that flips per theme — see Buttons. The `icon-tile` pair (`#fec78a` / `#0a4742`) is **not
 inverted** — it keeps its warm-peach light values in dark. Every status token has a dark variant.
 `--color-background` syncs with `BG_DARK` in `main.js`.
 
@@ -316,15 +319,49 @@ by 9.3 L\* in light mode. Meanwhile the neutral swapped ramp tokens and landed 2
 page it sits on, so the button dissolved into its own background on hover — which reads as "too
 dark" even though the step was the same size as primary's.
 
-The hover tokens step by a fixed perceptual amount, always downwards, and the neutral keeps its
-distance from the page:
+**On hover a control steps AWAY from the page behind it** — *darker* in light mode, where the page
+is the lightest thing on screen, *lighter* in dark mode, where it is the darkest — **unless it
+already sits at an end of the ramp, where outward has nothing left; then it steps inward.** Both
+brand fills are in that second case, and both are so far from the page that moving toward it costs
+them nothing. One rule, one gesture, every interactive surface in the app:
 
-| | base → hover | ΔL\* | clears the page by |
-|---|---|---|---|
-| primary, dark | `#fd9c42` → `#e28c3b` | −7.0 | — |
-| neutral, dark | `#393f4a` → `#353b45` | −2.0 | 6.8 L\* |
-| primary, light | `#33253b` → `#241a2a` | −6.1 | — |
-| neutral, light | `#eae8e4` → `#e4e2de` | −2.1 | 7.6 L\* |
+**Why "away from the page" and not "always darker".** A hover that darkens in *both* themes moves
+half the palette toward its own label, so contrast pays for every step and the ceiling arrives
+early: the dark orange stopped at 4.75:1, and the light neutral needed 8× its old step to be felt
+at all — one gesture that looked like six. Stepping away from the page moves a fill away from its
+label in exactly one theme, never both, so nothing has to spend AA headroom to be noticed, and the
+control always grows *more* distinct from its background under the pointer, which is what a hover
+means. It is also what the app already did everywhere else: rows and cards lift to
+`surface-container-highest`, subtle icon triggers to `surface-container-high`, menu items to
+`surface-container-low` — all of them away from the page. The filled variants were the outliers.
+
+**How big the step has to be depends on how far the fill sits from the page**, because the page is
+what the eye is adapted to. Near it, a little goes a long way: the light neutral is felt at 4.9 L\*,
+the dark neutral and dark danger at ~5. Far from it, small differences compress and the same step
+disappears — the plum used to rest at `#33253b`, 81 L\* below a near-white page, where 4.9 L\* was
+*invisible to the person using it*. The two brand fills are the far ones (68 L\* below in light,
+55 above in dark) and both owe ~7–9 L\*.
+
+**`primary` in light rests dark and lightens** (`#42304a` → `#52405b`). Outward here means darker,
+and the fill was already on the floor of the ramp at `#33253b` — 81 L\* below the page, where 4.9
+L\* of extra black was *invisible to the person using it*. The pair moved up until the step had
+somewhere to live and then turned around: the button still reads as the near-black plum at rest,
+and the pointer lifts it. `accent` keeps `#33253b` and the two tokens have parted ways — the ink
+wants to be as dark as it can, the fill needs headroom. `primary` is only ever a `bg-`, never a
+text colour, so nothing lost contrast in the move; the label actually gains it (11.98:1 at rest).
+
+**`primary` in dark is the same story at the other end** (`#fd9c42` → `#dd8837`). Outward there
+means lighter, and that orange is close enough to the sRGB edge that +3.3 L\* was the whole budget
+at full chroma — it read as no hover at all, and buying more costs 22% of the chroma, which is the
+brand. So it steps down. The resting orange itself never moves.
+
+The tonal red is also the one fill that gets painted under a foreign ink — a destructive menu item
+or card action is `text-error` at rest and only meets the fill on hover, where `error` on
+`error-container` is **2.94:1** in dark, under even the 3:1 non-text floor. Every
+`hover:bg-error-container` therefore carries `hover:text-on-error-container` with it.
+`test/unit/control-hover-tokens.test.js` holds all of it: the direction per theme and the two
+documented ramp-end exceptions, the step floor as a function of distance from the page, AA on every label
+over *both* states, the neutral's clearance, and that pairing.
 
 **The neutral base is one token, not a `dark:` variant, and that is load-bearing.** A
 `dark:bg-…` utility compiles to `.dark\:bg-x:is(.dark *)` — specificity (0,2,0), the same as a
@@ -334,11 +371,16 @@ later: the hover simply never applied in dark mode. The old code only worked bec
 the base is (0,1,0) and hover always wins. Prefer a theme-flipping token over a `dark:` variant on
 anything that also has interactive states.
 
-The neutral's step is deliberately much the smaller one — about a third of primary's. It starts
-only ~8 L\* above the page, so a primary-sized step reads as the button dissolving rather than
-responding; ~2 L\* is enough to acknowledge the pointer on a surface that quiet. Same tokens for
-the `ActionMenu` triggers, `PathRow`'s button, and the All/Favorites tabs on the spaces list,
-which are filled neutral chips and not the *lift* pattern below. (A transparent control that *lifts* into a visible
+The neutral is the row with the least room: a plain surface with no hue of its own, a few L\* off
+the page in either direction, so both of its states have to stay a visible object — 5.9 L\* of
+clearance at rest in light, 13.0 in dark, and more on hover, never less. Its dark rest was
+`#393f4a` and sat too close to the page to read as a control at all; `#434955` is the same slate
+lifted until the button has an edge. Same tokens for
+the `ActionMenu` triggers, `PathRow`'s button, and the *unselected* All/Favorites tab on the spaces
+list, which are filled neutral chips and not the *lift* pattern below. The **selected** tab wears the
+primary pair, hover included, so both states of that row answer the pointer the way the Create/Join
+buttons beside them do; it once carried `bg-primary` with no hover class at all, which read as the
+orange chip going dead under the cursor. (A transparent control that *lifts* into a visible
 surface on hover — `IconButton`, list rows — is the opposite pattern and still brightens.)
 - **`danger`** — tonal `bg-error-container text-on-error-container` →
   `hover:bg-error-container-hover` (stays in the red family, never jumps to neutral).

--- a/src/renderer/components/cards/FileCard.tsx
+++ b/src/renderer/components/cards/FileCard.tsx
@@ -126,7 +126,11 @@ function ActionSlot({
   const visibility = alwaysVisible
     ? ''
     : 'opacity-0 group-hover:opacity-100 focus:opacity-100'
-  const hoverBg = isDanger ? 'hover:bg-error-container' : 'hover:bg-surface-container-high'
+  // The error-container fill carries its own ink: `text-error` on it is 2.94:1 in dark, under
+  // even the 3:1 non-text floor. Same pairing as the relay row's remove button.
+  const hoverBg = isDanger
+    ? 'hover:bg-error-container hover:text-on-error-container'
+    : 'hover:bg-surface-container-high'
   const iconColor = isDanger ? 'text-error' : 'text-secondary'
   return (
     <button

--- a/src/renderer/components/primitives/Button.tsx
+++ b/src/renderer/components/primitives/Button.tsx
@@ -27,14 +27,20 @@ interface ButtonProps {
 // Every variant names its hover colour; none of them blends. `hover:opacity-90` looked like a
 // darkening but is really "mix 10% of whatever is behind me", so it darkened the orange in dark
 // mode and LIGHTENED the plum in light mode (+9.3 L*), while the neutral swapped tokens and dropped
-// to within 2.8 L* of the page it sits on — a button dissolving into its own background. The tokens
-// step by a fixed perceptual amount instead: primary ~7 L*, neutral ~3-4 L*, always downwards, and
-// the neutral stays clear of the page.
+// to within 2.8 L* of the page it sits on — a button dissolving into its own background. Each hover
+// token is instead the resting fill stepped AWAY from the page: darker in light mode, lighter in
+// dark. That is the same gesture the rows, cards and menu items already make, and because it moves
+// a fill toward its own label in only one theme, no variant has to spend AA headroom to be felt.
+// How far is a function of how far the fill sits from the page — ~5 L* near it, ~7-9 for the brand
+// fills out at the ends, where the eye (adapted to the page) stops resolving small steps. Those two
+// also invert the direction, because at the end of a ramp outward has nothing left: the light plum
+// rests near-black and LIGHTENS, the dark orange sits at the sRGB edge and DARKENS.
+// design.md carries the table; the invariants are pinned by test/unit/control-hover-tokens.test.js.
 // `secondary` is the neutral surface style shared with the top-nav "Send feedback" button and
 // the filter chips, used for cancel / dismiss actions.
 // `danger` is the tonal destructive style used for every destructive action (in-page
 // triggers and modal confirmations alike): it rests in the soft error-container fill and
-// hovers to a slightly shifted shade of the same red rather than jumping to a neutral color.
+// hovers to a deeper shade of the same red rather than jumping to a neutral color.
 const variantClasses: Record<ButtonVariant, string> = {
   primary: 'bg-primary text-on-primary shadow-lg shadow-primary/10 hover:bg-primary-hover focus-visible:ring-secondary/30',
   secondary: 'bg-surface-control text-on-surface-variant hover:bg-surface-control-hover focus-visible:ring-secondary/30',

--- a/src/renderer/components/widgets/ActionMenu.tsx
+++ b/src/renderer/components/widgets/ActionMenu.tsx
@@ -67,7 +67,7 @@ function MenuItemRow({ node, state, config, showSeparator }: {
             ? 'text-outline cursor-not-allowed opacity-60'
             : `cursor-pointer active:scale-[0.98] transition-all ${
                 isDanger
-                  ? 'text-error hover:bg-error-container'
+                  ? 'text-error hover:bg-error-container hover:text-on-error-container'
                   : 'text-accent hover:bg-surface-container-low'
               } ${isFocused || isFocusVisible ? 'bg-surface-container-low' : ''}`
           }

--- a/src/renderer/screens/SharedSpaces.tsx
+++ b/src/renderer/screens/SharedSpaces.tsx
@@ -50,7 +50,7 @@ export default function YourSpaces({ onSelectSpace, onShowCreate, onShowJoin }: 
               aria-pressed={filter === f}
               className={`px-6 py-2.5 rounded-full font-medium transition-all active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30 ${
                 filter === f
-                  ? 'bg-primary text-on-primary shadow-lg shadow-primary/10'
+                  ? 'bg-primary text-on-primary shadow-lg shadow-primary/10 hover:bg-primary-hover'
                   : 'bg-surface-control text-on-surface-variant hover:bg-surface-control-hover'
               }`}
             >

--- a/src/renderer/styles/tailwind.css
+++ b/src/renderer/styles/tailwind.css
@@ -11,8 +11,8 @@
   --color-online: #0d8b80;
   --color-offline: #a0a4ac;
   --color-accent: #33253b;
-  --color-primary: #33253b;
-  --color-primary-hover: #241a2a;
+  --color-primary: #42304a;
+  --color-primary-hover: #52405b;
   --color-primary-container: #4a3b52;
   --color-on-primary: #ffffff;
   --color-on-primary-container: #baa6c1;
@@ -43,7 +43,7 @@
   --color-surface-container-low: #f5f3ef;
   --color-surface-container-high: #eae8e4;
   --color-surface-control: #eae8e4;
-  --color-surface-control-hover: #e4e2de;
+  --color-surface-control-hover: #dcdad6;
   --color-surface-container-highest: #e4e2de;
   --color-surface-container-lowest: #ffffff;
   --color-surface-variant: #e4e2de;
@@ -65,8 +65,8 @@
   --color-outline-variant: #ccc4cc;
   --color-error: #ba1a1a;
   --color-on-error: #ffffff;
-  --color-error-container: #ffdad6;
-  --color-error-container-hover: #f5c8c4;
+  --color-error-container: #f6c8c4;
+  --color-error-container-hover: #e8bab6;
   --color-on-error-container: #93000a;
   --color-warning: #fcd34d;
   --color-on-warning: #1b1c1a;
@@ -88,7 +88,7 @@
   --color-offline: #5b6270;
   --color-accent: #fce8d2;
   --color-primary: #fd9c42;
-  --color-primary-hover: #e28c3b;
+  --color-primary-hover: #dd8837;
   --color-primary-container: #4a3320;
   --color-on-primary: #282c34;
   --color-on-primary-container: #f6c094;
@@ -118,8 +118,8 @@
   --color-surface-container: #2e323a;
   --color-surface-container-low: #2e3239;
   --color-surface-container-high: #5c6068;
-  --color-surface-control: #393f4a;
-  --color-surface-control-hover: #353b45;
+  --color-surface-control: #434955;
+  --color-surface-control-hover: #4f5561;
   --color-surface-container-highest: #393f4a;
   --color-surface-container-lowest: #21252b;
   --color-surface-variant: #333842;
@@ -136,7 +136,7 @@
   --color-error: #df6b75;
   --color-on-error: #282c34;
   --color-error-container: #6f3338;
-  --color-error-container-hover: #823e44;
+  --color-error-container-hover: #7c3f43;
   --color-on-error-container: #ffd2cf;
   --color-warning: #fbbf24;
   --color-on-warning: #1b1c1a;

--- a/test/unit/control-hover-tokens.test.js
+++ b/test/unit/control-hover-tokens.test.js
@@ -1,0 +1,183 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+
+// One rule governs every interactive fill in the app: **on hover a control steps ~5 L* AWAY from
+// the page behind it** — darker in light mode, where the page is the lightest thing on screen,
+// lighter in dark mode, where it is the darkest. That is already how the transparent controls
+// behave (rows and cards lift to `surface-container-highest`, the subtle icon triggers to
+// `surface-container-high`, menu items to `surface-container-low`), and the filled variants now
+// follow it too, so the pointer produces one gesture everywhere instead of three.
+//
+// Steering by "away from the page" rather than "always downwards" is what keeps the rule
+// affordable: it moves each fill AWAY from its own label in exactly one theme, never both, so no
+// variant has to spend its AA headroom to be felt. The version this replaced darkened every fill
+// in both themes and had to stop at whatever contrast allowed — the dark orange at 4.75:1, the
+// light neutral 8x its old step — which is how one gesture ended up looking like six.
+//
+// Checked here: the direction, the size of the step, AA on every label over both the rest fill and
+// the hover fill, the neutral's clearance from the page, and the one pairing (`error-container`
+// carries `on-error-container`, never `error`) that a fill change can silently break.
+
+const root = new URL('../../', import.meta.url)
+const read = (p) => readFileSync(fileURLToPath(new URL(p, root)), 'utf8')
+
+const css = read('src/renderer/styles/tailwind.css')
+const chips = read('src/renderer/screens/SharedSpaces.tsx')
+const button = read('src/renderer/components/primitives/Button.tsx')
+
+const tokensFor = (selector) => {
+  const start = css.indexOf(selector + ' {')
+  const block = css.slice(start, css.indexOf('\n}', start))
+  const out = {}
+  for (const m of block.matchAll(/--(color-[\w-]+):\s*(#[0-9a-fA-F]{6})/g)) out[m[1]] = m[2]
+  return out
+}
+
+const lin = (c) => { c /= 255; return c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4 }
+const lum = (hex) => {
+  const m = hex.replace('#', '')
+  return 0.2126 * lin(parseInt(m.slice(0, 2), 16)) +
+         0.7152 * lin(parseInt(m.slice(2, 4), 16)) +
+         0.0722 * lin(parseInt(m.slice(4, 6), 16))
+}
+const contrast = (a, b) => {
+  const la = lum(a), lb = lum(b), hi = Math.max(la, lb), lo = Math.min(la, lb)
+  return (hi + 0.05) / (lo + 0.05)
+}
+// CIE L* depends on luminance alone, so the perceptual step design.md quotes is computable here.
+const lstar = (hex) => {
+  const y = lum(hex)
+  return 116 * (y > 216 / 24389 ? Math.cbrt(y) : (841 / 108) * y + 4 / 29) - 16
+}
+
+// base → hover, plus every ink rendered on top of the pair.
+const VARIANTS = [
+  { name: 'primary', base: 'color-primary', hover: 'color-primary-hover', inks: ['color-on-primary'] },
+  { name: 'neutral', base: 'color-surface-control', hover: 'color-surface-control-hover', inks: ['color-on-surface-variant', 'color-accent'] },
+  { name: 'danger', base: 'color-error-container', hover: 'color-error-container-hover', inks: ['color-on-error-container'] },
+]
+// Light mode's page is the lightest surface, dark mode's the darkest, so "away from the page" is
+// a sign per theme.
+const AWAY = { ':root': -1, '.dark': +1 }
+// The two fills that cannot obey it, both for the same reason: they live at the ends of the ramp,
+// where outward has nothing left. The orange is at the sRGB edge — lighter is simply not available
+// at that chroma, and +3.3 L* read as no hover at all. The plum is at the other end, where outward
+// means darker and the black floor eats the difference. Both step INWARD instead, which is safe for
+// the reason the rule exists: each stays tens of L* clear of the page, so the control cannot get
+// lost against it.
+const INWARD = [
+  { theme: '.dark', variant: 'primary' },
+  { theme: ':root', variant: 'primary' },
+]
+const MIN_PAGE_GAP = 30
+
+// What it takes for a step to be FELT is not constant across the palette, and it is not about the
+// fill being dark: the dark neutral steps 5.1 L* at L*31 and reads fine, while the old plum's 4.9
+// at L*17 was invisible. The predictor is distance from the PAGE, because that is what the eye is
+// adapted to — a fill far from it (the plum 68 L* below a near-white page, the orange 55 L* above
+// a near-black one) sits outside that adaptation, where small differences compress. Those two owe
+// a bigger step; fills that live near the page can be felt with less.
+const MIN_STEP = (fill, page) => (Math.abs(fill - page) > 45 ? 6.5 : 4.5)
+
+test('every fill keeps its label at AA, at rest and on hover', (t) => {
+  for (const theme of [':root', '.dark']) {
+    const k = tokensFor(theme)
+    for (const v of VARIANTS) {
+      for (const ink of v.inks) {
+        for (const state of ['base', 'hover']) {
+          const c = contrast(k[ink], k[v[state]])
+          t.ok(c >= 4.5, `${theme} ${v.name} ${state}: ${ink} = ${c.toFixed(2)}:1`)
+        }
+      }
+    }
+  }
+})
+
+// REGRESSION (FIX-2: hovers that darkened in BOTH themes ran into the label instead of the page —
+// the dark orange could only reach 4.75:1, and the light neutral had to take an 8x step to be felt.)
+// REGRESSION (FIX-3: a uniform ~5 L* step left both brand fills without a visible hover — the plum
+// because it sat at the bottom of the ramp, the orange because sRGB capped it at 3.3.)
+test('REGRESSION (FIX-2, FIX-3): every hover steps away from the page, far enough to be felt', (t) => {
+  for (const theme of [':root', '.dark']) {
+    const k = tokensFor(theme)
+    for (const v of VARIANTS) {
+      const base = lstar(k[v.base]), hover = lstar(k[v.hover])
+      const step = hover - base
+      const inward = INWARD.some((x) => x.theme === theme && x.variant === v.name)
+      if (inward) {
+        const gap = Math.abs(hover - lstar(k['color-background']))
+        t.ok(gap >= MIN_PAGE_GAP,
+          `${theme} ${v.name}: steps toward the page but stays ${gap.toFixed(1)} L* clear of it`)
+      } else {
+        t.ok(Math.sign(step) === AWAY[theme], `${theme} ${v.name}: steps away from the page (ΔL* ${step.toFixed(1)})`)
+      }
+      const need = MIN_STEP(base, lstar(k['color-background']))
+      t.ok(Math.abs(step) >= need && Math.abs(step) <= 10,
+        `${theme} ${v.name}: step is ${Math.abs(step).toFixed(1)} L* (needs ${need}-10)`)
+    }
+  }
+})
+
+// The plum is a fill, not an ink. `accent` carries the text role in light mode and stays where it
+// was; lifting the BUTTON off the ramp floor is what bought its hover room, and conflating the two
+// tokens again would drag every heading up with it.
+test('light-mode primary is a fill that has left accent behind', (t) => {
+  const k = tokensFor(':root')
+  t.not(k['color-primary'], k['color-accent'], 'primary is no longer an alias of accent')
+  t.is(k['color-accent'], '#33253b', 'accent still carries the heading/text plum')
+  // The pair, not the rest fill, is what needs room: the button rests at the dark end and hovers
+  // toward the light one, so it is the LIGHTER of the two that has to sit off the ramp floor. On
+  // the floor (the old #33253b/#281b30 pair) a 5 L* step was invisible to the person using it.
+  const lighter = Math.max(lstar(k['color-primary']), lstar(k['color-primary-hover']))
+  t.ok(lighter >= 27, `the plum pair reaches up off the ramp floor (L* ${lighter.toFixed(1)})`)
+  const src = read('src/renderer/screens/SharedSpaces.tsx') + read('src/renderer/components/primitives/Button.tsx')
+  t.absent(/text-primary\b/.test(src), 'primary is never used as an ink')
+})
+
+// The neutral is the one that can vanish: it is a plain surface a few L* off the page, with no hue
+// of its own to hold the edge. Both of its states have to stay a visible object.
+test('the neutral control stays clear of the page behind it', (t) => {
+  for (const theme of [':root', '.dark']) {
+    const k = tokensFor(theme)
+    for (const state of ['color-surface-control', 'color-surface-control-hover']) {
+      const gap = Math.abs(lstar(k[state]) - lstar(k['color-background']))
+      t.ok(gap >= 5, `${theme} ${state}: clears the page by ${gap.toFixed(1)} L*`)
+    }
+  }
+})
+
+// The tonal red is the one fill that gets painted under a foreign ink: a destructive row is
+// `text-error` at rest and only meets the fill on hover. `error` on `error-container` is 2.94:1 in
+// dark — under even the 3:1 non-text floor — so the fill has to bring `on-error-container` with it.
+test('the error-container fill is never painted under text-error', (t) => {
+  const sources = ['src/renderer/components/widgets/ActionMenu.tsx',
+    'src/renderer/components/cards/FileCard.tsx',
+    'src/renderer/components/settings/RelaySettingsSection.tsx']
+  let checked = 0
+  for (const f of sources) {
+    const src = read(f)
+    for (const m of src.matchAll(/hover:bg-error-container(?!-)/g)) {
+      checked++
+      t.ok(/hover:text-on-error-container/.test(src.slice(m.index, m.index + 160)),
+        `${f}: the error-container hover brings its own ink`)
+    }
+  }
+  t.ok(checked >= 3, `all ${checked} error-container hovers were reached`)
+})
+
+// REGRESSION (FIX-1: the selected chip carried `bg-primary` with no hover class at all).
+test('REGRESSION (FIX-1): both spaces-filter chip states name a hover colour', (t) => {
+  const start = chips.indexOf('aria-pressed={filter === f}')
+  t.ok(start > 0, 'the filter chips were found at all')
+  const chipClasses = chips.slice(start, chips.indexOf('</button>', start))
+  t.ok(/'bg-primary [^']*hover:bg-primary-hover/.test(chipClasses), 'selected chip hovers to primary-hover')
+  t.ok(/'bg-surface-control [^']*hover:bg-surface-control-hover/.test(chipClasses), 'unselected chip hovers to surface-control-hover')
+})
+
+test('the chips hover to the same tokens as the Create/Join buttons beside them', (t) => {
+  for (const pair of ['bg-primary', 'bg-surface-control']) {
+    const hover = new RegExp(`${pair}[^'\`]*hover:${pair}-hover`)
+    t.ok(hover.test(button), `Button still pairs ${pair} with ${pair}-hover`)
+  }
+})


### PR DESCRIPTION
One rule for every filled control: on hover the fill steps away from the page — darker in light, lighter in dark — except the two brand fills at the ends of the ramp, which step inward because outward has no room (the plum hits the black floor, the orange the sRGB edge). It is the gesture rows, cards and menu items already made; the buttons were the outliers.

Resolved along the way:

- The selected All/Favorites chip had no hover class at all.
- `error-container` was painted under `text-error` in the action menu and the file-card delete — **2.94:1** in dark, under even the 3:1 non-text floor.
- Light `danger` rested too pale (`#ffdad6` → `#f6c8c4`), dark `neutral` too close to the page (`#393f4a` → `#434955`).
- Neither brand hover was visible: the plum pair sat on the ramp floor, the orange could only move +3.3 L\* before leaving sRGB.

Every label clears AA over both rest and hover in both themes. `test/unit/control-hover-tokens.test.js` pins the direction, the step floor as a function of distance from the page, AA on both states, the neutral's clearance, and the ink pairing. `design.md` carries the table.

Unit suite 1931/1931, build clean. Visual pass done in the running app.