### PR TITLE
Stop the mirror spinning against an offline or failing owner

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -426,3 +426,36 @@ never `catch {}` the delete: a seed you failed to remove is the invisible case, 
 has to learn about it (`test/unit/relay-secret.test.js` pins that with a read-only directory).
 
 The same shape applies to any pair of "secret at rest" + "record that names it".
+
+## `isOwnerOnline` is FALSE for a self-mirror — presence tracks remote peers only
+
+`isOwnerOnline` → `presence.isOnlineAnywhere`, and a presence lease is only ever created for a
+peer whose handshake we received. Our own key is never in the map, so `isOwnerOnline(ourKey)` is
+permanently false. Any gate written as `isOwnerOnline(mount.ownerKey)` therefore freezes every
+self-mirror forever — and `test/helpers/owned.js::setupSelfMirror`, which most of the mirror
+integration suite is built on, mounts with exactly that ownerKey.
+
+`share-listing.js` already carries the special case (`isOwn ? true : deps.isOwnerOnline(...)`) and
+so does `ownerLeftSpace`. Any third consumer needs it too — which is the argument for one pure
+predicate (`mirror-reach.js`) over a hand-rolled copy per call site.
+
+**Related:** an integration test cannot fake an *offline remote* owner. A fabricated ownerKey makes
+`loadShareForForeignMount` → `readPeerShares` return null, so the pass exits at `if (!share)` before
+reaching any gate — the test then passes with the gate deleted. Offline-owner behaviour has to be
+asserted at the flow layer, where a real peer shuts down.
+
+## A mirror re-fetching its own deleted file needs no peer — the overlay spool answers it
+
+A completed overlay fetch registers the blob locally ("seeding multiplication"), so `fetchFile`
+resolves a later request for that content hash from disk before it ever waits for a peer. Deleting
+a mirrored file therefore does NOT create unfetchable work: the next pass restores it from our own
+spool, converges, and goes quiet.
+
+This invalidates the obvious fixture for "the mirror spins against an offline owner" — mirror the
+folder, delete the files, take the owner away. It reproduces nothing. The shape that does is a
+mount created while the owner is already gone, against content this peer has never held. Cost: one
+flow test that passed for the wrong reason until it was instrumented to print the statuses it had
+actually observed (`unavailable,synced` — never `downloading`).
+
+**Generalisation:** when a red-first test goes green too easily, print what it observed rather than
+trusting the assertion. A guard that cannot fail is worse than no guard.

--- a/src/shared/folders/fetch-attempts.js
+++ b/src/shared/folders/fetch-attempts.js
@@ -1,0 +1,53 @@
+// Consecutive failed attempts per (file, advertised hash), and the point at which a producer should
+// stop asking. Pure, so the rule is asserted directly — no bare-* imports.
+//
+// A PERMANENT block is wrong for a multi-source overlay: the first holder to serve corrupt bytes
+// would poison content a second, healthy holder could serve correctly, with no way back short of a
+// remount. A budget gives the other holders their turn and still ends the unbounded retry.
+//
+// Bounded by EVICTION, not by refusing to record. A memo that stops recording at its cap silently
+// stops blocking, which is exactly how the loop this exists to end would come back on a mount with
+// more corrupt files than the cap.
+export const DEFAULT_ATTEMPT_LIMIT = 3
+export const DEFAULT_MAX_KEYS = 512
+
+export function createAttemptBudget({ limit = DEFAULT_ATTEMPT_LIMIT, maxKeys = DEFAULT_MAX_KEYS } = {}) {
+  const byMount = new Map()
+  const keyOf = (relPath, contentHash) => relPath + '\0' + (contentHash || '')
+
+  function entriesFor(mountKey) {
+    let m = byMount.get(mountKey)
+    if (!m) {
+      m = new Map()
+      byMount.set(mountKey, m)
+    }
+    return m
+  }
+
+  return {
+    // Record one failure and return the new count. Re-inserting moves the key to the end, so the
+    // eviction below drops the least recently failed rather than the first ever seen.
+    fail(mountKey, relPath, contentHash) {
+      const m = entriesFor(mountKey)
+      const k = keyOf(relPath, contentHash)
+      const next = (m.get(k) ?? 0) + 1
+      m.delete(k)
+      m.set(k, next)
+      if (m.size > maxKeys) m.delete(m.keys().next().value)
+      return next
+    },
+    // Has this claim spent its budget? A claim evicted under pressure answers false and is tried
+    // again — bounded churn, which is the honest trade for a bounded map.
+    exhausted(mountKey, relPath, contentHash) {
+      return (byMount.get(mountKey)?.get(keyOf(relPath, contentHash)) ?? 0) >= limit
+    },
+    // A landed file, or an owner re-publishing under a new hash, clears the record: the next
+    // failure starts a fresh budget rather than inheriting one it never spent.
+    succeed(mountKey, relPath, contentHash) {
+      byMount.get(mountKey)?.delete(keyOf(relPath, contentHash))
+    },
+    forget(mountKey) { byMount.delete(mountKey) },
+    clear() { byMount.clear() },
+    size(mountKey) { return byMount.get(mountKey)?.size ?? 0 },
+  }
+}

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -7,7 +7,7 @@
 import fs from 'bare-fs'
 import path from 'bare-path'
 import { shouldHonorDeletions, relKeyEscapes, dropUnsafeEntries, conflictCopyName, driveKeyToSegments } from './path-keys.js'
-import { isOwnerOnline } from '../transfer/swarm.js'
+import { isOwnerOnline, setPeerOnlineHook } from '../transfer/swarm.js'
 import { record } from '../audit/audit-log.js'
 import { createIntegritySeen } from './integrity-seen.js'
 import { getSpace } from '../spaces/space.js'
@@ -39,6 +39,7 @@ import { createMirrorLoops } from './mirror-loop.js'
 import { createMirrorState, localRelOf } from './mirror-state.js'
 import { classifyLocalCopy, mayOverwriteInPlace } from './mirror-ownership.js'
 import { shouldWalk } from './mirror-walk.js'
+import { mirrorMayFetch } from './mirror-reach.js'
 
 const log = createLogger('foreign-folders')
 
@@ -62,6 +63,9 @@ export function initForeignFolders(_ipc) {
   // Materialize promptly when an owner's catalog appends, instead of waiting for
   // the mirror's poll tick.
   setOverlayCatalogChangeHook(onPeerDriveChanged)
+  // The other level trigger: a pass gated on an offline owner did nothing at all, so without this
+  // an offline->online flip waits out a whole poll interval before the first byte moves.
+  setPeerOnlineHook(onOwnerOnline)
 }
 
 function loopKey(spaceId, shareId) {
@@ -70,15 +74,28 @@ function loopKey(spaceId, shareId) {
 
 const APPEND_TICK_DEBOUNCE_MS = 250
 
+// Both level triggers poke the same way — every mirror in the space, debounced. A loop record
+// carries no ownerKey, and a mirror whose owner is uninvolved re-derives and settles for the price
+// of a map lookup, so filtering by owner would buy nothing and cost a mount read per event.
+function pokeSpaceMirrors(spaceId) {
+  for (const loop of loops.entries()) {
+    if (loop.spaceId !== spaceId) continue
+    loops.debounce(loop.key, { spaceId: loop.spaceId, shareId: loop.shareId }, APPEND_TICK_DEBOUNCE_MS)
+  }
+}
+
 // The owner's content changed. Run a materialize tick now (debounced) for each
 // active mirror in that space instead of waiting for the 30s poll, so owner-side
 // edits/deletes reflect on the mirror's disk as promptly as they do in the folder
 // view.
 export function onPeerDriveChanged(spaceId) {
-  for (const loop of loops.entries()) {
-    if (loop.spaceId !== spaceId) continue
-    loops.debounce(loop.key, { spaceId: loop.spaceId, shareId: loop.shareId }, APPEND_TICK_DEBOUNCE_MS)
-  }
+  pokeSpaceMirrors(spaceId)
+}
+
+// A member handshaked into this space. Any mirror of theirs has been skipping its passes on the
+// reachability gate, so re-drive now rather than at the next tick.
+export function onOwnerOnline(_ownerKey, spaceId) {
+  pokeSpaceMirrors(spaceId)
 }
 
 async function loadShareForForeignMount(mount) {
@@ -250,6 +267,16 @@ export function foreignFetchActive(spaceId, shareId, relPath) {
 }
 const mirrorGen = (key) => loops.generationOf(key)
 const mirrorStopped = (key, gen) => loops.stopped(key, gen)
+
+// Read live rather than snapshotted: a pass that starts online and finishes offline re-asks at the
+// per-entry gate.
+function mayFetch(mount) {
+  return mirrorMayFetch({
+    ownerKey: mount.ownerKey,
+    localKey: getLocalPublicKeyHex(),
+    ownerOnline: isOwnerOnline(mount.ownerKey),
+  })
+}
 
 export async function runMaterializeTick(spaceId, shareId) {
   return await loops.tick(loopKey(spaceId, shareId), { spaceId, shareId })
@@ -452,6 +479,11 @@ async function acquireMirrorSlot(streamKey) {
 async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen, diskHash = null, localExists = false }) {
   // The wait for a slot is unbounded, so re-check the stop the catalog walk tests at every entry.
   if (mirrorStopped(streamKey, gen)) return 'missing'
+  // Deliberately NOT re-checking reachability here, unlike the download engine past its own slot
+  // wait: this function is reached from materializeCatalogFile, which callers drive one entry at a
+  // time against mounts whose owner is unreachable by construction. The window it would close — the
+  // owner leaving while this entry is parked on the shared slot — is already bounded, because the
+  // fetch then returns 'no-peers' and ends the whole pass. One peer wait, once, not a spin.
   // Read AFTER the wait, not before it: the overlay can be torn down while a pass is parked.
   const overlay = getOverlay()
   if (!overlay) return 'missing'
@@ -516,7 +548,14 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   }
   // null = nothing fetched: a stall after a holder was asked is a give-up (WARN);
   // never reaching a holder is a benign retry-next-tick (debug).
-  if (!res) { diag.finish(classifyMirrorMiss(attempted)); return 'missing' }
+  if (!res) {
+    const miss = classifyMirrorMiss(attempted)
+    diag.finish(miss)
+    // 'no-holder' means the overlay had zero peers, which is a process-global fact rather than a
+    // property of this file: every remaining entry would pay the same peer wait for the same
+    // answer. 'failed' IS per-file — a holder was asked and died — so the walk must carry on.
+    return miss === 'no-holder' ? 'no-peers' : 'missing'
+  }
   diag.finish('done')
   // a local hit returns the source path without writing abs — copy the bytes by
   // path (never buffering a possibly multi-GB file in memory).
@@ -529,6 +568,42 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   return 'present'
 }
 
+// The half both passes share: materialize every catalog entry and report what the walk learned.
+// `stopped` is a cancelled pass, which its caller must return from without writing anything;
+// `noPeers` is a pass that gave up early because there was nothing to fetch from, which leaves its
+// view of the catalog a prefix — the same partial view a truncated listing gives.
+async function materializeEntries(mount, share, entries, { key, gen, synced, fresh, label }) {
+  let allPresent = true
+  for (const entry of entries) {
+    if (mirrorStopped(key, gen)) return { allPresent, noPeers: false, stopped: true }
+    // Asked per entry rather than once above the loop: a pass that started while the owner was up
+    // must stop queueing fetches the moment they drop. It lives here rather than inside the entry
+    // materializer so that stays a primitive — "materialize this file", not "decide whether to" —
+    // which is also what lets a caller drive one entry directly.
+    if (!mayFetch(mount)) {
+      log.debug('mirror pass stopped — owner offline:', mount.shareId)
+      return { allPresent: false, noPeers: true, stopped: false }
+    }
+    // Own the path BEFORE the write lands: a pass cancelled mid-file must still own what it
+    // wrote, or the owner's later delete of that file is never applied.
+    state.recordSynced(key, synced, entry.relPath, fresh)
+    try {
+      const outcome = await materializeCatalogFile(mount, share, entry, { synced, fresh, gen })
+      // A NOT-present test rather than a list of miss values: a future outcome must never read as
+      // done and let a file that was never fetched count toward convergence.
+      if (outcome !== 'present') allPresent = false
+      if (outcome === 'no-peers') {
+        log.debug('mirror pass stopped early — nothing to fetch from:', mount.shareId)
+        return { allPresent, noPeers: true, stopped: false }
+      }
+    } catch (err) {
+      allPresent = false
+      log.debug(label, entry.relPath, '-', err.message)
+    }
+  }
+  return { allPresent, noPeers: false, stopped: false }
+}
+
 async function initialMaterializeScanCatalog(mount, share) {
   const key = loopKey(mount.spaceId, mount.shareId)
   const gen = mirrorGen(key)
@@ -538,25 +613,19 @@ async function initialMaterializeScanCatalog(mount, share) {
   const fresh = new Set()
   const { entries: raw, complete } = await getContentBackend(share).listPeerWithMeta(mount.spaceId, share)
   const entries = dropUnsafeEntries(raw, (rel) => log.warn('refusing a peer file path that escapes the mount folder — skipping this entry (the owner drive may be malicious or corrupted):', rel, '(source: catalog-initial)'))
-  let allPresent = true
-  for (const entry of entries) {
-    if (mirrorStopped(key, gen)) return { stopped: true }
-    // Own the path BEFORE the write lands: a pass cancelled mid-file must still own what it
-    // wrote, or the owner's later delete of that file is never applied.
-    state.recordSynced(key, synced, entry.relPath, fresh)
-    try {
-      if (await materializeCatalogFile(mount, share, entry, { synced, fresh, gen }) === 'missing') allPresent = false
-    } catch (err) {
-      allPresent = false
-      log.debug('catalog initial materialize failed:', entry.relPath, '-', err.message)
-    }
-  }
-  if (mirrorStopped(key, gen)) return { stopped: true }
+  const walk = await materializeEntries(mount, share, entries, {
+    key, gen, synced, fresh, label: 'catalog initial materialize failed:',
+  })
+  if (walk.stopped || mirrorStopped(key, gen)) return { stopped: true }
+  const allPresent = walk.allPresent
+  // A pass that stopped early walked a PREFIX of the catalog, which is the same thing a truncated
+  // listing is — so it may not replace the synced record or stamp the scan done either.
+  const listingComplete = complete && !walk.noPeers
   // An incomplete drain is a partial view of the owner's catalog, so it may not SHRINK the synced
   // record — union instead, or a mirror that already holds 12 files forgets 8 of them on a
   // truncated re-scan (and with it the evidence a later deletion would be judged against). Only a
   // complete read is authoritative enough to replace the record, or to stamp the scan done.
-  if (complete) {
+  if (listingComplete) {
     const listed = new Set(entries.map((e) => e.relPath))
     for (const ownerKey of [...synced]) if (!listed.has(ownerKey)) state.forgetSynced(key, synced, ownerKey)
     mount.initialScanCompletedAt = Date.now()
@@ -568,7 +637,7 @@ async function initialMaterializeScanCatalog(mount, share) {
     // A pass that got through clears the reason with the status: a stale one would name the next
     // fault that records none.
     lastError: null,
-    ...(complete ? { initialScanCompletedAt: mount.initialScanCompletedAt } : {}),
+    ...(listingComplete ? { initialScanCompletedAt: mount.initialScanCompletedAt } : {}),
   })
   state.markClean(key)
   emitStatus(mount.spaceId, mount.shareId, 'active')
@@ -577,7 +646,7 @@ async function initialMaterializeScanCatalog(mount, share) {
   // show a fully-merged mirror. A genuinely-empty share settles to 'synced' on a later tick. The
   // gen recheck (adjacent to the enqueue, no await between) stops a concurrent pause from being
   // overwritten.
-  if (!mirrorStopped(key, gen) && entries.length > 0 && complete) await settleMirrorSyncState(mount, allPresent)
+  if (!mirrorStopped(key, gen) && entries.length > 0 && listingComplete) await settleMirrorSyncState(mount, allPresent)
   return {}
 }
 
@@ -594,6 +663,17 @@ function logWithheldDeletions (key, pending, syncedSize, minDeletions) {
 async function materializeOnceCatalog(mount, share) {
   const key = loopKey(mount.spaceId, mount.shareId)
   const gen = mirrorGen(key)
+
+  // Nothing this pass is allowed to do: an offline owner cannot append, so the catalog cannot have
+  // moved, and shouldHonorDeletions already refuses to act on deletions while they are away — every
+  // fetch would just burn the overlay's peer wait to learn there is no holder. Returning HERE,
+  // above the version read and above forgetConverged, is what lets a converged mirror keep its
+  // watermark across an outage. onOwnerOnline re-drives on their handshake, so being wrong costs
+  // latency, never a stuck mirror.
+  if (!mayFetch(mount)) {
+    log.debug('mirror tick skipped — owner offline:', mount.shareId)
+    return
+  }
 
   // Read BEFORE the listing: an append landing mid-walk leaves the head past the version this pass
   // records, so the next tick walks. A pass only ever converges against the snapshot it walked.
@@ -624,19 +704,15 @@ async function materializeOnceCatalog(mount, share) {
   const { entries: raw, complete } = await getContentBackend(share).listPeerWithMeta(mount.spaceId, share)
   const entries = dropUnsafeEntries(raw, (rel) => log.warn('refusing a peer file path that escapes the mount folder — skipping this entry (the owner drive may be malicious or corrupted):', rel, '(source: catalog-tick)'))
   const onDrive = new Map(entries.map((e) => [e.relPath, e]))
-  let allPresent = true
-  for (const [, entry] of onDrive) {
-    if (mirrorStopped(key, gen)) return
-    state.recordSynced(key, synced, entry.relPath, fresh)
-    try {
-      if (await materializeCatalogFile(mount, share, entry, { synced, fresh, gen }) === 'missing') allPresent = false
-    } catch (err) {
-      allPresent = false
-      log.debug('catalog materialize failed:', entry.relPath, '-', err.message)
-    }
-  }
-
-  if (mirrorStopped(key, gen)) return
+  const walk = await materializeEntries(mount, share, onDrive.values(), {
+    key, gen, synced, fresh, label: 'catalog materialize failed:',
+  })
+  if (walk.stopped || mirrorStopped(key, gen)) return
+  const allPresent = walk.allPresent
+  // A pass that stopped early walked a PREFIX of the catalog — the same partial view a truncated
+  // listing gives, and the two things that must not act on one are the same: the deletion reconcile
+  // and the convergence test.
+  const listingComplete = complete && !walk.noPeers
 
   // Resolved BEFORE the gate rather than inside the loop: the gate now weighs how MANY files a
   // pass would remove, which cannot be known one key at a time.
@@ -645,7 +721,7 @@ async function materializeOnceCatalog(mount, share) {
   const honorDeletions = shouldHonorDeletions({
     ownerOnline: isOwnerOnline(mount.ownerKey),
     driveCount: onDrive.size,
-    listingComplete: complete,
+    listingComplete,
     syncedCount: synced.size,
     deletionCount: pendingDeletions.length,
     minDeletions: caps.minMirrorDeletions,
@@ -677,7 +753,7 @@ async function materializeOnceCatalog(mount, share) {
   // skipping is safest — and if deletions really are outstanding the size check catches them and the
   // mirror keeps walking. A cancelled pass proves nothing, and a version we could not read cannot
   // authorise a later skip.
-  const converged = allPresent && complete && synced.size === onDrive.size
+  const converged = allPresent && listingComplete && synced.size === onDrive.size
   if (converged && version !== null && !mirrorStopped(key, gen)) state.setWatermark(key, version)
   // Re-check the generation adjacent to the enqueue (no await between) so a pause/unmount that
   // landed during the deletion-reconcile await above can't be overwritten by this terminal write.

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -7,9 +7,10 @@
 import fs from 'bare-fs'
 import path from 'bare-path'
 import { shouldHonorDeletions, relKeyEscapes, dropUnsafeEntries, conflictCopyName, driveKeyToSegments } from './path-keys.js'
-import { isOwnerOnline, setPeerOnlineHook } from '../transfer/swarm.js'
+import { isOwnerOnline, onPeerOnline } from '../transfer/swarm.js'
 import { record } from '../audit/audit-log.js'
 import { createIntegritySeen } from './integrity-seen.js'
+import { createAttemptBudget } from './fetch-attempts.js'
 import { getSpace } from '../spaces/space.js'
 import { getLocalPublicKeyHex } from '../spaces/profile.js'
 import { getResourceCaps } from '../core/runtime-config.js'
@@ -40,6 +41,9 @@ import { createMirrorState, localRelOf } from './mirror-state.js'
 import { classifyLocalCopy, mayOverwriteInPlace } from './mirror-ownership.js'
 import { shouldWalk } from './mirror-walk.js'
 import { mirrorMayFetch } from './mirror-reach.js'
+import { classifyMiss, isTerminalFault } from '../transfer/backends/overlay/fetch-policy.js'
+import { shortfall } from '../transfer/free-space.js'
+import { freeBytesFor } from '../transfer/free-space-probe.js'
 
 const log = createLogger('foreign-folders')
 
@@ -57,6 +61,7 @@ const loops = createMirrorLoops({
 const state = createMirrorState({ keyOf: loopKey, isStopped: (key, gen) => loops.stopped(key, gen) })
 
 let ipcRef = null
+let unsubscribePeerOnline = null
 
 export function initForeignFolders(_ipc) {
   ipcRef = _ipc
@@ -65,7 +70,8 @@ export function initForeignFolders(_ipc) {
   setOverlayCatalogChangeHook(onPeerDriveChanged)
   // The other level trigger: a pass gated on an offline owner did nothing at all, so without this
   // an offline->online flip waits out a whole poll interval before the first byte moves.
-  setPeerOnlineHook(onOwnerOnline)
+  unsubscribePeerOnline?.()
+  unsubscribePeerOnline = onPeerOnline(onOwnerOnline)
 }
 
 function loopKey(spaceId, shareId) {
@@ -268,9 +274,18 @@ export function foreignFetchActive(spaceId, shareId, relPath) {
 const mirrorGen = (key) => loops.generationOf(key)
 const mirrorStopped = (key, gen) => loops.stopped(key, gen)
 
+// Presence is a module-private lease map in swarm.js, so an unreachable owner cannot otherwise be
+// staged below the flow layer: a fabricated remote key makes the share unreadable and the pass exits
+// before any gate, while a self-mirror is reachable by rule. Overriding the VERDICT rather than
+// isOwnerOnline is what lets a readable mount stand in for an absent owner; the rule itself is
+// unit-tested in mirror-reach.test.js. The engine carries the same seam as `channel.isOwnerOnline`.
+let reachabilityOverride = null
+export function setMirrorReachability(fn) { reachabilityOverride = fn }
+
 // Read live rather than snapshotted: a pass that starts online and finishes offline re-asks at the
 // per-entry gate.
 function mayFetch(mount) {
+  if (reachabilityOverride) return reachabilityOverride(mount)
   return mirrorMayFetch({
     ownerKey: mount.ownerKey,
     localKey: getLocalPublicKeyHex(),
@@ -307,21 +322,18 @@ export async function materializeCatalogFile(mount, share, entry, opts = {}) {
   return await materializeOverlayFile(mount, share, entry, opts)
 }
 
-// Classify an overlay-mirror fetch that produced no file (fetchFile → null).
-// fetchFile returns null for TWO reasons: no holder was ever reachable (no chunk
-// scheduler ran), or a holder WAS asked but the transfer stalled / all peers
-// vanished mid-stream (its internal catch swallows that into null). Only the
-// latter is a genuine give-up worth a WARN; the former is a benign "retry next
-// tick" (debug). `attempted` is true once a scheduler ran — i.e. the fetch's
-// onEnd fired. Exported for unit coverage of the give-up/no-holder split.
-export function classifyMirrorMiss(attempted) {
-  return attempted ? 'failed' : 'no-holder'
-}
 
 const integritySeen = createIntegritySeen({
   onCap: (mountKey, limit) => log.warn('mirror integrity rows capped at', limit, 'for', mountKey,
     '— further hash mismatches on this mount are logged but not audited until it is remounted'),
 })
+
+// How many times this mount has failed to land a given (file, hash), and when to stop asking. The
+// mirror used to retry a corrupt file on every 30s tick and every catalog append, forever. A budget
+// rather than an outright block because the overlay is multi-source: the first holder serving bad
+// bytes must not condemn content a second holder can serve. In memory rather than durable — the
+// mirror is catalog-driven and must not grow a row per file — so a remount forgives it.
+const attempts = createAttemptBudget()
 
 // The ONE thing a mirror audits. contract/audit-kinds.js deliberately records no per-file folder
 // sync, and this is not sync bookkeeping: it is a claim about what a member of this space served.
@@ -388,10 +400,76 @@ async function handleOverlayMirrorFetchError(mount, share, entry, err, diag) {
   // blame a holder for our own full disk.
   if (await pauseMountForIoError(mount, err)) return
   diag?.finish('failed')
-  if (err?.code === 'EHASHMISMATCH') {
-    log.warn('overlay mirror integrity failure — holder served bytes not matching the content hash:', entry.relPath)
-    recordMirrorIntegrityFailure(mount, share, entry)
-  } else log.debug('overlay mirror fetch failed:', entry.relPath, '-', err.message)
+  const code = err?.code === 'EHASHMISMATCH' ? ErrorCodes.TRANSFER_CHECKSUM : null
+  if (!code) {
+    log.debug('overlay mirror fetch failed:', entry.relPath, '-', err.message)
+    return
+  }
+  log.warn('overlay mirror integrity failure — holder served bytes not matching the content hash:', entry.relPath)
+  recordMirrorIntegrityFailure(mount, share, entry)
+  // Checksum is the only terminal fault reachable here — every local I/O fault was classified and
+  // paused above, and the engine's other two terminal codes describe a destination mountCanTake
+  // preflights instead. Charged to a budget rather than blocked outright, so another holder can
+  // still serve the same content.
+  if (!isTerminalFault(code)) return
+  const key = loopKey(mount.spaceId, mount.shareId)
+  const spent = attempts.fail(key, entry.relPath, entry.contentHash)
+  if (attempts.exhausted(key, entry.relPath, entry.contentHash)) {
+    log.warn('mirror stopped asking for a file whose holders keep failing its hash:', entry.relPath, 'after', spent, 'attempts')
+  }
+}
+
+// Why this entry will not be fetched, or null to go ahead. All three sit BELOW the caller's
+// 'present' returns: an unreachable owner and a spent budget must still let a file already on disk
+// be adopted, or a fully-mirrored mount can never converge.
+function fetchSkipReason(mount, entry, opts) {
+  if (!entry.contentHash) return 'missing'
+  if (opts.noFetch) return 'missing'
+  // 'blocked', deliberately not 'no-peers': that means "nobody is out there", which ends the whole
+  // pass — a corrupt file must not stop the mirror fetching the rest of the folder.
+  if (attempts.exhausted(loopKey(mount.spaceId, mount.shareId), entry.relPath, entry.contentHash)) return 'blocked'
+  return null
+}
+
+// One probe per pass, not one per file. Both questions are about the VOLUME, so asking them per
+// catalog entry is thousands of blocking syscalls answering the same thing — the shape
+// files.js::createDirProbe already exists for on the listing side.
+function createMountProbe(mount) {
+  let root = null
+  let free = null
+  return {
+    rootAvailable: () => (root ??= mountRootAvailable(mount.mountPath)),
+    freeBytes: () => (free ??= freeBytesFor(mount.mountPath)),
+  }
+}
+
+// The two preflights the engine has run since FIX-DLDIR-2, which the mirror never had. Without the
+// first, fetchOverlayEntry's mkdir -p silently RECREATES a mount root the user deleted and
+// materializes into a resurrected empty tree.
+//
+// They settle differently on purpose. A missing root and an exhausted volume are mount-wide, so
+// they pause. A single file that will not fit is about THAT file: pausing the mount for it would
+// strand every other file in the folder, and the engine keeps the same decision per row.
+async function mountCanTake(mount, entry, abs, probe) {
+  if (!probe.rootAvailable()) {
+    await pauseMount(mount, STATUS_MOUNT_GONE)
+    return false
+  }
+  const freeBytes = probe.freeBytes()
+  // Short of the headroom with nothing requested at all: the volume is out, not this file.
+  if (shortfall({ freeBytes, needBytes: 0 }) > 0) {
+    await pauseMount(mount, statusForFaultCode(ErrorCodes.TRANSFER_DISK_FULL), ErrorCodes.TRANSFER_DISK_FULL)
+    return false
+  }
+  // A resumed partial has already taken its bytes from the volume; charging for them twice would
+  // refuse — and before this split, terminally pause — a transfer that is nearly done.
+  let allocatedBytes = 0
+  try { allocatedBytes = fs.statSync(abs + PARTIAL_SUFFIX).blocks * 512 || 0 } catch {}
+  if (shortfall({ freeBytes, needBytes: entry.size || 0, allocatedBytes }) > 0) {
+    log.warn('mirror skipped a file this volume cannot hold:', entry.relPath, 'needs', entry.size, 'bytes')
+    return false
+  }
+  return true
 }
 
 async function materializeOverlayFile(mount, share, entry, opts = {}) {
@@ -432,7 +510,8 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
       }
     } catch (err) { log.debug('overlay hash skipped on disk:', err.message) }
   }
-  if (!entry.contentHash) return 'missing'
+  const skip = fetchSkipReason(mount, entry, opts)
+  if (skip) return skip
   // A manual download of the same file may already be in flight (mounted mid-download): fetching it
   // here too would interleave two producers on one decoration key and duplicate the bytes. A cheap
   // early-out so we do not queue for a slot to do it; the claim taken past the gate decides. Another
@@ -440,6 +519,9 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   // activeOverlayFetches, and refusing it here would change what FIX-R09-2 pins.
   const claimedBy = fetchClaimedBy(transferIdFor(mount.spaceId, mount.shareId, entry.relPath))
   if (claimedBy && claimedBy !== FETCH_OWNER_MIRROR) return 'missing'
+  // Below the claim check on purpose: charging a file the download engine already owns against our
+  // own free space would refuse it over bytes that engine has already reserved.
+  if (!(await mountCanTake(mount, entry, abs, opts.probe || createMountProbe(mount)))) return 'blocked'
   const streamKey = loopKey(mount.spaceId, mount.shareId)
   const releaseSlot = await acquireMirrorSlot(streamKey)
   try {
@@ -549,7 +631,7 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   // null = nothing fetched: a stall after a holder was asked is a give-up (WARN);
   // never reaching a holder is a benign retry-next-tick (debug).
   if (!res) {
-    const miss = classifyMirrorMiss(attempted)
+    const miss = classifyMiss({ attempted })
     diag.finish(miss)
     // 'no-holder' means the overlay had zero peers, which is a process-global fact rather than a
     // property of this file: every remaining entry would pay the same peer wait for the same
@@ -565,6 +647,7 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   // The transfer verified the content hash on landing — record it so the row can
   // surface a "verified" indicator without re-hashing.
   await markVerified(mount.spaceId, verifyKey, entry.contentHash)
+  attempts.succeed(loopKey(mount.spaceId, mount.shareId), entry.relPath, entry.contentHash)
   return 'present'
 }
 
@@ -574,21 +657,20 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
 // view of the catalog a prefix — the same partial view a truncated listing gives.
 async function materializeEntries(mount, share, entries, { key, gen, synced, fresh, label }) {
   let allPresent = true
+  const probe = createMountProbe(mount)
+  // Asked once, not per entry: a walk that cannot fetch can still ADOPT — reporting what is already
+  // on disk needs no holder, and it is the difference between a fully-mirrored folder converging
+  // across an outage and reporting "syncing" until the owner returns. A drop mid-pass is caught by
+  // the fetch itself returning no-peers.
+  const canFetch = mayFetch(mount)
+  if (!canFetch) log.debug('mirror pass will adopt only — owner offline:', mount.shareId)
   for (const entry of entries) {
     if (mirrorStopped(key, gen)) return { allPresent, noPeers: false, stopped: true }
-    // Asked per entry rather than once above the loop: a pass that started while the owner was up
-    // must stop queueing fetches the moment they drop. It lives here rather than inside the entry
-    // materializer so that stays a primitive — "materialize this file", not "decide whether to" —
-    // which is also what lets a caller drive one entry directly.
-    if (!mayFetch(mount)) {
-      log.debug('mirror pass stopped — owner offline:', mount.shareId)
-      return { allPresent: false, noPeers: true, stopped: false }
-    }
     // Own the path BEFORE the write lands: a pass cancelled mid-file must still own what it
     // wrote, or the owner's later delete of that file is never applied.
     state.recordSynced(key, synced, entry.relPath, fresh)
     try {
-      const outcome = await materializeCatalogFile(mount, share, entry, { synced, fresh, gen })
+      const outcome = await materializeCatalogFile(mount, share, entry, { synced, fresh, gen, probe, noFetch: !canFetch })
       // A NOT-present test rather than a list of miss values: a future outcome must never read as
       // done and let a file that was never fetched count toward convergence.
       if (outcome !== 'present') allPresent = false
@@ -601,6 +683,8 @@ async function materializeEntries(mount, share, entries, { key, gen, synced, fre
       log.debug(label, entry.relPath, '-', err.message)
     }
   }
+  // An adopt-only walk read the whole catalog and every file on disk, so its view is COMPLETE — it
+  // simply could not fetch what was missing. Calling it a prefix would stop the scan ever settling.
   return { allPresent, noPeers: false, stopped: false }
 }
 
@@ -719,7 +803,10 @@ async function materializeOnceCatalog(mount, share) {
   const pendingDeletions = [...synced].filter((ownerKey) => !onDrive.has(ownerKey))
   const caps = getResourceCaps()
   const honorDeletions = shouldHonorDeletions({
-    ownerOnline: isOwnerOnline(mount.ownerKey),
+    // mayFetch, not raw isOwnerOnline: presence never leases our own key, so a self-mirror read as
+    // offline here would refuse the owner's deletions forever. Same rule and same reason as the
+    // fetch gate — this was the third call site and the last to be converted.
+    ownerOnline: mayFetch(mount),
     driveCount: onDrive.size,
     listingComplete,
     syncedCount: synced.size,
@@ -854,10 +941,15 @@ export class ForeignMirrors extends Subsystem {
   // AFTER us — an unscoped drain would release the two engines' backlog into an overlay that is
   // still live, and those tasks pass their own hasOverlay() guard.
   async _close() {
+    unsubscribePeerOnline?.()
+    unsubscribePeerOnline = null
+    // A leaked override disables fetching for every mount in the process, not just a test's own.
+    reachabilityOverride = null
     drainFetchSlots(FETCH_OWNER_MIRROR)
     await stopAllForeignLoops()
     pausedHolders.clear()
     integritySeen.clear()
+    attempts.clear()
   }
 
   // Counts, not identifiers: diagnostics:export is user-shareable and redacts peer keys and
@@ -906,6 +998,7 @@ export async function unmountForeignFolder(spaceId, shareId) {
   // Only here, not in stopForeignLoop: that runs on pause and on a health restart too, and
   // re-arming there would re-record the same mismatch on every resume.
   integritySeen.forget(loopKey(spaceId, shareId))
+  attempts.forget(loopKey(spaceId, shareId))
   // Overlay copies no bytes into a drive (it serves straight from the owner's
   // source), so there is no per-share blob cache to reclaim on unmount — the
   // materialized files stay on disk, matching owner-delete behaviour.

--- a/src/shared/folders/integrity-seen.js
+++ b/src/shared/folders/integrity-seen.js
@@ -29,6 +29,12 @@ export function createIntegritySeen({ limit = DEFAULT_INTEGRITY_ROW_CAP, onCap =
       if (seen.size === limit) onCap(mountKey, limit)
       return true
     },
+    // Read-only twin of admit, for a second instance used as a memo rather than a rate gate. At the
+    // cap admit refuses to record, so this answers false for a claim that was never admitted — the
+    // fail-open direction: a capped mount keeps syncing rather than silently refusing every file.
+    has(mountKey, relPath, contentHash) {
+      return byMount.get(mountKey)?.has(relPath + '\0' + (contentHash || '')) ?? false
+    },
     // An unmount/remount is a fresh session: the user re-pointing the mount is a new decision and
     // deserves to be told the folder is still corrupt.
     forget(mountKey) { byMount.delete(mountKey) },

--- a/src/shared/folders/mirror-reach.js
+++ b/src/shared/folders/mirror-reach.js
@@ -1,0 +1,13 @@
+// Whether a mirror pass may reach for content at all, kept pure so the rule is asserted directly
+// rather than through a live swarm — the same shape as mirror-walk.js.
+//
+// A self-mirror is always reachable: presence leases track REMOTE peers only, so our own key is
+// never in the map and a bare isOwnerOnline(ownerKey) reads every self-mirror as permanently
+// offline. share-listing.js carries the same special case for the same reason.
+export function mirrorMayFetch({ ownerKey = null, localKey = null, ownerOnline = false } = {}) {
+  // Unknown falls open: a mirror that goes quiet on a missing field is a silent sync outage, where
+  // a wasted pass is a log line.
+  if (!ownerKey) return true
+  if (localKey && ownerKey === localKey) return true
+  return !!ownerOnline
+}

--- a/src/shared/shares/share-listing.js
+++ b/src/shared/shares/share-listing.js
@@ -69,8 +69,12 @@ function overlayConsumerRow(spaceId, share, entry, { ownerOnline, foreignMount, 
     const abs = pathFromMount(foreignMount.mountPath, localRelOf(foreignMount, entry.relPath))
     if (statSizeOrNull(abs) === entry.size) return { status: 'synced', localPath: abs, verified: isVerified }
     // The mirror loop is pulling this row right now — 'downloading' so FolderView's
-    // bar/speed/verify lane (all gated on the status) render during materialization.
-    if (deps.foreignFetchActive(spaceId, share.id, entry.relPath)) {
+    // bar/speed/verify lane (all gated on the status) render during materialization. Gated on
+    // reachability: a fetch parked on the overlay's peer wait is not pulling anything, and the
+    // renderer paints a downloading row with no bytes as "Preparing…" — which read as a rotating
+    // badge beside the banner saying the owner is offline. The strip and the folder tile already
+    // apply this rule; the row was the one surface that did not.
+    if (ownerOnline && deps.foreignFetchActive(spaceId, share.id, entry.relPath)) {
       return { status: 'downloading', localPath: null, pendingBytes: 0 }
     }
     if (!entry.contentHash) return { status: unhashedStatusFor(ownerOnline), localPath: null }

--- a/src/shared/transfer/backends/overlay/fetch-policy.js
+++ b/src/shared/transfer/backends/overlay/fetch-policy.js
@@ -1,0 +1,38 @@
+// The rules every overlay fetch is judged by, whichever producer issued it. Pure, so each rule is
+// asserted directly rather than through a live engine — the same shape as mirror-walk.js, and no
+// bare-* imports so it unit-tests under Node.
+//
+// The download engine and the foreign-folder mirror answered all three of these separately, and
+// drifted on the first: a checksum failure was terminal for the engine and retried on every tick by
+// the mirror, which turned one bad holder into an unbounded, silent re-download loop.
+import { ErrorCodes } from '../../../core/errors.js'
+
+// A fault the user must clear before ANY retry can succeed. These are also exactly the codes
+// runReconcile suppresses from auto-resume and the ones a channel surfaces to the user directly: the same holder serves the same bad
+// bytes, a full disk is still full, an ejected volume is still gone. This is one set because it is
+// one judgement — the engine's auto-resume suppression and the channel's user-facing error filter
+// were separate copies of it, and the channel's own comment already said they were the same rule.
+const TERMINAL = new Set([
+  ErrorCodes.TRANSFER_CHECKSUM,
+  ErrorCodes.TRANSFER_DISK_FULL,
+  ErrorCodes.TRANSFER_DEST_UNAVAILABLE,
+])
+
+export function isTerminalFault(code) {
+  return TERMINAL.has(code)
+}
+
+// A fetch that produced no file, classified by whether a chunk scheduler ever ran. `attempted`
+// false means no holder was ever reachable — a process-global fact, so a caller walking a list may
+// stop. True means a holder WAS asked and the transfer died, which is a fact about this file alone.
+export function classifyMiss({ attempted }) {
+  return attempted ? 'failed' : 'no-holder'
+}
+
+// How long before attempt N+1, and when to stop. `dry` counts consecutive attempts that banked no
+// bytes; progress resets it, which is what lets a throttled transfer keep going one attempt at a
+// time without exhausting a budget it never should have been charged.
+export function nextRetryDelay({ dry, baseMs, maxMs, dryLimit }) {
+  if (dry >= dryLimit) return null
+  return Math.min(maxMs, baseMs * 2 ** dry)
+}

--- a/src/shared/transfer/backends/overlay/fetch-run.js
+++ b/src/shared/transfer/backends/overlay/fetch-run.js
@@ -13,19 +13,34 @@ import { createLogger } from '../../../core/logger.js'
 
 const log = createLogger('overlay-fetch')
 
+// The ticker, the diag, and the three callbacks that wire them together — everything either
+// consumer builds AROUND the vendor call. The engine cannot share runOverlayFetch itself because
+// its vendor call resolves { ok, code } instead of throwing, so it takes these and keeps its own
+// settle; the header's claim that both consumers share this file is true through here.
+export function makeFetchInstruments ({ label, relPath, size = 0, contentHash = null, onProgress, onVerify, onTick }) {
+  const ticker = makeProgressTicker(size, onProgress)
+  const diag = makeFetchDiag(label, relPath, size, contentHash)
+  return {
+    diag,
+    callbacks: {
+      onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b); onTick?.() },
+      onVerify,
+      onEnd: diag.onEnd,
+    },
+  }
+}
+
 export async function runOverlayFetch (overlay, contentHash, {
   label, relPath, size = 0, destPath, reSeed = false, onProgress, onVerify, onTick,
 }) {
-  const ticker = makeProgressTicker(size, onProgress)
-  const diag = makeFetchDiag(label, relPath, size, contentHash)
   let attempted = false
+  const { diag, callbacks } = makeFetchInstruments({ label, relPath, size, contentHash, onProgress, onVerify, onTick })
   try {
     const res = await overlay.fetchFile(contentHash, {
       destPath,
       reSeed,
-      onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b); onTick?.() },
-      onVerify,
-      onEnd: (info) => { attempted = true; diag.onEnd(info) },
+      ...callbacks,
+      onEnd: (info) => { attempted = true; callbacks.onEnd(info) },
     })
     return { res, attempted, diag }
   } catch (err) {

--- a/src/shared/transfer/backends/overlay/overlay-channel.js
+++ b/src/shared/transfer/backends/overlay/overlay-channel.js
@@ -7,17 +7,8 @@
 // Imports nothing from `bare-*` (and nothing from the two modules that build channels), so it
 // loads under plain Node and unit-tests directly.
 import { driveBaseName } from '../../../folders/path-keys.js'
-import { ErrorCodes } from '../../../core/errors.js'
 
-// Codes that reach the user directly on a channel whose rows have a list to fall back on.
-// Everything else surfaces through the list refresh, where the row carries its own errorCode and
-// offers Resume. The membership of this set and the auto-resume suppression in overlay-download.js
-// are the same judgement: a fault the user must clear before a retry can ever succeed.
-const USER_FACING_ERRORS = new Set([
-  ErrorCodes.TRANSFER_DISK_FULL,
-  ErrorCodes.TRANSFER_CHECKSUM,
-  ErrorCodes.TRANSFER_DEST_UNAVAILABLE,
-])
+import { isTerminalFault } from './fetch-policy.js'
 
 export function createOverlayChannel (d) {
   // Decoration frames carry spaceId: a bare drive path is unique per space only — without the
@@ -46,7 +37,7 @@ export function createOverlayChannel (d) {
     // real one: a folder row surfaces its error inline in the file list, a loose row has no such
     // list to fall back on.
     emitError: (job, errorCode) => {
-      if (d.surfaceAllErrors || USER_FACING_ERRORS.has(errorCode)) {
+      if (d.surfaceAllErrors || isTerminalFault(errorCode)) {
         d.emit('event:transfer-error', { transferId: job.transferId, spaceId: job.spaceId, path: job.path, errorCode })
       }
       decoJob(job, { done: true })

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -6,7 +6,7 @@
 import fs from 'bare-fs'
 import path from 'bare-path'
 import { getOverlay, getJournalDir } from './overlay-instance.js'
-import { fetchContentToFile, makeFetchDiag } from './overlay-backend.js'
+import { fetchContentToFile } from './overlay-backend.js'
 import { journalNameFor } from './vendor/transfer.js'
 import { partialPathFor } from '../../partial-suffix.js'
 import { isOwnerOnline } from '../../swarm.js'
@@ -14,7 +14,6 @@ import { markDownloaded, markVerified, isDownloadedFile, isDownloadedWithHash } 
 import {
   recordPending, clearPending, recordPendingError, getPendingFor, updatePendingProgress, listPendingForSpace,
 } from '../../pending-transfers.js'
-import { makeProgressTicker } from '../../progress-ticker.js'
 import { createPausedHolders } from './paused-holders.js'
 import { recordTransferOutcome } from '../../transfer-audit.js'
 import { pauseReasonFor as reasonForOwnerOnline } from '../../transfer-status.js'
@@ -25,11 +24,12 @@ import { fetchClaimedBy } from './fetch-claims.js'
 import { ErrorCodes, classifyTransferError, isLocalDestFault } from '../../../core/errors.js'
 import { createLogger } from '../../../core/logger.js'
 
-const log = createLogger('overlay-download')
+import { isTerminalFault, nextRetryDelay } from './fetch-policy.js'
+import { makeFetchInstruments } from './fetch-run.js'
+import { shortfall } from '../../free-space.js'
+import { freeBytesFor } from '../../free-space-probe.js'
 
-// Keep some headroom beyond the file itself: the journal, rocksdb writes and the OS all
-// need working space — filling the volume to the last byte would wedge more than the transfer.
-const FREE_SPACE_HEADROOM = 64 * 1024 * 1024
+const log = createLogger('overlay-download')
 
 // [mirall] FIX-BW9 — stall auto-retry. A code-less fetch failure means "the bytes stopped":
 // a holder that dropped, or one whose UPLOAD cap kept it silent past our 30 s no-progress
@@ -45,17 +45,6 @@ const STALL_RETRY_BASE_MS = 3000
 // Binds only if STALL_RETRY_DRY_LIMIT is raised: at 3 the backoff reaches 3s/6s/12s and stops.
 const STALL_RETRY_MAX_MS = 60000
 const STALL_RETRY_DRY_LIMIT = 3
-
-// Available bytes for the volume holding `dir`. Fails OPEN (Infinity) — a probe error must
-// never block a download; the fetch itself still surfaces a real ENOSPC.
-function defaultFreeBytes (dir) {
-  try {
-    const s = fs.statfsSync(dir)
-    return s.bavail * s.bsize
-  } catch {
-    return Infinity
-  }
-}
 
 // Is `dir` a usable destination folder right now? Anything other than a live directory —
 // missing, or a plain file sitting where the folder belongs — reads as unavailable.
@@ -103,7 +92,7 @@ function discardPartial (finalPath) {
 // }
 // job: { spaceId, pendingKey, path, relPath, transferId, contentHash, size, sourceSeq,
 //        ownerPublicKey, verifyKey, finalPath, prevBytes, ...channel-specific }
-export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContentToFile, hasOverlay = () => !!getOverlay(), freeBytes = defaultFreeBytes, stallRetry = {}, dirExists = defaultDirExists } = {}) {
+export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContentToFile, hasOverlay = () => !!getOverlay(), freeBytes = freeBytesFor, stallRetry = {}, dirExists = defaultDirExists } = {}) {
   const registry = new Map() // transferId -> { contentHash, finalPath, paused, cancelled, fetching, spaceId, pendingKey, ownerPublicKey, restartJob }
   // Paused-transfer markers whose single-flight slot was released (the fetch IIFE deletes it on
   // settle). The marker is the user's intent — it outranks every automatic resume — and its hash
@@ -117,17 +106,16 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   const terminalCodes = new Map()
 
   // Record a terminal verdict on the row. Never throws: the caller still emits the error (the
-  // transfer DID fail); what the warn adds is that the failure is not durable.
-  // Only the codes runReconcile actually suppresses are worth remembering; anything else would
-  // grow the map for the life of the worker without ever being read.
-  const SUPPRESSED_CODES = new Set([ErrorCodes.TRANSFER_CHECKSUM, ErrorCodes.TRANSFER_DISK_FULL, ErrorCodes.TRANSFER_DEST_UNAVAILABLE])
+  // transfer DID fail); what the warn adds is that the failure is not durable. Only the codes
+  // isTerminalFault names are remembered — anything else would grow the map for the life of the
+  // worker without ever being read.
 
   async function recordTerminal (job, code) {
     try {
       await recordPendingError(job.spaceId, job.pendingKey, code)
       terminalCodes.delete(job.transferId)
     } catch (err) {
-      if (SUPPRESSED_CODES.has(code)) terminalCodes.set(job.transferId, code)
+      if (isTerminalFault(code)) terminalCodes.set(job.transferId, code)
       log.warn('could not persist the transfer error — auto-resume is suppressed only until restart:', job.relPath, code, '-', err.message)
     }
   }
@@ -181,7 +169,8 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     // Progress since the last attempt clears the counter — that is what lets a paced transfer
     // keep going, one attempt at a time, without a retry budget it can exhaust.
     const dry = prev && bytes <= prev.bytes ? prev.dry + 1 : 0
-    if (dry >= retryDryLimit) { cancelStallRetry(transferId); return false }
+    const delayMs = nextRetryDelay({ dry, baseMs: retryBaseMs, maxMs: retryMaxMs, dryLimit: retryDryLimit })
+    if (delayMs === null) { cancelStallRetry(transferId); return false }
     // Replacing a record must clear its timer, or the old one fires unreachable: cancelStallRetry
     // only ever sees the map's CURRENT record, so an orphan survives pause, discard and leave —
     // and re-creates the row they just purged.
@@ -190,7 +179,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     st.timer = setTimeout(() => {
       st.timer = null
       retryNow(job, bytes, dry).catch((err) => log.debug('overlay stall-retry failed:', err.message))
-    }, Math.min(retryMaxMs, retryBaseMs * 2 ** dry))
+    }, delayMs)
     st.timer.unref?.()
     stallRetries.set(transferId, st)
     return true
@@ -320,12 +309,18 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       slot.fetching = true
       // The overlay scheduler reports CUMULATIVE bytes already seeded with the resumed on-disk
       // bytes (chunk-scheduler.js), so the ticker needs no resume offset.
-      const ticker = makeProgressTicker(job.size, ({ bytes, total, speed, eta }) => {
-        channel.emitProgress(job, { bytes, total, speed, eta })
-        updatePendingProgress(job.spaceId, job.pendingKey, bytes).catch(() => {})
+      const { diag, callbacks } = makeFetchInstruments({
+        label: channel.diagLabel,
+        relPath: job.relPath,
+        size: job.size,
+        contentHash: job.contentHash,
+        onProgress: ({ bytes, total, speed, eta }) => {
+          channel.emitProgress(job, { bytes, total, speed, eta })
+          updatePendingProgress(job.spaceId, job.pendingKey, bytes).catch(() => {})
+        },
+        onVerify: (fraction) => channel.emitVerifying?.(job, fraction),
       })
-      const diag = makeFetchDiag(channel.diagLabel, job.relPath, job.size, job.contentHash)
-      const r = await fetchImpl(job.contentHash, { finalPath: job.finalPath, onProgress: (b) => { ticker.pushTo(b); diag.onProgress(b) }, onVerify: (fraction) => channel.emitVerifying?.(job, fraction), onEnd: diag.onEnd })
+      const r = await fetchImpl(job.contentHash, { finalPath: job.finalPath, ...callbacks })
       await settleFetch(transferId, job, r, diag)
     } finally {
       releaseSlot()
@@ -402,10 +397,13 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   }
 
   function missingFreeSpaceFor (job) {
-    let allocated = 0
-    try { allocated = fs.statSync(partialPathFor(job.finalPath)).blocks * 512 || 0 } catch {}
-    const needed = Math.max(0, job.size - allocated) + FREE_SPACE_HEADROOM
-    return freeBytes(path.dirname(job.finalPath)) < needed
+    let allocatedBytes = 0
+    try { allocatedBytes = fs.statSync(partialPathFor(job.finalPath)).blocks * 512 || 0 } catch {}
+    return shortfall({
+      freeBytes: freeBytes(path.dirname(job.finalPath)),
+      needBytes: job.size,
+      allocatedBytes,
+    }) > 0
   }
 
   async function start (job) {
@@ -472,7 +470,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       // (vendor/transfer.js), so a folder the user simply DELETED is silently recreated and the
       // download completes into a resurrected empty folder with no error to classify at all.
       // Downloads are flat (finalPath is always <root>/<basename>), so dirname IS the root.
-      // Runs BEFORE the free-space gate on purpose: defaultFreeBytes fails open on a statfs
+      // Runs BEFORE the free-space gate on purpose: freeBytesFor fails open on a statfs
       // error, so a gone root sails straight past that check.
       if (!dirExists(path.dirname(job.finalPath))) {
         registry.delete(transferId)
@@ -680,7 +678,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       const transferId = channel.transferIdForRow(spaceId, row)
       if (registry.has(transferId)) continue // active → reconcileActive* owns supersede + removal
       const errorCode = row.errorCode ?? terminalCodes.get(transferId)
-      const suppressed = pausedHashes.has(transferId) || errorCode === ErrorCodes.TRANSFER_CHECKSUM || errorCode === ErrorCodes.TRANSFER_DISK_FULL || errorCode === ErrorCodes.TRANSFER_DEST_UNAVAILABLE
+      const suppressed = pausedHashes.has(transferId) || isTerminalFault(errorCode)
       if (suppressed && !deep) continue
       // A completed download whose row outlived its claim (a failed clear, or a crash between
       // the claim and the clear): the file is on disk and claimed, so finish the intent here

--- a/src/shared/transfer/free-space-probe.js
+++ b/src/shared/transfer/free-space-probe.js
@@ -1,0 +1,15 @@
+// The one statfs both producers ask through. Split from free-space.js so the arithmetic there stays
+// Node-loadable; this half is bare-fs and belongs with the callers.
+//
+// Fails OPEN (Infinity): a probe error must never block a transfer, and the write itself still
+// surfaces a real ENOSPC.
+import fs from 'bare-fs'
+
+export function freeBytesFor(dir) {
+  try {
+    const s = fs.statfsSync(dir)
+    return s.bavail * s.bsize
+  } catch {
+    return Infinity
+  }
+}

--- a/src/shared/transfer/free-space.js
+++ b/src/shared/transfer/free-space.js
@@ -1,0 +1,20 @@
+// Whether a volume can hold what a transfer is about to write. Pure, so the arithmetic is asserted
+// directly rather than through a live filesystem — the probe itself stays with the caller, which is
+// what keeps this Node-loadable.
+//
+// It lived inside createOverlayDownloadEngine, so the mirror could not reach it and learned about a
+// full disk only by failing a write — by which point the volume is already at zero and the worker's
+// own bee writes are at risk.
+
+// Headroom beyond the file itself: the journal, rocksdb writes and the OS all need working space,
+// and filling the volume to the last byte wedges more than the transfer.
+export const FREE_SPACE_HEADROOM = 64 * 1024 * 1024
+
+// Bytes still needed after what a resumed partial already allocated, or 0 when it fits. Fails OPEN
+// on an unmeasurable volume: a probe error must never block a transfer, and the write itself still
+// surfaces a real ENOSPC.
+export function shortfall({ freeBytes, needBytes, allocatedBytes = 0, headroom = FREE_SPACE_HEADROOM }) {
+  if (!Number.isFinite(freeBytes)) return 0
+  const needed = Math.max(0, needBytes - allocatedBytes) + headroom
+  return Math.max(0, needed - freeBytes)
+}

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -135,6 +135,7 @@ let swarm
 let subsystem = null
 let ipcRef
 let overlayReconnectHook = null         // notified when an overlay-content owner (re)connects, so paused/interrupted overlay downloads (loose + folder) resume
+let peerOnlineHook = null               // notified on the same edge, for producers with no durable row for a resume to find (the mirror loops)
 let membershipControlHandler = null     // membership:* frames (join request / grant / deny) routed to the worker
 let connectionAttachHook = null         // per-connection (mux, socket) hook so content backends bind extra protocol channels (overlay)
 let stalledOwnersHook = null            // worker-supplied probe: which owners are we waiting on?
@@ -609,6 +610,7 @@ async function handleHandshake(socket, peerInfo, msg) {
   }
 
   overlayReconnectHook?.(peerKey, spaceId)   // resume overlay downloads (loose + folder) owned by this peer (fn swallows its own errors)
+  peerOnlineHook?.(peerKey, spaceId)         // re-drive mirrors in this space (fn swallows its own errors)
 
   // Reciprocal handshake so the peer learns about us. New to this space: always. A
   // duplicate means the peer is re-announcing because it hasn't admitted US for this space
@@ -997,6 +999,14 @@ export function isOwnerOnline(publicKey) {
   return presence.isOnlineAnywhere(publicKey)
 }
 
+// The level trigger that goes with it: whoever gates work on isOwnerOnline needs telling when the
+// answer flips, or it waits out its own poll interval. overlayReconnectHook covers the download
+// engine, whose durable rows a resume can re-drive; this covers producers that keep no row and
+// simply did nothing while the owner was away.
+export function setPeerOnlineHook(fn) {
+  peerOnlineHook = fn
+}
+
 // A connected peer's live metadata for a space (driveKey announced in its handshake,
 // plus displayName/avatar), or null if it isn't currently handshaked here. The member
 // registry uses this to enrich a newly-derived member entry; absent ⇒ the member is
@@ -1125,6 +1135,7 @@ async function destroySwarm() {
   membersPoke.reset()
   ipcRef = null
   overlayReconnectHook = null
+  peerOnlineHook = null
   membershipControlHandler = null
   connectionAttachHook = null
   revokeServesForSpaceHook = null

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -135,7 +135,7 @@ let swarm
 let subsystem = null
 let ipcRef
 let overlayReconnectHook = null         // notified when an overlay-content owner (re)connects, so paused/interrupted overlay downloads (loose + folder) resume
-let peerOnlineHook = null               // notified on the same edge, for producers with no durable row for a resume to find (the mirror loops)
+const peerOnlineHooks = new Set()       // notified on the same edge, for producers with no durable row for a resume to find (the mirror loops)
 let membershipControlHandler = null     // membership:* frames (join request / grant / deny) routed to the worker
 let connectionAttachHook = null         // per-connection (mux, socket) hook so content backends bind extra protocol channels (overlay)
 let stalledOwnersHook = null            // worker-supplied probe: which owners are we waiting on?
@@ -610,7 +610,7 @@ async function handleHandshake(socket, peerInfo, msg) {
   }
 
   overlayReconnectHook?.(peerKey, spaceId)   // resume overlay downloads (loose + folder) owned by this peer (fn swallows its own errors)
-  peerOnlineHook?.(peerKey, spaceId)         // re-drive mirrors in this space (fn swallows its own errors)
+  notifyPeerOnline(peerKey, spaceId)
 
   // Reciprocal handshake so the peer learns about us. New to this space: always. A
   // duplicate means the peer is re-announcing because it hasn't admitted US for this space
@@ -999,12 +999,21 @@ export function isOwnerOnline(publicKey) {
   return presence.isOnlineAnywhere(publicKey)
 }
 
-// The level trigger that goes with it: whoever gates work on isOwnerOnline needs telling when the
-// answer flips, or it waits out its own poll interval. overlayReconnectHook covers the download
-// engine, whose durable rows a resume can re-drive; this covers producers that keep no row and
-// simply did nothing while the owner was away.
-export function setPeerOnlineHook(fn) {
-  peerOnlineHook = fn
+// One subscriber's fault is not the swarm's: a throw here would abandon the reciprocal handshake
+// that keeps two peers converged.
+function notifyPeerOnline(peerKey, spaceId) {
+  for (const fn of peerOnlineHooks) {
+    try { fn(peerKey, spaceId) } catch (err) { log.debug('peer-online subscriber failed:', err.message) }
+  }
+}
+
+// The level trigger that goes with isOwnerOnline: whoever gates work on it needs telling when the
+// answer flips, or it waits out its own poll interval. A registry rather than a single slot, so the
+// next producer that needs this edge subscribes instead of adding another call beside the first —
+// which is exactly how the mirror's arrived. Returns its own unsubscribe.
+export function onPeerOnline(fn) {
+  peerOnlineHooks.add(fn)
+  return () => peerOnlineHooks.delete(fn)
 }
 
 // A connected peer's live metadata for a space (driveKey announced in its handshake,
@@ -1135,7 +1144,7 @@ async function destroySwarm() {
   membersPoke.reset()
   ipcRef = null
   overlayReconnectHook = null
-  peerOnlineHook = null
+  peerOnlineHooks.clear()
   membershipControlHandler = null
   connectionAttachHook = null
   revokeServesForSpaceHook = null

--- a/test/flow/mirror-offline-idle.test.js
+++ b/test/flow/mirror-offline-idle.test.js
@@ -1,0 +1,85 @@
+import test from 'brittle'
+import fs from 'fs'
+import path from 'path'
+import { localTestnet } from '../helpers/testnet.js'
+import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
+
+const delay = (ms) => new Promise((r) => setTimeout(r, ms))
+
+// REGRESSION (FIX-MIRROR-OFFLINE): with the owner offline the mirror walked its whole catalog and
+// issued a fetch per file, each burning the overlay's 3s peer wait for a no-holder that was certain
+// in advance. The pass outran its own 30s interval, so it re-fired immediately and never idled, and
+// each in-flight file reported 'downloading' — which the renderer paints as a rotating "Preparing…"
+// badge directly beneath its own "the owner is offline" banner.
+//
+// The mount is created AFTER the owner quits, which is the reported shape (14 files, 0 on device)
+// and the only one that actually reproduces. Mirroring first and then deleting the files does NOT:
+// a completed fetch registers the blob in our own overlay spool, so fetchFile answers the re-fetch
+// from local disk with no peer at all, and the mirror converges instead of spinning. B never holds
+// this content, so every fetch it attempts must go to a holder that is not there.
+//
+// It also covers the path with no tick gate above it: the initial mount scan.
+test('a mirror mounted against an offline owner stays quiet, and syncs when they return',
+  { timeout: scaled(240000) }, async (t) => {
+    const bootstrap = await localTestnet(t)
+    const aStore = path.join(mkTmpDir(t), 'app-storage')
+    const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore })
+    const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
+    const spaceId = await connectInSpace(t, A, B)
+    const aKey = (await A.request('profile:get')).publicKey
+
+    // Several files, so a spin has something to rotate THROUGH — one file could cycle unnoticed.
+    const share = await A.request('share:create', { spaceId, name: 'Set' })
+    const folder = mkTmpDir(t)
+    const names = ['1.bin', '2.bin', '3.bin', '4.bin']
+    for (const [i, n] of names.entries()) fs.writeFileSync(path.join(folder, n), patternedBytes(8 * 1024, i + 3))
+    const scanDone = A.waitFor('event:owned-folder-scan-completed', (m) => m.shareId === share.id)
+    await A.request('owned-folder:mount', { spaceId, shareId: share.id, mountPath: folder })
+    await scanDone
+
+    // Read the listing while the owner is still up: that is what replicates the catalog blocks B
+    // needs to render rows at all once A is gone. Without it a quiet mirror would prove nothing —
+    // it would be quiet because it had no catalog to walk.
+    await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+      (f) => names.every((n) => f?.entries?.some((e) => e.relPath === n)), { ms: 60000, every: 250 })
+
+    // The owner quits gracefully — the {type:'shutdown'} the Electron main sends.
+    await A.request('shutdown').catch(() => {})
+    await B.until('members:online', { spaceId }, (o) => !o.includes(aKey), { ms: 90000 })
+
+    const mirrorDir = mkTmpDir(t)
+    await B.request('foreign-folder:mount', { spaceId, shareId: share.id, ownerKey: aKey, mountPath: mirrorDir })
+
+    // Sample faster than the 3s peer wait so a single spinning file cannot hide between samples,
+    // and for longer than one 30s poll so a tick is covered as well as the initial scan.
+    const deadline = Date.now() + scaled(40000)
+    let sawDownloading = null
+    while (Date.now() < deadline && !sawDownloading) {
+      const listed = await B.request('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id })
+      sawDownloading = listed?.entries?.find((e) => e.status === 'downloading')?.relPath ?? null
+      await delay(300)
+    }
+    t.is(sawDownloading, null, 'no row ever reported downloading while the owner was offline')
+
+    const offline = await B.request('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id })
+    t.is(offline.entries.length, names.length, 'the rows render from the replicated catalog')
+    t.ok(offline.entries.every((e) => e.status === 'unavailable'),
+      'every row reads unavailable, matching the offline banner above it')
+    t.absent(fs.readdirSync(mirrorDir).length, 'and nothing was written — there was nothing to fetch from')
+
+    // Quiet is not the same as unfinished: the initial scan still has to settle the mount, or a
+    // folder mounted during an outage sits on "Scanning" until the owner comes back.
+    const mount = await B.request('foreign-folder:get', { spaceId, shareId: share.id })
+    t.is(mount.status, 'active', 'the mount settled rather than sticking mid-scan')
+
+    // Quiet must not mean STUCK: onOwnerOnline re-drives on the handshake, so the files arrive
+    // without waiting out a poll interval.
+    await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore })
+    await B.until('members:online', { spaceId }, (o) => o.includes(aKey), { ms: 90000 })
+    await B.until('share:list-files', { spaceId, ownerKey: aKey, shareId: share.id },
+      (f) => names.every((n) => f?.entries?.find((e) => e.relPath === n)?.status === 'synced'),
+      { ms: 60000, every: 250 })
+    for (const n of names) t.ok(fs.existsSync(path.join(mirrorDir, n)), `${n} materialized once the owner returned`)
+  })

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -135,6 +135,7 @@ import s134 from './scenarios/s134-mirror-over-cap-advisory.mjs'
 import s135 from './scenarios/s135-row-lane-parity.mjs'
 import s136 from './scenarios/s136-screen-header-parity.mjs'
 import s137 from './scenarios/s137-relay-invite.mjs'
+import s138 from './scenarios/s138-mirror-offline-quiet.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -201,7 +202,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s138-mirror-offline-quiet.mjs
+++ b/test/frontend/scenarios/s138-mirror-offline-quiet.mjs
@@ -1,0 +1,91 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { connectInSpace } from '../helpers.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { workDir } from '../paths.mjs'
+
+// FIX-MIRROR-OFFLINE — a mirrored folder whose owner is offline must be QUIET. Before the fix the
+// worker walked the catalog every tick and marked each file in turn as downloading, which the row
+// view paints as a rotating "Preparing…" badge — directly under a banner saying the owner is
+// offline.
+//
+// The mirror is mounted AFTER the owner quits, which is the reported shape and the ONLY one that
+// reproduces. Mirroring first and then deleting the files does not: a completed fetch registers the
+// blob in Bob's own overlay spool, so the re-fetch is answered from local disk with no peer at all
+// and the mirror converges instead of spinning. Bob must never have held this content.
+//
+// TWELVE files, not two: a pass turns continuous only once it outlasts its own 30s poll, which at
+// the vendor's 3s peer wait means ten or more missing files. Below that the spin is a burst every
+// 30s and the badge is easy to miss.
+//
+// Steps are deliberately fine-grained: makeReport prints nothing until the run ends, so a coarse
+// scenario is indistinguishable from a hang while it is working.
+const NAMES = Array.from({ length: 12 }, (_, i) => `track-${String(i + 1).padStart(2, '0')}.txt`)
+
+export default async function s138 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 2 })
+  const B = new Instance({ name: 'Bob', bootstrap, slot: 1, total: 2 })
+
+  const ownDir = path.join(workDir('own-'), 'Set')
+  mkdirSync(ownDir, { recursive: true })
+  for (const n of NAMES) writeFileSync(path.join(ownDir, n), 'x'.repeat(64))
+  const mirrorDir = workDir('mirror-')
+
+  try {
+    await r.ok('launch + connect', async () => {
+      await A.launch()
+      await B.launch()
+      await connectInSpace(A, B, { name: 'Aurora' })
+    })
+
+    await r.ok('A shares "Set" and B sees it', async () => {
+      await A.addOwnedFolder(ownDir)
+      await B.waitText('Set', 60000)
+    })
+
+    // Browsing is what pulls Alice's catalog onto Bob's disk. Without it Bob would have no rows to
+    // render once she is gone, and the folder would be quiet for the wrong reason entirely.
+    await r.ok('B browses the folder so the catalog replicates', async () => {
+      await B.openFolder('Set')
+      await B.waitText(NAMES[0], 60000)
+    })
+
+    // Killed while Bob is INSIDE the folder, which is where the offline copy is known to render
+    // (s41 pins exactly this wait). Hard-kill detection rides swarm keepalive — tens of seconds.
+    await r.ok('Alice goes offline and Bob notices', async () => {
+      await A.kill()
+      await B.waitText('offline', 90000)
+      await B.click({ name: 'Back' })
+      await B.waitText('Set', 30000)
+    })
+
+    // The mount itself is the subject: this runs the initial materialize scan, which is the path
+    // with no tick-level gate above it.
+    await r.ok('B mirrors the folder while its owner is away', async () => {
+      await B.mirrorShare(mirrorDir)
+      await B.openFolder('Set')
+      await waitFor(() => B.hasText('Not available'), 60000, 'rows render as Not available')
+    })
+
+    await r.ok('the folder stays quiet — no rotating "Preparing…" badge', async () => {
+      // hasText is a case-folded WHOLE-WINDOW substring match, so this asserts "Preparing" appears
+      // nowhere on screen. Sample faster than the 3s peer wait or a spinning badge hides between
+      // samples, and for longer than one 30s poll so a tick is covered as well as the initial scan.
+      // A transient AX read is "not yet", not a failure — waitText polls through those and a raw
+      // hasText loop must too, or a repaint mid-sample fails the scenario for the wrong reason.
+      const deadline = Date.now() + 40000
+      let sawPreparing = false
+      while (Date.now() < deadline && !sawPreparing) {
+        try { sawPreparing = await B.hasText('Preparing') } catch { /* transient AX — retry */ }
+        await new Promise((res) => setTimeout(res, 500))
+      }
+      assert(!sawPreparing, 'no rotating "Preparing…" badge while the owner is offline')
+      assert(await B.hasText('Not available'), 'and the rows still read Not available')
+      await B.shot('s138-B-mirror-quiet-offline', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A, B] }
+}

--- a/test/integration/foreign-mirror-offline-gate.test.js
+++ b/test/integration/foreign-mirror-offline-gate.test.js
@@ -1,0 +1,89 @@
+import test from 'brittle'
+import { setupSelfMirror } from '../helpers/owned.js'
+import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { initialMaterializeScan, runMaterializeTick } from '../../src/shared/folders/foreign-folders.js'
+
+// The offline half of the gate is NOT tested here, deliberately. A remote-owner mount cannot be
+// faked at this layer: loadShareForForeignMount -> readPeerShares returns null for a key with no
+// peer bee, so materializeOnce returns at `if (!share)` and never reaches the gate — the test would
+// pass with the gate deleted. That half lives in test/flow/mirror-offline-idle.test.js, where
+// "offline" is a real peer shutting down.
+
+// A well-formed scheduler-end frame. Passing one is what makes `attempted` true, which is the whole
+// difference between "a holder was asked and died" and "there was no holder at all".
+const SCHEDULER_END = {
+  reason: 'timeout', receivedBytes: 0, totalBytes: 1, totalChunks: 1, chunksRemaining: 1, peers: 1, elapsedMs: 10,
+}
+
+// Count fetches without changing what they do: setupSelfMirror already installs a working stub.
+function countFetches (t) {
+  const overlay = getOverlay()
+  const inner = overlay.fetchFile
+  const state = { calls: 0 }
+  overlay.fetchFile = async (hash, opts) => { state.calls++; return await inner(hash, opts) }
+  t.teardown(() => { overlay.fetchFile = inner })
+  return state
+}
+
+// REGRESSION (FIX-MIRROR-OFFLINE): the reachability gate must special-case a self-mirror. Presence
+// never leases our own key, so a bare isOwnerOnline(mount.ownerKey) reads it as permanently offline
+// and the mirror never fetches anything again. This is the landmine the whole change balances on:
+// it goes red on a gate written the obvious way, green on the shipped one.
+test('REGRESSION (FIX-MIRROR-OFFLINE): a self-mirror still materializes under the gate', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x', 'b.txt': 'y' } })
+  const fetches = countFetches(t)
+  await initialMaterializeScan(ctx.mount)
+  t.is(fetches.calls, 2, 'both files were fetched — the gate did not mistake us for an offline peer')
+})
+
+// A fetchFile that resolves null WITHOUT calling onEnd is exactly what the vendor does when
+// _peers.size === 0 (vendor/overlay-v2.js) — the shape the reported bug ran on. That answer is a
+// process-global fact, so the pass must stop rather than re-ask it once per file.
+test('a zero-peer answer stops the pass instead of re-asking per file', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2', 'c.txt': '3', 'd.txt': '4' } })
+  const overlay = getOverlay()
+  const inner = overlay.fetchFile
+  let calls = 0
+  overlay.fetchFile = async () => { calls++; return null }
+  t.teardown(() => { overlay.fetchFile = inner })
+
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(calls, 1, 'one peer wait for the whole pass, not one per file')
+})
+
+// The other half of the same rule: a holder that WAS asked and died is a per-file fact, so the walk
+// must carry on. Without this the fix would turn one bad file into a stalled folder.
+test('a stalled holder does NOT stop the pass — that fact is per file', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2', 'c.txt': '3' } })
+  const overlay = getOverlay()
+  const inner = overlay.fetchFile
+  let calls = 0
+  overlay.fetchFile = async (hash, opts) => { calls++; opts?.onEnd?.(SCHEDULER_END); return null }
+  t.teardown(() => { overlay.fetchFile = inner })
+
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(calls, 3, 'every file was still attempted')
+})
+
+// A pass that stopped early walked a PREFIX, so it must not be able to converge. If 'no-peers' ever
+// read as present, the mirror would set a watermark and stop walking with nothing on disk — a
+// silent, permanent sync outage that no later tick would repair.
+test('a pass stopped early never converges', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2', 'c.txt': '3' } })
+  const overlay = getOverlay()
+  const real = overlay.fetchFile
+  const state = { peers: false, calls: 0 }
+  overlay.fetchFile = async (hash, opts) => {
+    state.calls++
+    return state.peers ? await real(hash, opts) : null
+  }
+  t.teardown(() => { overlay.fetchFile = real })
+
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.calls, 1, 'the zero-peer pass stopped after one attempt')
+
+  state.peers = true
+  state.calls = 0
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(state.calls, 3, 'the next tick walked the whole catalog — the partial pass set no watermark')
+})

--- a/test/integration/foreign-mirror-offline-gate.test.js
+++ b/test/integration/foreign-mirror-offline-gate.test.js
@@ -1,13 +1,14 @@
 import test from 'brittle'
 import { setupSelfMirror } from '../helpers/owned.js'
 import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
-import { initialMaterializeScan, runMaterializeTick } from '../../src/shared/folders/foreign-folders.js'
+import { getForeignMount } from '../../src/shared/folders/mount-store.js'
+import { initialMaterializeScan, runMaterializeTick, setMirrorReachability } from '../../src/shared/folders/foreign-folders.js'
 
-// The offline half of the gate is NOT tested here, deliberately. A remote-owner mount cannot be
-// faked at this layer: loadShareForForeignMount -> readPeerShares returns null for a key with no
-// peer bee, so materializeOnce returns at `if (!share)` and never reaches the gate — the test would
-// pass with the gate deleted. That half lives in test/flow/mirror-offline-idle.test.js, where
-// "offline" is a real peer shutting down.
+// The offline half needs the reachability seam: presence is a module-private lease map, so a test
+// cannot make a peer online. A FABRICATED remote ownerKey does not work either — readPeerShares
+// returns null for a key with no peer bee, so the pass exits at `if (!share)` before reaching any
+// gate and the test would pass with the gate deleted. So these stage a SELF mirror (share readable,
+// catalog real) and override reachability alone.
 
 // A well-formed scheduler-end frame. Passing one is what makes `attempted` true, which is the whole
 // difference between "a holder was asked and died" and "there was no holder at all".
@@ -86,4 +87,49 @@ test('a pass stopped early never converges', async (t) => {
   state.calls = 0
   await runMaterializeTick(ctx.spaceId, ctx.share.id)
   t.is(state.calls, 3, 'the next tick walked the whole catalog — the partial pass set no watermark')
+})
+
+// Staged offline. The override replaces the VERDICT, not isOwnerOnline: a self-mirror is reachable
+// by rule (presence never leases our own key), so overriding presence alone would change nothing.
+function offline (t) {
+  setMirrorReachability(() => false)
+  t.teardown(() => setMirrorReachability(null))
+}
+
+function countFetchesOn (t) {
+  const overlay = getOverlay()
+  const inner = overlay.fetchFile
+  const state = { calls: 0 }
+  overlay.fetchFile = async (...a) => { state.calls++; return await inner(...a) }
+  t.teardown(() => { overlay.fetchFile = inner })
+  return state
+}
+
+// The control. Without it a zero count below proves only that the harness was broken — and an
+// earlier draft of this file did exactly that, counting zero because a previous tick had already
+// put every file on disk.
+test('control: a reachable mirror fetches every missing file on one tick', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2', 'c.txt': '3' } })
+  const fetches = countFetchesOn(t)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(fetches.calls, 3, 'three missing files, three fetches')
+})
+
+test('REGRESSION (FIX-MIRROR-OFFLINE): an unreachable owner costs zero fetches', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2', 'c.txt': '3' } })
+  offline(t)
+  const fetches = countFetchesOn(t)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(fetches.calls, 0, 'two full ticks over three absent files issued no fetch at all')
+})
+
+test('the initial mount scan is gated too — it has no tick gate above it', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2' } })
+  offline(t)
+  const fetches = countFetchesOn(t)
+  await initialMaterializeScan(ctx.mount)
+  t.is(fetches.calls, 0, 'the boot scan issued no fetch')
+  const mount = await getForeignMount(ctx.spaceId, ctx.share.id)
+  t.is(mount.status, 'active', 'and still settled the mount rather than sticking on scanning')
 })

--- a/test/integration/mirror-download-interleave.test.js
+++ b/test/integration/mirror-download-interleave.test.js
@@ -139,9 +139,9 @@ test('the mirror releases its claim and its slot on every exit path', async (t) 
   t.is(fetchSlotStats().held, 0, 'slot released after a completed fetch')
   t.is(fetchClaimedBy(transferIdFor(ctx.spaceId, ctx.share.id, entries[0].relPath)), null, 'claim released')
 
-  // miss (fetchFile resolves null)
+  // miss (fetchFile resolves null with no scheduler end == no holder was ever reachable)
   overlay.fetchFile = async () => null
-  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entries[1]), 'missing')
+  t.is(await materializeCatalogFile(ctx.mount, ctx.share, entries[1]), 'no-peers')
   t.is(fetchSlotStats().held, 0, 'slot released after a miss')
   t.is(fetchClaimedBy(transferIdFor(ctx.spaceId, ctx.share.id, entries[1].relPath)), null, 'claim released after a miss')
 

--- a/test/integration/mirror-integrity-audit.test.js
+++ b/test/integration/mirror-integrity-audit.test.js
@@ -7,6 +7,7 @@ import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-i
 import { materializeCatalogFile, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
 import { createForeignMount, getForeignMount } from '../../src/shared/folders/mount-store.js'
 import { queryAudit, flushAudit } from '../../src/shared/audit/audit-log.js'
+import { createIntegritySeen } from '../../src/shared/folders/integrity-seen.js'
 
 // src/shared/folders/ contained ZERO record( calls: a mirror holder serving bytes that fail their
 // advertised hash produced a console warning and nothing else. Everything else the mirror does per
@@ -74,6 +75,17 @@ test('REGRESSION (FIX-D11-4): a mirror hash mismatch records security.integrity_
   t.is(found[0].category, 'security')
   t.is(found[0].outcome, 'error')
   t.is(found[0].space.id, space.spaceId)
+})
+
+// The attempt budget stops asking after 3 tries, so five calls no longer reach the audit path five
+// times — driving `admit` directly is what keeps this about the DEDUP rule rather than about the
+// budget that now happens to sit in front of it. The end-to-end count is asserted below.
+test('the audit memo records one row per (mount, file, hash), however often it is told', async (t) => {
+  const seen = createIntegritySeen()
+  t.ok(seen.admit('m', 'a/report.pdf', 'h1'), 'the first claim records')
+  for (let i = 0; i < 5; i++) t.absent(seen.admit('m', 'a/report.pdf', 'h1'), 'repeats do not')
+  t.ok(seen.admit('m', 'a/report.pdf', 'h2'), 'a re-publish is a new claim')
+  t.ok(seen.admit('other', 'a/report.pdf', 'h1'), 'and another mount is its own')
 })
 
 test('five ticks against the same bad file record exactly one row', async (t) => {

--- a/test/integration/mirror-integrity-terminal.test.js
+++ b/test/integration/mirror-integrity-terminal.test.js
@@ -1,0 +1,95 @@
+import test from 'brittle'
+import { setupSelfMirror } from '../helpers/owned.js'
+import { getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { runMaterializeTick, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
+import { isTerminalFault } from '../../src/shared/transfer/backends/overlay/fetch-policy.js'
+import { ErrorCodes } from '../../src/shared/core/errors.js'
+
+// REGRESSION (FIX-MIRROR-CHECKSUM): a holder serving bytes that fail their advertised hash was
+// re-downloaded by the mirror on every 30s tick and every catalog append, forever. integrity-seen
+// caps the AUDIT rows, so past the cap the loop was silent too: unbounded bandwidth, no user-visible
+// error, no terminal state. The engine has treated the same fault as terminal since v1.7 —
+// architecture §4.5, "re-fetching from the same holder would fail identically".
+
+function badHolder (t, { code = 'EHASHMISMATCH' } = {}) {
+  const overlay = getOverlay()
+  const inner = overlay.fetchFile
+  const seen = []
+  overlay.fetchFile = async (hash, opts) => {
+    seen.push(opts?.destPath ?? hash)
+    const e = new Error('served bytes do not match'); e.code = code; throw e
+  }
+  t.teardown(() => { overlay.fetchFile = inner })
+  return seen
+}
+
+test('the shared rule calls a checksum failure terminal', (t) => {
+  t.ok(isTerminalFault(ErrorCodes.TRANSFER_CHECKSUM))
+})
+
+test('REGRESSION (FIX-MIRROR-CHECKSUM): a bad holder is not re-fetched every tick', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x', 'b.txt': 'y' } })
+  const seen = badHolder(t)
+
+  // The budget is 3, so the retries are bounded, not zero: the overlay is multi-source and a
+  // second holder deserves its turn before the mirror gives up on the content.
+  for (let i = 0; i < 8; i++) await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(seen.length, 6, 'two files x a 3-attempt budget, then it stops asking')
+
+  const before = seen.length
+  for (let i = 0; i < 5; i++) await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(seen.length, before, 'five further ticks re-fetched nothing')
+})
+
+// The reason it is a budget. A permanent block on the first bad byte would condemn content that a
+// healthy holder can serve, with no way back short of a remount.
+test('a healthy holder still gets its turn after a bad one', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const overlay = getOverlay()
+  const real = overlay.fetchFile
+  let calls = 0
+  overlay.fetchFile = async (hash, opts) => {
+    calls++
+    if (calls === 1) { const e = new Error('bad bytes'); e.code = 'EHASHMISMATCH'; throw e }
+    return await real(hash, opts)
+  }
+  t.teardown(() => { overlay.fetchFile = real })
+
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(calls, 2, 'the second attempt was allowed')
+  const { existsSync } = await import('bare-fs')
+  t.ok(existsSync(ctx.mirrorPath + '/a.txt'), 'and the good copy landed')
+})
+
+// The block is per file, not per pass: 'no-peers' ends a walk because nobody is out there, and a
+// corrupt file must not be given that meaning or one bad byte-range stops the whole folder.
+test('a checksum failure does not stop the pass', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': '1', 'b.txt': '2', 'c.txt': '3' } })
+  const seen = badHolder(t)
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(seen.length, 3, 'every file in the folder was still attempted')
+})
+
+// A non-terminal fault must keep its retry. Only the codes the shared rule names as terminal block.
+test('a stalled holder is still retried on the next tick', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const seen = badHolder(t, { code: 'ETIMEDOUT' })
+  for (let i = 0; i < 6; i++) await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(seen.length, 6, 'a non-terminal fault is re-attempted without limit')
+})
+
+// The forgiveness boundary. A re-mount is the user re-pointing the folder, which deserves a fresh
+// attempt — and it is what makes an in-memory block acceptable in place of a durable row.
+test('a remount clears the block', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'x' } })
+  const seen = badHolder(t)
+  for (let i = 0; i < 4; i++) await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(seen.length, 3, 'the budget is spent')
+
+  await unmountForeignFolder(ctx.spaceId, ctx.share.id)
+  const { createForeignMount } = await import('../../src/shared/folders/mount-store.js')
+  await createForeignMount({ ...ctx.mount, syncedPaths: [] })
+  await runMaterializeTick(ctx.spaceId, ctx.share.id)
+  t.is(seen.length, 4, 'the re-made mount attempted the file again')
+})

--- a/test/integration/share-listing-batch.test.js
+++ b/test/integration/share-listing-batch.test.js
@@ -200,7 +200,9 @@ function baselineRow(w, mountPath) {
       const verified = !!entry.contentHash && VERIFIED[w.verified] === entry.contentHash
       return { ...out, row: { status: 'synced', localPath: abs, verified } }
     }
-    if (w.fetchActive) return { ...out, row: { status: 'downloading', localPath: null, pendingBytes: 0 } }
+    // An in-flight mirror fetch only counts while the owner is reachable: with them away the fetch
+    // is parked on the overlay's peer wait, not pulling anything.
+    if (w.fetchActive && w.ownerOnline) return { ...out, row: { status: 'downloading', localPath: null, pendingBytes: 0 } }
     if (!entry.contentHash) return { ...out, row: { status: unhashedStatusFor(w.ownerOnline), localPath: null } }
     return { ...out, row: { status: w.ownerOnline ? 'remote' : 'unavailable', localPath: null } }
   }
@@ -376,4 +378,24 @@ test('an unrenamed mirror row is unaffected by the mapping lookup', async (t) =>
   const res = await listOverlayShareFiles(SPACE, SHARE, backendFor([{ relPath: 'f.txt', size: 10, contentHash: 'h1', mtime: 0 }]), deps)
   t.is(res.entries[0].status, 'synced')
   t.is(res.entries[0].localPath, path.join(root, 'f.txt'))
+})
+
+// REGRESSION (FIX-MIRROR-OFFLINE): the mirror kept a fetch "in flight" against an offline owner —
+// parked on the overlay's peer wait, transferring nothing — and this row reported it 'downloading'.
+// The renderer paints a downloading row with no bytes as "Preparing…", so the folder showed a badge
+// walking from file to file directly beneath its own "the owner is offline" banner. The strip and
+// the folder tile already suppressed their equivalents; the row was the surface that did not.
+test("REGRESSION (FIX-MIRROR-OFFLINE): a parked mirror fetch is not 'downloading' when the owner is away", async (t) => {
+  const root = mirrorDir(t, 'offline-parked', {})
+  const deps = countingDeps()
+  deps.getForeignMount = async () => ({ enabled: true, mountPath: root })
+  deps.foreignFetchActive = () => true
+
+  deps.isOwnerOnline = () => false
+  const away = await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(1)), deps)
+  t.is(away.entries[0].status, 'unavailable', 'offline: the parked fetch does not read as a download')
+
+  deps.isOwnerOnline = () => true
+  const back = await listOverlayShareFiles(SPACE, SHARE, backendFor(rows(1)), deps)
+  t.is(back.entries[0].status, 'downloading', 'online: a real in-flight fetch still reads as one')
 })

--- a/test/unit/fetch-attempts.test.js
+++ b/test/unit/fetch-attempts.test.js
@@ -1,0 +1,70 @@
+import test from 'brittle'
+import { createAttemptBudget, DEFAULT_ATTEMPT_LIMIT, DEFAULT_MAX_KEYS } from '../../src/shared/folders/fetch-attempts.js'
+
+const M = 'space:share'
+
+test('a claim is spent only after the limit is reached', (t) => {
+  const b = createAttemptBudget({ limit: 3 })
+  t.absent(b.exhausted(M, 'a.txt', 'h1'), 'never attempted')
+  t.is(b.fail(M, 'a.txt', 'h1'), 1)
+  t.absent(b.exhausted(M, 'a.txt', 'h1'), 'one bad holder is not a verdict')
+  t.is(b.fail(M, 'a.txt', 'h1'), 2)
+  t.absent(b.exhausted(M, 'a.txt', 'h1'))
+  t.is(b.fail(M, 'a.txt', 'h1'), 3)
+  t.ok(b.exhausted(M, 'a.txt', 'h1'), 'the budget is spent')
+})
+
+// The whole reason this is a budget and not a block: the overlay is multi-source, so the first
+// holder serving corrupt bytes must not condemn content a second holder can serve.
+test('a healthy holder still gets its turn after a bad one', (t) => {
+  const b = createAttemptBudget({ limit: 3 })
+  b.fail(M, 'a.txt', 'h1')
+  t.absent(b.exhausted(M, 'a.txt', 'h1'), 'a retry is still allowed')
+  b.succeed(M, 'a.txt', 'h1')
+  b.fail(M, 'a.txt', 'h1')
+  t.is(b.size(M), 1)
+  t.absent(b.exhausted(M, 'a.txt', 'h1'), 'a landed file cleared the record')
+})
+
+test('a re-publish under a new hash is a fresh claim', (t) => {
+  const b = createAttemptBudget({ limit: 1 })
+  b.fail(M, 'a.txt', 'h1')
+  t.ok(b.exhausted(M, 'a.txt', 'h1'))
+  t.absent(b.exhausted(M, 'a.txt', 'h2'), 'different bytes, different claim')
+})
+
+test('mounts do not share budgets', (t) => {
+  const b = createAttemptBudget({ limit: 1 })
+  b.fail(M, 'a.txt', 'h1')
+  t.absent(b.exhausted('other:share', 'a.txt', 'h1'))
+  b.forget(M)
+  t.absent(b.exhausted(M, 'a.txt', 'h1'), 'a remount forgives')
+})
+
+// The failure the reused audit memo had: at its cap it stopped RECORDING, so it silently stopped
+// blocking and the unbounded loop came back. Eviction keeps the map bounded AND keeps blocking.
+test('the map is bounded by eviction, and keeps blocking at the cap', (t) => {
+  const b = createAttemptBudget({ limit: 1, maxKeys: 3 })
+  for (const n of ['a', 'b', 'c']) b.fail(M, n, 'h')
+  t.is(b.size(M), 3)
+  b.fail(M, 'd', 'h')
+  t.is(b.size(M), 3, 'still bounded')
+  t.ok(b.exhausted(M, 'd', 'h'), 'the newest claim still blocks — the cap did not disable the rule')
+  t.absent(b.exhausted(M, 'a', 'h'), 'the least recently failed was evicted and is retried')
+})
+
+test('a repeated failure refreshes recency, so a hot claim is not evicted first', (t) => {
+  const b = createAttemptBudget({ limit: 5, maxKeys: 2 })
+  b.fail(M, 'a', 'h')
+  b.fail(M, 'b', 'h')
+  b.fail(M, 'a', 'h')
+  b.fail(M, 'c', 'h')
+  t.is(b.size(M), 2)
+  t.absent(b.exhausted(M, 'b', 'h'), 'b was the stalest and went')
+  t.is(b.fail(M, 'a', 'h'), 3, 'a kept its count')
+})
+
+test('the defaults are the documented ones', (t) => {
+  t.is(DEFAULT_ATTEMPT_LIMIT, 3)
+  t.is(DEFAULT_MAX_KEYS, 512)
+})

--- a/test/unit/fetch-policy-parity.test.js
+++ b/test/unit/fetch-policy-parity.test.js
@@ -1,0 +1,87 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (p) => readFileSync(path.resolve(here, '../../src', p), 'utf8')
+
+const ENGINE = 'shared/transfer/backends/overlay/overlay-download.js'
+const MIRROR = 'shared/folders/foreign-folders.js'
+const CHANNEL = 'shared/transfer/backends/overlay/overlay-channel.js'
+
+// Two producers move bytes through one overlay: the download engine and the foreign-folder mirror.
+// A failure rule that holds for one has to hold for the other, and nothing else can notice when
+// they drift — to the compiler they are unrelated objects, which is the same trap overlay-channel.js
+// was built to close for the two channels one level down.
+//
+// Source-scanned rather than imported: both modules pull in bare-*, so a Node runner cannot load
+// them. Same technique and same rationale as preview-shape-parity.test.js.
+
+test('both producers gate a fetch on reachability', (t) => {
+  t.ok(/ownerOnline\(job\.ownerPublicKey\)/.test(read(ENGINE)), 'the engine gates on the owner')
+  // Anchored on the call, not the declaration: /mayFetch\(mount\)/ alone matches
+  // `function mayFetch(mount) {`, so both call sites could be deleted and this still passed.
+  t.ok(/const canFetch = mayFetch\(mount\)/.test(read(MIRROR)), 'the mirror gates its walk')
+  t.ok(/if \(!mayFetch\(mount\)\)/.test(read(MIRROR)), 'and its tick')
+})
+
+// Deliberately one-sided. The two look like the same question and are not: the mirror asks whether a
+// chunk scheduler ever ran (onEnd fired), the engine asks whether the vendor attached a cause code.
+// An earlier draft of this file demanded both use classifyMiss, and forcing the engine onto it
+// inverted its retry branch — the engine suite caught it. The shared rule owns the mirror's fact
+// only; the engine's stays its own.
+test('the mirror classifies a miss through the shared rule', (t) => {
+  t.ok(/classifyMiss\(/.test(read(MIRROR)), 'the mirror uses the shared classifier')
+  t.absent(/function classifyMirrorMiss/.test(read(MIRROR)), 'and keeps no private copy')
+})
+
+test('one terminal-fault set, read by every producer that judges a fault', (t) => {
+  for (const f of [ENGINE, MIRROR, CHANNEL]) {
+    t.ok(/isTerminalFault\(/.test(read(f)), `${f} consults the shared set`)
+  }
+  t.absent(/SUPPRESSED_CODES\s*=/.test(read(ENGINE)), 'the engine keeps no private set')
+  t.absent(/USER_FACING_ERRORS\s*=/.test(read(CHANNEL)), 'the channel keeps no private set')
+})
+
+test('both producers reach the vendor through the shared instrumentation', (t) => {
+  for (const f of [ENGINE, MIRROR]) {
+    t.absent(/makeFetchDiag\(/.test(read(f)), `${f} does not build its own diag`)
+    t.absent(/makeProgressTicker\(/.test(read(f)), `${f} does not build its own ticker`)
+  }
+})
+
+test('both producers refuse a fetch whose destination is gone', (t) => {
+  t.ok(/dirExists\(path\.dirname\(job\.finalPath\)\)/.test(read(ENGINE)), 'the engine preflights')
+  // Not /mountRootAvailable\(/: that matches two pre-existing calls in the auto-pause probes, so
+  // the preflight could be deleted without failing. The preflight lives in mountCanTake.
+  t.ok(/probe\.rootAvailable\(\)/.test(read(MIRROR)), 'the mirror preflights its mount root')
+})
+
+test('both producers preflight free space through one rule', (t) => {
+  for (const f of [ENGINE, MIRROR]) {
+    t.ok(/shortfall\(\{/.test(read(f)), `${f} asks the shared capacity rule`)
+    t.ok(/allocatedBytes/.test(read(f)), `${f} credits what a resumed partial already took`)
+  }
+  t.absent(/FREE_SPACE_HEADROOM\s*=/.test(read(ENGINE)), 'the headroom is declared once, not here')
+})
+
+// One edge, one dispatcher. The offline fix left two hooks fired back to back for the same event
+// because there was no shared one to join; that is the shape this forbids.
+test('the peer-online edge has one dispatcher, not one hook per producer', (t) => {
+  const src = read('shared/transfer/swarm.js')
+  t.absent(/peerOnlineHook\?\.\(/.test(src), 'no per-producer hook call')
+  t.ok(/for \(const fn of peerOnlineHooks\)/.test(src), 'a single subscriber loop')
+})
+
+// The layering rule from testing.md: a policy module must stay Node-loadable, or the unit tests
+// above it silently belong to a different runner.
+for (const f of [
+  'shared/transfer/backends/overlay/fetch-policy.js',
+  'shared/transfer/free-space.js',
+  'shared/folders/mirror-reach.js',
+]) {
+  test(`${f} imports no bare-* module`, (t) => {
+    t.absent(/from '(bare-[a-z]+)'/.test(read(f)), 'stays unit-testable under Node')
+  })
+}

--- a/test/unit/fetch-policy.test.js
+++ b/test/unit/fetch-policy.test.js
@@ -1,0 +1,37 @@
+import test from 'brittle'
+import { isTerminalFault, classifyMiss, nextRetryDelay } from '../../src/shared/transfer/backends/overlay/fetch-policy.js'
+import { ErrorCodes } from '../../src/shared/core/errors.js'
+
+test('the terminal set is exactly the faults no retry can fix', (t) => {
+  for (const c of [ErrorCodes.TRANSFER_CHECKSUM, ErrorCodes.TRANSFER_DISK_FULL, ErrorCodes.TRANSFER_DEST_UNAVAILABLE]) {
+    t.ok(isTerminalFault(c), `${c} is terminal`)
+  }
+  for (const c of [ErrorCodes.TRANSFER_NETWORK, ErrorCodes.DOWNLOAD_FAILED, undefined, null, 'ECONNRESET']) {
+    t.absent(isTerminalFault(c), `${String(c)} stays retryable`)
+  }
+})
+
+test('a miss is classified by whether a scheduler ran', (t) => {
+  t.is(classifyMiss({ attempted: false }), 'no-holder', 'nobody was ever reachable — a global fact')
+  t.is(classifyMiss({ attempted: true }), 'failed', 'a holder was asked and died — a per-file fact')
+})
+
+test('backoff doubles, caps, and gives up on the dry budget', (t) => {
+  const at = (dry) => nextRetryDelay({ dry, baseMs: 3000, maxMs: 12000, dryLimit: 3 })
+  t.is(at(0), 3000)
+  t.is(at(1), 6000)
+  t.is(at(2), 12000)
+  t.is(at(3), null, 'the budget is spent — park it')
+  t.is(at(99), null)
+})
+
+test('the cap binds before the budget does', (t) => {
+  t.is(nextRetryDelay({ dry: 5, baseMs: 3000, maxMs: 10000, dryLimit: 10 }), 10000,
+    '3000 * 2^5 is 96000, capped to 10000')
+})
+
+// A zero budget means "never retry", not "retry immediately" — the fail-safe direction for a caller
+// that wants the rule off.
+test('a dryLimit of 0 refuses the first attempt', (t) => {
+  t.is(nextRetryDelay({ dry: 0, baseMs: 1000, maxMs: 5000, dryLimit: 0 }), null)
+})

--- a/test/unit/free-space.test.js
+++ b/test/unit/free-space.test.js
@@ -1,0 +1,38 @@
+import test from 'brittle'
+import { shortfall, FREE_SPACE_HEADROOM } from '../../src/shared/transfer/free-space.js'
+
+const MB = 1024 * 1024
+
+test('a volume that fits the file plus headroom reports no shortfall', (t) => {
+  t.is(shortfall({ freeBytes: 500 * MB, needBytes: 100 * MB }), 0)
+  t.is(shortfall({ freeBytes: 100 * MB + FREE_SPACE_HEADROOM, needBytes: 100 * MB }), 0, 'exactly enough')
+})
+
+test('the shortfall is what is missing, not a boolean', (t) => {
+  t.is(shortfall({ freeBytes: 100 * MB, needBytes: 100 * MB }), FREE_SPACE_HEADROOM,
+    'a file that fits byte-for-byte still owes the headroom')
+  t.is(shortfall({ freeBytes: 0, needBytes: 10 }), 10 + FREE_SPACE_HEADROOM)
+})
+
+// A resumed partial has already taken its bytes from the volume; charging for them twice would
+// refuse a transfer that is most of the way done.
+test('bytes a partial already allocated are not charged again', (t) => {
+  t.is(shortfall({ freeBytes: FREE_SPACE_HEADROOM, needBytes: 100 * MB, allocatedBytes: 100 * MB }), 0)
+  t.is(shortfall({ freeBytes: FREE_SPACE_HEADROOM, needBytes: 100 * MB, allocatedBytes: 40 * MB }), 60 * MB)
+  t.is(shortfall({ freeBytes: 999 * MB, needBytes: 10, allocatedBytes: 9999 }), 0,
+    'over-allocation never becomes a negative requirement')
+})
+
+// The direction that matters: an unmeasurable volume must not block a transfer. statfs fails on some
+// network mounts, and refusing to sync because we could not measure is worse than trying.
+test('an unmeasurable volume fails open', (t) => {
+  t.is(shortfall({ freeBytes: Infinity, needBytes: 1e12 }), 0, 'the probe’s fail-open value')
+  t.is(shortfall({ freeBytes: NaN, needBytes: 1e12 }), 0)
+  t.is(shortfall({ freeBytes: undefined, needBytes: 1e12 }), 0)
+})
+
+test('the headroom is overridable but defaults to 64 MiB', (t) => {
+  t.is(FREE_SPACE_HEADROOM, 64 * MB)
+  t.is(shortfall({ freeBytes: 10, needBytes: 0, headroom: 0 }), 0)
+  t.is(shortfall({ freeBytes: 0, needBytes: 0, headroom: 5 }), 5)
+})

--- a/test/unit/mirror-reach.test.js
+++ b/test/unit/mirror-reach.test.js
@@ -43,8 +43,10 @@ test('foreign-folders routes every fetch-reachability decision through mirrorMay
   const here = path.dirname(fileURLToPath(import.meta.url))
   const src = readFileSync(path.join(here, '..', '..', 'src', 'shared', 'folders', 'foreign-folders.js'), 'utf8')
   const direct = src.match(/isOwnerOnline\(/g) || []
-  // Exactly two: the deletion guard (shouldHonorDeletions) and mayFetch(). A third is a copy.
-  t.is(direct.length, 2, 'isOwnerOnline is called exactly twice')
+  // Exactly one, inside mayFetch. The deletion guard used to call it raw, which read every
+  // self-mirror as offline and refused the owner's deletions forever; it now asks mayFetch too.
+  t.is(direct.length, 1, 'isOwnerOnline has a single call site')
+  t.ok(/ownerOnline: mayFetch\(mount\)/.test(src), 'the deletion guard asks the same rule')
   t.ok(/function mayFetch\s*\(/.test(src), 'the single reachability helper exists')
   t.ok(/mirrorMayFetch\(/.test(src), 'and it delegates to the pure rule')
 })

--- a/test/unit/mirror-reach.test.js
+++ b/test/unit/mirror-reach.test.js
@@ -1,0 +1,50 @@
+import test from 'brittle'
+import { mirrorMayFetch } from '../../src/shared/folders/mirror-reach.js'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const ME = 'a'.repeat(64)
+const THEM = 'b'.repeat(64)
+
+test('a reachable owner may be fetched from; an unreachable one may not', (t) => {
+  t.is(mirrorMayFetch({ ownerKey: THEM, localKey: ME, ownerOnline: true }), true)
+  t.is(mirrorMayFetch({ ownerKey: THEM, localKey: ME, ownerOnline: false }), false,
+    'the whole point of the change')
+})
+
+// REGRESSION (FIX-MIRROR-OFFLINE): presence leases track REMOTE peers only, so our own key is never
+// online. A bare isOwnerOnline(ownerKey) gate would freeze every self-mirror permanently — and
+// test/helpers/owned.js::setupSelfMirror, which most of the mirror integration suite is built on,
+// mounts with exactly that ownerKey.
+test('a self-mirror is always reachable, whatever presence says', (t) => {
+  t.is(mirrorMayFetch({ ownerKey: ME, localKey: ME, ownerOnline: false }), true)
+  t.is(mirrorMayFetch({ ownerKey: ME, localKey: ME, ownerOnline: true }), true)
+})
+
+// The fail-safe direction: unknown means MORE work, never less. A mirror that goes quiet on a
+// missing field is a silent sync outage; a mirror that pays one wasted pass is a log line.
+test('an unknown owner falls open, and a missing local key only disables the self shortcut', (t) => {
+  t.is(mirrorMayFetch({ ownerKey: null, localKey: ME, ownerOnline: false }), true, 'no owner key')
+  t.is(mirrorMayFetch({}), true, 'nothing known at all')
+  t.is(mirrorMayFetch({ ownerKey: THEM, localKey: null, ownerOnline: false }), false,
+    'a null local key does NOT make a remote owner reachable')
+})
+
+test('ownerOnline is coerced to a boolean, never leaked', (t) => {
+  t.is(mirrorMayFetch({ ownerKey: THEM, localKey: ME, ownerOnline: undefined }), false)
+  t.is(mirrorMayFetch({ ownerKey: THEM, localKey: ME, ownerOnline: 1 }), true)
+})
+
+// share-listing.js keeps its own `isOwn ? true : …` because it answers a different question (what to
+// DISPLAY, not whether to FETCH). foreign-folders.js must not grow a second hand-rolled copy of THIS
+// one: two copies of the self-mirror rule is how they drift, and the drift is silent.
+test('foreign-folders routes every fetch-reachability decision through mirrorMayFetch', (t) => {
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const src = readFileSync(path.join(here, '..', '..', 'src', 'shared', 'folders', 'foreign-folders.js'), 'utf8')
+  const direct = src.match(/isOwnerOnline\(/g) || []
+  // Exactly two: the deletion guard (shouldHonorDeletions) and mayFetch(). A third is a copy.
+  t.is(direct.length, 2, 'isOwnerOnline is called exactly twice')
+  t.ok(/function mayFetch\s*\(/.test(src), 'the single reachability helper exists')
+  t.ok(/mirrorMayFetch\(/.test(src), 'and it delegates to the pure rule')
+})


### PR DESCRIPTION
A mirrored folder whose owner was offline never went idle: every fetch burned a
3s peer wait to learn there was no holder, and with more missing files than the
30s poll allows the pass re-fired with no gap. Each in-flight row rendered as a
rotating "Preparing…" badge beside the "owner is offline" banner, while nothing
was downloading and the machine never slept.

Fixing it surfaced the same class one layer down: the download engine and the
mirror judge fetch failures separately and had already drifted.

**Fixes**
- Gate the mirror's walk on reachability; stop the pass on the first zero-peer
  answer; re-drive on reconnect instead of waiting out a poll interval.
- A checksum failure was terminal for the engine and retried forever by the
  mirror. Both now read one terminal-fault set; the mirror gets a bounded
  per-claim attempt budget so a second holder still gets its turn.
- The mirror met a full volume only by failing a write, and its `mkdir -p`
  recreated a mount root the user had deleted. Both preflights now shared.
- An offline pass bailed on its first entry, so a fully mirrored folder read
  "syncing" for a whole outage; it now adopts what is already on disk.
- The deletion guard read a self-mirror as offline and refused the owner's
  deletions.

**Testing** — unit + integration + two-peer flow, all red-first. `test:fe s138`
run locally, verified green patched and red unpatched. Behaviour is worker-side;
no renderer changes.