### PR TITLE
[fix] Journal the real scan gaps on an allowed sweep

### DIFF
--- a/src/shared/storage/leftover.js
+++ b/src/shared/storage/leftover.js
@@ -381,12 +381,14 @@ export async function purgeLeftovers({ categories = PURGEABLE, onProgress, compa
       purged++
       purgedDks.push(dkHex)
     } catch (err) {
-      log.debug('leftover purge skip:', dkHex.slice(0, 12), err.message)
+      // A core the sweep decided to delete and could not is a store that no longer matches its
+      // own journal, so it is reported rather than swallowed.
+      log.warn('leftover purge failed:', dkHex.slice(0, 12), err.message)
     }
   }
   await recordSweep({
     refused: null, targets: dks.length, totalCores: scan.totalCores,
-    gaps: [], categories: allowed, purged, purgedDks,
+    gaps: scan.gaps, categories: allowed, purged, purgedDks,
   })
   // Tombstoning the cores is what makes the leave effective; the compaction only returns the
   // bytes. A boot-path caller passes compact:false rather than block startup on a full-range

--- a/src/shared/storage/storage.js
+++ b/src/shared/storage/storage.js
@@ -95,6 +95,10 @@ export async function getSpaceCacheBytes(spaceId) {
 // Boot sweep. Prunes leftover peer metadata (profile and catalog bee cores no longer tied to any
 // active space) — never system bees, active drives, or any raw blob/drive core.
 //
+// The deletes are irreversible, so the go/no-go is sweep-decision.js and it fails closed: any gap
+// in the scan refuses the WHOLE sweep, and past a floor the target set is refused above an
+// absolute cap or a fraction of the store. Every pass, allowed or refused, is journaled.
+//
 // Orphan drives ride along exactly once, on the first boot after upgrading past the copy-based
 // content path (see legacy-orphan-drives.js). That is the only category that can free gigabytes,
 // so it is also the only one worth a compaction: metadata tombstones are collected by whatever

--- a/src/shared/storage/sweep-journal.js
+++ b/src/shared/storage/sweep-journal.js
@@ -8,7 +8,9 @@
 // Entry (written by leftover.js purgeLeftovers, one per sweep):
 //   { at, refused: <decideSweep reason> | null, targets, totalCores, gaps: [{ stage, detail }],
 //     categories: ('profiles' | 'catalogs' | 'orphanDrives')[], purged, purgedDks?: dkHex[] }
-//   A refused sweep carries its gaps and purged: 0; a sweep that ran carries gaps: [] and purgedDks.
+//   A refused sweep carries its gaps and purged: 0; a sweep that ran carries purgedDks. Gaps are
+//   the scan's own, either way: a sweep with nothing to delete is allowed on a scan that may
+//   still have been incomplete, and journaling that as [] would report a clean scan.
 // Keys in `reclaim-meta`: purge/<at, 16 digits>-<seq, 4 digits> (this journal, chronological) and
 // overlay-index-compacted (worker/sweeps.js's last-compaction stamp).
 import { createLocalBee } from '../core/store.js'

--- a/test/integration/sweep-fail-closed.test.js
+++ b/test/integration/sweep-fail-closed.test.js
@@ -138,3 +138,21 @@ test('REGRESSION (FIX-D1-4): a refused sweep does not consume the one-shot orpha
   t.ok(await shouldReclaimOrphanDrives(),
     'the one-shot pass survives — a refused sweep looked at nothing, so it must not spend it')
 })
+
+// D12 — a sweep with nothing to delete is allowed (there is no risk to weigh), but its scan can
+// still have been incomplete. Journaling that pass as `gaps: []` reports a clean scan, so the one
+// record that makes a missing-spaces boot reconstructable hides the reason it saw nothing.
+test('REGRESSION (FIX-D12-1): a gapped scan with no targets journals the gap', async (t) => {
+  await freshPeer(t)
+  await createSpace('Aurora')
+
+  const res = await purgeLeftovers({ openSystemBee: failOpening('spaces-meta') })
+  t.is(res.purged, 0, 'precondition: nothing to delete, so the sweep is allowed rather than refused')
+  t.is(res.refused, null)
+  t.absent(res.scanComplete, 'and the scan itself was incomplete')
+
+  const [entry] = await listRecentSweeps(1)
+  t.is(entry.refused, null, 'the allowed pass is journaled')
+  t.ok(entry.gaps.some((g) => g.stage === 'system-bee:spaces-meta'),
+    'carrying the gap it actually saw, not an empty list that reads as a clean scan')
+})


### PR DESCRIPTION
Closes #226

## Bug
`purgeLeftovers` hard-coded `gaps: []` in the sweep journal on the allowed path. A sweep with **no targets** is allowed unconditionally (`decideSweep` returns early — there is nothing to weigh), so a boot whose wanted-set scan was incomplete but found nothing to delete was journaled as a clean scan. The journal is the only forensic record of the one path that destroys user data with no user action behind it.

Secondary: a core the sweep decided to delete and failed to delete was logged at `debug` and otherwise swallowed.

## Root cause
The literal was correct only for the refuse-on-gap path (`gaps.length > 0` ⇒ refused, so an allowed sweep "cannot" have gaps). The `targetCount === 0` early return breaks that assumption.

## Fix
- `leftover.js`: journal `scan.gaps`, not `[]`.
- `leftover.js`: `log.warn` on a failed core delete — a store that no longer matches its own journal.
- `storage.js`: the boot-sweep header now states the actual model (fail closed, refuse-on-gap, floor/cap/ratio, journaled).
- `sweep-journal.js`: entry-shape comment corrected to match.

Already done by #215, verified with `git grep`, so untouched here: `withheldDrives` is gone, the `storage.js` per-category-withholding wording is gone, and `solution-architecture.md` §14 already describes the real model. §14 is left alone to keep #222's edit conflict-free.

## Tests
Integration (data layer), red-first: `REGRESSION (FIX-D12-1): a gapped scan with no targets journals the gap` in `test/integration/sweep-fail-closed.test.js`. Verified failing before the fix on the gap assertion only.

## Security audit
No new deps, no user input, no deserialization, no secrets, no auth surface. The deletion-eligible set is unchanged: `decideSweep`'s inputs and the target list are untouched, and `recordSweep` runs after the deletes. Truncated discovery keys at `warn` are non-secret swarm identifiers already present in the journal's `purgedDks`; gap `detail` strings now ride on allowed passes too, the same shape already stored on refused passes, in the at-rest-encrypted `reclaim-meta` bee.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wtnbw81zAL4wbxkoH6q2Yd