### PR TITLE
[fix] Bound bee prefix scans so names above U+00FF are not dropped

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1149,6 +1149,7 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/shared/core/crash-backstop.js` | Installs the pre-first-`await` rejection handler; 10 uncaught errors in 60 s exits the worker for respawn, latched to fire once |
 | `src/shared/core/timers.js` | `createTimers()` — an owned timer set that clears on close and refuses to schedule after it |
 | `src/shared/core/bee-writer.js` | One serialized read-modify-write path over a bee, with `cas` |
+| `src/shared/core/bee-keys.js` | `prefixRange()` — the one upper bound every data-layer bee prefix scan uses; bumps the prefix's final ASCII byte so a suffix above U+00FF is not dropped |
 | `src/shared/core/paths.js` | Download-root resolution: the global root plus the per-space override map (§3.3) |
 | `src/shared/core/handler-table.js` | `createHandlerTable()` + `validateArgs()` — each request's function beside its declared shape (§2) |
 | `src/shared/core/lru.js` | `createRefCountedLru()` — bounded cache of live handles; an entry with readers is never evicted |

--- a/src/shared/audit/audit-log.js
+++ b/src/shared/audit/audit-log.js
@@ -24,6 +24,7 @@ import { createLocalBee, getStore } from '../core/store.js'
 import { createLogger } from '../core/logger.js'
 import { buildRecord } from './audit-record.js'
 import { STATE_OFF } from './peer-observer.js'
+import { prefixRange } from '../core/bee-keys.js'
 import {
   AGE_HYSTERESIS,
   DEFAULT_MAX_ENTRIES,
@@ -44,7 +45,6 @@ const CONFIG_KEY = 'config'
 const SEEN = 'seen/'
 const PSTATE = 'pstate/'
 const NSTATE = 'nstate'
-const HIGH = '￿'
 
 // Rows walked per query call before returning a partial page. A filtered listing may have to
 // walk far past `limit` to fill it; this bounds the work so one query cannot stall the worker.
@@ -104,14 +104,14 @@ export async function closeAuditLog() {
 
 
 async function newestSeq() {
-  for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH }, { reverse: true, limit: 1 })) {
+  for await (const entry of bee.createReadStream(prefixRange(EVT), { reverse: true, limit: 1 })) {
     return Number(entry.key.slice(EVT.length))
   }
   return -1
 }
 
 async function oldestSeq() {
-  for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH }, { limit: 1 })) {
+  for await (const entry of bee.createReadStream(prefixRange(EVT), { limit: 1 })) {
     return Number(entry.key.slice(EVT.length))
   }
   return -1
@@ -203,7 +203,7 @@ function matches(rec, { kindSet, catSet, actorKey, needle, since, until }) {
 }
 
 async function* fromIndex(prefix, upper) {
-  const range = { gte: prefix, lt: upper == null ? prefix + HIGH : prefix + upper }
+  const range = { gte: prefix, lt: upper == null ? prefixRange(prefix).lt : prefix + upper }
   for await (const entry of bee.createReadStream(range, { reverse: true })) {
     const node = await bee.get(EVT + pad(entry.value))
     if (node?.value) yield node.value
@@ -243,7 +243,7 @@ async function* walk(spaceId, cursor) {
     yield* mergeDesc(fromIndex(BY_SPACE + spaceId + '/', upper), fromIndex(BY_DEVICE, upper))
     return
   }
-  const range = { gte: EVT, lt: upper == null ? EVT + HIGH : EVT + upper }
+  const range = { gte: EVT, lt: upper == null ? prefixRange(EVT).lt : EVT + upper }
   for await (const entry of bee.createReadStream(range, { reverse: true })) {
     if (entry.value) yield entry.value
   }
@@ -315,7 +315,7 @@ export async function auditSpaces() {
   if (!bee) return []
   const seen = new Map()
   let walked = 0
-  for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH }, { reverse: true })) {
+  for await (const entry of bee.createReadStream(prefixRange(EVT), { reverse: true })) {
     if (walked++ >= SCAN_BUDGET) break
     const space = entry.value?.space
     if (space?.id && !seen.has(space.id)) seen.set(space.id, space.name || null)
@@ -327,7 +327,7 @@ export async function auditActors() {
   if (!bee) return []
   const seen = new Map()
   let walked = 0
-  for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH }, { reverse: true })) {
+  for await (const entry of bee.createReadStream(prefixRange(EVT), { reverse: true })) {
     if (walked++ >= SCAN_BUDGET) break
     const actor = entry.value?.actor
     if (actor?.key && !seen.has(actor.key)) seen.set(actor.key, actor.name || null)
@@ -433,7 +433,7 @@ export async function pruneAudit({ now = Date.now() } = {}) {
     // scan, using the same hysteresis as the query so a clock jump cannot over-prune.
     let aboveAge = 0
     let firstYoungSeq = null
-    for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH })) {
+    for await (const entry of bee.createReadStream(prefixRange(EVT))) {
       const rec = entry.value
       if (!rec) continue
       if (rec.ts < cutoff) {
@@ -484,9 +484,9 @@ export async function purgeAudit() {
   await flushAudit()
 
   let purged = 0
-  for await (const _entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH })) purged += 1
+  for await (const _entry of bee.createReadStream(prefixRange(EVT))) purged += 1
   const seen = []
-  for await (const entry of bee.createReadStream({ gte: SEEN, lt: SEEN + HIGH })) {
+  for await (const entry of bee.createReadStream(prefixRange(SEEN))) {
     seen.push([entry.key, entry.value])
   }
   const keptConfig = { ...config }
@@ -530,7 +530,7 @@ export async function exportAudit({ spaceId = null, since = null, until = null }
   if (!bee) return []
   await flushAudit()
   const out = []
-  for await (const entry of bee.createReadStream({ gte: EVT, lt: EVT + HIGH })) {
+  for await (const entry of bee.createReadStream(prefixRange(EVT))) {
     const rec = entry.value
     if (!rec) continue
     if (spaceId && rec.space?.id !== spaceId) continue

--- a/src/shared/core/bee-keys.js
+++ b/src/shared/core/bee-keys.js
@@ -1,0 +1,18 @@
+// The range bound for a Hyperbee prefix scan.
+//
+// A bee keyed `utf-8` compares keys as UTF-8 bytes, and UTF-8 preserves code-point order. So the
+// exclusive upper bound for "every key under `prefix`" is the prefix with its final character
+// incremented: whatever the suffix holds, `prefix + suffix` differs from that bound at the final
+// character and sorts below it. Appending a high sentinel to the prefix instead only bounds
+// suffixes whose first character sorts below the sentinel and silently drops the rest — under
+// '\xff' (U+00FF) a share holding `Łódź.pdf` or `日本語.txt` at its top level lists short.
+//
+// The final character must be ASCII, so incrementing it stays one well-formed code point. Every key
+// namespace in the data layer ends its prefix with a separator ('/', ':', '|'), which satisfies that.
+export function prefixRange(prefix) {
+  const last = typeof prefix === 'string' ? prefix.charCodeAt(prefix.length - 1) : NaN
+  if (!(last >= 0x20 && last < 0x7f)) {
+    throw new Error('prefixRange needs a prefix ending in an ASCII separator, got ' + JSON.stringify(prefix))
+  }
+  return { gte: prefix, lt: prefix.slice(0, -1) + String.fromCharCode(last + 1) }
+}

--- a/src/shared/core/intents.js
+++ b/src/shared/core/intents.js
@@ -4,6 +4,8 @@
 //
 // No domain knowledge and no bare-* imports: the bee arrives as a dependency, so this unit-tests
 // under Node and the reconcilers live with the flows they complete.
+import { prefixRange } from './bee-keys.js'
+
 export const INTENT_PREFIX = 'intent/'
 
 let seq = 0
@@ -56,7 +58,7 @@ export function createIntentLog({ bee, log } = {}) {
 
     async list() {
       const out = []
-      for await (const node of bee().createReadStream({ gte: INTENT_PREFIX, lt: INTENT_PREFIX + '\xff' })) {
+      for await (const node of bee().createReadStream(prefixRange(INTENT_PREFIX))) {
         out.push({ id: node.key, ...node.value })
       }
       return out

--- a/src/shared/folders/mirror-records.js
+++ b/src/shared/folders/mirror-records.js
@@ -7,6 +7,7 @@
 import { getProfileBee, withPeerBee } from '../spaces/profile.js'
 import { withReadTimeout, peerReadTimeoutMs } from '../core/with-timeout.js'
 import { createLogger } from '../core/logger.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('mirror-records')
 
@@ -85,7 +86,7 @@ export async function readOwnMirrors(spaceId) {
   const bee = getProfileBee()
   const prefix = MIRROR_PREFIX + spaceId + '/'
   const out = []
-  for await (const entry of bee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+  for await (const entry of bee.createReadStream(prefixRange(prefix))) {
     if (!entry.value.unmirroredAt) out.push(entry.value)
   }
   return out
@@ -127,7 +128,7 @@ function collectPeerMirrors(profileKeyHex, spaceId, timeoutMs) {
   return withPeerMirrorBee(profileKeyHex, async (bee) => {
     const prefix = MIRROR_PREFIX + spaceId + '/'
     const out = []
-    for await (const entry of bee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+    for await (const entry of bee.createReadStream(prefixRange(prefix))) {
       if (!entry.value.unmirroredAt) out.push(entry.value)
     }
     return out

--- a/src/shared/folders/mount-store.js
+++ b/src/shared/folders/mount-store.js
@@ -5,6 +5,7 @@ import { createLocalBee, storeEpoch } from '../core/store.js'
 import { createRecordWriter } from '../core/bee-writer.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('mount-store')
 
@@ -84,7 +85,7 @@ export function touchOwnedMountScan(spaceId, shareId) {
 
 export async function listOwnedMounts() {
   const out = []
-  for await (const entry of bee.createReadStream({ gte: OWNED_PREFIX, lt: OWNED_PREFIX + '\xff' })) {
+  for await (const entry of bee.createReadStream(prefixRange(OWNED_PREFIX))) {
     out.push(entry.value)
   }
   return out
@@ -118,7 +119,7 @@ export async function deleteForeignMount(spaceId, shareId) {
 
 export async function listForeignMounts() {
   const out = []
-  for await (const entry of bee.createReadStream({ gte: FOREIGN_PREFIX, lt: FOREIGN_PREFIX + '\xff' })) {
+  for await (const entry of bee.createReadStream(prefixRange(FOREIGN_PREFIX))) {
     out.push(entry.value)
   }
   return out

--- a/src/shared/shares/share-catalog.js
+++ b/src/shared/shares/share-catalog.js
@@ -16,6 +16,7 @@ import { relKeyEscapes } from '../folders/path-keys.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { createRefCountedLru } from '../core/lru.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('share-catalog')
 
@@ -313,7 +314,7 @@ export async function collectPeerShare(catalogKeyHex, shareId, { sck = null, lim
     // core.get, so a missing block throws instead of parking for a peer — rows we replicated
     // before still surface (an offline owner keeps its `unavailable` rows), and the drain can
     // never park for a second budget.
-    const stream = bee.createReadStream({ gte: prefix, lt: prefix + '\xff', wait: left > 0 })
+    const stream = bee.createReadStream({ ...prefixRange(prefix), wait: left > 0 })
     const { entries, complete, total, totalBytes } = await drainWithTimeout(stream, prefix, Math.max(left, LOCAL_DRAIN_MS), limit, onEach)
     // `complete` also requires blocks (length>0) so the renderer keeps its last list over an
     // empty read; `stalled` is the narrower "the read could not finish" signal (head-sync
@@ -458,7 +459,7 @@ export async function purgeLegacyPlaintextCatalog(space, spaceId) {
 
 async function* streamShare(bee, shareId) {
   const prefix = sharePrefixKey(shareId)
-  for await (const node of bee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+  for await (const node of bee.createReadStream(prefixRange(prefix))) {
     if (node.value?.deletedAt) continue
     yield {
       relPath: node.key.slice(prefix.length),

--- a/src/shared/shares/shares.js
+++ b/src/shared/shares/shares.js
@@ -6,6 +6,7 @@
 import { getProfileBee, withPeerBee } from '../spaces/profile.js'
 import { withReadTimeout, peerReadTimeoutMs } from '../core/with-timeout.js'
 import { createLogger } from '../core/logger.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('shares')
 
@@ -35,7 +36,7 @@ export async function readOwnShares(spaceId) {
   const bee = getProfileBee()
   const prefix = SHARE_PREFIX + spaceId + '/'
   const shares = []
-  for await (const entry of bee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+  for await (const entry of bee.createReadStream(prefixRange(prefix))) {
     if (!entry.value.deletedAt) shares.push(entry.value)
   }
   return shares
@@ -63,7 +64,7 @@ function collectPeerShares(profileKeyHex, spaceId, timeoutMs) {
     if (!cap?.value) return null
     const prefix = SHARE_PREFIX + spaceId + '/'
     const shares = []
-    for await (const entry of bee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+    for await (const entry of bee.createReadStream(prefixRange(prefix))) {
       if (!entry.value.deletedAt) shares.push(entry.value)
     }
     return shares

--- a/src/shared/spaces/member-view.js
+++ b/src/shared/spaces/member-view.js
@@ -6,6 +6,7 @@ import { createDerivedView } from '../state/derived-view.js'
 import { getResourceCaps } from '../core/runtime-config.js'
 import { peerReadTimeoutMs } from '../core/with-timeout.js'
 import { SHARE_PREFIX } from '../shares/shares.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 // Transitive discovery + fold. Walks the approval graph FORWARD from the creator (the
 // root of the OR-Set fold — see member-set.js) and self, reading each reachable peer's
@@ -124,23 +125,23 @@ export function createMemberView ({ spaceId, creatorKey, selfKey, onMembers, onE
   // added/removed a share, letting the share list re-derive instead of waiting for an unrelated
   // event. Watch ONLY that peer's share/<space>/ sub-range, not the whole core: an avatar/
   // displayName/membership append shares the same bee but must not trigger a share re-fetch.
-  const shareRange = { gte: SHARE_PREFIX + spaceId + '/', lt: SHARE_PREFIX + spaceId + '/\xff' }
+  const shareRange = prefixRange(SHARE_PREFIX + spaceId + '/')
   const shareWatchers = new Map()
 
   // The fold's read set as watch ranges — one per read deriveMemberSet issues. Watching the WHOLE
   // bee instead would wake a full serial roster re-fold (one network-bounded read per member) on
   // every profile write a peer makes. This range set IS the membership convergence guarantee: a key
   // family the fold reads but this set omits yields a view that is correct at fold time and then
-  // silently never re-folds. The bounds mirror profile.js's read streams byte-for-byte, including
-  // the '0' upper bound (the byte after '/'). member/<spaceId> is an exact key, not a prefix:
+  // silently never re-folds. The prefix bounds come from the same prefixRange() profile.js's read
+  // streams use, so the two can never drift. member/<spaceId> is an exact key, not a prefix:
   // member/<other> is another space's membership. caps/membership-manifest is exact and almost
   // never fires, but a peer publishing its manifest after we first folded it must re-fold us.
   const foldRanges = [
     { gte: CAP_MEMBERSHIP_MANIFEST, lte: CAP_MEMBERSHIP_MANIFEST },
     { gte: 'member/' + spaceId, lte: 'member/' + spaceId },
-    { gte: 'approved/' + spaceId + '/', lt: 'approved/' + spaceId + '0' },
-    { gte: 'request/' + spaceId + '/', lt: 'request/' + spaceId + '0' },
-    { gte: 'denied/' + spaceId + '/', lt: 'denied/' + spaceId + '0' },
+    prefixRange('approved/' + spaceId + '/'),
+    prefixRange('request/' + spaceId + '/'),
+    prefixRange('denied/' + spaceId + '/'),
   ]
   let closed = false
   const follow = (key, bee) => {

--- a/src/shared/spaces/profile.js
+++ b/src/shared/spaces/profile.js
@@ -13,6 +13,7 @@ import { voucheesToAdopt } from './member-set.js'
 import b4a from 'b4a'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('membership')
 
@@ -271,7 +272,7 @@ export async function listOwnInvites(spaceId) {
   const prefix = 'invite/' + spaceId + '/'
   const limit = getResourceCaps().invitesPerMember
   const out = []
-  for await (const entry of profileBee.createReadStream({ gte: prefix, lt: prefix.slice(0, -1) + '0' }, limit ? { limit } : undefined)) {
+  for await (const entry of profileBee.createReadStream(prefixRange(prefix), limit ? { limit } : undefined)) {
     out.push({ inviteId: entry.key.slice(prefix.length), ...entry.value })
   }
   return out
@@ -335,8 +336,7 @@ export async function readPeerDenials(profileKeyHex, spaceId) {
   catch { return [] }
 }
 
-// Stream one prefix of a peer's replicated bee (the `lt` bound mirrors the approvals stream:
-// '0' (0x30) is the byte after '/' (0x2f)). Cap-gated + bounded like the other peer reads.
+// Stream one prefix of a peer's replicated bee. Cap-gated + bounded like the other peer reads.
 function loadPeerEntries(profileKeyHex, prefix) {
   return withPeerBee(profileKeyHex, async (bee) => {
 
@@ -344,7 +344,7 @@ function loadPeerEntries(profileKeyHex, prefix) {
     if (!cap?.value) return []
     const limit = getResourceCaps().requestsPerMember
     const out = []
-    for await (const entry of bee.createReadStream({ gte: prefix, lt: prefix.slice(0, -1) + '0' }, limit ? { limit } : undefined)) {
+    for await (const entry of bee.createReadStream(prefixRange(prefix), limit ? { limit } : undefined)) {
       const joiner = entry.key.slice(prefix.length)
       const v = entry.value || {}
       out.push({
@@ -388,7 +388,7 @@ function loadMembershipRecord(profileKeyHex, spaceId) {
     const limit = getResourceCaps().approvalsPerMember
     const approvals = []
     const approvalSeqs = new Map()
-    for await (const entry of bee.createReadStream({ gte: prefix, lt: 'approved/' + spaceId + '0' }, limit ? { limit } : undefined)) {
+    for await (const entry of bee.createReadStream(prefixRange(prefix), limit ? { limit } : undefined)) {
       const joiner = entry.key.slice(prefix.length)
       approvals.push(joiner)
       if (typeof entry.seq === 'number') approvalSeqs.set(joiner, entry.seq)

--- a/src/shared/spaces/space.js
+++ b/src/shared/spaces/space.js
@@ -17,6 +17,7 @@ import { runLeaveTeardown } from './leave-flow.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record } from '../audit/audit-log.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('space')
 const { store: keysStore, core: keysCore } = keysMod
@@ -235,7 +236,7 @@ export async function joinSpace(topicHex, name = 'Unnamed Space', icon = 'folder
 
 export async function listSpaces() {
   const spaces = []
-  for await (const entry of spacesBee.createReadStream({ gte: 'space/', lt: 'space0' })) {
+  for await (const entry of spacesBee.createReadStream(prefixRange('space/'))) {
     const spaceId = entry.key.replace('space/', '')
     spaces.push({ spaceId, ...entry.value })
   }
@@ -410,7 +411,7 @@ export async function resumeInterruptedLeave(spaceId) {
 // Stamped with the leaver's clock so a genuine rejoin (a strictly-later member/<S> ts) self-clears
 // it via tombstoneActive.
 const LEFT_TOMBSTONE_PREFIX = 'left/'
-const leftRange = (spaceId) => ({ gte: LEFT_TOMBSTONE_PREFIX + spaceId + '/', lt: LEFT_TOMBSTONE_PREFIX + spaceId + '0' })
+const leftRange = (spaceId) => prefixRange(LEFT_TOMBSTONE_PREFIX + spaceId + '/')
 // Coerced to a positive finite number: a negative reaching the tombstoneActive comparison would
 // flip it false and re-admit the leaver, so on-disk garbage collapses to an inert 0.
 const sanitizeLeaveTs = (v) => (Number.isFinite(v) && v > 0 ? v : 0)
@@ -461,7 +462,7 @@ export async function clearPendingLeave(spaceId) {
 
 export async function listPendingLeaves() {
   const out = []
-  for await (const entry of spacesBee.createReadStream({ gte: PENDING_LEAVE_PREFIX, lt: PENDING_LEAVE_PREFIX + '\xff' })) {
+  for await (const entry of spacesBee.createReadStream(prefixRange(PENDING_LEAVE_PREFIX))) {
     out.push({
       spaceId: entry.key.slice(PENDING_LEAVE_PREFIX.length),
       topic: entry.value?.topic || null,

--- a/src/shared/storage/leftover.js
+++ b/src/shared/storage/leftover.js
@@ -19,6 +19,7 @@ import { decideSweep } from './sweep-decision.js'
 import { recordSweep } from './sweep-journal.js'
 import { getResourceCaps } from '../core/runtime-config.js'
 import { listContentKeys } from '../spaces/space-keys.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('leftover')
 
@@ -84,7 +85,7 @@ function localPeerCatalogKeys(profileKeyHex, spaceId) {
   // sync:false keeps this a purely local read (no head pull); withPeerBee owns the close.
   return withPeerBee(profileKeyHex, async (bee) => {
     const prefix = SHARE_PREFIX + spaceId + '/'
-    for await (const entry of bee.createReadStream({ gte: prefix, lt: prefix + '\xff' }, { wait: false })) {
+    for await (const entry of bee.createReadStream(prefixRange(prefix), { wait: false })) {
       const ck = readCatalogKey(entry.value).keyHex
       if (ck && HEX64.test(ck)) keys.push(ck)
     }

--- a/src/shared/storage/sweep-journal.js
+++ b/src/shared/storage/sweep-journal.js
@@ -13,6 +13,7 @@
 // overlay-index-compacted (worker/sweeps.js's last-compaction stamp).
 import { createLocalBee } from '../core/store.js'
 import { createLogger } from '../core/logger.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('sweep-journal')
 const PREFIX = 'purge/'
@@ -29,7 +30,7 @@ export async function recordSweep (entry) {
     await bee.ready()
     await bee.put(journalKey(Date.now()), { at: Date.now(), ...entry })
     const keys = []
-    for await (const node of bee.createReadStream({ gte: PREFIX, lt: PREFIX + '\xff' })) keys.push(node.key)
+    for await (const node of bee.createReadStream(prefixRange(PREFIX))) keys.push(node.key)
     for (const key of keys.slice(0, Math.max(0, keys.length - KEEP))) await bee.del(key)
   } catch (err) {
     // Never throws. A journal failure must not be the thing that aborts a sweep — or, worse, that
@@ -45,7 +46,7 @@ export async function listRecentSweeps (limit = 20) {
   const out = []
   try {
     await bee.ready()
-    for await (const node of bee.createReadStream({ gte: PREFIX, lt: PREFIX + '\xff', reverse: true })) {
+    for await (const node of bee.createReadStream({ ...prefixRange(PREFIX), reverse: true })) {
       out.push(node.value)
       if (out.length >= limit) break
     }

--- a/src/shared/transfer/backends/overlay/vendor/PROVENANCE.md
+++ b/src/shared/transfer/backends/overlay/vendor/PROVENANCE.md
@@ -596,6 +596,20 @@ re-diffable against upstream. Categories:
     progress, since then slow and wedged are indistinguishable and the window has to cover a whole
     4 MiB tier-3 flush at 1 Mbit/s. Pinned by `test/flow/content-plane-hol.test.js`.
 
+24. **§4.22 — prefix-scan upper bound (`file-index.js`, correctness).** `listFiles`, `listSyncStates`
+    and `listTrees` bounded their range scans with `prefix + '\xff'`. The index bee is keyed
+    `utf-8`, where U+00FF encodes to `C3 BF`, so any key whose next character is U+0100 or above
+    (ł, Cyrillic, Greek, CJK, emoji) has a lead byte above the bound and never appears in the scan.
+    The three sites now call a local `prefixUpperBound()` that increments the prefix's final code
+    point — sound because UTF-8 preserves code-point order — leaving upstream's prefix-match
+    semantics (`gt: prefix`) unchanged.
+
+    This is load-bearing on the serve path: `protocol-v2._onContentRequest` falls back to
+    `listFiles()` to resolve a content hash to a disk path, and a miss there is a silent drop that
+    the requester can only observe as a timeout. A shared file whose top-level name starts with such
+    a character was unservable through that fallback. Covered by
+    `test/integration/overlay-vendor-prefix-bound.test.js`.
+
 ## Re-diffing against upstream
 
 ```

--- a/src/shared/transfer/backends/overlay/vendor/file-index.js
+++ b/src/shared/transfer/backends/overlay/vendor/file-index.js
@@ -37,6 +37,18 @@ const CHUNKS_PER_PAGE = 32768
 const CHUNK_ENTRY_BYTES = 160
 const CHUNK_MAP_BASE_BYTES = 64
 
+// [mirall] §4.22 Upper bound for a prefix scan. Upstream bounded these with `prefix + '\xff'`,
+// but the index is keyed `utf-8`, where U+00FF encodes to C3 BF: any path whose next character is
+// U+0100 or above (ł, Cyrillic, CJK, emoji) has a lead byte above that bound and is dropped from
+// the scan. UTF-8 preserves code-point order, so the prefix with its final code point incremented
+// bounds every suffix. Prefix-match semantics are upstream's and unchanged. Kept local rather
+// than imported from the app, so this file stays re-diffable; every call site passes a
+// non-empty constant prefix ending ':'. See PROVENANCE.md.
+function prefixUpperBound (prefix) {
+  const lastChar = Array.from(prefix).pop()
+  return prefix.slice(0, prefix.length - lastChar.length) + String.fromCodePoint(lastChar.codePointAt(0) + 1)
+}
+
 // The content hash an owner-side entry is addressed by (page suffix folded in), or
 // null for entries not keyed by a single content hash (real-path file:/chunkmap:,
 // tree:, sync:, config:). compact() drops the content-addressed entries whose hash is
@@ -218,7 +230,7 @@ export class FileIndex extends ReadyResource {
     const prefix = dir ? `file:${dir}` : 'file:'
     const files = []
 
-    for await (const entry of this._bee.createReadStream({ gt: prefix, lt: prefix + '\xff' })) {
+    for await (const entry of this._bee.createReadStream({ gt: prefix, lt: prefixUpperBound(prefix) })) {
       files.push({
         path: entry.key.slice('file:'.length),
         ...entry.value
@@ -454,7 +466,7 @@ export class FileIndex extends ReadyResource {
     const prefix = `sync:${peerKey}:`
     const states = []
 
-    for await (const entry of this._bee.createReadStream({ gt: prefix, lt: prefix + '\xff' })) {
+    for await (const entry of this._bee.createReadStream({ gt: prefix, lt: prefixUpperBound(prefix) })) {
       states.push({
         path: entry.key.slice(prefix.length),
         ...entry.value
@@ -563,7 +575,7 @@ export class FileIndex extends ReadyResource {
    */
   async listTrees (opts = {}) {
     const trees = []
-    for await (const entry of this._bee.createReadStream({ gt: 'tree:', lt: 'tree:\xff' })) {
+    for await (const entry of this._bee.createReadStream({ gt: 'tree:', lt: prefixUpperBound('tree:') })) {
       trees.push({
         hash: entry.key.slice('tree:'.length),
         entryCount: entry.value.entries.length,

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -28,6 +28,7 @@ import { looseShareFile, looseUnshareFile, looseHasOwn, looseListOwn, looseListP
 import { LOOSE_SHARE_ID, looseTransferIdFor } from './transfer-id.js'
 import { unhashedStatusFor } from './transfer-status.js'
 import { claimVerdict } from './download-claim.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('files')
 
@@ -81,7 +82,7 @@ export async function getVerifiedHash(spaceId, key) {
 export async function listVerifiedForShare(spaceId, shareId, { keep = null } = {}) {
   const prefix = 'verified:' + spaceId + ':' + shareId + '|'
   const map = new Map()
-  for await (const node of downloadsBee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+  for await (const node of downloadsBee.createReadStream(prefixRange(prefix))) {
     const relPath = node.key.slice(prefix.length)
     if (keep && !keep.has(relPath)) continue
     if (node.value?.hash) map.set(relPath, node.value.hash)
@@ -101,7 +102,7 @@ export async function listVerifiedForShare(spaceId, shareId, { keep = null } = {
 export async function listDownloadClaimsForShare(spaceId, shareName, { keep = null } = {}) {
   const prefix = spaceId + ':/' + shareName + '/'
   const map = new Map()
-  for await (const node of downloadsBee.createReadStream({ gte: prefix, lt: prefix + '\xff' })) {
+  for await (const node of downloadsBee.createReadStream(prefixRange(prefix))) {
     const drivePath = node.key.slice(spaceId.length + 1)
     if (keep && !keep.has(drivePath)) continue
     if (node.value) map.set(drivePath, node.value)
@@ -501,10 +502,10 @@ export function revealLocalPath(target, missingCode = CODES.FILE_NOT_ON_DEVICE) 
 
 export async function cleanupDownloadHistory(spaceId) {
   const batch = downloadsBee.batch()
-  for await (const entry of downloadsBee.createReadStream({ gte: spaceId + ':', lt: spaceId + ';' })) {
+  for await (const entry of downloadsBee.createReadStream(prefixRange(spaceId + ':'))) {
     await batch.del(entry.key)
   }
-  for await (const entry of downloadsBee.createReadStream({ gte: 'verified:' + spaceId + ':', lt: 'verified:' + spaceId + ';' })) {
+  for await (const entry of downloadsBee.createReadStream(prefixRange('verified:' + spaceId + ':'))) {
     await batch.del(entry.key)
   }
   await batch.flush()

--- a/src/shared/transfer/pending-transfers.js
+++ b/src/shared/transfer/pending-transfers.js
@@ -6,6 +6,7 @@ import { createLocalBee, storeEpoch } from '../core/store.js'
 import { createKeyedLock } from '../core/keyed-lock.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { prefixRange } from '../core/bee-keys.js'
 
 const log = createLogger('pending-transfers')
 
@@ -83,7 +84,7 @@ export async function listPending() {
 
 export async function listPendingForSpace(spaceId) {
   const out = []
-  for await (const entry of bee.createReadStream({ gte: spaceId + ':', lt: spaceId + ';' })) {
+  for await (const entry of bee.createReadStream(prefixRange(spaceId + ':'))) {
     out.push({
       spaceId,
       filePath: entry.key.slice(spaceId.length + 1),
@@ -109,7 +110,7 @@ export async function listPendingOwnerKeys() {
 // after the purge and resurrect a row for a space the user just left.
 export async function clearPendingForSpace(spaceId) {
   const keys = []
-  for await (const entry of bee.createReadStream({ gte: spaceId + ':', lt: spaceId + ';' })) {
+  for await (const entry of bee.createReadStream(prefixRange(spaceId + ':'))) {
     keys.push(entry.key)
   }
   await Promise.all(keys.map((key) => exclusive(key, () => bee.del(key))))

--- a/test/integration/catalog-unicode-names.test.js
+++ b/test/integration/catalog-unicode-names.test.js
@@ -1,0 +1,57 @@
+import test from 'brittle'
+import { freshPeer } from '../helpers/store.js'
+import { makePeer, replicate, waitFor } from '../helpers/peer-bee.js'
+import { getStore } from '../../src/shared/core/store.js'
+import { createSpace } from '../../src/shared/spaces/space.js'
+import { advertise, collectOwnShare, listPeerShareMeta } from '../../src/shared/shares/share-catalog.js'
+import { markVerified, markDownloaded, listVerifiedForShare, listDownloadClaimsForShare } from '../../src/shared/transfer/files.js'
+
+const shareId = 's1'
+
+// Each of these has a first byte above the old `'\xff'` (C3 BF) bound: ł is C5 82, О is D0 9E,
+// 日 is E6 97 A5, 😀 is F0 9F 98 80. A plain ASCII name and a U+00FF one pin that the fix does
+// not lose what already worked.
+const NAMES = ['plain.txt', 'ÿ-latin1.txt', 'Łódź.pdf', 'Отчёты.txt', '日本語.txt', '😀.png']
+
+// REGRESSION (FIX-BEEKEY-1: every catalog and download-history range scan bounded its prefix with
+// `prefix + '\xff'`. Under `keyEncoding: 'utf-8'` that is U+00FF, so a top-level file whose name
+// starts at U+0100 or above sorted ABOVE the bound: it was invisible in the owner's own listing
+// AND in every peer's listing, and the owner re-diffed it on every reconcile.)
+test('REGRESSION (FIX-BEEKEY-1): a share lists top-level names above U+00FF, own and peer', async (t) => {
+  await freshPeer(t)
+  const space = await createSpace('Aurora')
+  for (const name of NAMES) await advertise(space.spaceId, shareId, name, { size: 1, mtime: 1 })
+
+  const own = await collectOwnShare(space.spaceId, shareId)
+  t.is(own.total, NAMES.length, 'own listing counts every name')
+  t.alike(own.entries.map((e) => e.relPath).sort(), [...NAMES].sort(), 'own listing yields every name')
+
+  // The same keys read back through a peer's replicated catalog — the path that decides what
+  // other members can see and download.
+  const B = await makePeer(t)
+  for (const name of NAMES) await B.bee.put('file/' + shareId + '/' + name, { size: 1, mtime: 1, contentHash: 'h' })
+  replicate(getStore(), B.store, t)
+  t.ok(await waitFor(async () => (await listPeerShareMeta(B.key, shareId)).entries.length === NAMES.length), 'peer catalog replicates every name')
+
+  const peer = await listPeerShareMeta(B.key, shareId)
+  t.alike(peer.entries.map((e) => e.relPath).sort(), [...NAMES].sort(), 'peer listing yields every name')
+})
+
+// The download history is keyed by the same user-controlled text, and its two bulk scans feed the
+// per-row "downloaded" state and the mirror's on-device byte total.
+test('REGRESSION (FIX-BEEKEY-1): the download-history bulk scans see names above U+00FF', async (t) => {
+  await freshPeer(t)
+  const space = await createSpace('Aurora')
+  const shareName = 'Проект'
+
+  for (const name of NAMES) {
+    await markVerified(space.spaceId, shareId + '|' + name, 'h'.repeat(64))
+    await markDownloaded(space.spaceId, '/' + shareName + '/' + name, '/tmp/' + name, { hash: 'h'.repeat(64) })
+  }
+
+  const verified = await listVerifiedForShare(space.spaceId, shareId)
+  t.is(verified.size, NAMES.length, 'verified-hash scan sees every name')
+
+  const claims = await listDownloadClaimsForShare(space.spaceId, shareName)
+  t.is(claims.size, NAMES.length, 'download-claim scan sees every name under a non-ASCII share name')
+})

--- a/test/integration/overlay-vendor-prefix-bound.test.js
+++ b/test/integration/overlay-vendor-prefix-bound.test.js
@@ -1,0 +1,29 @@
+import test from 'brittle'
+import { freshPeer } from '../helpers/store.js'
+import { getStore } from '../../src/shared/core/store.js'
+import { FileIndex } from '../../src/shared/transfer/backends/overlay/vendor/file-index.js'
+
+// Each name's first byte is above the old `'\xff'` (C3 BF) bound.
+const NAMES = ['plain.txt', 'ÿ-latin1.txt', 'Łódź.pdf', 'Отчёты.txt', '日本語.txt', '😀.png']
+
+// REGRESSION (FIX-BEEKEY-1: the vendored overlay file index bounded its prefix scans with
+// `prefix + '\xff'`. A file whose top-level name starts at U+0100 or above was missing from
+// listFiles(), so protocol-v2's content-hash -> disk-path fallback could not resolve it and the
+// serve silently dropped the chunk request.)
+test('REGRESSION (FIX-BEEKEY-1): the overlay file index lists paths above U+00FF', async (t) => {
+  await freshPeer(t)
+  const index = new FileIndex(getStore().namespace('overlay-prefix-bound-test'))
+  await index.ready()
+  t.teardown(() => index.close())
+
+  for (const name of NAMES) {
+    await index.putFile(name, { contentHash: 'h'.repeat(64), size: 1, mtime: 1 })
+    await index.putSyncState('peer-a', name, { lastSeq: 1, lastHash: 'h'.repeat(64) })
+  }
+
+  const files = await index.listFiles()
+  t.alike(files.map((f) => f.path).sort(), [...NAMES].sort(), 'listFiles yields every name')
+
+  const states = await index.listSyncStates('peer-a')
+  t.alike(states.map((s) => s.path).sort(), [...NAMES].sort(), 'listSyncStates yields every name')
+})

--- a/test/unit/bee-keys.test.js
+++ b/test/unit/bee-keys.test.js
@@ -1,0 +1,72 @@
+import test from 'brittle'
+import b4a from 'b4a'
+import path from 'node:path'
+import { readFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { prefixRange } from '../../src/shared/core/bee-keys.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+// A bee keyed `utf-8` compares keys as UTF-8 bytes, so the property that matters is a BYTE
+// property: every key under the prefix must sort below the bound, and the first key outside
+// the prefix must not.
+const below = (a, b) => b4a.compare(b4a.from(a, 'utf-8'), b4a.from(b, 'utf-8')) < 0
+
+// REGRESSION (FIX-BEEKEY-1: prefix scans were bounded with `prefix + '\xff'`. U+00FF encodes to
+// C3 BF, so a suffix starting at U+0100 or above — ł, Cyrillic, CJK, emoji — has a lead byte
+// above the bound and was silently dropped from the scan.)
+test('REGRESSION (FIX-BEEKEY-1): the upper bound covers suffixes above U+00FF', (t) => {
+  const prefix = 'file/share-x/'
+  const { gte, lt } = prefixRange(prefix)
+  t.is(gte, prefix, 'lower bound is the prefix itself')
+
+  for (const name of ['a.txt', 'zz.txt', 'ÿ.txt', 'Łódź.pdf', 'Отчёты/x.txt', '日本語.txt', '😀.png', '\u{10FFFF}']) {
+    t.ok(below(prefix + name, lt), 'covered: ' + name)
+  }
+  t.ok(below(prefix + '\xff', lt), 'a suffix that IS the old sentinel stays inside the range')
+})
+
+test('the upper bound excludes the next namespace', (t) => {
+  const { lt } = prefixRange('file/share-x/')
+  t.absent(below('file/share-x0', lt), 'the byte after the separator is outside')
+  t.absent(below('file/share-xy/a.txt', lt), 'a longer sibling share id is outside')
+  t.ok(below('file/share-x/', lt), 'the bare prefix key is inside')
+})
+
+test('bounds each separator the data layer uses', (t) => {
+  t.alike(prefixRange('intent/'), { gte: 'intent/', lt: 'intent0' })
+  t.alike(prefixRange('verified:s1:sh|'), { gte: 'verified:s1:sh|', lt: 'verified:s1:sh}' })
+  t.alike(prefixRange('tree:'), { gte: 'tree:', lt: 'tree;' })
+})
+
+// The bound is only sound while the final character is one ASCII code point; a non-ASCII
+// terminator would need a byte-level carry. Failing loud beats returning a bound that
+// silently truncates the scan — the exact failure this module exists to remove.
+test('rejects a prefix it cannot bound soundly', (t) => {
+  for (const bad of ['', 'file/ł', 'x😀', null, undefined, 42]) {
+    t.exception(() => prefixRange(bad), 'rejects ' + JSON.stringify(bad))
+  }
+})
+
+// The sentinel idiom this module replaces reads as correct and fails silently — a scan that
+// truncates mid-range returns a short list, never an error. Nothing but this gate stops a new
+// range scan from reintroducing it, so the bound stays greppable: a literal high character
+// appended to a prefix in an `lt:`/`lte:` bound is the shape that must not come back.
+test('no bee range bound reintroduces a high-character sentinel', (t) => {
+  const root = path.join(here, '..', '..', 'src')
+  const files = spawnSync('git', ['ls-files', '-z', root], { encoding: 'utf-8' })
+    .stdout.split('\0').filter((f) => f.endsWith('.js'))
+  t.ok(files.length > 100, 'the sweep found the source tree (' + files.length + ' files)')
+
+  const offenders = []
+  for (const file of files) {
+    if (file.endsWith('src/shared/core/bee-keys.js')) continue
+    const body = readFileSync(path.join(here, '..', '..', file), 'utf-8')
+    body.split('\n').forEach((line, i) => {
+      if (line.trimStart().startsWith('//')) return
+      if (/\b(lt|lte):[^,}]*\+\s*'[\\ÿ￿]/.test(line)) offenders.push(`${file}:${i + 1}`)
+    })
+  }
+  t.alike(offenders, [], 'range bounds use prefixRange(), not an appended sentinel')
+})


### PR DESCRIPTION
Fixes #216.

## Problem

Every Hyperbee prefix scan bounded itself with `lt: prefix + '\xff'`. The bees are keyed `utf-8`, where U+00FF encodes to `C3 BF`, so any key whose next character is U+0100 or above (ł, Cyrillic, Greek, CJK, emoji) has a lead byte above the bound and never appears in the scan.

Measured against a real hyperbee holding seven top-level names:

| bound | names returned |
|---|---|
| `prefix + '\xff'` (shipped) | 2 of 7 |
| `prefix + '￿'` | 6 of 7 — drops `😀.png` |
| prefix with its final byte bumped | 7 of 7 |

`Łódź.pdf`, `Отчёты/x.txt`, `日本語.txt` and `😀.png` were all outside the range. Impact: such a file was invisible in the owner's own listing and in every peer's listing, re-diffed by the owner on every reconcile, and — via `protocol-v2._onContentRequest`'s `listFiles()` fallback — unservable over the overlay, which the requester sees only as a timeout.

## Change

- `src/shared/core/bee-keys.js` — `prefixRange(prefix)`, the one bound every data-layer scan now uses. It bumps the prefix's final ASCII byte; UTF-8 preserves code-point order, so that is the exact exclusive supremum of the prefix set. It throws on a prefix it cannot bound soundly rather than returning a quietly-truncating one.
- All 16 `'\xff'` bounds replaced, plus the 11 hand-rolled `'/'→'0'` / `':'→';'` bounds in `profile.js`, `member-view.js`, `space.js`, `pending-transfers.js` and `files.js` (those were already correct, but duplicated the idiom) and the 10 `'￿'` bounds in `audit-log.js` (latent: safe only because every suffix there happens to be ASCII).
- Vendor: `file-index.js`'s three scans get an equivalent local `prefixUpperBound()` under a `[mirall]` marker, kept local so the snapshot stays re-diffable. Recorded as PROVENANCE §4.22.

## Tests

Red-first, per `.claude/testing.md`:

- `test/integration/catalog-unicode-names.test.js` — own listing, peer listing, and both download-history bulk scans. **0/6 asserts pre-fix → 6/6 post-fix.**
- `test/integration/overlay-vendor-prefix-bound.test.js` — the vendored index. **0/2 → 2/2.**
- `test/unit/bee-keys.test.js` — byte-level bound properties, plus a **ratchet gate** sweeping the source tree for a reintroduced sentinel. Verified it fires: restoring the old bound in `intents.js` flagged `intents.js:61`.

Local: `test:node:core` 2161/2161 · `test:bare` 1098/1098 · `test:flow` 202/202 · typecheck + `lint:ci` clean. No renderer change, so no frontend/a11y layer applies.