### PR TITLE
[refactor] Give the renderer's duplicated scaffolding one home each

### DIFF
--- a/.claude/design.md
+++ b/.claude/design.md
@@ -186,11 +186,18 @@ mapped in `tailwind.config.js`:
   Weights **400–600**. All body and UI text.
 
 There is **no named type scale** (no `display-lg`, `body-lg`, etc.). Headings use
-plain Tailwind sizes + `font-headline`:
+plain Tailwind sizes + `font-headline`.
+
+Two page-title treatments, and which one a screen takes is decided by whether the title is a
+translated constant or a name someone typed. A settings page uses `PageHeader`. A screen *about
+something* — a space, a folder — uses `EntityHeader`, which adds a back button, an eyebrow line, an
+actions cluster, and the three classes a user-supplied name needs: `truncate`, plus `leading-tight`
+and `pb-1.5` to keep the 800-weight descenders out of the clip that `truncate` introduces.
 
 | Use | Classes | Where |
 |---|---|---|
 | Page title | `text-4xl font-headline font-extrabold text-accent tracking-tight` (`md:text-5xl` on onboarding) | `components/layout/PageHeader.tsx` |
+| Entity title (a name someone typed) | `text-4xl font-headline font-extrabold text-accent tracking-tighter leading-tight truncate pb-1.5` | `components/layout/EntityHeader.tsx` |
 | Modal title | `text-2xl font-headline font-extrabold text-accent tracking-tight` | modals, `keyboard/*` |
 | Section heading | `text-xl font-headline font-bold text-accent mb-6` | `components/layout/SectionHeading.tsx` |
 | Eyebrow / group label | `text-xs font-bold uppercase tracking-wide text-secondary` | `keyboard/ShortcutsHint.tsx`, `screens/ActivityLog.tsx` day headings, what's-new |

--- a/.claude/design.md
+++ b/.claude/design.md
@@ -524,8 +524,13 @@ pure function, `primitives/modalKeys.ts`, unit-tested in `test/unit/modal-keys.t
   as its final action, and a two-state dialog wires the "Done" of its second state.
 - Panel default: `glass-modal w-full max-w-xl rounded-3xl shadow-2xl shadow-black/30 overflow-hidden`
   (override `max-w-*` per modal; `max-w-md` for compact/confirm, `max-w-2xl max-h-[80vh]` for What's New).
-- Anatomy: header `px-10 pt-10 pb-6` (title + close `IconButton`); body
-  `px-10 pb-10 space-y-{4–8}`. Three footer shapes:
+- Anatomy: header `px-10 pt-10 pb-6` (title + close `IconButton`) — **one component,
+  `components/layout/ModalHeader.tsx`**, used by every dialog including the purge confirm that
+  `screens/ActivityLogSettings.tsx` mounts inline; `keyboard/ShortcutsHint.tsx` and
+  `keyboard/CommandPalette.tsx` are the two `<Modal>` consumers with no header row. It takes either a
+  `title` string or a `titleNode` (a `<FilenameTitle>`), an optional `description` in one of two sizes,
+  and a close button that can be disabled or omitted. Body: `px-10 pb-10 space-y-{4–8}`.
+  Three footer shapes:
   1. A single full-width `lg` button.
   2. **Confirm/destructive** — Cancel(`secondary`) + Action(`danger`), both `flex-1 h-14`.
   3. **Wizard step** — `flex justify-end gap-3`, Cancel(`secondary`) + Action(`primary`)

--- a/.claude/design.md
+++ b/.claude/design.md
@@ -468,6 +468,11 @@ Used by Add Folder, Mirror to Disk, Edit Folder, Edit Space and Storage settings
 second form — a bare line of path text next to a `secondary` button is the drift this replaced, and
 it read as a different kind of thing depending on which door you came through.
 
+The two mount wizards reach it through **`widgets/MountPathField.tsx`**, which adds the field's
+headline label and its `role="alert"` validation line. The label is a `<span>` with an id rather
+than a `<label>`, because the row's action is a button, not a form control — the association goes
+through `aria-describedby`.
+
 `FilePath` and `FileName` keep **exactly one flexible run** next to a pinned ending (the final
 segment, or a filename's extension): ranking two shrinkable spans by `flex-shrink` does not work —
 once the first freezes at zero width Chromium leaves the rest overflowing, which is how a long
@@ -524,8 +529,10 @@ pure function, `primitives/modalKeys.ts`, unit-tested in `test/unit/modal-keys.t
   1. A single full-width `lg` button.
   2. **Confirm/destructive** — Cancel(`secondary`) + Action(`danger`), both `flex-1 h-14`.
   3. **Wizard step** — `flex justify-end gap-3`, Cancel(`secondary`) + Action(`primary`)
-     at default `sm` size, the action carrying a trailing `arrow_forward`.
-     Used by Add Folder / Mirror Folder and their shared scan-preview step.
+     at default `sm` size, the action carrying a trailing `arrow_forward`. Owned by
+     **`modals/MountWizardStep.tsx`** (header + body slot + this footer), which Add Folder and
+     Mirror to Disk both render; their shared second step is `modals/ScanPreviewModal.tsx`, and the
+     state machine behind both — validate, scan, commit — is `hooks/useMountWizard.ts`.
 - **Destructive intent is carried only by the `danger` button** — titles and
   body text stay in normal `text-accent` / `text-on-surface-variant`.
 - Progress modals (Leave / Reclaim / Clear cache) animate through

--- a/src/renderer/components/layout/EntityHeader.tsx
+++ b/src/renderer/components/layout/EntityHeader.tsx
@@ -1,0 +1,45 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import IconButton from '../primitives/IconButton.js'
+
+// The header of a screen ABOUT SOMETHING — a space, a folder — as opposed to PageHeader, which titles
+// a settings page. The difference is not decoration: this title carries a name someone typed, so it
+// truncates, and `truncate` is `overflow: hidden`, which clips the 800-weight headline's descenders
+// unless the line box is loosened and given room below the baseline. That triple
+// (truncate + leading-tight + pb-1.5) is what makes this a second component rather than a flag on the
+// first, and test/unit/space-title-descender.test.js pins it.
+interface EntityHeaderProps {
+  name: string
+  titleAdornment?: ReactNode
+  eyebrow?: ReactNode
+  actions?: ReactNode
+  onBack: () => void
+}
+
+export default function EntityHeader({ name, titleAdornment, eyebrow, actions, onBack }: EntityHeaderProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="shrink-0 pt-8 pb-4">
+      <div className="flex items-start gap-4">
+        <IconButton
+          icon="arrow_back"
+          onClick={onBack}
+          ariaLabel={t('actions.back')}
+          className="mt-1 shrink-0"
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-3">
+            <h1 className="text-4xl font-headline font-extrabold text-accent tracking-tighter leading-tight truncate pb-1.5">
+              {name}
+            </h1>
+            {titleAdornment}
+          </div>
+          {eyebrow && (
+            <p className="text-xs font-bold text-secondary tracking-wide uppercase mt-1">{eyebrow}</p>
+          )}
+        </div>
+        {actions && <div className="flex gap-3 mt-2 shrink-0">{actions}</div>}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/components/layout/ModalHeader.tsx
+++ b/src/renderer/components/layout/ModalHeader.tsx
@@ -1,0 +1,65 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import IconButton from '../primitives/IconButton.js'
+
+// The block every dialog opens with, and the one design.md fixes the anatomy of. Seventeen dialogs
+// wrote it out by hand: two drifted off the documented padding, one titled itself with an <h2>, and
+// twelve were missing the gap that keeps a long title off the close button.
+//
+// Two axes are real variation and stay props. The title is either a plain sentence or a
+// <FilenameTitle> carrying a name someone typed, and the close button can be disabled (an operation
+// is running) or absent (the dialog has passed the point where dismissing it means anything). The
+// description's two sizes are NOT a rule — nothing separates the seven base ones from the six small
+// ones — so the prop records the split rather than restyling thirteen dialogs inside a refactor.
+type ModalHeaderProps = {
+  description?: ReactNode
+  descriptionSize?: 'base' | 'sm'
+  descriptionId?: string
+  onClose?: () => void
+  closeDisabled?: boolean
+  className?: string
+} & (
+  | { title: string; titleNode?: never }
+  | { title?: never; titleNode: ReactNode }
+)
+
+export default function ModalHeader({
+  title,
+  titleNode,
+  description,
+  descriptionSize = 'base',
+  descriptionId,
+  onClose,
+  closeDisabled,
+  className,
+}: ModalHeaderProps) {
+  const { t } = useTranslation()
+  return (
+    <div className={`px-10 pt-10 pb-6${className ? ` ${className}` : ''}`}>
+      {/* gap-3 unconditionally: a title long enough to reach the close button is one locale away on
+          every dialog, not only on the four that interpolate a file name. */}
+      <div className="flex justify-between items-start mb-2 gap-3">
+        {titleNode ?? (
+          <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{title}</h1>
+        )}
+        {onClose && (
+          <IconButton
+            icon="close"
+            onClick={onClose}
+            ariaLabel={t('actions.close')}
+            disabled={closeDisabled}
+            iconClassName="text-secondary"
+          />
+        )}
+      </div>
+      {description && (
+        <p
+          id={descriptionId}
+          className={`text-on-surface-variant font-medium${descriptionSize === 'sm' ? ' text-sm' : ''}`}
+        >
+          {description}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/components/modals/AddFolderShareModal.tsx
+++ b/src/renderer/components/modals/AddFolderShareModal.tsx
@@ -2,18 +2,12 @@
 // path and share name, then confirm via the scan preview.
 import { useEffect, useMemo, useState } from 'react'
 import { useTranslation } from 'react-i18next'
-import Modal from '../primitives/Modal.js'
-import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
-import Button from '../primitives/Button.js'
-import PathRow from '../widgets/PathRow.js'
+import MountPathField from '../widgets/MountPathField.js'
+import MountWizardStep from './MountWizardStep.js'
 import ScanPreviewModal from './ScanPreviewModal.js'
 import { validateOwnedMount, previewOwnedMount, cancelOwnedPreview, createShareThenMount } from '../../hooks/useFolderMount.js'
-import { usePreviewFlow } from '../../hooks/usePreviewFlow.js'
-import type { MountValidationResult } from '../../types.js'
-import { useToast } from '../toast/useToast.js'
+import { useMountWizard } from '../../hooks/useMountWizard.js'
 import { basename, isValidShareName } from '../../sharePaths.js'
-import { useErrorText } from '../../hooks/useErrorText.js'
 
 interface AddFolderShareModalProps {
   isOpen: boolean
@@ -25,86 +19,31 @@ interface AddFolderShareModalProps {
   onCreated: () => void
 }
 
-type Step = 'edit' | 'preview'
-
-interface FolderShareEditStepProps {
-  isOpen: boolean
-  spaceName: string
-  mountPath: string
-  shareName: string
-  validationError: string | null
-  nameError: string | null
-  canProceed: boolean
-  previewLoading: boolean
-  onBrowse: () => void
-  onNext: () => void
-  onChangeName: (value: string) => void
-  onClose: () => void
+interface ShareNameFieldProps {
+  value: string
+  error: string | null
+  onChange: (value: string) => void
 }
 
-function FolderShareEditStep({ isOpen, spaceName, mountPath, shareName, validationError, nameError, canProceed, previewLoading, onBrowse, onNext, onChangeName, onClose }: FolderShareEditStepProps) {
+function ShareNameField({ value, error, onChange }: ShareNameFieldProps) {
   const { t } = useTranslation()
   return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      onConfirm={canProceed && !previewLoading ? onNext : undefined}
-      ariaLabel={t('addFolder.title')}
-    >
-      <div className="px-10 pt-10 pb-6">
-        <div className="flex justify-between items-start mb-2">
-          <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{t('addFolder.title')}</h1>
-          <IconButton
-            icon="close"
-            onClick={onClose}
-            ariaLabel={t('actions.close')}
-            iconClassName="text-secondary"
-          />
-        </div>
-        <p className="text-on-surface-variant font-medium">
-          {t('addFolder.description', { space: spaceName })}
-        </p>
-      </div>
-
-      <div className="px-10 pb-10 space-y-6">
-        <div className="space-y-3">
-          <span id="add-folder-path-label" className="block font-headline text-sm font-bold text-accent px-1">
-            {t('addFolder.pathLabel')}
-          </span>
-          <PathRow path={mountPath} onAction={onBrowse} ariaDescribedBy="add-folder-path-label" />
-          {validationError && (
-            <p role="alert" className="text-xs text-error px-1">{validationError}</p>
-          )}
-        </div>
-
-        <div className="space-y-3">
-          <label htmlFor="add-share-name" className="font-headline text-sm font-bold text-accent px-1">{t('addFolder.nameLabel')}</label>
-          <input
-            id="add-share-name"
-            value={shareName}
-            onChange={(e) => onChangeName(e.target.value)}
-            aria-invalid={nameError ? true : undefined}
-            aria-describedby={nameError ? 'add-share-name-error' : undefined}
-            className="w-full bg-surface-container-low border-none focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30 rounded-xl px-6 py-4 text-accent font-medium placeholder:text-outline/50"
-          />
-          {nameError ? (
-            <p id="add-share-name-error" role="alert" className="text-xs text-error px-1">{nameError}</p>
-          ) : (
-            <p className="text-xs text-on-surface-variant px-1">{t('addFolder.nameHelp')}</p>
-          )}
-        </div>
-
-        <div className="pt-2 flex justify-end gap-3">
-          <Button variant="secondary" onClick={onClose}>
-            {t('actions.cancel')}
-          </Button>
-          <Button onClick={onNext} disabled={!canProceed || previewLoading}>
-            {previewLoading ? t('scanPreview.computing') : t('addFolder.next')}
-            <Icon name="arrow_forward" size={16} />
-          </Button>
-        </div>
-      </div>
-    </Modal>
+    <div className="space-y-3">
+      <label htmlFor="add-share-name" className="font-headline text-sm font-bold text-accent px-1">{t('addFolder.nameLabel')}</label>
+      <input
+        id="add-share-name"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={error ? 'add-share-name-error' : undefined}
+        className="w-full bg-surface-container-low border-none focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30 rounded-xl px-6 py-4 text-accent font-medium placeholder:text-outline/50"
+      />
+      {error ? (
+        <p id="add-share-name-error" role="alert" className="text-xs text-error px-1">{error}</p>
+      ) : (
+        <p className="text-xs text-on-surface-variant px-1">{t('addFolder.nameHelp')}</p>
+      )}
+    </div>
   )
 }
 
@@ -118,46 +57,23 @@ export default function AddFolderShareModal({
   onCreated,
 }: AddFolderShareModalProps) {
   const { t } = useTranslation()
-  const toast = useToast()
-  const errorText = useErrorText()
-  const [mountPath, setMountPath] = useState(initialMountPath)
   const [shareName, setShareName] = useState(basename(initialMountPath))
-  const [validation, setValidation] = useState<MountValidationResult | null>(null)
-  const [validationError, setValidationError] = useState<string | null>(null)
-  const [step, setStep] = useState<Step>('edit')
-  const { preview, progress: previewProgress, loading: previewLoading, run: runPreview, cancel: cancelPreview, reset: resetPreview } = usePreviewFlow(cancelOwnedPreview)
-  const [submitting, setSubmitting] = useState(false)
 
+  const wizard = useMountWizard({
+    isOpen,
+    initialPath: initialMountPath,
+    validate: validateOwnedMount,
+    startPreview: (path, onProgress) => previewOwnedMount(spaceId, null, path, { onProgress }),
+    cancelPreview: cancelOwnedPreview,
+    commit: async (path) => { await createShareThenMount(spaceId, shareName.trim(), path) },
+    onCommitted: () => { onCreated(); onClose() },
+  })
+
+  // The name is the wizard's only field it does not own, so it re-seeds on the same edge the wizard
+  // resets on: a fresh open, or a different folder dropped in.
   useEffect(() => {
-    if (!isOpen) return
-    setMountPath(initialMountPath)
-    setShareName(basename(initialMountPath))
-    setValidation(null)
-    setValidationError(null)
-    setStep('edit')
-    resetPreview()
-    return () => { cancelPreview() }
+    if (isOpen) setShareName(basename(initialMountPath))
   }, [isOpen, initialMountPath])
-
-  // Deliberately NOT on the query store, though it is param-keyed and looks like a query: this is
-  // a point-in-time filesystem probe. The folder can be deleted, unmounted or filled between two
-  // opens of the modal, and a cached verdict would show a stale answer for a path the user just
-  // changed — a correctness regression traded for a round-trip nobody is waiting on. The cancel
-  // flag stays.
-  useEffect(() => {
-    if (!isOpen || !mountPath) return
-    let cancelled = false
-    setValidation(null)
-    setValidationError(null)
-    validateOwnedMount(mountPath).then(
-      (result) => { if (!cancelled) setValidation(result) },
-      (err) => {
-        if (cancelled) return
-        setValidationError(errorText(err))
-      },
-    )
-    return () => { cancelled = true }
-  }, [isOpen, mountPath, errorText])
 
   const collision = useMemo(
     () => existingShareNames.some((n) => n === shareName.trim()),
@@ -166,79 +82,48 @@ export default function AddFolderShareModal({
   const nameInvalid = !isValidShareName(shareName)
   const nameError = collision ? t('addFolder.nameCollision') : nameInvalid ? t('addFolder.nameInvalid') : null
 
-  const canProceedToPreview =
-    !!validation && !validationError && !nameError && mountPath.length > 0
-
   async function handleBrowse() {
-    const picked = await window.bridge.browseShareFolder()
-    if (!picked) return
-    setMountPath(picked)
-    setShareName(basename(picked))
+    const picked = await wizard.browse()
+    if (picked) setShareName(basename(picked))
   }
 
-  async function handleNext() {
-    if (!canProceedToPreview) return
-    setStep('preview')
-    try {
-      await runPreview((onProgress) => previewOwnedMount(spaceId, null, mountPath, { onProgress }))
-    } catch (err) {
-      const code = (err as { code?: string } | null)?.code
-      if (code !== 'PREVIEW_CANCELLED') {
-        toast.error(errorText(err))
-        setStep('edit')
-      }
-    }
-  }
-
-  function handlePreviewCancel() {
-    cancelPreview()
-    setStep('edit')
-  }
-
-  async function handleCreate() {
-    if (submitting) return
-    setSubmitting(true)
-    try {
-      await createShareThenMount(spaceId, shareName.trim(), mountPath)
-      onCreated()
-      onClose()
-    } catch (err) {
-      toast.error(errorText(err))
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  if (step === 'preview') {
+  if (wizard.step === 'preview') {
     return (
       <ScanPreviewModal
         isOpen={isOpen}
         title={t('addFolder.title')}
         description={t('addFolder.description', { space: spaceName })}
-        preview={preview}
-        primaryLabel={submitting ? t('addFolder.creating') : t('addFolder.create')}
-        loading={previewLoading}
-        progress={previewProgress}
-        onConfirm={handleCreate}
-        onCancel={handlePreviewCancel}
+        preview={wizard.preview}
+        primaryLabel={wizard.submitting ? t('addFolder.creating') : t('addFolder.create')}
+        loading={wizard.previewLoading}
+        progress={wizard.progress}
+        onConfirm={wizard.confirm}
+        onCancel={wizard.backToEdit}
       />
     )
   }
 
   return (
-    <FolderShareEditStep
+    <MountWizardStep
       isOpen={isOpen}
-      spaceName={spaceName}
-      mountPath={mountPath}
-      shareName={shareName}
-      validationError={validationError}
-      nameError={nameError}
-      canProceed={canProceedToPreview}
-      previewLoading={previewLoading}
-      onBrowse={handleBrowse}
-      onNext={handleNext}
-      onChangeName={setShareName}
+      ariaLabel={t('addFolder.title')}
+      title={t('addFolder.title')}
+      description={t('addFolder.description', { space: spaceName })}
+      nextLabel={t('addFolder.next')}
+      canProceed={wizard.pathValid && !nameError}
+      busy={wizard.previewLoading}
+      onNext={() => { void wizard.next() }}
       onClose={onClose}
-    />
+    >
+      <MountPathField
+        id="add-folder-path-label"
+        label={t('addFolder.pathLabel')}
+        path={wizard.mountPath}
+        error={wizard.validationError}
+        onBrowse={() => { void handleBrowse() }}
+      />
+
+      <ShareNameField value={shareName} error={nameError} onChange={setShareName} />
+    </MountWizardStep>
   )
 }

--- a/src/renderer/components/modals/AddRelayModal.tsx
+++ b/src/renderer/components/modals/AddRelayModal.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next'
 import { isWellFormedRelayKey } from '../../relay-key.js'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 
 interface AddRelayModalProps {
@@ -45,15 +45,12 @@ export default function AddRelayModal({ isOpen, onClose, onAdd }: AddRelayModalP
       panelClassName="glass-modal w-full max-w-md rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative"
     >
       <>
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-              {t('networkSettings.relays.addTitle')}
-            </h1>
-            <IconButton icon="close" onClick={handleClose} ariaLabel={t('actions.close')} iconClassName="text-secondary" />
-          </div>
-          <p className="text-on-surface-variant font-medium text-sm">{t('networkSettings.relays.addDesc')}</p>
-        </div>
+        <ModalHeader
+          title={t('networkSettings.relays.addTitle')}
+          description={t('networkSettings.relays.addDesc')}
+          descriptionSize="sm"
+          onClose={handleClose}
+        />
         <div className="px-10 pb-10 space-y-6">
           <div className="space-y-3">
             <label htmlFor="add-relay-key" className="font-headline text-sm font-bold text-accent px-1">

--- a/src/renderer/components/modals/ApprovalModal.tsx
+++ b/src/renderer/components/modals/ApprovalModal.tsx
@@ -6,6 +6,7 @@ import Modal from '../primitives/Modal.js'
 import Avatar from '../primitives/Avatar.js'
 import Button from '../primitives/Button.js'
 import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 
 interface ApprovalModalProps {
   isOpen: boolean
@@ -47,13 +48,12 @@ export default function ApprovalModal({ isOpen, requests, busyKeys, onApprove, o
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} onConfirm={selected.size > 0 ? approveSelected : undefined} ariaLabel={t('space.joinRequests')} panelClassName="glass-modal w-full max-w-xl rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative">
-      <div className="px-10 pt-10 pb-5 flex items-start justify-between">
-        <div>
-          <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{t('space.joinRequests')}</h1>
-          <p className="text-on-surface-variant text-sm mt-1">{t('space.joinRequestsDesc')}</p>
-        </div>
-        <IconButton icon="close" onClick={onClose} ariaLabel={t('actions.close')} iconClassName="text-secondary" />
-      </div>
+      <ModalHeader
+        title={t('space.joinRequests')}
+        description={t('space.joinRequestsDesc')}
+        descriptionSize="sm"
+        onClose={onClose}
+      />
       <ul className="px-10 pb-4 space-y-2 max-h-64 overflow-y-auto scrollbar-thin">
         {requests.map((r) => (
           <li key={r.publicKey} className="flex items-center gap-3 rounded-xl bg-surface-container-low p-3">

--- a/src/renderer/components/modals/CreateSpaceModal.tsx
+++ b/src/renderer/components/modals/CreateSpaceModal.tsx
@@ -5,7 +5,7 @@ import { gradientForSpaceId } from "../../utils.js";
 import IconPicker from "../widgets/IconPicker.js";
 import Modal from "../primitives/Modal.js";
 import Icon, { type IconName } from "../primitives/Icon.js";
-import IconButton from "../primitives/IconButton.js";
+import ModalHeader from "../layout/ModalHeader.js";
 import Button from "../primitives/Button.js";
 
 interface CreateSpaceModalProps {
@@ -62,26 +62,11 @@ export default function CreateSpaceModal({
       panelClassName={`glass-modal w-full ${createdSpace ? "max-w-lg" : "max-w-xl"} rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative`}
     >
       <>
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-              {createdSpace
-                ? t("createSpace.titleCreated")
-                : t("createSpace.titleNew")}
-            </h1>
-            <IconButton
-              icon="close"
-              onClick={handleClose}
-              ariaLabel={t("actions.close")}
-              iconClassName="text-secondary"
-            />
-          </div>
-          <p className="text-on-surface-variant font-medium">
-            {createdSpace
-              ? t("createSpace.descCreated")
-              : t("createSpace.descNew")}
-          </p>
-        </div>
+        <ModalHeader
+          title={createdSpace ? t("createSpace.titleCreated") : t("createSpace.titleNew")}
+          description={createdSpace ? t("createSpace.descCreated") : t("createSpace.descNew")}
+          onClose={handleClose}
+        />
 
         <div className="px-10 pb-10 space-y-8">
           {!createdSpace && (

--- a/src/renderer/components/modals/DeleteFolderShareModal.tsx
+++ b/src/renderer/components/modals/DeleteFolderShareModal.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Modal from '../primitives/Modal.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import FilenameTitle from '../widgets/FilenameTitle.js'
 
@@ -40,18 +40,11 @@ export default function DeleteFolderShareModal({
       ariaLabel={t('deleteFolder.title', { name: folderName })}
       panelClassName="glass-modal w-full max-w-md rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative"
     >
-      <div className="px-10 pt-10 pb-6">
-        <div className="flex justify-between items-start mb-2 gap-3">
-          <FilenameTitle i18nKey="deleteFolder.title" name={folderName} />
-          <IconButton
-            icon="close"
-            onClick={onClose}
-            ariaLabel={t('actions.close')}
-            disabled={busy}
-            iconClassName="text-secondary"
-          />
-        </div>
-      </div>
+      <ModalHeader
+        titleNode={<FilenameTitle i18nKey="deleteFolder.title" name={folderName} />}
+        onClose={onClose}
+        closeDisabled={busy}
+      />
 
       <div className="px-10 pb-10 space-y-6">
         <p id="delete-folder-body" className="text-on-surface-variant font-medium">

--- a/src/renderer/components/modals/DiagnosticsPreviewModal.tsx
+++ b/src/renderer/components/modals/DiagnosticsPreviewModal.tsx
@@ -1,7 +1,7 @@
 import { useTranslation } from 'react-i18next'
 import Modal from '../primitives/Modal.js'
 import Button from '../primitives/Button.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import { formatSize } from '../../formatSize.js'
 
 interface Props {
@@ -17,22 +17,11 @@ export default function DiagnosticsPreviewModal({ isOpen, text, byteLength, reda
   const { t } = useTranslation()
   return (
     <Modal isOpen={isOpen} onClose={onClose} onConfirm={onSave} ariaLabel={t('diagnostics.previewTitle')}>
-      <div className="px-10 pt-10 pb-4">
-        <div className="flex justify-between items-start mb-2">
-          <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-            {t('diagnostics.previewTitle')}
-          </h1>
-          <IconButton
-            icon="close"
-            onClick={onClose}
-            ariaLabel={t('actions.close')}
-            iconClassName="text-secondary"
-          />
-        </div>
-        <p className="text-on-surface-variant font-medium">
-          {redacted ? t('diagnostics.previewIntro') : t('diagnostics.previewIntroRaw')}
-        </p>
-      </div>
+      <ModalHeader
+        title={t('diagnostics.previewTitle')}
+        description={redacted ? t('diagnostics.previewIntro') : t('diagnostics.previewIntroRaw')}
+        onClose={onClose}
+      />
 
       <div className="px-10 pb-4">
         <pre

--- a/src/renderer/components/modals/EditFolderModal.tsx
+++ b/src/renderer/components/modals/EditFolderModal.tsx
@@ -6,7 +6,7 @@ import { useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import PathRow from '../widgets/PathRow.js'
 import { useErrorText } from '../../hooks/useErrorText.js'
@@ -95,15 +95,12 @@ export default function EditFolderModal({
   return (
     <Modal isOpen onClose={onClose} onConfirm={handleSave} ariaLabel={t('editFolder.title')} panelClassName={PANEL}>
       <>
-        <div className="px-10 pt-10 pb-6 shrink-0">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{t('editFolder.title')}</h1>
-            <IconButton icon="close" onClick={onClose} ariaLabel={t('actions.close')} iconClassName="text-secondary" />
-          </div>
-          <p className="text-on-surface-variant font-medium">
-            {isOwner ? t('editFolder.descOwner') : t('editFolder.descMirror')}
-          </p>
-        </div>
+        <ModalHeader
+          title={t('editFolder.title')}
+          description={isOwner ? t('editFolder.descOwner') : t('editFolder.descMirror')}
+          onClose={onClose}
+          className="shrink-0"
+        />
 
         <div className="px-10 pb-10 space-y-8 overflow-y-auto">
           <div className="space-y-3">

--- a/src/renderer/components/modals/EditSpaceModal.tsx
+++ b/src/renderer/components/modals/EditSpaceModal.tsx
@@ -5,7 +5,7 @@ import IconPicker from '../widgets/IconPicker.js'
 import PathRow from '../widgets/PathRow.js'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import { useErrorText } from '../../hooks/useErrorText.js'
 import { useMainQuery } from '../../store/useMainQuery.js'
@@ -89,22 +89,12 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   return (
     <Modal isOpen onClose={onClose} onConfirm={handleSave} ariaLabel={t('editSpace.title')} panelClassName={PANEL}>
       <>
-        <div className="px-10 pt-10 pb-6 shrink-0">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-              {t('editSpace.title')}
-            </h1>
-            <IconButton
-              icon="close"
-              onClick={onClose}
-              ariaLabel={t('actions.close')}
-              iconClassName="text-secondary"
-            />
-          </div>
-          <p className="text-on-surface-variant font-medium">
-            {t('editSpace.desc')}
-          </p>
-        </div>
+        <ModalHeader
+          title={t('editSpace.title')}
+          description={t('editSpace.desc')}
+          onClose={onClose}
+          className="shrink-0"
+        />
 
         <div className="px-10 pb-10 space-y-8 overflow-y-auto">
           <div className="space-y-3">

--- a/src/renderer/components/modals/FeedbackModal.tsx
+++ b/src/renderer/components/modals/FeedbackModal.tsx
@@ -7,7 +7,7 @@ import { request } from '../../ipc.js'
 import { getFeedbackEmail, setFeedbackEmail } from '../../config-client.js'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import { useErrorText } from '../../hooks/useErrorText.js'
 
@@ -130,22 +130,12 @@ export default function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
           <FeedbackSentView onDone={handleClose} />
         ) : (
           <>
-            <div className="px-10 pt-10 pb-6">
-              <div className="flex justify-between items-start mb-2">
-                <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-                  {t('feedback.titleNew')}
-                </h1>
-                <IconButton
-                  icon="close"
-                  onClick={handleClose}
-                  ariaLabel={t('actions.close')}
-                  iconClassName="text-secondary"
-                />
-              </div>
-              <p className="text-on-surface-variant font-medium text-sm">
-                {t('feedback.intro')}
-              </p>
-            </div>
+            <ModalHeader
+              title={t('feedback.titleNew')}
+              description={t('feedback.intro')}
+              descriptionSize="sm"
+              onClose={handleClose}
+            />
             <div className="px-10 pb-10 space-y-6">
               <div className="space-y-3">
                 <label htmlFor="feedback-message" className="font-headline text-sm font-bold text-accent px-1">{t('feedback.messageLabel')}</label>

--- a/src/renderer/components/modals/InviteModal.tsx
+++ b/src/renderer/components/modals/InviteModal.tsx
@@ -4,7 +4,7 @@ import { Fragment, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import Toggle from '../primitives/Toggle.js'
 import { useErrorText } from '../../hooks/useErrorText.js'
@@ -77,17 +77,12 @@ export default function InviteModal({ isOpen, onClose, onCreate }: InviteModalPr
       panelClassName="glass-modal w-full max-w-md rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative"
     >
       <>
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-              {code ? t('invite.readyTitle') : t('invite.title')}
-            </h1>
-            <IconButton icon="close" onClick={onClose} ariaLabel={t('actions.close')} iconClassName="text-secondary" />
-          </div>
-          <p className="text-on-surface-variant font-medium text-sm">
-            {code ? t('invite.readyDesc') : t('invite.configureDesc')}
-          </p>
-        </div>
+        <ModalHeader
+          title={code ? t('invite.readyTitle') : t('invite.title')}
+          description={code ? t('invite.readyDesc') : t('invite.configureDesc')}
+          descriptionSize="sm"
+          onClose={onClose}
+        />
 
         <div className="px-10 pb-10 space-y-5">
           {/* The two steps are keyed so the swap remounts cleanly — unkeyed, React reuses the

--- a/src/renderer/components/modals/JoinSpaceModal.tsx
+++ b/src/renderer/components/modals/JoinSpaceModal.tsx
@@ -6,7 +6,7 @@ import type { Space } from '../../types.js'
 import { decodeInvite, extractInviteCode } from '../../invite-envelope.js'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import { useErrorText } from '../../hooks/useErrorText.js'
 
@@ -79,20 +79,12 @@ export default function JoinSpaceModal({ isOpen, initialCode, initialName, onClo
   return (
     <Modal isOpen={isOpen} onClose={handleClose} onConfirm={handleJoin} ariaLabel={t('joinSpace.title')} panelClassName="glass-modal w-full max-w-md rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative">
       <>
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-              {t('joinSpace.title')}
-            </h1>
-            <IconButton
-              icon="close"
-              onClick={handleClose}
-              ariaLabel={t('actions.close')}
-              iconClassName="text-secondary"
-            />
-          </div>
-          <p className="text-on-surface-variant font-medium text-sm">{t('joinSpace.desc')}</p>
-        </div>
+        <ModalHeader
+          title={t('joinSpace.title')}
+          description={t('joinSpace.desc')}
+          descriptionSize="sm"
+          onClose={handleClose}
+        />
         <div className="px-10 pb-10 space-y-6">
           <div className="space-y-3">
             <label htmlFor="join-space-code" className="font-headline text-sm font-bold text-accent px-1">{t('joinSpace.codeLabel')}</label>

--- a/src/renderer/components/modals/LeaveSpaceModal.tsx
+++ b/src/renderer/components/modals/LeaveSpaceModal.tsx
@@ -5,7 +5,7 @@ import { useTranslation } from 'react-i18next'
 import { subscribe } from '../../ipc.js'
 import { formatSize } from '../../utils.js'
 import Modal from '../primitives/Modal.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import FilenameTitle from '../widgets/FilenameTitle.js'
 
@@ -104,25 +104,14 @@ export default function LeaveSpaceModal({ isOpen, spaceName, spaceId, onClose, o
       ariaLabel={leaving ? t('leaveSpace.titleProgress') : t('leaveSpace.titleConfirm', { name: spaceName })}
     >
       <>
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2 gap-3">
-            {leaving ? (
-              <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-                {t('leaveSpace.titleProgress')}
-              </h1>
-            ) : (
-              <FilenameTitle i18nKey="leaveSpace.titleConfirm" name={spaceName} />
-            )}
-            {!leaving && (
-              <IconButton
-                icon="close"
-                onClick={onClose}
-                ariaLabel={t('actions.close')}
-                iconClassName="text-secondary"
-              />
-            )}
-          </div>
-        </div>
+        {leaving ? (
+          <ModalHeader title={t('leaveSpace.titleProgress')} />
+        ) : (
+          <ModalHeader
+            titleNode={<FilenameTitle i18nKey="leaveSpace.titleConfirm" name={spaceName} />}
+            onClose={onClose}
+          />
+        )}
 
         <div className="px-10 pb-10 space-y-6">
           {leaving ? (

--- a/src/renderer/components/modals/MirrorFolderModal.tsx
+++ b/src/renderer/components/modals/MirrorFolderModal.tsx
@@ -1,24 +1,20 @@
 // Two-step wizard for mirroring a peer's shared folder to a local path: pick and
 // validate the destination, then confirm via the scan preview.
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import { useTranslation } from 'react-i18next'
-import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
-import Button from '../primitives/Button.js'
 import Avatar from '../primitives/Avatar.js'
-import PathRow from '../widgets/PathRow.js'
+import MountPathField from '../widgets/MountPathField.js'
 import FilenameTitle from '../widgets/FilenameTitle.js'
+import MountWizardStep from './MountWizardStep.js'
 import ScanPreviewModal from './ScanPreviewModal.js'
 import { validateForeignMount, previewForeignMount, cancelForeignPreview, createForeignMount } from '../../hooks/useForeignMount.js'
-import { usePreviewFlow } from '../../hooks/usePreviewFlow.js'
-import type { MountValidationResult, SpaceMember } from '../../types.js'
+import { useMountWizard } from '../../hooks/useMountWizard.js'
+import type { SpaceMember } from '../../types.js'
 import type { ShareWithRole } from '../../hooks/useShares.js'
 import { formatSize } from '../../utils.js'
-import { useToast } from '../toast/useToast.js'
 import { useQuery } from '../../store/useQuery.js'
 import { Scope } from '../../scope.js'
-import { useErrorText } from '../../hooks/useErrorText.js'
 
 interface MirrorFolderModalProps {
   isOpen: boolean
@@ -30,11 +26,38 @@ interface MirrorFolderModalProps {
 
 interface FolderInfo { fileCount: number; totalBytes: number; blobsLength: number | null }
 
-function OwnerChip({ owner }: { owner: SpaceMember | null }) {
-  return <Avatar src={owner?.avatar} displayName={owner?.displayName} size="md" />
+interface OwnerLineProps {
+  owner: SpaceMember | null
+  ownerName: string
+  folderName: string
+  info: FolderInfo | undefined
+  infoError: Error | null
 }
 
-type Step = 'edit' | 'preview'
+function OwnerLine({ owner, ownerName, folderName, info, infoError }: OwnerLineProps) {
+  const { t } = useTranslation()
+  return (
+    <div className="flex items-center gap-3 bg-surface-container rounded-xl p-3">
+      <Avatar src={owner?.avatar} displayName={owner?.displayName} size="md" />
+      <div className="min-w-0">
+        <p className="font-bold text-accent text-sm truncate">{folderName}</p>
+        {/* A failed read is said, not filled in: rendering the fallback totals would put a
+            fabricated measurement of the folder in front of the person about to mirror it. */}
+        {infoError ? (
+          <p role="alert" className="text-xs text-error">{t('mirrorFolder.infoUnavailable')}</p>
+        ) : (
+          <p className="text-xs text-on-surface-variant">
+            {t('mirrorFolder.ownerLine', {
+              count: info?.fileCount ?? 0,
+              size: info ? formatSize(info.totalBytes) : '—',
+              owner: ownerName,
+            })}
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
 
 export default function MirrorFolderModal({
   isOpen,
@@ -44,14 +67,6 @@ export default function MirrorFolderModal({
   onMounted,
 }: MirrorFolderModalProps) {
   const { t } = useTranslation()
-  const toast = useToast()
-  const errorText = useErrorText()
-  const [mountPath, setMountPath] = useState('')
-  const [validation, setValidation] = useState<MountValidationResult | null>(null)
-  const [validationError, setValidationError] = useState<string | null>(null)
-  const [step, setStep] = useState<Step>('edit')
-  const [submitting, setSubmitting] = useState(false)
-  const { preview, progress: previewProgress, loading: previewLoading, run: runPreview, cancel: cancelPreview, reset: resetPreview } = usePreviewFlow(cancelForeignPreview)
   const ownerName = owner?.displayName ?? '?'
 
   // The folder's file count and byte total change when the owner's catalog does. Two scopes, the
@@ -71,199 +86,67 @@ export default function MirrorFolderModal({
     { enabled: isOpen },
   )
 
-  // Form state only: it is genuinely per-open, unlike the folder info above.
-  useEffect(() => {
-    if (!isOpen) return
-    setMountPath('')
-    setValidation(null)
-    setValidationError(null)
-    setStep('edit')
-    resetPreview()
-    return () => { cancelPreview() }
-  }, [isOpen, share.id, share.owner, share.spaceId])
+  const wizard = useMountWizard({
+    isOpen,
+    resetKey: `${share.spaceId}/${share.owner}/${share.id}`,
+    validate: (path) => validateForeignMount(path, share.id),
+    startPreview: (path, onProgress) => previewForeignMount(share.spaceId, share.owner, share.id, path, { onProgress }),
+    cancelPreview: cancelForeignPreview,
+    commit: async (path) => { await createForeignMount(share.spaceId, share.owner, share.id, path) },
+    onCommitted: () => { onMounted(); onClose() },
+  })
 
-  // Deliberately NOT on the query store — the twin of AddFolderShareModal's owned-mount probe.
-  // This is a point-in-time filesystem check of a path the user is still editing: a cached verdict
-  // would answer for a path they have since changed. The cancel flag stays.
-  useEffect(() => {
-    if (!isOpen || !mountPath) return
-    let cancelled = false
-    setValidation(null)
-    setValidationError(null)
-    validateForeignMount(mountPath, share.id).then(
-      (result) => { if (!cancelled) setValidation(result) },
-      (err) => {
-        if (cancelled) return
-        setValidationError(errorText(err))
-      },
-    )
-    return () => { cancelled = true }
-  }, [isOpen, mountPath, share.id, errorText])
-
-  const canProceed = !!validation && !validationError && mountPath.length > 0
-
-  async function handleBrowse() {
-    const picked = await window.bridge.browseShareFolder()
-    if (picked) setMountPath(picked)
-  }
-
-  async function handleNext() {
-    if (!canProceed) return
-    setStep('preview')
-    try {
-      await runPreview((onProgress) => previewForeignMount(share.spaceId, share.owner, share.id, mountPath, { onProgress }))
-    } catch (err) {
-      const code = (err as { code?: string } | null)?.code
-      if (code !== 'PREVIEW_CANCELLED') {
-        toast.error(errorText(err))
-        setStep('edit')
-      }
-    }
-  }
-
-  function handlePreviewCancel() {
-    cancelPreview()
-    setStep('edit')
-  }
-
-  async function handleConfirm() {
-    if (submitting) return
-    setSubmitting(true)
-    try {
-      await createForeignMount(share.spaceId, share.owner, share.id, mountPath)
-      onMounted()
-      onClose()
-    } catch (err) {
-      toast.error(errorText(err))
-    } finally {
-      setSubmitting(false)
-    }
-  }
-
-  if (step === 'preview') {
+  if (wizard.step === 'preview') {
     return (
       <ScanPreviewModal
         isOpen={isOpen}
         title={t('mirrorFolder.title', { name: share.name })}
         description={t('mirrorFolder.description', { owner: ownerName })}
-        preview={preview}
-        primaryLabel={submitting ? t('mirrorFolder.creating') : t('mirrorFolder.create')}
+        preview={wizard.preview}
+        primaryLabel={wizard.submitting ? t('mirrorFolder.creating') : t('mirrorFolder.create')}
         readOnlyWarning={t('mirrorFolder.readOnlyWarning', { owner: ownerName })}
-        loading={previewLoading}
-        progress={previewProgress}
-        onConfirm={handleConfirm}
-        onCancel={handlePreviewCancel}
+        loading={wizard.previewLoading}
+        progress={wizard.progress}
+        onConfirm={wizard.confirm}
+        onCancel={wizard.backToEdit}
       />
     )
   }
 
   return (
-    <MirrorEditStep
+    <MountWizardStep
       isOpen={isOpen}
-      share={share}
-      owner={owner}
-      ownerName={ownerName}
-      info={info}
-      infoError={infoError}
-      mountPath={mountPath}
-      validationError={validationError}
-      canProceed={canProceed}
-      previewLoading={previewLoading}
-      onBrowse={handleBrowse}
-      onNext={handleNext}
-      onClose={onClose}
-    />
-  )
-}
-
-interface MirrorEditStepProps {
-  isOpen: boolean
-  share: ShareWithRole
-  owner: SpaceMember | null
-  ownerName: string
-  info: FolderInfo | undefined
-  infoError: Error | null
-  mountPath: string
-  validationError: string | null
-  canProceed: boolean
-  previewLoading: boolean
-  onBrowse: () => void
-  onNext: () => void
-  onClose: () => void
-}
-
-function MirrorEditStep({ isOpen, share, owner, ownerName, info, infoError, mountPath, validationError, canProceed, previewLoading, onBrowse, onNext, onClose }: MirrorEditStepProps) {
-  const { t } = useTranslation()
-  return (
-    <Modal
-      isOpen={isOpen}
-      onClose={onClose}
-      onConfirm={canProceed && !previewLoading ? onNext : undefined}
       ariaLabel={t('mirrorFolder.title', { name: share.name })}
+      titleNode={<FilenameTitle i18nKey="mirrorFolder.title" name={share.name} />}
+      description={t('mirrorFolder.description', { owner: ownerName })}
+      nextLabel={t('mirrorFolder.next')}
+      canProceed={wizard.pathValid}
+      busy={wizard.previewLoading}
+      onNext={() => { void wizard.next() }}
+      onClose={onClose}
     >
-      <div className="px-10 pt-10 pb-6">
-        <div className="flex justify-between items-start mb-2 gap-3">
-          <FilenameTitle i18nKey="mirrorFolder.title" name={share.name} />
-          <IconButton
-            icon="close"
-            onClick={onClose}
-            ariaLabel={t('actions.close')}
-            iconClassName="text-secondary"
-          />
-        </div>
-        <p className="text-on-surface-variant font-medium">
-          {t('mirrorFolder.description', { owner: ownerName })}
+      <OwnerLine
+        owner={owner}
+        ownerName={ownerName}
+        folderName={share.name}
+        info={info}
+        infoError={infoError}
+      />
+
+      <MountPathField
+        id="mirror-folder-path-label"
+        label={t('mirrorFolder.pathLabel')}
+        path={wizard.mountPath}
+        error={wizard.validationError}
+        onBrowse={() => { void wizard.browse() }}
+      />
+
+      <div className="bg-warning-container rounded-xl p-3.5 flex items-start gap-3">
+        <Icon name="lock" size={18} className="text-on-warning-container shrink-0 mt-0.5" />
+        <p className="text-xs text-on-warning-container leading-relaxed">
+          {t('mirrorFolder.readOnlyWarning', { owner: ownerName })}
         </p>
       </div>
-
-      <div className="px-10 pb-10 space-y-6">
-        <div className="flex items-center gap-3 bg-surface-container rounded-xl p-3">
-          <OwnerChip owner={owner} />
-          <div className="min-w-0">
-            <p className="font-bold text-accent text-sm truncate">{share.name}</p>
-            {/* A failed read is said, not filled in: rendering the fallback totals would put a
-                fabricated measurement of the folder in front of the person about to mirror it. */}
-            {infoError ? (
-              <p role="alert" className="text-xs text-error">{t('mirrorFolder.infoUnavailable')}</p>
-            ) : (
-              <p className="text-xs text-on-surface-variant">
-                {t('mirrorFolder.ownerLine', {
-                  count: info?.fileCount ?? 0,
-                  size: info ? formatSize(info.totalBytes) : '—',
-                  owner: ownerName,
-                })}
-              </p>
-            )}
-          </div>
-        </div>
-
-        <div className="space-y-3">
-          <span id="mirror-folder-path-label" className="block font-headline text-sm font-bold text-accent px-1">
-            {t('mirrorFolder.pathLabel')}
-          </span>
-          <PathRow path={mountPath} onAction={onBrowse} ariaDescribedBy="mirror-folder-path-label" />
-          {validationError && (
-            <p role="alert" className="text-xs text-error px-1">{validationError}</p>
-          )}
-        </div>
-
-        <div className="bg-warning-container rounded-xl p-3.5 flex items-start gap-3">
-          <Icon name="lock" size={18} className="text-on-warning-container shrink-0 mt-0.5" />
-          <p className="text-xs text-on-warning-container leading-relaxed">
-            {t('mirrorFolder.readOnlyWarning', { owner: ownerName })}
-          </p>
-        </div>
-
-        <div className="pt-2 flex justify-end gap-3">
-          <Button variant="secondary" onClick={onClose}>
-            {t('actions.cancel')}
-          </Button>
-          <Button onClick={onNext} disabled={!canProceed || previewLoading}>
-            {previewLoading ? t('scanPreview.computing') : t('mirrorFolder.next')}
-            <Icon name="arrow_forward" size={16} />
-          </Button>
-        </div>
-      </div>
-    </Modal>
+    </MountWizardStep>
   )
 }

--- a/src/renderer/components/modals/MountWizardStep.tsx
+++ b/src/renderer/components/modals/MountWizardStep.tsx
@@ -2,8 +2,8 @@ import type { ReactNode } from 'react'
 import { useTranslation } from 'react-i18next'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
 import Button from '../primitives/Button.js'
+import ModalHeader from '../layout/ModalHeader.js'
 
 // The edit step of a folder-mount wizard: the dialog, its header, the body its caller fills, and the
 // wizard footer design.md calls footer shape 3 — Cancel plus a primary carrying a trailing arrow,
@@ -44,20 +44,9 @@ export default function MountWizardStep({
   const ready = canProceed && !busy
   return (
     <Modal isOpen={isOpen} onClose={onClose} onConfirm={ready ? onNext : undefined} ariaLabel={ariaLabel}>
-      <div className="px-10 pt-10 pb-6">
-        <div className="flex justify-between items-start mb-2 gap-3">
-          {titleNode ?? (
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{title}</h1>
-          )}
-          <IconButton
-            icon="close"
-            onClick={onClose}
-            ariaLabel={t('actions.close')}
-            iconClassName="text-secondary"
-          />
-        </div>
-        <p className="text-on-surface-variant font-medium">{description}</p>
-      </div>
+      {titleNode
+        ? <ModalHeader titleNode={titleNode} description={description} onClose={onClose} />
+        : <ModalHeader title={title as string} description={description} onClose={onClose} />}
 
       <div className="px-10 pb-10 space-y-6">
         {children}

--- a/src/renderer/components/modals/MountWizardStep.tsx
+++ b/src/renderer/components/modals/MountWizardStep.tsx
@@ -1,0 +1,77 @@
+import type { ReactNode } from 'react'
+import { useTranslation } from 'react-i18next'
+import Modal from '../primitives/Modal.js'
+import Icon from '../primitives/Icon.js'
+import IconButton from '../primitives/IconButton.js'
+import Button from '../primitives/Button.js'
+
+// The edit step of a folder-mount wizard: the dialog, its header, the body its caller fills, and the
+// wizard footer design.md calls footer shape 3 — Cancel plus a primary carrying a trailing arrow,
+// whose label goes to "Computing…" while the scan runs.
+//
+// The whole body is one slot rather than a set of named field props: Add Folder puts a share-name
+// field below the path, Mirror puts an owner chip above it and a read-only warning below, and a
+// component that tried to name those positions would fit neither.
+type MountWizardStepProps = {
+  isOpen: boolean
+  ariaLabel: string
+  description: ReactNode
+  nextLabel: string
+  canProceed: boolean
+  busy: boolean
+  onNext: () => void
+  onClose: () => void
+  children: ReactNode
+} & (
+  | { title: string; titleNode?: never }
+  | { title?: never; titleNode: ReactNode }
+)
+
+export default function MountWizardStep({
+  isOpen,
+  ariaLabel,
+  title,
+  titleNode,
+  description,
+  nextLabel,
+  canProceed,
+  busy,
+  onNext,
+  onClose,
+  children,
+}: MountWizardStepProps) {
+  const { t } = useTranslation()
+  const ready = canProceed && !busy
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} onConfirm={ready ? onNext : undefined} ariaLabel={ariaLabel}>
+      <div className="px-10 pt-10 pb-6">
+        <div className="flex justify-between items-start mb-2 gap-3">
+          {titleNode ?? (
+            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{title}</h1>
+          )}
+          <IconButton
+            icon="close"
+            onClick={onClose}
+            ariaLabel={t('actions.close')}
+            iconClassName="text-secondary"
+          />
+        </div>
+        <p className="text-on-surface-variant font-medium">{description}</p>
+      </div>
+
+      <div className="px-10 pb-10 space-y-6">
+        {children}
+
+        <div className="pt-2 flex justify-end gap-3">
+          <Button variant="secondary" onClick={onClose}>
+            {t('actions.cancel')}
+          </Button>
+          <Button onClick={onNext} disabled={!ready}>
+            {busy ? t('scanPreview.computing') : nextLabel}
+            <Icon name="arrow_forward" size={16} />
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/renderer/components/modals/RemoveFileModal.tsx
+++ b/src/renderer/components/modals/RemoveFileModal.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { fileName as getFileName } from '../../utils.js'
 import Modal from '../primitives/Modal.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import FilenameTitle from '../widgets/FilenameTitle.js'
 
@@ -27,17 +27,10 @@ export default function RemoveFileModal({ isOpen, filePath, onClose, onRemove }:
   return (
     <Modal isOpen={isOpen} onClose={onClose} isDismissable={!removing} role="alertdialog" ariaDescribedBy="remove-file-body" ariaLabel={t('removeFile.titleConfirm', { name: getFileName(filePath) })} panelClassName="glass-modal w-full max-w-md rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative">
       <>
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2 gap-3">
-            <FilenameTitle i18nKey="removeFile.titleConfirm" name={getFileName(filePath)} />
-            <IconButton
-              icon="close"
-              onClick={onClose}
-              ariaLabel={t('actions.close')}
-              iconClassName="text-secondary"
-            />
-          </div>
-        </div>
+        <ModalHeader
+          titleNode={<FilenameTitle i18nKey="removeFile.titleConfirm" name={getFileName(filePath)} />}
+          onClose={onClose}
+        />
 
         <div className="px-10 pb-10 space-y-6">
           <p id="remove-file-body" className="text-on-surface-variant font-medium">

--- a/src/renderer/components/modals/ScanPreviewModal.tsx
+++ b/src/renderer/components/modals/ScanPreviewModal.tsx
@@ -4,7 +4,7 @@ import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import Modal from '../primitives/Modal.js'
 import Icon from '../primitives/Icon.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 import ProgressBar from '../primitives/ProgressBar.js'
 import FilePath from '../widgets/FilePath.js'
@@ -62,18 +62,7 @@ export default function ScanPreviewModal({
       onConfirm={busy || overLimit ? undefined : handleConfirm}
       ariaLabel={title}
     >
-      <div className="px-10 pt-10 pb-6">
-        <div className="flex justify-between items-start mb-2">
-          <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">{title}</h1>
-          <IconButton
-            icon="close"
-            onClick={onCancel}
-            ariaLabel={t('actions.close')}
-            iconClassName="text-secondary"
-          />
-        </div>
-        <p className="text-on-surface-variant font-medium">{description}</p>
-      </div>
+      <ModalHeader title={title} description={description} onClose={onCancel} />
 
       <div className="px-10 pb-10 space-y-4">
         <ScanPreviewBody

--- a/src/renderer/components/modals/WhatsNewModal.tsx
+++ b/src/renderer/components/modals/WhatsNewModal.tsx
@@ -8,7 +8,7 @@ import { dismissChangelog, type ChangelogEntry } from '../../changelog.js'
 import type { WhatsNewState } from '../../whats-new.js'
 import { useHasVerticalOverflow } from '../../hooks/useHasVerticalOverflow.js'
 import Modal from '../primitives/Modal.js'
-import IconButton from '../primitives/IconButton.js'
+import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
 
 interface RenderedEntry {
@@ -46,22 +46,13 @@ export default function WhatsNewModal() {
   return (
     <Modal isOpen onClose={handleDismiss} onConfirm={handleDismiss} ariaLabel={t('whatsNew.title')} panelClassName="glass-modal w-full max-w-2xl max-h-[80vh] rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative flex flex-col">
       <>
-        <div className="px-10 pt-10 pb-6 shrink-0">
-          <div className="flex justify-between items-start mb-2">
-            <h1 className="font-headline text-2xl font-extrabold text-accent tracking-tight">
-              {t('whatsNew.title')}
-            </h1>
-            <IconButton
-              icon="close"
-              onClick={handleDismiss}
-              ariaLabel={t('actions.close')}
-              iconClassName="text-secondary"
-            />
-          </div>
-          <p className="text-on-surface-variant font-medium text-sm">
-            {t(introKey)}
-          </p>
-        </div>
+        <ModalHeader
+          title={t('whatsNew.title')}
+          description={t(introKey)}
+          descriptionSize="sm"
+          onClose={handleDismiss}
+          className="shrink-0"
+        />
         <div
           ref={scrollRef}
           tabIndex={0}

--- a/src/renderer/components/widgets/MountPathField.tsx
+++ b/src/renderer/components/widgets/MountPathField.tsx
@@ -1,0 +1,21 @@
+import PathRow from './PathRow.js'
+
+interface MountPathFieldProps {
+  id: string
+  label: string
+  path: string
+  error: string | null
+  onBrowse: () => void
+}
+
+// The label is a <span> carrying an id rather than a <label>: PathRow's action is a button, not a
+// form control, so the association goes through aria-describedby.
+export default function MountPathField({ id, label, path, error, onBrowse }: MountPathFieldProps) {
+  return (
+    <div className="space-y-3">
+      <span id={id} className="block font-headline text-sm font-bold text-accent px-1">{label}</span>
+      <PathRow path={path} onAction={onBrowse} ariaDescribedBy={id} />
+      {error && <p role="alert" className="text-xs text-error px-1">{error}</p>}
+    </div>
+  )
+}

--- a/src/renderer/hooks/useLocateShare.ts
+++ b/src/renderer/hooks/useLocateShare.ts
@@ -1,0 +1,41 @@
+import { useCallback } from 'react'
+import { useTranslation } from 'react-i18next'
+import { request } from '../ipc.js'
+import { useToast } from '../components/toast/useToast.js'
+import { useErrorText } from './useErrorText.js'
+
+export interface LocatableShare {
+  id: string
+  name: string
+}
+
+// Re-pointing an owned folder at a new path on disk, from the five surfaces that offer it: the
+// folder card's menu, the folder screen's primary button, its work strip, its command-palette entry,
+// and Edit Folder's path field.
+//
+// The two halves fail differently on purpose. `relocate` THROWS — Edit Folder renders the failure in
+// its own field error, so it must reach the caller unswallowed and untoasted. `locate` catches,
+// because the surfaces that call it have nowhere to put an error but a toast, and a picker that
+// returns nothing is a cancel rather than a failure.
+export function useLocateShare(spaceId: string) {
+  const { t } = useTranslation()
+  const toast = useToast()
+  const errorText = useErrorText()
+
+  const relocate = useCallback(async (share: LocatableShare, mountPath: string) => {
+    await request('owned-folder:relocate', { spaceId, shareId: share.id, mountPath })
+    toast.success(t('share.locateSuccess', { name: share.name }))
+  }, [spaceId, toast, t])
+
+  const locate = useCallback(async (share: LocatableShare) => {
+    const picked = await window.bridge.browseShareFolder()
+    if (!picked) return
+    try {
+      await relocate(share, picked)
+    } catch (err) {
+      toast.error(errorText(err))
+    }
+  }, [relocate, toast, errorText])
+
+  return { locate, relocate }
+}

--- a/src/renderer/hooks/useMountWizard.ts
+++ b/src/renderer/hooks/useMountWizard.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { usePreviewFlow, type PreviewHandle } from './usePreviewFlow.js'
+import { useToast } from '../components/toast/useToast.js'
+import { useErrorText } from './useErrorText.js'
+import type { MountValidationResult, PreviewProgress } from '../types.js'
+
+export type MountWizardStepName = 'edit' | 'preview'
+
+export interface MountWizardOps {
+  isOpen: boolean
+  initialPath?: string
+  // The identity the form belongs to. Changing it while the wizard is open starts it over, which is
+  // what keeps a re-targeted dialog from carrying the previous folder's path and verdict.
+  resetKey?: string
+  validate: (path: string) => Promise<MountValidationResult>
+  startPreview: (path: string, onProgress: (p: PreviewProgress) => void) => PreviewHandle
+  cancelPreview: (previewId: string) => void
+  commit: (path: string) => Promise<void>
+  onCommitted: () => void
+}
+
+// The two folder-mount wizards are one state machine over three injected calls — validate a path,
+// scan it, commit it. They had a copy each: the same step/submitting pair, the same reset-on-open
+// effect, the same point-in-time validation probe with its own cancel flag, the same "cancelling the
+// scan returns you to the edit step", and the same swallow of PREVIEW_CANCELLED.
+export function useMountWizard({
+  isOpen,
+  initialPath = '',
+  resetKey = '',
+  validate,
+  startPreview,
+  cancelPreview,
+  commit,
+  onCommitted,
+}: MountWizardOps) {
+  const toast = useToast()
+  const errorText = useErrorText()
+  const [mountPath, setMountPath] = useState(initialPath)
+  const [validation, setValidation] = useState<MountValidationResult | null>(null)
+  const [validationError, setValidationError] = useState<string | null>(null)
+  const [step, setStep] = useState<MountWizardStepName>('edit')
+  const [submitting, setSubmitting] = useState(false)
+  const { preview, progress, loading, run, cancel, reset } = usePreviewFlow(cancelPreview)
+
+  // The injected calls are read through a ref, never through a dependency list. Both callers build
+  // them from props as inline arrows, so their identity changes every render; a validate() in the
+  // deps below would clear the verdict, re-render, and spin. This is the same technique
+  // useRegisterCommand uses for `run`, and it keeps both effects' deps exactly what the two modals
+  // had before they shared one machine.
+  const opsRef = useRef({ validate, startPreview, commit, onCommitted })
+  opsRef.current = { validate, startPreview, commit, onCommitted }
+
+  useEffect(() => {
+    if (!isOpen) return
+    setMountPath(initialPath)
+    setValidation(null)
+    setValidationError(null)
+    setStep('edit')
+    setSubmitting(false)
+    reset()
+    return () => { cancel() }
+  }, [isOpen, initialPath, resetKey])
+
+  // Deliberately NOT on the query store, though it is param-keyed and looks like a query: this is a
+  // point-in-time filesystem probe. The folder can be deleted, unmounted or filled between two opens
+  // of the dialog, and a cached verdict would answer for a path the user has since changed. The
+  // cancel flag is what keeps a superseded answer off the screen.
+  useEffect(() => {
+    if (!isOpen || !mountPath) return
+    let cancelled = false
+    setValidation(null)
+    setValidationError(null)
+    opsRef.current.validate(mountPath).then(
+      (result) => { if (!cancelled) setValidation(result) },
+      (err) => {
+        if (cancelled) return
+        setValidationError(errorText(err))
+      },
+    )
+    return () => { cancelled = true }
+  }, [isOpen, mountPath, errorText])
+
+  const pathValid = !!validation && !validationError && mountPath.length > 0
+
+  // Returns what was picked so a caller can derive from it — Add Folder seeds the share name — rather
+  // than watching mountPath and guessing whether the user or the reset moved it.
+  const browse = useCallback(async () => {
+    const picked = await window.bridge.browseShareFolder()
+    if (picked) setMountPath(picked)
+    return picked
+  }, [])
+
+  const next = useCallback(async () => {
+    setStep('preview')
+    try {
+      await run((onProgress) => opsRef.current.startPreview(mountPath, onProgress))
+    } catch (err) {
+      // Cancelling the scan is the user's own act, and backToEdit has already handled it.
+      const code = (err as { code?: string } | null)?.code
+      if (code === 'PREVIEW_CANCELLED') return
+      toast.error(errorText(err))
+      setStep('edit')
+    }
+  }, [run, mountPath, toast, errorText])
+
+  const backToEdit = useCallback(() => {
+    cancel()
+    setStep('edit')
+  }, [cancel])
+
+  const confirm = useCallback(async () => {
+    if (submitting) return
+    setSubmitting(true)
+    try {
+      await opsRef.current.commit(mountPath)
+      opsRef.current.onCommitted()
+    } catch (err) {
+      toast.error(errorText(err))
+    } finally {
+      setSubmitting(false)
+    }
+  }, [submitting, mountPath, toast, errorText])
+
+  return {
+    mountPath,
+    setMountPath,
+    browse,
+    validation,
+    validationError,
+    pathValid,
+    step,
+    preview,
+    progress,
+    previewLoading: loading,
+    submitting,
+    next,
+    backToEdit,
+    confirm,
+  }
+}

--- a/src/renderer/screens/ActivityLogSettings.tsx
+++ b/src/renderer/screens/ActivityLogSettings.tsx
@@ -11,7 +11,7 @@ import PageHeader from '../components/layout/PageHeader.js'
 import SectionHeading from '../components/layout/SectionHeading.js'
 import Modal from '../components/primitives/Modal.js'
 import Button from '../components/primitives/Button.js'
-import IconButton from '../components/primitives/IconButton.js'
+import ModalHeader from '../components/layout/ModalHeader.js'
 import { useErrorText } from '../hooks/useErrorText.js'
 
 interface ActivityLogSettingsProps {
@@ -204,20 +204,11 @@ export default function ActivityLogSettings({ onBack, onOpenLog }: ActivityLogSe
         ariaLabel={t('activityLogSettings.deleteConfirmTitle')}
         panelClassName="glass-modal w-full max-w-md rounded-3xl shadow-2xl shadow-black/30 overflow-hidden relative"
       >
-        <div className="px-10 pt-10 pb-6">
-          <div className="flex justify-between items-start mb-2 gap-3">
-            <h2 className="text-2xl font-headline font-extrabold text-accent tracking-tight">
-              {t('activityLogSettings.deleteConfirmTitle')}
-            </h2>
-            <IconButton
-              icon="close"
-              onClick={() => setConfirmPurge(false)}
-              ariaLabel={t('actions.close')}
-              disabled={busy}
-              iconClassName="text-secondary"
-            />
-          </div>
-        </div>
+        <ModalHeader
+          title={t('activityLogSettings.deleteConfirmTitle')}
+          onClose={() => setConfirmPurge(false)}
+          closeDisabled={busy}
+        />
         <div className="px-10 pb-10 space-y-6">
           <p id="purge-activity-body" className="text-on-surface-variant font-medium">{t('activityLogSettings.deleteConfirmBody')}</p>
           <div className="flex gap-3">

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -35,6 +35,7 @@ import { useIndexProgress } from '../hooks/useIndexProgress.js'
 import { deriveIndexSummary } from '../indexSummary.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { useFolderCommands } from '../hooks/useFolderCommands.js'
+import { useLocateShare } from '../hooks/useLocateShare.js'
 import { useToast } from '../components/toast/useToast.js'
 import type { ShareWithRole } from '../hooks/useShares.js'
 import type { FileTreeNode } from '../types.js'
@@ -53,6 +54,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   const { t } = useTranslation()
   const toast = useToast()
   const errorText = useErrorText()
+  const { locate, relocate } = useLocateShare(spaceId)
   const { profile } = useProfile()
   const { members } = useMembers(spaceId)
   const { getDownloadSummary } = usePeerDownloads(spaceId)
@@ -230,17 +232,6 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
     }
   }
 
-  async function handleLocate() {
-    const picked = await window.bridge.browseShareFolder()
-    if (!picked) return
-    try {
-      await request('owned-folder:relocate', { spaceId, shareId: share.id, mountPath: picked })
-      toast.success(t('share.locateSuccess', { name: share.name }))
-    } catch (err) {
-      toast.error(errorText(err))
-    }
-  }
-
   async function handleDelete() {
     try {
       await request('owned-folder:delete', { spaceId, shareId: share.id })
@@ -279,17 +270,13 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   }
 
   async function handleRelocate(mountPath: string) {
-    if (isYou) {
-      await request('owned-folder:relocate', { spaceId, shareId: share.id, mountPath })
-      toast.success(t('share.locateSuccess', { name: share.name }))
-      return
-    }
+    if (isYou) return relocate(share, mountPath)
     await request('foreign-folder:relocate', { spaceId, shareId: share.id, mountPath })
     toast.success(t('share.mirrorLocationSuccess'))
   }
 
   function handleStripAction(action: 'locate' | 'resume' | 'pause') {
-    if (action === 'locate') void handleLocate()
+    if (action === 'locate') void locate(share)
     else void setPaused(action === 'pause')
   }
 
@@ -304,7 +291,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
     sourceMissing,
     canMirror: !!onMirror,
     onOpen: handleRevealFolder,
-    onLocate: handleLocate,
+    onLocate: () => { void locate(share) },
     onSetPaused: (next) => { void setPaused(next) },
     onMirror: () => onMirror?.(share),
     onEdit: () => setShowEdit(true),
@@ -372,7 +359,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
             ) : (
               <>
                 {sourceMissing ? (
-                  <Button icon="folder_open" onClick={handleLocate}>
+                  <Button icon="folder_open" onClick={() => { void locate(share) }}>
                     {t('share.locateFolder')}
                   </Button>
                 ) : (

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -10,8 +10,8 @@ import { useSpaces } from '../hooks/useSpaces.js'
 import { useProfile } from '../hooks/useProfile.js'
 import { useTreeExpansion } from '../hooks/useTreeExpansion.js'
 import Icon from '../components/primitives/Icon.js'
-import IconButton from '../components/primitives/IconButton.js'
 import Button from '../components/primitives/Button.js'
+import EntityHeader from '../components/layout/EntityHeader.js'
 import ActionMenu, { type ActionMenuItemConfig } from '../components/widgets/ActionMenu.js'
 import FolderTree from '../components/widgets/FolderTree.js'
 import FolderWorkStrip from '../components/widgets/FolderWorkStrip.js'
@@ -38,8 +38,57 @@ import { useFolderCommands } from '../hooks/useFolderCommands.js'
 import { useLocateShare } from '../hooks/useLocateShare.js'
 import { useToast } from '../components/toast/useToast.js'
 import type { ShareWithRole } from '../hooks/useShares.js'
-import type { FileTreeNode } from '../types.js'
+import type { FileTreeNode, ShareRole } from '../types.js'
 import { useErrorText } from '../hooks/useErrorText.js'
+
+interface FolderEyebrowProps {
+  isYou: boolean
+  ownerName: string
+  spaceName: string | null
+  role: ShareRole
+  mirrorEnabled: boolean
+}
+
+function FolderEyebrow({ isYou, ownerName, spaceName, role, mirrorEnabled }: FolderEyebrowProps) {
+  const { t } = useTranslation()
+  return (
+    <>
+      {isYou ? t('share.sharedByYou') : t('share.ownedBy', { name: ownerName })}
+      {spaceName !== null ? ' · ' + t('space.in', { name: spaceName }) : null}
+      {role === 'mirrored'
+        ? ' · ' + t('share.badgeMirrored') + ' · ' + (mirrorEnabled ? t('share.readOnly') : t('folder.paused'))
+        : null}
+    </>
+  )
+}
+
+interface FolderHeaderActionsProps {
+  role: ShareRole
+  sourceMissing: boolean
+  onMirror?: () => void
+  onLocate: () => void
+  onReveal: () => void
+  menuItems: ActionMenuItemConfig[]
+}
+
+function FolderHeaderActions({ role, sourceMissing, onMirror, onLocate, onReveal, menuItems }: FolderHeaderActionsProps) {
+  const { t } = useTranslation()
+  if (role === 'browse') {
+    return onMirror
+      ? <Button icon="folder_download" onClick={onMirror}>{t('share.mirrorToDisk')}</Button>
+      : null
+  }
+  return (
+    <>
+      {sourceMissing ? (
+        <Button icon="folder_open" onClick={onLocate}>{t('share.locateFolder')}</Button>
+      ) : (
+        <Button icon="folder_open" onClick={onReveal}>{t('share.openInFinder')}</Button>
+      )}
+      <ActionMenu label={t('share.moreActions')} items={menuItems} ariaLabel={t('share.moreActions')} />
+    </>
+  )
+}
 
 interface FolderViewProps {
   spaceId: string
@@ -327,56 +376,29 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
 
   return (
     <div className="max-w-7xl mx-auto px-8 flex flex-col h-[calc(100vh-5rem-var(--banner-h,0px))]">
-      <div className="shrink-0 pt-8 pb-4">
-        <div className="flex items-start gap-4">
-          <IconButton
-            icon="arrow_back"
-            onClick={onBack}
-            ariaLabel={t('actions.back')}
-            className="mt-1 shrink-0"
+      <EntityHeader
+        name={share.name}
+        onBack={onBack}
+        eyebrow={
+          <FolderEyebrow
+            isYou={isYou}
+            ownerName={owner?.displayName || t('avatar.unknown')}
+            spaceName={space ? space.name : null}
+            role={share.role}
+            mirrorEnabled={foreignEnabled}
           />
-          <div className="min-w-0 flex-1">
-            <h1 className="text-4xl font-headline font-extrabold text-accent tracking-tighter leading-tight truncate pb-1.5">
-              {share.name}
-            </h1>
-            <p className="text-xs font-bold text-secondary tracking-wide uppercase mt-1">
-              {isYou
-                ? t('share.sharedByYou')
-                : t('share.ownedBy', { name: owner?.displayName || t('avatar.unknown') })}
-              {space ? ' · ' + t('space.in', { name: space.name }) : null}
-              {share.role === 'mirrored'
-                ? ' · ' + t('share.badgeMirrored') + ' · ' + (foreignEnabled ? t('share.readOnly') : t('folder.paused'))
-                : null}
-            </p>
-          </div>
-          <div className="flex gap-3 mt-2 shrink-0">
-            {share.role === 'browse' ? (
-              onMirror && (
-                <Button icon="folder_download" onClick={() => onMirror(share)}>
-                  {t('share.mirrorToDisk')}
-                </Button>
-              )
-            ) : (
-              <>
-                {sourceMissing ? (
-                  <Button icon="folder_open" onClick={() => { void locate(share) }}>
-                    {t('share.locateFolder')}
-                  </Button>
-                ) : (
-                  <Button icon="folder_open" onClick={handleRevealFolder}>
-                    {t('share.openInFinder')}
-                  </Button>
-                )}
-                <ActionMenu
-                  label={t('share.moreActions')}
-                  items={menuItems}
-                  ariaLabel={t('share.moreActions')}
-                />
-              </>
-            )}
-          </div>
-        </div>
-      </div>
+        }
+        actions={
+          <FolderHeaderActions
+            role={share.role}
+            sourceMissing={sourceMissing}
+            onMirror={onMirror ? () => onMirror(share) : undefined}
+            onLocate={() => { void locate(share) }}
+            onReveal={handleRevealFolder}
+            menuItems={menuItems}
+          />
+        }
+      />
 
       {/* The strips are a band, not a reserved slot: no strip, no height. Outside the scroll pane,
           so folder state can never scroll away from the folder it describes.

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -33,14 +33,88 @@ import ActionMenu from '../components/widgets/ActionMenu.js'
 import InviteModal from '../components/modals/InviteModal.js'
 import EditSpaceModal from '../components/modals/EditSpaceModal.js'
 import Icon from '../components/primitives/Icon.js'
-import IconButton from '../components/primitives/IconButton.js'
 import Button from '../components/primitives/Button.js'
+import EntityHeader from '../components/layout/EntityHeader.js'
 import Avatar from '../components/primitives/Avatar.js'
 import DocsCard from '../components/widgets/DocsCard.js'
 import { SPACE_ACTION_EVENT, type SpaceAction } from '../space-actions.js'
 import { showSpaceEmptyState, showSpaceLoading } from '../spaceContentState.js'
 import { useErrorText } from '../hooks/useErrorText.js'
 import { useLocateShare } from '../hooks/useLocateShare.js'
+
+interface SpaceHeaderActionsProps {
+  isPending: boolean
+  isLegacy: boolean
+  favorite: boolean
+  onCancelRequest: () => void
+  onInvite: () => void
+  onToggleFavorite: () => void
+  onEdit: () => void
+  onManageStorage: () => void
+  onLeave: () => void
+}
+
+function SpaceHeaderActions({
+  isPending,
+  isLegacy,
+  favorite,
+  onCancelRequest,
+  onInvite,
+  onToggleFavorite,
+  onEdit,
+  onManageStorage,
+  onLeave,
+}: SpaceHeaderActionsProps) {
+  const { t } = useTranslation()
+  // Not a member yet — expose nothing member-only (invite/edit/storage), just a way to withdraw
+  // the request.
+  if (isPending) {
+    return (
+      <Button variant="secondary" icon="close" onClick={onCancelRequest}>
+        {t('space.cancelRequest')}
+      </Button>
+    )
+  }
+  return (
+    <>
+      <Button icon="group_add" onClick={onInvite} disabled={isLegacy}>
+        {t('space.inviteShort')}
+      </Button>
+      <ActionMenu
+        label={t('space.more')}
+        items={[
+          {
+            id: 'favorite',
+            label: favorite ? t('space.removeFavorite') : t('space.addFavorite'),
+            icon: 'star',
+            iconFilled: favorite,
+            onAction: onToggleFavorite,
+          },
+          {
+            id: 'edit',
+            label: t('space.edit'),
+            icon: 'edit',
+            disabled: isLegacy,
+            onAction: onEdit,
+          },
+          {
+            id: 'manage-storage',
+            label: t('space.manageStorage'),
+            icon: 'database',
+            onAction: onManageStorage,
+          },
+          {
+            id: 'leave',
+            label: t('space.leave'),
+            icon: 'logout',
+            variant: 'danger',
+            onAction: onLeave,
+          },
+        ]}
+      />
+    </>
+  )
+}
 
 interface SpaceViewProps {
   spaceId: string
@@ -240,75 +314,28 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
           e.target.value = ''
         }}
       />
-      <div className="shrink-0 pt-8 pb-4">
-        <div className="flex items-start gap-4 mb-2">
-          <IconButton
-            icon="arrow_back"
-            onClick={onBack}
-            ariaLabel={t('actions.back')}
-            className="mt-1 shrink-0"
+      <EntityHeader
+        name={space?.name || t('space.fallbackName')}
+        onBack={onBack}
+        titleAdornment={isLegacy ? (
+          <span className="shrink-0 inline-flex items-center px-2.5 py-1 rounded-full bg-error-container text-on-error-container text-xs font-bold border border-outline">
+            {t('space.legacyBadge')}
+          </span>
+        ) : null}
+        actions={
+          <SpaceHeaderActions
+            isPending={isPending}
+            isLegacy={isLegacy}
+            favorite={!!space?.favorite}
+            onCancelRequest={handleCancelRequest}
+            onInvite={handleInvite}
+            onToggleFavorite={() => toggleFavorite(spaceId)}
+            onEdit={() => setShowEditModal(true)}
+            onManageStorage={onManageStorage}
+            onLeave={() => setShowLeaveModal(true)}
           />
-          <div className="flex-1 min-w-0">
-            <div className="flex items-center gap-3">
-              <h1 className="text-4xl font-headline font-extrabold text-accent tracking-tighter leading-tight truncate pb-1.5">
-                {space?.name || t('space.fallbackName')}
-              </h1>
-              {isLegacy && (
-                <span className="shrink-0 inline-flex items-center px-2.5 py-1 rounded-full bg-error-container text-on-error-container text-xs font-bold border border-outline">
-                  {t('space.legacyBadge')}
-                </span>
-              )}
-            </div>
-          </div>
-          <div className="flex gap-3 mt-2 shrink-0">
-            {isPending ? (
-              // Not a member yet — expose nothing member-only (invite/edit/storage),
-              // just a way to withdraw the request.
-              <Button variant="secondary" icon="close" onClick={handleCancelRequest}>
-                {t('space.cancelRequest')}
-              </Button>
-            ) : (
-              <>
-                <Button icon="group_add" onClick={handleInvite} disabled={isLegacy}>
-                  {t('space.inviteShort')}
-                </Button>
-                <ActionMenu
-                  label={t('space.more')}
-                  items={[
-                    {
-                      id: 'favorite',
-                      label: space?.favorite ? t('space.removeFavorite') : t('space.addFavorite'),
-                      icon: 'star',
-                      iconFilled: space?.favorite,
-                      onAction: () => toggleFavorite(spaceId),
-                    },
-                    {
-                      id: 'edit',
-                      label: t('space.edit'),
-                      icon: 'edit',
-                      disabled: isLegacy,
-                      onAction: () => setShowEditModal(true),
-                    },
-                    {
-                      id: 'manage-storage',
-                      label: t('space.manageStorage'),
-                      icon: 'database',
-                      onAction: onManageStorage,
-                    },
-                    {
-                      id: 'leave',
-                      label: t('space.leave'),
-                      icon: 'logout',
-                      variant: 'danger',
-                      onAction: () => setShowLeaveModal(true),
-                    },
-                  ]}
-                />
-              </>
-            )}
-          </div>
-        </div>
-      </div>
+        }
+      />
 
       {isLegacy && (
         <div className="shrink-0 pb-4">

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -40,6 +40,7 @@ import DocsCard from '../components/widgets/DocsCard.js'
 import { SPACE_ACTION_EVENT, type SpaceAction } from '../space-actions.js'
 import { showSpaceEmptyState, showSpaceLoading } from '../spaceContentState.js'
 import { useErrorText } from '../hooks/useErrorText.js'
+import { useLocateShare } from '../hooks/useLocateShare.js'
 
 interface SpaceViewProps {
   spaceId: string
@@ -77,6 +78,7 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
   const { shares, loading: sharesLoading } = useShares(spaceId, profile?.publicKey ?? null)
   const toast = useToast()
   const errorText = useErrorText()
+  const { locate } = useLocateShare(spaceId)
   const [showInviteModal, setShowInviteModal] = useState(false)
   const [showApproval, setShowApproval] = useState(false)
   const [showLeaveModal, setShowLeaveModal] = useState(false)
@@ -147,18 +149,8 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
 
   // The row handlers below are useCallback'd because they are props of memoized rows (ShareCard,
   // FileCard): an identity that changes every render defeats the memo, and the decoration
-  // heartbeat re-renders this screen once a second for as long as a transfer is live.
-  const handleLocate = useCallback(async (share: ShareWithRole) => {
-    const picked = await window.bridge.browseShareFolder()
-    if (!picked) return
-    try {
-      await request('owned-folder:relocate', { spaceId, shareId: share.id, mountPath: picked })
-      toast.success(t('share.locateSuccess', { name: share.name }))
-    } catch (err) {
-      toast.error(errorText(err))
-    }
-  }, [spaceId, toast, t, errorText])
-
+  // heartbeat re-renders this screen once a second for as long as a transfer is live. `locate` comes
+  // out of useLocateShare already wrapped, for the same reason.
   const handleOpenShare = useCallback((share: ShareWithRole) => { onOpenShare?.(share) }, [onOpenShare])
 
   const handleOpenInFinder = useCallback(async (share: ShareWithRole) => {
@@ -464,7 +456,7 @@ export default function SpaceView({ spaceId, onBack, onManageStorage, onOpenShar
                           onOpen={handleOpenShare}
                           onOpenInFinder={handleOpenInFinder}
                           onDelete={handleDeleteRequest}
-                          onLocate={handleLocate}
+                          onLocate={locate}
                           onMirror={handleMirrorRequest}
                           onUnmount={handleUnmount}
                           onPauseMirror={handlePauseMirror}

--- a/test/frontend-layout/harness-modaltitle-entry.tsx
+++ b/test/frontend-layout/harness-modaltitle-entry.tsx
@@ -72,7 +72,10 @@ async function run(): Promise<void> {
   let dialogs: HTMLElement[] = []
   while (dialogs.length < 2 && Date.now() < deadline) {
     await sleep(50)
-    dialogs = Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"]'))
+    // Both roles: the destructive confirms this harness mounts declare `alertdialog`, and a
+    // selector that named only `dialog` matched nothing and reported "expected 2 dialogs, got 0"
+    // for every run rather than measuring anything.
+    dialogs = Array.from(document.querySelectorAll<HTMLElement>('[role="dialog"], [role="alertdialog"]'))
   }
   if (dialogs.length < 2) return publishError('expected 2 dialogs, got ' + dialogs.length)
   await document.fonts.ready

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -133,6 +133,7 @@ import s132 from './scenarios/s132-activity-log-settings-parity.mjs'
 import s133 from './scenarios/s133-modal-keyboard.mjs'
 import s134 from './scenarios/s134-mirror-over-cap-advisory.mjs'
 import s135 from './scenarios/s135-row-lane-parity.mjs'
+import s136 from './scenarios/s136-screen-header-parity.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -199,7 +200,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s136-screen-header-parity.mjs
+++ b/test/frontend/scenarios/s136-screen-header-parity.mjs
@@ -1,0 +1,81 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, assert } from '../assert.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { workDir } from '../paths.mjs'
+
+// The space screen and the folder screen now take their header from one component. Nothing below is
+// visible to a unit test: the header is where the back control, the title, the eyebrow line and the
+// actions cluster meet, and the extraction moved the <h1> into a flex row beside a badge slot —
+// exactly the change that splits an AX node while typecheck, lint and every ratchet stay green.
+//
+// Both screens are asserted through the AX tree, in both directions of a navigation, and on both
+// sides of the share so the owner and the peer eyebrow are each exercised.
+export default async function s136 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('hdr-'), 'Quarterlies')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'q1.txt'), 'so the folder exists at share time')
+
+  try {
+    await r.ok('A and B share a space; A owns "Quarterlies"', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+      await A.focus()
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Quarterlies', 60000)
+    })
+
+    await r.ok('the space header carries a back control, the space name and its actions', async () => {
+      assert(await A.has({ name: 'Back' }), 'the back control is reachable by name')
+      assert(await A.hasText('Aurora'), 'the space name is on screen')
+      assert(await A.has({ name: 'Invite' }), 'the primary action is reachable by name')
+      assert(await A.has({ name: 'More' }), 'the overflow menu is reachable by name')
+      await A.shot('s136-space-header', runDir)
+    })
+
+    await r.ok("the owner's folder header says who shares it, and offers the folder acts", async () => {
+      await A.openFolder('Quarterlies')
+      // Wait on the space clause, not on "Shared by you": the folder CARD says the latter too, so a
+      // wait on it returns while the space screen is still up and the assertions below race the
+      // navigation.
+      await A.waitText('in Aurora', 20000)
+      assert(await A.hasText('Shared by you'), 'the eyebrow says who shares it')
+      assert(await A.has({ name: 'Back' }), 'the back control survives the second screen')
+      assert(await A.has({ name: 'Open Folder' }), 'the primary action is reachable by name')
+      assert(await A.has({ name: 'More' }), 'and so is the overflow menu')
+      await A.shot('s136-folder-header-owner', runDir)
+    })
+
+    await r.ok('going back restores the space header', async () => {
+      await A.back()
+      await A.waitText('Aurora', 20000)
+      assert(await A.has({ name: 'Invite' }), 'the space actions are back')
+      // The folder screen's eyebrow must not survive the navigation: a header that kept it would be
+      // a header rendered for the wrong screen.
+      //
+      // The discriminator is the SPACE clause, not "Shared by you". hasText matches the whole
+      // window, and the folder CARD's meta line (shareSizeLine) says "Shared by you" too for every
+      // folder you own — so that string is on the space screen by design and proves nothing here.
+      // `space.in` has exactly one renderer, the folder eyebrow.
+      assert(!(await A.hasText('in Aurora')), 'the folder eyebrow is gone with the folder screen')
+    })
+
+    await r.ok("the peer's folder header names the owner instead", async () => {
+      await B.focus()
+      await B.waitText('Quarterlies', 60000)
+      await B.openFolder('Quarterlies')
+      await B.waitText('in Aurora', 20000)
+      assert(await B.hasText('Owned by Alice'), 'the eyebrow names the owner instead of you')
+      assert(await B.has({ name: 'Back' }), 'the back control is there for the peer too')
+      await B.shot('s136-folder-header-peer', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/unit/entity-header-single-source.test.js
+++ b/test/unit/entity-header-single-source.test.js
@@ -1,0 +1,31 @@
+import test from 'brittle'
+import { readFileSync, readdirSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const SCREENS = path.resolve(here, '../../src/renderer/screens')
+const read = (file) => readFileSync(path.join(SCREENS, file), 'utf8')
+
+// A screen title is one of exactly two things: a settings page's fixed heading (PageHeader) or the
+// name of the thing on screen (EntityHeader). The second needs truncate + leading-tight + pb-1.5, or
+// the 800-weight headline's descenders are clipped by its own overflow:hidden — a silent failure,
+// visible only as a shaved "g". A third screen writing its own <h1> is how that comes back.
+test('no screen declares its own page title', (t) => {
+  // Two heroes, both centred, neither with a back button or an actions cluster, both at a size no
+  // other screen uses.
+  const HEROES = new Set(['SharedSpaces.tsx', 'Onboarding.tsx'])
+  let checked = 0
+  for (const file of readdirSync(SCREENS)) {
+    if (!file.endsWith('.tsx') || HEROES.has(file)) continue
+    checked++
+    t.absent(/<h1/.test(read(file)), `${file}: take the title from PageHeader or EntityHeader`)
+  }
+  t.ok(checked >= 13, `checked ${checked} screens`)
+})
+
+test('the two name-bearing screens use EntityHeader', (t) => {
+  for (const file of ['SpaceView.tsx', 'FolderView.tsx']) {
+    t.ok(read(file).includes('<EntityHeader'), `${file} renders <EntityHeader>`)
+  }
+})

--- a/test/unit/locate-share-single-source.test.js
+++ b/test/unit/locate-share-single-source.test.js
@@ -1,0 +1,50 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const RENDERER = path.resolve(here, '../../src/renderer')
+const OWNER = 'hooks/useLocateShare.ts'
+
+function sourceFiles (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) sourceFiles(p, out)
+    else if (name.endsWith('.ts') || name.endsWith('.tsx')) out.push(p)
+  }
+  return out
+}
+
+const files = sourceFiles(RENDERER).map((f) => ({
+  rel: path.relative(RENDERER, f).split(path.sep).join('/'),
+  src: readFileSync(f, 'utf8'),
+}))
+const read = (rel) => files.find((f) => f.rel === rel).src
+
+// Relocating an owned folder is offered from five surfaces and says a sentence that names the share.
+// Two screens had written that pair out; a third would have said it differently.
+test('only useLocateShare issues owned-folder:relocate', (t) => {
+  for (const f of files) {
+    if (f.rel === OWNER) continue
+    t.absent(f.src.includes("'owned-folder:relocate'"), `${f.rel}: go through useLocateShare`)
+  }
+  t.ok(read(OWNER).includes("'owned-folder:relocate'"), 'and it is where the channel actually lives')
+  t.ok(read(OWNER).includes("t('share.locateSuccess'"), 'along with the sentence it says on success')
+})
+
+// Collapsing the two halves into one is the mistake this names: Edit Folder renders the failure in
+// its own field error, so `relocate` has to reach it.
+test('relocate propagates; only the browse-then-relocate path toasts', (t) => {
+  const src = read(OWNER)
+  const relocate = src.slice(src.indexOf('const relocate'), src.indexOf('const locate'))
+  t.absent(/catch/.test(relocate), 'relocate has no catch of its own')
+  t.ok(/toast\.error/.test(src.slice(src.indexOf('const locate'))), 'locate does')
+})
+
+// The foreign half is a different channel and a different sentence, and it is deliberately not
+// shared — one folder screen issues it, from the branch the owner half returns before.
+test('the mirror relocate stays where it is', (t) => {
+  const screens = files.filter((f) => f.src.includes("'foreign-folder:relocate'")).map((f) => f.rel)
+  t.alike(screens, ['screens/FolderView.tsx'])
+})

--- a/test/unit/modal-header-single-source.test.js
+++ b/test/unit/modal-header-single-source.test.js
@@ -1,0 +1,81 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const RENDERER = path.resolve(here, '../../src/renderer')
+const OWNER = 'components/layout/ModalHeader.tsx'
+
+function tsxFiles (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) tsxFiles(p, out)
+    else if (name.endsWith('.tsx')) out.push(p)
+  }
+  return out
+}
+
+const files = tsxFiles(RENDERER).map((f) => ({
+  rel: path.relative(RENDERER, f).split(path.sep).join('/'),
+  src: readFileSync(f, 'utf8'),
+}))
+const read = (rel) => files.find((f) => f.rel === rel).src
+
+// Seventeen dialogs wrote out the same header block. Two had drifted off the padding design.md
+// documents, one titled itself with an <h2>, and twelve were missing the gap that keeps a long title
+// off the close button. The checks below are STRUCTURAL — the header row and its container —
+// deliberately not the title's class string: two legitimate non-headers reuse that type
+// (FilenameTitle, and the centred "sent" panel in FeedbackModal), and the seventeenth dialog wrote
+// the same six utilities in a different order, so a string match both over- and under-reports.
+test('only ModalHeader declares the dialog header block', (t) => {
+  const HEADER_ROW = 'flex justify-between items-start'
+  const CONTAINER = 'px-10 pt-10'
+  // Two <Modal> consumers that legitimately have no header row: the cheatsheet's close button is
+  // absolutely positioned in the corner and its title sits in its own block, and the command palette
+  // opens straight into its search field with no title at all.
+  const NO_HEADER = new Set(['keyboard/ShortcutsHint.tsx', 'keyboard/CommandPalette.tsx'])
+
+  for (const f of files) {
+    if (f.rel === OWNER) continue
+    t.absent(f.src.includes(HEADER_ROW), `${f.rel}: the title/close row belongs to ModalHeader`)
+    if (!NO_HEADER.has(f.rel)) {
+      t.absent(f.src.includes(CONTAINER), `${f.rel}: the header container belongs to ModalHeader`)
+    }
+  }
+})
+
+// Every dialog, including the one that does not live in the dialog folder. ActivityLogSettings mounts
+// its purge confirm inline, which is how it stayed out of sight long enough to diverge twice — so it
+// is named here rather than found by a folder walk.
+//
+// The two mount wizards reach the header through MountWizardStep, which is a dialog SHELL rather
+// than a dialog; the assertion below it closes that indirection so the hop cannot become a hole.
+const SHELL = 'components/modals/MountWizardStep.tsx'
+
+test('every dialog gets its header from the owner', (t) => {
+  const dialogs = files.filter((f) => f.rel.startsWith('components/modals/')).map((f) => f.rel)
+  t.ok(dialogs.length >= 16, `found ${dialogs.length} dialogs under components/modals`)
+  for (const rel of [...dialogs, 'screens/ActivityLogSettings.tsx']) {
+    const src = read(rel)
+    t.ok(src.includes('<ModalHeader') || src.includes('<MountWizardStep'),
+      `${rel} takes its header from ModalHeader`)
+  }
+  t.ok(read(SHELL).includes('<ModalHeader'), 'and the wizard shell takes its own from there too')
+})
+
+// The title comes from ModalHeader or from FilenameTitle, which renders its own. A dialog that
+// declares one itself is a dialog that picked its own heading level, which is how the seventeenth
+// ended up an <h2> while sixteen others used <h1>.
+test('no dialog declares its own heading', (t) => {
+  for (const f of files) {
+    if (!f.rel.startsWith('components/modals/')) continue
+    t.absent(/<h1/.test(f.src), `${f.rel}: the title is ModalHeader's or FilenameTitle's`)
+  }
+})
+
+test('the header row keeps its floor between title and close', (t) => {
+  const owner = read(OWNER)
+  t.ok(/flex justify-between items-start mb-2 gap-3/.test(owner), 'title and close can never touch')
+  t.ok(/px-10 pt-10 pb-6/.test(owner), 'and the container is the padding design.md documents')
+})

--- a/test/unit/mount-wizard-single-source.test.js
+++ b/test/unit/mount-wizard-single-source.test.js
@@ -1,0 +1,68 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const RENDERER = path.resolve(here, '../../src/renderer')
+
+function sourceFiles (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) sourceFiles(p, out)
+    else if (name.endsWith('.ts') || name.endsWith('.tsx')) out.push(p)
+  }
+  return out
+}
+
+const files = sourceFiles(RENDERER).map((f) => ({
+  rel: path.relative(RENDERER, f).split(path.sep).join('/'),
+  src: readFileSync(f, 'utf8'),
+}))
+const read = (rel) => files.find((f) => f.rel === rel).src
+
+const WIZARDS = ['components/modals/AddFolderShareModal.tsx', 'components/modals/MirrorFolderModal.tsx']
+
+// The owned and foreign mount wizards are one state machine over three injected calls — validate a
+// path, scan it, commit it. Each had a copy: the same step and submitting state, the same
+// reset-on-open effect, the same point-in-time validation probe, the same rule that a cancelled scan
+// returns you to the edit step. Nothing enforced that the two copies stayed one answer.
+test('neither mount wizard runs its own step machine', (t) => {
+  for (const rel of WIZARDS) {
+    const src = read(rel)
+    t.ok(src.includes('useMountWizard('), `${rel} uses the shared machine`)
+    t.absent(/useState<Step>|type Step =/.test(src), `${rel} keeps no step state of its own`)
+    t.absent(/PREVIEW_CANCELLED/.test(src), `${rel} does not re-decide what a cancelled scan means`)
+    t.absent(/browseShareFolder\(\)/.test(src), `${rel} does not open the picker itself`)
+    t.absent(/validationError, set/.test(src), `${rel} does not hold its own validation verdict`)
+  }
+})
+
+test('the wizard shell and its path field have one implementation each', (t) => {
+  for (const rel of WIZARDS) {
+    const src = read(rel)
+    t.ok(src.includes('<MountWizardStep'), `${rel} renders the shared edit step`)
+    t.ok(src.includes('<MountPathField'), `${rel} renders the shared path field`)
+    t.absent(src.includes('<PathRow'), `${rel} reaches PathRow through MountPathField`)
+  }
+})
+
+test('usePreviewFlow has one consumer', (t) => {
+  const consumers = files.filter((f) => f.src.includes('usePreviewFlow')).map((f) => f.rel).sort()
+  t.alike(consumers, ['hooks/useMountWizard.ts', 'hooks/usePreviewFlow.ts'])
+})
+
+// The injected calls are inline arrows built from props, so their identity changes every render. A
+// validate() reaching the validation effect's dependency list would clear the verdict, re-render and
+// spin — which is why the hook holds them in a ref.
+test('the injected calls stay out of the effect dependency lists', (t) => {
+  const src = read('hooks/useMountWizard.ts')
+  t.ok(src.includes('opsRef.current.validate('), 'validate is called through the ref')
+  t.ok(src.includes('opsRef.current.startPreview('), 'so is startPreview')
+  t.ok(src.includes('opsRef.current.commit('), 'and commit')
+  for (const deps of src.match(/\}, \[[^\]]*\]\)/g) ?? []) {
+    for (const op of ['validate', 'startPreview', 'commit', 'onCommitted']) {
+      t.absent(new RegExp(`\\b${op}\\b`).test(deps), `${op} is not a dependency (${deps.trim()})`)
+    }
+  }
+})

--- a/test/unit/path-field-harmonized.test.js
+++ b/test/unit/path-field-harmonized.test.js
@@ -51,7 +51,7 @@ test('every path the user can re-pick goes through PathRow', (t) => {
   // show the path at all, each named with why.
   const PICKS_WITHOUT_SHOWING = new Map([
     ['screens/SpaceView.tsx', 'drag-drop / Add folder hand the picked path straight to a modal'],
-    ['screens/FolderView.tsx', 'its Locate entry re-points the folder and renders no row'],
+    ['hooks/useLocateShare.ts', 'Locate re-points the folder and reports it in a toast; there is no field'],
     ['hooks/useMountWizard.ts', 'a hook renders nothing; its callers show the path, asserted below'],
   ])
   const pickers = files.filter((f) => /window\.bridge\.browse(DownloadFolder|ShareFolder)\(/.test(f.src))

--- a/test/unit/path-field-harmonized.test.js
+++ b/test/unit/path-field-harmonized.test.js
@@ -13,17 +13,19 @@ const here = path.dirname(fileURLToPath(import.meta.url))
 const RENDERER = path.resolve(here, '../../src/renderer')
 const read = (p) => readFileSync(p, 'utf8')
 
-function tsxFiles (dir) {
+// `.ts` as well as `.tsx`: the picker is opened from hooks now, and a walk that saw only components
+// could not tell a hook that shows the path it picked from one that does not.
+function sourceFiles (dir) {
   const out = []
   for (const entry of readdirSync(dir)) {
     const full = path.join(dir, entry)
-    if (statSync(full).isDirectory()) out.push(...tsxFiles(full))
-    else if (entry.endsWith('.tsx')) out.push(full)
+    if (statSync(full).isDirectory()) out.push(...sourceFiles(full))
+    else if (entry.endsWith('.tsx') || entry.endsWith('.ts')) out.push(full)
   }
   return out
 }
 
-const files = tsxFiles(RENDERER).map((f) => ({ rel: path.relative(RENDERER, f), src: read(f) }))
+const files = sourceFiles(RENDERER).map((f) => ({ rel: path.relative(RENDERER, f), src: read(f) }))
 const pathRow = read(path.join(RENDERER, 'components/widgets/PathRow.tsx'))
 
 // `FilePath` renders the path text alone. Beside an action it is the bare-text form this
@@ -43,15 +45,31 @@ test('FilePath is rendered only where a path field would be wrong', (t) => {
 })
 
 test('every path the user can re-pick goes through PathRow', (t) => {
-  // The two folder pickers main exposes. A screen that opens one and shows the result IS a path
-  // field; the only callers that legitimately open one without showing a path are the action-menu
-  // entries (Locate / relocate from a card), which navigate rather than render a row.
-  const MENU_ONLY = new Set(['screens/SpaceView.tsx', 'screens/FolderView.tsx'])
+  // The two folder pickers main exposes. A caller that opens one and shows the result IS a path
+  // field, and it renders one — directly, or through the wizards' <MountPathField>, which is a
+  // PathRow with its label and its validation message. The exceptions are the callers that never
+  // show the path at all, each named with why.
+  const PICKS_WITHOUT_SHOWING = new Map([
+    ['screens/SpaceView.tsx', 'drag-drop / Add folder hand the picked path straight to a modal'],
+    ['screens/FolderView.tsx', 'its Locate entry re-points the folder and renders no row'],
+    ['hooks/useMountWizard.ts', 'a hook renders nothing; its callers show the path, asserted below'],
+  ])
   const pickers = files.filter((f) => /window\.bridge\.browse(DownloadFolder|ShareFolder)\(/.test(f.src))
   t.ok(pickers.length > 0, 'the picker calls were found at all')
   for (const f of pickers) {
-    if (MENU_ONLY.has(f.rel)) continue
-    t.ok(f.src.includes('<PathRow'), `${f.rel} picks a folder and must show it in a PathRow`)
+    if (PICKS_WITHOUT_SHOWING.has(f.rel)) continue
+    t.ok(/<PathRow|<MountPathField/.test(f.src), `${f.rel} picks a folder and must show it in a PathRow`)
+  }
+  // A stale exemption is the same failure wearing a green tick: every name above must still be a
+  // caller that opens a picker.
+  for (const rel of PICKS_WITHOUT_SHOWING.keys()) {
+    t.ok(pickers.some((f) => f.rel === rel), `${rel} still opens a folder picker`)
+  }
+  // The one exemption that delegates rather than declines: close it where it is actually kept.
+  const wizards = files.filter((f) => f.rel !== 'hooks/useMountWizard.ts' && f.src.includes('useMountWizard('))
+  t.ok(wizards.length > 0, 'the wizard callers were found at all')
+  for (const f of wizards) {
+    t.ok(f.src.includes('<MountPathField'), `${f.rel} drives the wizard and must show the path it picks`)
   }
 })
 

--- a/test/unit/space-title-descender.test.js
+++ b/test/unit/space-title-descender.test.js
@@ -7,6 +7,7 @@ const read = (p) => readFileSync(fileURLToPath(new URL(p, root)), 'utf8')
 
 const SPACEVIEW = 'src/renderer/screens/SpaceView.tsx'
 const FOLDERVIEW = 'src/renderer/screens/FolderView.tsx'
+const ENTITYHEADER = 'src/renderer/components/layout/EntityHeader.tsx'
 const SPACECARD = 'src/renderer/components/cards/SpaceCard.tsx'
 const CREATESPACE = 'src/renderer/components/modals/CreateSpaceModal.tsx'
 
@@ -26,13 +27,17 @@ const titleClass = (src, size) => {
   return src.match(re)?.[1] ?? null
 }
 
+// The two screens that title a name now share one header, so the property lives in one file. Both
+// halves still have to hold: the class is right, AND the screens actually reach it — otherwise this
+// passes over a component nobody renders.
 test('REGRESSION (FIX-1): text-4xl space/folder titles get leading-tight + pb headroom', (t) => {
+  const cls = titleClass(read(ENTITYHEADER), 'text-4xl')
+  t.ok(cls, 'EntityHeader has a text-4xl font-headline title')
+  t.ok(cls.includes('truncate'), 'the title still truncates long names')
+  t.ok(cls.includes('leading-tight'), 'the title loosens the tight text-4xl line box')
+  t.ok(/\bpb-\d/.test(cls), 'the title has bottom padding for clip headroom')
   for (const [name, path] of [['SpaceView', SPACEVIEW], ['FolderView', FOLDERVIEW]]) {
-    const cls = titleClass(read(path), 'text-4xl')
-    t.ok(cls, `${name} has a text-4xl font-headline title`)
-    t.ok(cls.includes('truncate'), `${name} title still truncates long names`)
-    t.ok(cls.includes('leading-tight'), `${name} title loosens the tight text-4xl line box`)
-    t.ok(/\bpb-\d/.test(cls), `${name} title has bottom padding for clip headroom`)
+    t.ok(read(path).includes('<EntityHeader'), `${name} takes its title from EntityHeader`)
   }
 })
 


### PR DESCRIPTION
## What & why

Four scaffolds that were written twice. **No defect is closed here** — every
pair still agrees today. What this prevents is the eighteenth dialog header
that forgets `gap-3`, or a third screen title that forgets `pb-1.5` and clips
its descenders. Both have already happened once in this tree.

- **`ModalHeader`** — the title/close row existed **17** times. Two dialogs had
  drifted off the padding `design.md` documents (`ApprovalModal` `pb-5`,
  `DiagnosticsPreviewModal` `pb-4`), one titled itself with an `<h2>`, and
  twelve lacked the `gap-3` that keeps a long title off the ✕. The seventeenth
  is the inline purge confirm in `screens/ActivityLogSettings.tsx` — out of
  sight of anything scanning the modal folder, which is how it diverged twice.
- **`EntityHeader`** — the space and folder screens wrote the same
  back-button/title/actions block, 8px apart. Not a flag on `PageHeader`: this
  title carries a name someone typed, so it needs
  `truncate + leading-tight + pb-1.5`, and a settings title needs none of it.
- **`useLocateShare`** — `owned-folder:relocate` was issued from three places
  across two screens, serving five surfaces. The asymmetry is kept on purpose:
  `relocate` throws so Edit Folder can render the failure in its own field
  error; `locate` catches because a toast is all its callers have.
- **`useMountWizard` + `MountWizardStep` + `MountPathField`** — the two mount
  wizards each held the same step/submitting state, reset-on-open effect,
  point-in-time path probe and cancelled-scan rule. The shell needed no
  per-caller prop, so plan 04's permission to reject C4 was not used.

Pixel changes to show, not mention: the two dialogs above move **toward** the
documented anatomy, and the space screen's header ends 8px higher.

## Coverage

Four new ratchets (`modal-header`, `entity-header`, `locate-share`,
`mount-wizard` single-source). `space-title-descender` and
`path-field-harmonized` were **retargeted, not widened** — the first now pins
the descender triple on `EntityHeader` and still proves both screens reach it;
the second names each picker caller that shows no path, and fails if a name in
that list stops opening a picker. New frontend scenario `s136`.

`test/frontend-layout/harness-modaltitle-entry.tsx` queried `[role="dialog"]`
against an `alertdialog` — it has reported "expected 2 dialogs, got 0" rather
than measuring anything since #190. Fixed here because this PR is what it
guards.

## Not cleared by this PR

`lint:ci` stays at **21** warnings. `FolderView` goes cx 83 → 78 and
`SpaceView` 46 → 43 — both still far over the ceiling of 20, because eslint
scores each function separately and the remaining branching is out of scope.

## Ran locally

Unit 2010/2010, `tsc`, `lint:ci` — and each of the four commits typechecks and
passes its own ratchets in isolation. **Outstanding: the frontend scenarios,
the axe pass and the VoiceOver spot-check have not been run against this
rebase**, and the pixel changes above have not been looked at in the running
app.
