### PR TITLE
[fix] Keep simultaneously-prepared files as separate rows

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -318,7 +318,7 @@ Created via `store.namespace('space-drive-<spaceId>-<driveSuffix>')` → `new Hy
 
 `verifying` also exists in the renderer's `FileStatus` union, surfaced from the `event:decoration` `phase` (§8) rather than derived by the resolver.
 
-Duplicates collapse per **content hash** (`dedupeByHash`): the most-progressed candidate wins by `STATUS_PRIORITY` (`mine` > `downloaded` > `downloading`/`publishing` > `paused-*` > `remote` > `unavailable` > `error`) and the rest fold into a `sharedByCount`.
+Duplicates collapse per **content hash** (`file-dedupe.js#dedupeFileRows`): the most-progressed candidate wins by `STATUS_RANK` (`mine` > `downloaded` > `verifying` > `downloading`/`publishing` > `paused-*` > `remote` > `preparing` > `unavailable` > `error`) and the rest fold into a `sharedByCount`. A candidate whose owner has not finished hashing carries no content hash and keys on **owner + path** instead, so files prepared at the same moment stay separate rows and a shared name alone never merges two owners' copies. Every `FILE_STATUS` member has a rank, asserted by `test/unit/file-dedupe.test.js`.
 
 #### Sharing a file (in-place publish)
 
@@ -1285,6 +1285,7 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/shared/transfer/download-claim.js` | `claimVerdict(...)` — the downloaded / prune ladder for one download-history claim, pure (§3.3) |
 | `src/shared/transfer/progress-ticker.js` | `makeProgressTicker(total, emit)` — 250 ms-throttled `{bytes,total,speed,eta}` over `EtaEstimator`; shared by single-file transfers and folder mirroring |
 | `src/shared/transfer/swarm-registries.js` | The swarm's shared indexes — `connectedPeers`, `socketToPeers`, `spaceTopics`, the pending-requester and handler maps — plus `announceLedger` and `resetRegistries` (§4.4) |
+| `src/shared/transfer/file-dedupe.js` | The pure fold from per-owner loose-file candidates to listing rows: one row per distinct file, the most-progressed copy winning, the rest counted as `sharedByCount` (§3.5) |
 | `src/shared/transfer/transfer-status.js` | The pure consumer-row status ladder (`consumerRowStatusFor` & co.) for a share-file row (§7.3) |
 | `src/shared/transfer/content-backends.js` | The seam: `getContentBackend(share)` → the overlay backend, else `UNSUPPORTED`; the presence-sweep fan-out. Locked by `content-backend-conformance.test.js` (§7.7) |
 | `src/shared/transfer/net-impair.js` | Test-only link shaper (runtime-config `netImpair`) applied to a socket in place; production never sets it |

--- a/src/shared/transfer/file-dedupe.js
+++ b/src/shared/transfer/file-dedupe.js
@@ -1,0 +1,51 @@
+// Folds a space's per-owner loose-file candidates into the listing's rows: one row per distinct
+// file, the most-progressed copy winning and the rest counted as `sharedByCount`. Pure (no drive,
+// no bee) so `test/unit` can drive it under plain Node.
+
+// Most-progressed first, so the group's winner is the copy the user can act on. `downloading` and
+// `publishing` tie — a peer fetch and our own indexing are equally in flight — and a tie keeps
+// candidate order, which is member order. Every FILE_STATUS member carries a rank: a status
+// missing from this table makes the comparator return NaN, and an inconsistent comparator leaves
+// the group's winner unspecified.
+// test seam
+export const STATUS_RANK = Object.freeze({
+  mine: 0,
+  downloaded: 1,
+  verifying: 2,
+  downloading: 3,
+  publishing: 3,
+  'paused-interrupted': 4,
+  'paused-offline': 5,
+  remote: 6,
+  preparing: 7,
+  unavailable: 8,
+  error: 9,
+})
+
+// Content hash identifies a file across owners, but a row whose owner is still hashing carries no
+// hash yet. An empty hash is an absence, not an identity: those rows key on owner AND path, so
+// each file being prepared stays its own row and two owners preparing the same name are not
+// merged on the strength of the name. Once a hash lands the row folds across owners as usual.
+function groupKey (candidate) {
+  if (candidate.hash) return 'hash:' + candidate.hash
+  return 'unhashed:' + (candidate.owner?.publicKey || '') + ':' + candidate.path
+}
+
+export function dedupeFileRows (candidates) {
+  const groups = new Map()
+  for (const candidate of candidates) {
+    const key = groupKey(candidate)
+    const group = groups.get(key)
+    if (group) group.push(candidate)
+    else groups.set(key, [candidate])
+  }
+
+  const files = []
+  for (const group of groups.values()) {
+    group.sort((a, b) => STATUS_RANK[a.status] - STATUS_RANK[b.status])
+    const [winner] = group
+    const others = group.length - 1
+    files.push(others > 0 ? { ...winner, sharedByCount: others } : winner)
+  }
+  return files
+}

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -1,7 +1,7 @@
 // File-level operations for a space: the local `downloads-meta` bee (downloaded-copy
 // claims, hash-verified records, owned-source paths), the add/remove entry points for
-// loose files, the aggregated file listing (one row per content hash; the most-progressed
-// copy wins), and reveal-in-file-manager. "On your device" is always re-verified against
+// loose files, the aggregated file listing (rows folded by file-dedupe), and
+// reveal-in-file-manager. "On your device" is always re-verified against
 // the disk before it is reported — the bee rows are claims, the file is the truth.
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
@@ -27,6 +27,7 @@ import { revealExitIsFailure } from './reveal-exit.js'
 import { looseShareFile, looseUnshareFile, looseHasOwn, looseListOwn, looseListPeer, looseTransferActive } from './loose-overlay.js'
 import { LOOSE_SHARE_ID, looseTransferIdFor } from './transfer-id.js'
 import { unhashedStatusFor } from './transfer-status.js'
+import { dedupeFileRows } from './file-dedupe.js'
 import { claimVerdict } from './download-claim.js'
 
 const log = createLogger('files')
@@ -286,18 +287,6 @@ export async function addFile(spaceId, filePath, fileName) {
   await looseShareFile(spaceId, filePath, fileName || path.basename(filePath))
 }
 
-const STATUS_PRIORITY = {
-  mine: 0,
-  downloaded: 1,
-  downloading: 2,
-  publishing: 2,
-  'paused-interrupted': 3,
-  'paused-offline': 4,
-  remote: 5,
-  unavailable: 6,
-  error: 7,
-}
-
 // The display status of a peer-held file, most-progressed first. Exported for unit coverage.
 export function peerFileStatus(downloaded, pendingRow, ownerOnline, isActive) {
   if (downloaded) return 'downloaded'
@@ -307,28 +296,8 @@ export function peerFileStatus(downloaded, pendingRow, ownerOnline, isActive) {
   return ownerOnline ? 'remote' : 'unavailable'
 }
 
-// One row per distinct file (by content hash). When the same content is held by several peers,
-// the most-progressed copy wins (STATUS_PRIORITY) and the rest become a sharedByCount.
-function dedupeByHash(candidates) {
-  const byHash = new Map()
-  for (const candidate of candidates) {
-    const list = byHash.get(candidate.hash)
-    if (list) list.push(candidate)
-    else byHash.set(candidate.hash, [candidate])
-  }
-
-  const files = []
-  for (const [, group] of byHash) {
-    group.sort((a, b) => STATUS_PRIORITY[a.status] - STATUS_PRIORITY[b.status])
-    const winner = group[0]
-    const others = group.length - 1
-    files.push(others > 0 ? { ...winner, sharedByCount: others } : winner)
-  }
-  return files
-}
-
 // In-place loose files (own + each peer's) read from the loose catalog, shaped
-// like drive-backed candidates so dedupeByHash merges them with the rest.
+// like drive-backed candidates so dedupeFileRows merges them with the rest.
 async function collectLooseInPlace(spaceId, members, localPublicKey, localDriveKeyHex) {
   if (!isInPlaceFilesEnabled()) return []
   const out = []
@@ -374,7 +343,7 @@ async function collectLooseInPlace(spaceId, members, localPublicKey, localDriveK
     }
   }))
   // Row mapping stays sequential in member order: claim verification has side effects
-  // (stale-claim pruning) and dedupeByHash breaks ties by candidate order.
+  // (stale-claim pruning) and dedupeFileRows breaks ties by candidate order.
   for (const [i, member] of peerMembers.entries()) {
     const ownerOnline = isOwnerOnline(member.publicKey)
     for (const e of peerEntries[i]) {
@@ -418,7 +387,7 @@ export async function listFiles(spaceId, members) {
   const localDriveKeyHex = b4a.toString(localDrive.key, 'hex')
   const localPublicKey = getLocalPublicKeyHex()
 
-  const files = dedupeByHash(await collectLooseInPlace(spaceId, members, localPublicKey, localDriveKeyHex))
+  const files = dedupeFileRows(await collectLooseInPlace(spaceId, members, localPublicKey, localDriveKeyHex))
   log.debug('listed', files.length, 'files in space', spaceId, '(' + members?.length, 'members)')
   return files
 }

--- a/test/integration/list-files.test.js
+++ b/test/integration/list-files.test.js
@@ -10,7 +10,7 @@ import { publishShare, generateShareId } from '../../src/shared/shares/shares.js
 import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
 import { getStore, createBee } from '../../src/shared/core/store.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
-import { initOverlay, teardownOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
+import { initOverlay, teardownOverlay, getOverlay } from '../../src/shared/transfer/backends/overlay/overlay-instance.js'
 import { initContentBackendOverlay } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
 import { LOOSE_SHARE_ID } from '../../src/shared/transfer/transfer-id.js'
 import { takeIncompleteListSpaces } from '../../src/shared/transfer/list-deficits.js'
@@ -61,6 +61,47 @@ test('files inside an owned-folder share are excluded from the loose list', asyn
   const paths = (await listFiles(ctx.spaceId, [])).map((f) => f.path)
   t.ok(paths.includes('/loose.txt'), 'the loose file is listed')
   t.absent(paths.includes('/MyFolder/inside.txt'), 'a file inside an owned share is NOT a loose file')
+})
+
+// REGRESSION (FIX-1: an entry that has not finished hashing carries an empty contentHash, and the
+// listing grouped rows on that hash alone — so every file being prepared at once collapsed into a
+// single row claiming the others as co-sharers).
+test('two files added at once are listed as two rows while both are still preparing', async (t) => {
+  const ctx = await setup(t)
+  const overlay = getOverlay()
+  const orig = overlay.prepareForServe.bind(overlay)
+  let release
+  const held = new Promise((resolve) => { release = resolve })
+  overlay.prepareForServe = async (diskPath, opts) => { await held; return await orig(diskPath, opts) }
+  t.teardown(() => { overlay.prepareForServe = orig })
+
+  const dir = ctx.tmpDir('src')
+  fs.writeFileSync(path.join(dir, 'a.txt'), 'alpha')
+  fs.writeFileSync(path.join(dir, 'b.txt'), 'bravo')
+  const adds = [
+    addFile(ctx.spaceId, path.join(dir, 'a.txt'), 'a.txt', 5, null),
+    addFile(ctx.spaceId, path.join(dir, 'b.txt'), 'b.txt', 5, null),
+  ]
+
+  try {
+    let files = []
+    const deadline = Date.now() + 10000
+    while (Date.now() < deadline && files.length < 2) {
+      files = await listFiles(ctx.spaceId, [])
+      if (files.length < 2) await new Promise((r) => setTimeout(r, 20))
+    }
+
+    t.alike(files.map((f) => f.path).sort(), ['/a.txt', '/b.txt'], 'both in-progress files are listed')
+    for (const f of files) {
+      t.is(f.status, 'publishing', f.path + ' is still preparing')
+      t.absent(f.sharedByCount, f.path + ' claims no co-sharer')
+    }
+  } finally {
+    // Unblock the held hashes whatever happened: leaving them parked wedges teardown behind the
+    // publish scheduler's settle window and hides the real failure.
+    release()
+    await Promise.all(adds)
+  }
 })
 
 test('distinct loose files are each listed', async (t) => {

--- a/test/unit/file-dedupe.test.js
+++ b/test/unit/file-dedupe.test.js
@@ -1,0 +1,68 @@
+import test from 'brittle'
+import { dedupeFileRows, STATUS_RANK } from '../../src/shared/transfer/file-dedupe.js'
+import { FILE_STATUS } from '../../src/shared/contract/statuses.js'
+
+const candidate = (over = {}) => ({
+  path: '/a.txt', size: 1, hash: 'h-a', inPlace: true, status: 'remote',
+  owner: { displayName: 'Peer', publicKey: 'pk' }, ...over,
+})
+
+test('every file status has a rank and every rank names a file status', (t) => {
+  const ranked = Object.keys(STATUS_RANK).sort()
+  t.alike(ranked, [...FILE_STATUS].sort(), 'the rank table and FILE_STATUS name the same statuses')
+  for (const status of FILE_STATUS) t.is(typeof STATUS_RANK[status], 'number', status + ' has a numeric rank')
+})
+
+test('the same content held by several peers folds into one row with a sharedByCount', (t) => {
+  const rows = dedupeFileRows([
+    candidate({ status: 'remote', owner: { displayName: 'A', publicKey: 'a' } }),
+    candidate({ status: 'downloaded', owner: { displayName: 'B', publicKey: 'b' } }),
+  ])
+  t.is(rows.length, 1, 'one row per content hash')
+  t.is(rows[0].status, 'downloaded', 'the most-progressed copy wins')
+  t.is(rows[0].sharedByCount, 1, 'the rest become a sharedByCount')
+})
+
+// REGRESSION (FIX-1: unhashed rows all carry hash '', so grouping on the hash alone collapsed
+// every simultaneously-prepared file into one row with a bogus sharedByCount).
+test('files still being prepared stay one row each', (t) => {
+  const rows = dedupeFileRows([
+    candidate({ path: '/a.txt', hash: '', status: 'publishing' }),
+    candidate({ path: '/b.txt', hash: '', status: 'publishing' }),
+    candidate({ path: '/c.txt', hash: '', status: 'preparing' }),
+  ])
+  t.alike(rows.map((r) => r.path).sort(), ['/a.txt', '/b.txt', '/c.txt'], 'three prepared files, three rows')
+  for (const row of rows) t.absent(row.sharedByCount, 'no phantom co-sharer')
+})
+
+// Two owners preparing the same NAME are not the same file until their hashes say so.
+test('two peers preparing the same path stay separate rows', (t) => {
+  const rows = dedupeFileRows([
+    candidate({ path: '/a.txt', hash: '', status: 'preparing', owner: { displayName: 'A', publicKey: 'a' } }),
+    candidate({ path: '/a.txt', hash: '', status: 'preparing', owner: { displayName: 'B', publicKey: 'b' } }),
+  ])
+  t.is(rows.length, 2, 'a name is not an identity')
+  t.alike(rows.map((r) => r.owner.publicKey).sort(), ['a', 'b'], 'both owners keep a row')
+
+  const folded = dedupeFileRows(rows.map((r) => ({ ...r, hash: 'h-a' })))
+  t.is(folded.length, 1, 'once both hashes land the rows fold across owners')
+  t.is(folded[0].sharedByCount, 1)
+})
+
+// REGRESSION (FIX-1: 'preparing' was absent from the rank table, so the comparator returned NaN
+// and the group's winner fell back to insertion order).
+test('a preparing copy loses to a downloadable one whichever way round they arrive', (t) => {
+  const preparing = candidate({ status: 'preparing', owner: { displayName: 'A', publicKey: 'a' } })
+  const remote = candidate({ status: 'remote', owner: { displayName: 'B', publicKey: 'b' } })
+
+  t.is(dedupeFileRows([preparing, remote])[0].status, 'remote', 'preparing first')
+  t.is(dedupeFileRows([remote, preparing])[0].status, 'remote', 'remote first')
+})
+
+test('a verifying copy outranks one still downloading', (t) => {
+  const verifying = candidate({ status: 'verifying', owner: { displayName: 'A', publicKey: 'a' } })
+  const downloading = candidate({ status: 'downloading', owner: { displayName: 'B', publicKey: 'b' } })
+
+  t.is(dedupeFileRows([downloading, verifying])[0].status, 'verifying')
+  t.is(dedupeFileRows([verifying, downloading])[0].status, 'verifying')
+})


### PR DESCRIPTION
Closes #217.

The loose listing grouped candidates by content hash. A row whose owner has not finished hashing carries `hash: ''`, so every file being prepared at once collapsed into a single row with a bogus `sharedByCount`. `STATUS_PRIORITY` also lacked `preparing` and `verifying`, making the winner comparator return `NaN` for exactly those rows.

- Unhashed rows key on owner + path; hashed rows still fold across owners by hash.
- The rank table covers every `FILE_STATUS` member (asserted both directions).
- The fold moved to a pure `transfer/file-dedupe.js` so `test/unit` drives it under plain Node.

**Deviation from the issue:** it asked to derive the priority from `FILE_STATUS` order. That order is a vocabulary, not a progress ladder — deriving from it would rank `remote` above `downloading`. The ladder stays explicit and the completeness assertion is the gate instead.

Tests (red-first, both proven failing against the old logic): `test/unit/file-dedupe.test.js`, plus a two-concurrent-`addFile` case in `test/integration/list-files.test.js`. Full `test:unit` (2144) and `test:bare` (1096) green; typecheck and `lint:ci` clean. No UI change, so no a11y surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011qvssgjoCWzwYFtUYgeiGb