### PR TITLE
Warn before mirroring a folder that will list short

### DIFF
--- a/src/renderer/components/modals/ScanPreviewModal.tsx
+++ b/src/renderer/components/modals/ScanPreviewModal.tsx
@@ -166,6 +166,17 @@ function ScanPreviewBody({ preview, loading, progress, readOnlyWarning }: ScanPr
         />
       )}
 
+      {/* A warning, not a refusal: the primary action stays enabled. Mirroring an over-cap share
+          works and every file syncs — only the list is short — so the honest move is to say so and
+          let the user decide, which is the same thing the folder screen says after the mount. */}
+      {preview.listingAdvisory === true && (
+        <SummaryCard
+          tone="warning"
+          title={t('scanPreview.listingCapped', { total: preview.totalFiles ?? 0, limit: preview.fileLimit ?? 0 })}
+          detail={t('scanPreview.listingCappedDetail', { limit: preview.fileLimit ?? 0 })}
+        />
+      )}
+
       {readOnlyWarning && (
         <SummaryCard tone="warning" title={t('scanPreview.readOnly')} detail={readOnlyWarning} />
       )}

--- a/src/renderer/locales/de/common.json
+++ b/src/renderer/locales/de/common.json
@@ -130,6 +130,8 @@
     "conflictDetail": "Dateien am Zielort unterscheiden sich von der Freigabe. Deine vorhandenen Dateien bleiben erhalten; die Versionen aus der Freigabe werden daneben mit einem nummerierten Namen gespeichert.",
     "overFileLimit": "Dieser Ordner enthält {{total}} Dateien und liegt über dem Limit von {{limit}} Dateien",
     "overFileLimitDetail": "Wähle einen kleineren Ordner oder teile ihn auf mehrere Freigaben auf.",
+    "listingCapped": "Dieser Ordner enthält {{total}} Dateien und liegt über dem Limit von {{limit}} Dateien",
+    "listingCappedDetail": "Das Spiegeln funktioniert und alle Dateien werden synchronisiert, in der Dateiliste werden aber nur die ersten {{limit}} angezeigt.",
     "noConflicts": "Keine Konflikte",
     "noConflictDetail": "Der Zielort ist sauber.",
     "noConflictDetailOwned": "Es wird nichts überschrieben.",

--- a/src/renderer/locales/en/common.json
+++ b/src/renderer/locales/en/common.json
@@ -154,6 +154,8 @@
     "conflictDetail": "Files at the destination differ from the share. Your existing files are kept; the share's versions are saved alongside with a numbered name.",
     "overFileLimit": "This folder has {{total}} files, above the {{limit}}-file limit",
     "overFileLimitDetail": "Choose a smaller folder, or split it into several shares.",
+    "listingCapped": "This folder has {{total}} files, above the {{limit}}-file limit",
+    "listingCappedDetail": "Mirroring works and every file syncs, but the file list will only show the first {{limit}}.",
     "noConflicts": "No conflicts",
     "noConflictDetail": "The destination is clean.",
     "noConflictDetailOwned": "Nothing will be overwritten.",

--- a/src/renderer/locales/es/common.json
+++ b/src/renderer/locales/es/common.json
@@ -130,6 +130,8 @@
     "conflictDetail": "Los archivos del destino son distintos a los del recurso compartido. Tus archivos existentes se conservan; las versiones del recurso compartido se guardan junto a ellos con un nombre numerado.",
     "overFileLimit": "Esta carpeta tiene {{total}} archivos, por encima del límite de {{limit}}",
     "overFileLimitDetail": "Elige una carpeta más pequeña o divídela en varios recursos compartidos.",
+    "listingCapped": "Esta carpeta tiene {{total}} archivos, por encima del límite de {{limit}}",
+    "listingCappedDetail": "La duplicación funciona y todos los archivos se sincronizan, pero la lista solo mostrará los primeros {{limit}}.",
     "noConflicts": "Sin conflictos",
     "noConflictDetail": "El destino está limpio.",
     "noConflictDetailOwned": "No se sobrescribirá nada.",

--- a/src/renderer/locales/fr/common.json
+++ b/src/renderer/locales/fr/common.json
@@ -130,6 +130,8 @@
     "conflictDetail": "Les fichiers à destination diffèrent de ceux du partage. Vos fichiers existants sont conservés ; les versions du partage sont enregistrées à côté avec un nom numéroté.",
     "overFileLimit": "Ce dossier contient {{total}} fichiers, au-delà de la limite de {{limit}} fichiers",
     "overFileLimitDetail": "Choisissez un dossier plus petit, ou répartissez-le sur plusieurs partages.",
+    "listingCapped": "Ce dossier contient {{total}} fichiers, au-delà de la limite de {{limit}} fichiers",
+    "listingCappedDetail": "La mise en miroir fonctionne et tous les fichiers sont synchronisés, mais la liste n’affichera que les {{limit}} premiers.",
     "noConflicts": "Aucun conflit",
     "noConflictDetail": "La destination est propre.",
     "noConflictDetailOwned": "Rien ne sera écrasé.",

--- a/src/renderer/locales/it/common.json
+++ b/src/renderer/locales/it/common.json
@@ -130,6 +130,8 @@
     "conflictDetail": "I file nella destinazione differiscono da quelli condivisi. I tuoi file esistenti vengono mantenuti; le versioni della condivisione vengono salvate accanto con un nome numerato.",
     "overFileLimit": "Questa cartella contiene {{total}} file, oltre il limite di {{limit}} file",
     "overFileLimitDetail": "Scegli una cartella più piccola oppure suddividila in più condivisioni.",
+    "listingCapped": "Questa cartella contiene {{total}} file, oltre il limite di {{limit}} file",
+    "listingCappedDetail": "La copia speculare funziona e tutti i file vengono sincronizzati, ma l’elenco mostrerà solo i primi {{limit}}.",
     "noConflicts": "Nessun conflitto",
     "noConflictDetail": "La destinazione è pulita.",
     "noConflictDetailOwned": "Non verrà sovrascritto nulla.",

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -221,11 +221,14 @@ export interface ScanPreview {
   totalBytes: number
   perFile: ScanPreviewEntry[]
   perFileOmitted?: boolean
-  // Owned-folder flow only: the folder's total file count against the share limit, so the
-  // confirmation step can refuse before the user commits.
+  // The folder's total file count against the limit, so the confirmation step can act before the
+  // user commits. Both flows carry it; only the owned one can REFUSE on overFileLimit, because
+  // mounting a peer share creates no share of your own. A mirror over the display cap sets
+  // listingAdvisory instead: a warning it can proceed past, not a wall.
   totalFiles?: number
   fileLimit?: number
   overFileLimit?: boolean
+  listingAdvisory?: boolean
 }
 
 export interface PreviewProgress {

--- a/src/shared/folders/foreign-preview.js
+++ b/src/shared/folders/foreign-preview.js
@@ -7,6 +7,8 @@ import { DEFAULT_IGNORE, dropUnsafeEntries } from './path-keys.js'
 import { getContentBackend, hasContentBackend } from '../transfer/content-backends.js'
 import { overlayHashFile } from '../transfer/backends/overlay/overlay-backend.js'
 import { isVerifiedUnchanged } from '../transfer/files.js'
+import { getListFilesCap } from '../core/runtime-config.js'
+import { listingWillTruncate } from './share-limits.js'
 import { createPreviewTally } from './preview-tally.js'
 import { createLogger } from '../core/logger.js'
 import { mapLimit } from '../core/concurrency.js'
@@ -78,8 +80,16 @@ export async function previewMaterializeScan(spaceId, ownerKey, shareId, mountPa
   ])
   checkAborted()
 
+  // A preview that could not read the listing must not advise about its size: totalFiles 0 here
+  // means "unknown", not "small".
   if (!entries) {
-    return createPreviewTally().result('mount-foreign-folder', 'download', { existingAtDestination })
+    return createPreviewTally().result('mount-foreign-folder', 'download', {
+      existingAtDestination,
+      totalFiles: 0,
+      fileLimit: getListFilesCap(),
+      overFileLimit: false,
+      listingAdvisory: false,
+    })
   }
 
   let scanned = 0
@@ -97,5 +107,15 @@ export async function previewMaterializeScan(spaceId, ownerKey, shareId, mountPa
     if (!r.download) continue
     tally.add({ relPath: r.relPath, size: r.size, conflict: !!r.conflict })
   }
-  return tally.result('mount-foreign-folder', 'download', { existingAtDestination })
+  // overFileLimit is the wizard's REFUSAL flag and stays false for a mirror: mounting creates no
+  // share, so the admission gate is not this flow's to enforce. listingAdvisory is the separate,
+  // non-blocking fact — the folder screen already degrades for a truncated listing after the mount,
+  // and this is the same news delivered before it.
+  return tally.result('mount-foreign-folder', 'download', {
+    existingAtDestination,
+    totalFiles: entries.length,
+    fileLimit: getListFilesCap(),
+    overFileLimit: false,
+    listingAdvisory: listingWillTruncate(entries.length),
+  })
 }

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -17,7 +17,7 @@ import { listOwnShare } from '../shares/share-catalog.js'
 import { ensureServable, setFolderPublishLane } from '../transfer/backends/overlay/overlay-backend.js'
 import { pathFromMount } from '../transfer/path-guard.js'
 import { makeKeyedCoalescer } from '../state/coalesce.js'
-import { walkDisk } from './walk-disk.js'
+import { countDiskFiles, walkDisk } from './walk-disk.js'
 import { relToDriveKey as relToKey, shouldIgnore, DEFAULT_IGNORE, isAbsoluteDriveKey, relKeyEscapes } from './path-keys.js'
 import { OP, PRIORITY } from './work-item.js'
 import { mountRootAvailable } from './publish-runner.js'
@@ -500,11 +500,12 @@ export async function initialPublishScan(spaceId, shareId, mountPath, ignore, op
 
 export const periodicReconcile = initialPublishScan
 
-// The count the worker's admission gate reads. Stat-only, and it walks the same way the publish
-// scan does, so the gate can never admit a folder the scan would then find too large.
+// The count the worker's admission gate reads. It counts what is on disk under the same key rule
+// the publish scan walks by, INCLUDING files the scan will set aside as unreadable — so the gate
+// can only ever be stricter than the scan, never looser, and can never admit a folder the scan
+// would then find too large.
 export async function countFolderFiles(mountPath, ignore) {
-  const { onDisk } = await walkDisk(mountPath, ignore)
-  return onDisk.size
+  return await countDiskFiles(mountPath, ignore)
 }
 
 export function getIndexStatus(spaceId, shareId) {

--- a/src/shared/folders/owned-preview.js
+++ b/src/shared/folders/owned-preview.js
@@ -6,7 +6,7 @@ import { listOwnShare } from '../shares/share-catalog.js'
 import { overlayHashFile } from '../transfer/backends/overlay/overlay-backend.js'
 import { getMaxFilesPerShare } from '../core/runtime-config.js'
 import { driveKeyToSegments } from './path-keys.js'
-import { exceedsShareFileLimit } from './share-limits.js'
+import { exceedsShareFileLimit, listingWillTruncate } from './share-limits.js'
 import { createPreviewTally } from './preview-tally.js'
 import { walkDisk } from './walk-disk.js'
 
@@ -45,10 +45,15 @@ export async function previewInitialPublishScan(spaceId, shareId, mountPath, ign
   // The limit is about how many files the folder HOLDS, not how many this scan would upload —
   // a re-preview of an existing share uploads only the changed ones.
   const totalFiles = onDisk.size
+  // Both verdicts, computed the same way for both flows. An admitted owned folder is under the
+  // display cap too while the two caps are held equal, so the advisory is dead weight today — but
+  // it is dead weight that cannot go stale, and a field only one flow computes is how the mirror
+  // side ended up silent about the limit in the first place.
   return tally.result('add-owned-folder', 'upload', {
     existingAtDestination: totalFiles,
     totalFiles,
     fileLimit: getMaxFilesPerShare(),
     overFileLimit: exceedsShareFileLimit(totalFiles),
+    listingAdvisory: listingWillTruncate(totalFiles),
   })
 }

--- a/src/shared/folders/share-limits.js
+++ b/src/shared/folders/share-limits.js
@@ -1,11 +1,21 @@
 // The one rule behind the folder-share file limit. The add-folder preview, the worker's mount
 // gate and the renderer all read it from here so they cannot drift: a folder the gate ADMITS
 // must always render in full.
-import { getMaxFilesPerShare } from '../core/runtime-config.js'
+import { getListFilesCap, getMaxFilesPerShare } from '../core/runtime-config.js'
 
 export function exceedsShareFileLimit(fileCount) {
   const limit = getMaxFilesPerShare()
   return Number.isFinite(limit) && fileCount > limit
+}
+
+// The mirror's constraint, and a different one from exceedsShareFileLimit: mounting a peer share
+// creates no share of your own, so admission does not apply — but the display ceiling does, and a
+// mirror of an over-cap share lists short exactly like an owned one would. Reads the display cap
+// rather than the admission limit because that is the ceiling a mirror actually meets — the two are
+// held equal by default, so today they agree, but only one of them is the mirror's reason.
+export function listingWillTruncate(fileCount) {
+  const cap = getListFilesCap()
+  return Number.isFinite(cap) && fileCount > cap
 }
 
 export function shareFileLimitMessage(fileCount) {

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -983,6 +983,16 @@ ipc.handle('event:loose-file-fs-event', async (msg) => {
 
 const previewAborts = new Map()
 
+// Both wizards cancel the same way over the same map, so they are one function under two request
+// names — the names are a wire contract (contract/requests.js), the behaviour never differed.
+const cancelPreview = async (msg) => {
+  const sig = previewAborts.get(msg.previewId)
+  if (sig) sig.aborted = true
+  return { ok: true }
+}
+ipc.handle('owned-folder:cancel-preview', cancelPreview)
+ipc.handle('foreign-folder:cancel-preview', cancelPreview)
+
 ipc.handle('owned-folder:preview', async (msg) => {
   const ignore = msg.ignore || DEFAULT_IGNORE
   const shareId = msg.shareId && msg.shareId !== 'preview' ? msg.shareId : null
@@ -999,12 +1009,6 @@ ipc.handle('owned-folder:preview', async (msg) => {
   } finally {
     if (previewId) previewAborts.delete(previewId)
   }
-})
-
-ipc.handle('owned-folder:cancel-preview', async (msg) => {
-  const sig = previewAborts.get(msg.previewId)
-  if (sig) sig.aborted = true
-  return { ok: true }
 })
 
 ipc.handle('owned-folder:validate', async (msg) => {
@@ -1218,12 +1222,6 @@ ipc.handle('foreign-folder:preview', async (msg) => {
   } finally {
     if (previewId) previewAborts.delete(previewId)
   }
-})
-
-ipc.handle('foreign-folder:cancel-preview', async (msg) => {
-  const sig = previewAborts.get(msg.previewId)
-  if (sig) sig.aborted = true
-  return { ok: true }
 })
 
 ipc.handle('foreign-folder:mount', async (msg) => {

--- a/test/frontend/instance.mjs
+++ b/test/frontend/instance.mjs
@@ -598,6 +598,26 @@ export class Instance {
     await this._confirmPreview('Start Mirroring', 'Download')
   }
 
+  // Mirror's counterpart to openAddFolderPreview: advance to the ScanPreviewModal and STOP there,
+  // so the preview's own verdict can be inspected before committing.
+  async openMirrorPreview(mirrorDir) {
+    await this.click({ name: 'More', last: true })
+    await new Promise((r) => setTimeout(r, POLL_MS))
+    await this.click({ name: 'Mirror to Disk…' })
+    await this.waitText('to Disk', 20000)
+    await this.nativeChoosePath(mirrorDir, { trigger: () => this.click({ role: 'button', name: 'Browse…' }) })
+    await new Promise((r) => setTimeout(r, 400))
+    for (let i = 0; i < 20; i++) {
+      const next = flatten(await this.snap()).find(
+        (n) => n.role === 'button' && (n.name === 'Next: Preview' || n.description === 'Next: Preview'),
+      )
+      if (next && !(next.states ?? []).includes('disabled')) break
+      await new Promise((r) => setTimeout(r, POLL_MS))
+    }
+    await this.click({ role: 'button', name: 'Next: Preview' })
+    await this.waitText('Download', 20000)
+  }
+
   async unmountShare() {
     await this.click({ name: 'More', last: true })
     await new Promise((r) => setTimeout(r, POLL_MS))

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -131,6 +131,7 @@ import s130 from './scenarios/s130-mirror-name-collision.mjs'
 import s131 from './scenarios/s131-mirror-fault-clears-on-unmount.mjs'
 import s132 from './scenarios/s132-activity-log-settings-parity.mjs'
 import s133 from './scenarios/s133-modal-keyboard.mjs'
+import s134 from './scenarios/s134-mirror-over-cap-advisory.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -197,7 +198,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s134-mirror-over-cap-advisory.mjs
+++ b/test/frontend/scenarios/s134-mirror-over-cap-advisory.mjs
@@ -1,0 +1,52 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert } from '../assert.mjs'
+import { workDir } from '../paths.mjs'
+
+// FIX-PI6-2 (UI) — mirroring a share with more files than the display cap WARNS, where adding an
+// over-limit folder of your own REFUSES (s104). The difference is the whole point: a mount creates
+// no share, so the admission gate is not this flow's to enforce — but the listing ceiling is real,
+// and the folder screen already says so afterwards (s78). This is the same news delivered before
+// the user commits, with the primary action still enabled.
+//
+// The cap is shrunk via MIRALL_LIST_FILES_CAP so a handful of files trips it.
+export default async function s134 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  process.env.MIRALL_LIST_FILES_CAP = '3'
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Big')
+  mkdirSync(ownDir, { recursive: true })
+  const N = 8 // > cap (3)
+  for (let i = 0; i < N; i++) writeFileSync(path.join(ownDir, 'f' + String(i).padStart(2, '0') + '.txt'), 'x'.repeat(64))
+  const mirrorDir = workDir('mirror-')
+
+  try {
+    await r.ok('launch + connect + A shares a folder with more files than the cap', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      await A.addOwnedFolder(ownDir)
+      await B.waitText('Big', 60000)
+    })
+
+    await r.ok('B\'s mirror preview warns about the short list, and lets him proceed anyway', async () => {
+      await B.openMirrorPreview(mirrorDir)
+      await B.waitText('above the 3-file limit', 30000)
+      assert(await B.hasText('has 8 files'), 'the advisory names the TRUE remote count (8), not the capped 3')
+      assert(await B.hasText('only show the first'), 'and says what is actually capped — the list, not the sync')
+      assert(
+        !(await B.isDisabled({ role: 'button', name: 'Start Mirroring', last: true })),
+        'the confirm stays ENABLED — this is a warning, not a refusal (contrast s104)',
+      )
+      await B.shot('s134-B-mirror-over-cap-advisory', runDir)
+    })
+  } catch {} finally {
+    delete process.env.MIRALL_LIST_FILES_CAP
+  }
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/integration/preview-scan.test.js
+++ b/test/integration/preview-scan.test.js
@@ -6,6 +6,7 @@ import { initialPublishScan } from '../../src/shared/folders/owned-folders.js'
 import { previewInitialPublishScan } from '../../src/shared/folders/owned-preview.js'
 import { previewMaterializeScan } from '../../src/shared/folders/foreign-preview.js'
 import { overlayHashFile } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
+import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 
 // The scan-preview dialogs are the user's last confirmation before bytes move.
 // They must count uploads/downloads and conflicts honestly.
@@ -233,4 +234,61 @@ test('foreign preview: ignored files do not inflate the destination count', asyn
   fs.writeFileSync(path.join(ctx.mirrorPath, 'half.mirall.part'), 'junk')
   const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, ctx.mirrorPath)
   t.is(preview.existingAtDestination, 1, 'DEFAULT_IGNORE still applies through the shared walk')
+})
+
+function withCap (t, cap) {
+  const saved = getRuntimeConfig()
+  t.teardown(() => setRuntimeConfig(saved))
+  setRuntimeConfig({ ...saved, listFilesCap: cap })
+}
+
+function fiveFiles () {
+  const files = {}
+  for (let i = 0; i < 5; i++) files['f' + i + '.txt'] = 'x'
+  return files
+}
+
+// REGRESSION (FIX-PI6-2): the mirror preview carried none of the file-limit fields, because the two
+// previews assembled their summary separately and only the owned one grew them. So mirroring an
+// over-cap share said nothing, and the user met the short list for the first time inside the folder
+// — where the app has told them about it, correctly, all along.
+test('REGRESSION (FIX-PI6-2): a mirror preview of an over-cap share advises, and does not refuse', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: fiveFiles() })
+  withCap(t, 3)
+
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, ctx.mirrorPath)
+  t.is(preview.totalFiles, 5, 'the TRUE remote count — the preview listing is read uncapped')
+  t.is(preview.fileLimit, 3)
+  t.ok(preview.listingAdvisory, 'the wizard has what it needs to warn')
+  t.absent(preview.overFileLimit, 'but never what it needs to REFUSE — a mount creates no share')
+})
+
+test('a mirror preview under the cap carries no advisory', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: fiveFiles() })
+  withCap(t, 5)
+
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, ctx.mirrorPath)
+  t.is(preview.totalFiles, 5)
+  t.absent(preview.listingAdvisory, 'exactly at the cap lists in full')
+})
+
+// A preview that could not read the listing knows nothing about its size. The trap is a totalFiles
+// of 0 reading as "small" — it means "unknown", and neither field may claim otherwise.
+test('a mirror preview that cannot read the share advises nothing', async (t) => {
+  const ctx = await setupSelfMirror(t)
+  withCap(t, 1)
+
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, 'no-such-share', ctx.mirrorPath)
+  t.is(preview.totalFiles, 0, 'unknown, not small')
+  t.absent(preview.listingAdvisory, 'and nothing is claimed about a listing that was never read')
+  t.absent(preview.overFileLimit)
+})
+
+// The two flows answer one dialog through one component, so a field must never exist on one of them
+// by accident — which is exactly how the mirror side ended up silent about the limit.
+test('both previews return the same fields', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: fiveFiles() })
+  const owned = await previewInitialPublishScan(ctx.spaceId, null, ctx.mountPath, [])
+  const mirror = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, ctx.mirrorPath)
+  t.alike(Object.keys(owned).sort(), Object.keys(mirror).sort())
 })

--- a/test/integration/share-file-limit.test.js
+++ b/test/integration/share-file-limit.test.js
@@ -8,6 +8,7 @@ import {
 import { previewInitialPublishScan } from '../../src/shared/folders/owned-preview.js'
 import { collectOwnShare } from '../../src/shared/shares/share-catalog.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
+import { exceedsShareFileLimit } from '../../src/shared/folders/share-limits.js'
 
 function writeFiles (dir, n, from = 0) {
   for (let i = from; i < from + n; i++) {
@@ -46,7 +47,34 @@ test('a folder at exactly the limit is admitted', async (t) => {
   const preview = await previewInitialPublishScan(spaceId, null, mountPath, [])
   t.is(preview.totalFiles, 10)
   t.absent(preview.overFileLimit, 'exactly at the limit is not over it')
-  t.is(await countFolderFiles(mountPath, []), 10, 'the gate counts the same folder the scan will publish')
+  t.is(await countFolderFiles(mountPath, []), 10, 'the gate counts at least what the scan will publish')
+})
+
+// REGRESSION (FIX-PI6-1): the gate stopped stat-ing every file to count it, and the stat-free count
+// keeps a file it cannot read where the stat-ing walk drops it. That moves the count UP, never down
+// — the only safe direction, because a gate that under-counts admits a folder that then lists short.
+test('REGRESSION (FIX-PI6-1): the gate counts a file it cannot stat', async (t) => {
+  const { mountPath } = await setupOwnedShare(t)
+  withLimit(t, 10)
+  writeFiles(mountPath, 10)
+  const locked = path.join(mountPath, 'f009.txt')
+  fs.chmodSync(locked, 0o000)
+  t.teardown(() => { try { fs.chmodSync(locked, 0o644) } catch {} })
+
+  t.is(await countFolderFiles(mountPath, []), 10, 'the unreadable file is still a file at the destination')
+  t.absent(exceedsShareFileLimit(await countFolderFiles(mountPath, [])), 'and ten is still ten — the boundary has not moved')
+})
+
+test('the gate refuses an over-limit folder whose last file is unreadable', async (t) => {
+  const { mountPath } = await setupOwnedShare(t)
+  withLimit(t, 10)
+  writeFiles(mountPath, 11)
+  const locked = path.join(mountPath, 'f010.txt')
+  fs.chmodSync(locked, 0o000)
+  t.teardown(() => { try { fs.chmodSync(locked, 0o644) } catch {} })
+
+  t.ok(exceedsShareFileLimit(await countFolderFiles(mountPath, [])),
+    'the eleventh file counts even though the scan would set it aside — the gate rounds towards refusal')
 })
 
 // REGRESSION (FIX-360): the limit is an ADMISSION gate, not a runtime ceiling. A share admitted at

--- a/test/integration/walk-disk.test.js
+++ b/test/integration/walk-disk.test.js
@@ -17,12 +17,12 @@ test('stat-only walk returns size+mtime and never a hash', async (t) => {
   fs.mkdirSync(path.join(root, 'sub'))
   fs.writeFileSync(path.join(root, 'sub', 'b.txt'), 'bb')
 
-  const { onDisk } = await walkDisk(root, [], { hash: false })
+  const { onDisk } = await walkDisk(root, [])
   t.is(onDisk.size, 2)
   const a = onDisk.get('a.txt')
   t.is(a.size, 4)
   t.ok(typeof a.mtime === 'number')
-  t.absent(a.hash, 'no content hash in stat-only mode')
+  t.absent(a.hash, 'the walk reads no file contents')
   t.ok(onDisk.has('sub/b.txt'), 'recurses, posix-joined keys')
 })
 
@@ -30,7 +30,7 @@ test('ignore globs are honored', async (t) => {
   const root = tmp()
   fs.writeFileSync(path.join(root, 'keep.txt'), 'k')
   fs.writeFileSync(path.join(root, '.DS_Store'), 'junk')
-  const { onDisk } = await walkDisk(root, ['.DS_Store'], { hash: false })
+  const { onDisk } = await walkDisk(root, ['.DS_Store'])
   t.ok(onDisk.has('keep.txt'))
   t.absent(onDisk.has('.DS_Store'))
 })
@@ -39,7 +39,7 @@ test('onProgress is monotonic and ends at the file count', async (t) => {
   const root = tmp()
   for (let i = 0; i < 5; i++) fs.writeFileSync(path.join(root, `f${i}.txt`), 'x'.repeat(i + 1))
   const seen = []
-  const { onDisk } = await walkDisk(root, [], { hash: false, onProgress: (p) => seen.push(p) })
+  const { onDisk } = await walkDisk(root, [], { onProgress: (p) => seen.push(p) })
   t.ok(seen.length >= 1)
   t.is(seen[seen.length - 1].scanned, onDisk.size)
   for (let i = 1; i < seen.length; i++) t.ok(seen[i].scanned >= seen[i - 1].scanned, 'scanned monotonic')
@@ -49,7 +49,7 @@ test('an aborted signal throws PREVIEW_CANCELLED', async (t) => {
   const root = tmp()
   for (let i = 0; i < 3; i++) fs.writeFileSync(path.join(root, `f${i}.txt`), 'x')
   try {
-    await walkDisk(root, [], { hash: false, signal: { aborted: true } })
+    await walkDisk(root, [], { signal: { aborted: true } })
     t.fail('should have thrown')
   } catch (err) {
     t.is(err.code, 'PREVIEW_CANCELLED')

--- a/test/unit/contract-requests.test.js
+++ b/test/unit/contract-requests.test.js
@@ -67,3 +67,17 @@ test('the unreferenced-handler list only shrinks', (t) => {
   t.ok(UNREFERENCED_REQUESTS.length <= 0, 'no new unreferenced handler was introduced')
   for (const name of UNREFERENCED_REQUESTS) t.ok(REQUESTS[name], `${name} is still a real request`)
 })
+
+// The two cancel-preview handlers were byte-identical five-line copies over one shared abort map.
+// Registered from one identifier now, so the pair cannot drift: the request names are the wire
+// contract and stay two, the behaviour behind them is one function.
+test('the two cancel-preview request names are registered from one function', (t) => {
+  const src = readFileSync(path.join(root, 'src', 'worker', 'main.js'), 'utf8')
+  const bound = {}
+  for (const m of src.matchAll(/ipc\.handle\('((?:owned|foreign)-folder:cancel-preview)',\s*([A-Za-z_$][\w$]*)\)/g)) {
+    bound[m[1]] = m[2]
+  }
+  t.is(Object.keys(bound).length, 2, 'both names are registered by identifier, not by a fresh literal')
+  t.is(bound['owned-folder:cancel-preview'], bound['foreign-folder:cancel-preview'],
+    'and both reach the same handler')
+})

--- a/test/unit/share-file-limit.test.js
+++ b/test/unit/share-file-limit.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { exceedsShareFileLimit } from '../../src/shared/folders/share-limits.js'
+import { exceedsShareFileLimit, listingWillTruncate } from '../../src/shared/folders/share-limits.js'
 import { getMaxFilesPerShare, getListFilesCap, getRuntimeConfig, setRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 
 // The admission gate behind the add-folder wizard: a folder with more files than a share may hold
@@ -49,3 +49,37 @@ test('the admission limit and the display ceiling are the same number', (t) => {
   t.is(getMaxFilesPerShare(), getListFilesCap(), 'maxFilesPerShare === listFilesCap by default')
 })
 
+// The mirror's half of the same question. A mount creates no share, so the admission gate does not
+// apply to it — but the display ceiling does, and the mirror wizard has to be able to say so.
+test('listingWillTruncate is exclusive at the boundary, like the admission gate', (t) => {
+  const saved = getRuntimeConfig()
+  t.teardown(() => setRuntimeConfig(saved))
+
+  setRuntimeConfig({ ...saved, listFilesCap: 5000 })
+  t.absent(listingWillTruncate(4999))
+  t.absent(listingWillTruncate(5000), 'exactly at the cap is listed in full')
+  t.ok(listingWillTruncate(5001), 'one over lists short')
+})
+
+// The two are equal by default, which is what makes the owned gate safe. They are still different
+// questions, and a mirror asks the display one — so this pins WHICH knob is read, not just the
+// number it happens to hold.
+test('listingWillTruncate reads the display ceiling, not the admission limit', (t) => {
+  const saved = getRuntimeConfig()
+  t.teardown(() => setRuntimeConfig(saved))
+
+  setRuntimeConfig({ ...saved, listFilesCap: 10, maxFilesPerShare: 1000 })
+  t.ok(listingWillTruncate(11), 'over the display cap, well under the admission limit')
+  t.absent(exceedsShareFileLimit(11), 'and the admission gate is untouched by it')
+})
+
+test('an explicit 0 / Infinity disables the listing advisory too', (t) => {
+  const saved = getRuntimeConfig()
+  t.teardown(() => setRuntimeConfig(saved))
+
+  setRuntimeConfig({ ...saved, listFilesCap: 0 })
+  t.absent(listingWillTruncate(150000), 'nothing truncates an uncapped listing')
+
+  setRuntimeConfig({ ...saved, listFilesCap: Infinity })
+  t.absent(listingWillTruncate(150000))
+})


### PR DESCRIPTION
## What & why

Three findings from the plan-06 re-measure. Its first two sections had
already shipped in #177/#180; these are what was left.

- **The add-folder gate stat-ed every file to count it.** It walked the
  folder a second time for size+mtime it discarded. Now uses the
  stat-free walk. That walk also counts files it cannot read, so the
  gate rounds towards refusal — it can never admit a folder that then
  lists short, which is the invariant it exists to hold.
- **`cancel-preview` had two byte-identical handlers** over one shared
  abort map. One function, both request names (they are a wire contract).
- **The mirror wizard was silent about the file limit.** Adding an
  over-limit folder of your own is refused; mirroring a peer's said
  nothing, and the capped file list came as a surprise after the mount —
  an asymmetry nobody decided, left over from writing the summary twice.
  The mirror preview now carries the count and shows a warning with the
  confirm still **enabled**: a mount creates no share, so refusing would
  be wrong, but the listing ceiling is real. `listingWillTruncate()`
  reads `listFilesCap` (the display ceiling), not `maxFilesPerShare`
  (admission) — equal today, but only one is the mirror's reason.

## Coverage

Unit (`listingWillTruncate`, the handler pair), Integration (the gate's
unreadable-file delta, both previews' fields), Frontend + a11y (s134).
Both previews are asserted to return the same field set, so a key cannot
exist on one flow by accident again.

## Ran locally

`test:fe s134` — mirror an over-cap share: the advisory renders and
`Start Mirroring` stays enabled (contrast s104's refusal). Evidence
screenshot in `test/frontend/evidence/`. axe clean; VoiceOver spot-check
on the mirror wizard passed — the card is a plain region, not an alert,
so it does not interrupt or take focus.