### PR TITLE
[fix] Refuse an unknown audit outcome

### DIFF
--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -1,4 +1,5 @@
 import type { FILE_STATUS, BADGE_STATUS, SHARE_FILE_STATUS, OWNED_MOUNT_STATUS, FOREIGN_MOUNT_STATUS } from '../shared/contract/statuses.js'
+import type { OUTCOMES, ACTOR_TYPES } from '../shared/contract/audit-kinds.js'
 export interface Profile {
   displayName: string
   avatar: string | null
@@ -362,10 +363,10 @@ export interface NetworkStatus {
 
 export type AuditCategory = 'members' | 'files' | 'folders' | 'security' | 'network'
 type AuditTier = 'A' | 'B' | 'C'
-type AuditOutcome = 'ok' | 'denied' | 'error'
+type AuditOutcome = (typeof OUTCOMES)[number]
 
 interface AuditParty {
-  type: 'self' | 'peer' | 'system'
+  type: (typeof ACTOR_TYPES)[number]
   key: string | null
   name: string | null
 }

--- a/src/shared/audit/audit-log.js
+++ b/src/shared/audit/audit-log.js
@@ -33,6 +33,7 @@ import {
   normalizeConfig,
   pruneUpTo,
 } from './audit-retention.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 const log = createLogger('audit')
 
@@ -160,8 +161,8 @@ export function record(kind, fields = {}) {
 }
 
 function withSelfIdentity(actor) {
-  if (!actor || actor.type !== 'self') return actor
-  return { type: 'self', key: actor.key ?? selfIdentity.key, name: actor.name ?? selfIdentity.name }
+  if (!actor || actor.type !== ACTOR_TYPE.SELF) return actor
+  return { type: ACTOR_TYPE.SELF, key: actor.key ?? selfIdentity.key, name: actor.name ?? selfIdentity.name }
 }
 
 async function append(kind, fields, target = bee) {

--- a/src/shared/audit/audit-record.js
+++ b/src/shared/audit/audit-record.js
@@ -5,14 +5,13 @@
 // must be in the row itself. Live state cannot be joined against — leaving a space deletes its
 // record, and a peer's name needs that peer online or replicated — so a row holding only ids
 // would render raw hex forever. Hence a name snapshot on every participant, taken at write time.
-import { isKnownKind, categoryOf, tierOf } from '../contract/audit-kinds.js'
+import { isKnownKind, categoryOf, tierOf, OUTCOME, OUTCOMES } from '../contract/audit-kinds.js'
 import { NAME_MAX } from '../contract/limits.js'
 
 export const SCHEMA_VERSION = 1
 
 const SEARCH_MAX = 300
 const CODE_MAX = 64
-const OUTCOMES = ['ok', 'denied', 'error']
 
 function clampName(value) {
   return typeof value === 'string' && value ? value.slice(0, NAME_MAX) : null
@@ -53,11 +52,12 @@ export function buildRecord({
   space = null,
   target = null,
   subject = null,
-  outcome = 'ok',
+  outcome = OUTCOME.OK,
   code = null,
   device = null,
 }) {
   if (!isKnownKind(kind)) throw new Error('audit: unknown kind ' + kind)
+  if (!OUTCOMES.includes(outcome)) throw new Error('audit: unknown outcome ' + outcome)
   if (!Number.isInteger(seq) || seq < 0) throw new Error('audit: seq must be a non-negative integer')
   const a = normalizeActor(actor)
   const s = normalizeSpace(space)
@@ -70,7 +70,7 @@ export function buildRecord({
     kind,
     category: categoryOf(kind),
     tier: tierOf(kind),
-    outcome: OUTCOMES.includes(outcome) ? outcome : 'ok',
+    outcome,
     code: typeof code === 'string' && code ? code.slice(0, CODE_MAX) : null,
     device: device || null,
     actor: a,

--- a/src/shared/audit/network-watch.js
+++ b/src/shared/audit/network-watch.js
@@ -11,6 +11,7 @@ import { createLogger } from '../core/logger.js'
 import { record, getNetworkState, setNetworkState } from './audit-log.js'
 import { createEpisodeTracker, evidenceFor } from './network-episodes.js'
 import { createPeerPresenceTracker } from './peer-episodes.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 const log = createLogger('network-watch')
 
@@ -97,7 +98,7 @@ async function pumpDevice() {
     if (!row) return
 
     const written = record(row.kind, {
-      actor: { type: 'system', key: null, name: null },
+      actor: { type: ACTOR_TYPE.SYSTEM, key: null, name: null },
       code: row.code,
       subject: { ...row.subject, ...evidenceFor(row.kind, last.evidence) },
     })
@@ -166,7 +167,7 @@ function writePeerRow(row) {
     return
   }
   const written = record(row.kind, {
-    actor: { type: 'peer', key: row.publicKey, name },
+    actor: { type: ACTOR_TYPE.PEER, key: row.publicKey, name },
     space,
     target: { kind: 'member', id: row.publicKey, name },
     subject: row.subject,

--- a/src/shared/audit/peer-watch.js
+++ b/src/shared/audit/peer-watch.js
@@ -14,6 +14,7 @@ import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record, getSeenVersion, setSeenVersion, getPeerSubjectState, setPeerSubjectState } from './audit-log.js'
 import { classifyProfileChange, classifyCatalogChange, isTransition, readChangesSince, stateOf, subjectKey } from './peer-observer.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 const log = createLogger('peer-watch')
 
@@ -80,7 +81,7 @@ async function applyProfileChange(peerKey, change) {
   const space = await getSpace(change.spaceId)
   // Not a space we are in — their records for it are none of our business.
   if (!space || space.leaving) return
-  const actor = { type: 'peer', key: peerKey, name: peerName(space, peerKey) }
+  const actor = { type: ACTOR_TYPE.PEER, key: peerKey, name: peerName(space, peerKey) }
   const spaceRef = { id: space.spaceId, name: space.name ?? null }
 
   if (change.kind === 'share') {
@@ -116,7 +117,7 @@ async function applyCatalogChange(peerKey, spaceId, change) {
   const commit = await transitioned('file', peerKey, spaceId, change.relPath, change.removed)
   if (!commit) return
   const written = record(change.removed ? 'peer.file_unshared' : 'peer.file_shared', {
-    actor: { type: 'peer', key: peerKey, name: peerName(space, peerKey) },
+    actor: { type: ACTOR_TYPE.PEER, key: peerKey, name: peerName(space, peerKey) },
     space: { id: space.spaceId, name: space.name ?? null },
     target: { kind: 'file', id: change.relPath, name: change.relPath },
   })

--- a/src/shared/contract/audit-kinds.d.ts
+++ b/src/shared/contract/audit-kinds.d.ts
@@ -1,6 +1,10 @@
 export declare const CATEGORY: Readonly<Record<string, string>>
 export declare const KINDS: Readonly<Record<string, { category: string; tier: string }>>
+export declare const OUTCOME: Readonly<{ OK: 'ok'; DENIED: 'denied'; ERROR: 'error' }>
+export declare const ACTOR_TYPE: Readonly<{ SELF: 'self'; PEER: 'peer'; SYSTEM: 'system' }>
 export declare const CATEGORIES: readonly string[]
+export declare const OUTCOMES: readonly ['ok', 'denied', 'error']
+export declare const ACTOR_TYPES: readonly ['self', 'peer', 'system']
 export declare function isKnownKind (kind: string): boolean
 // Throws on an unknown kind — the vocabulary is closed, so a kind absent from it is a programming
 // error; `| null` would invite a guard that still crashes.

--- a/src/shared/contract/audit-kinds.js
+++ b/src/shared/contract/audit-kinds.js
@@ -11,15 +11,15 @@
 // There is no tier D: what a peer does with bytes after receipt, and transfers between two
 // other members, are unobservable here (overlay transfers are point-to-point — only the holder
 // sees them).
-export const CATEGORY = {
+export const CATEGORY = Object.freeze({
   MEMBERS: 'members',
   FILES: 'files',
   FOLDERS: 'folders',
   SECURITY: 'security',
   NETWORK: 'network',
-}
+})
 
-export const KINDS = {
+export const KINDS = Object.freeze({
   'space.created': { category: CATEGORY.MEMBERS, tier: 'A' },
   'space.joined': { category: CATEGORY.MEMBERS, tier: 'A' },
   'space.updated': { category: CATEGORY.MEMBERS, tier: 'A' },
@@ -77,7 +77,7 @@ export const KINDS = {
   // healthy, because a blocked device makes every peer look gone.
   'network.peer_lost': { category: CATEGORY.NETWORK, tier: 'B' },
   'network.peer_back': { category: CATEGORY.NETWORK, tier: 'B' },
-}
+})
 
 // Absent on purpose — a kind that can never fire still shows in the search labels and the i18n
 // catalogue:
@@ -93,7 +93,18 @@ export const KINDS = {
 //   per-file folder sync  the deliberate act is mounting (share.mounted carries the totals); the
 //                       reconcile and the watcher's per-file publishes produce no rows
 
-export const CATEGORIES = Object.values(CATEGORY)
+// Did the described act succeed? The viewer badges a row on this alone, so the vocabulary is
+// closed exactly as the kinds are: buildRecord refuses a spelling absent from it rather than
+// defaulting, because a denial stored as `ok` claims the opposite of what happened.
+export const OUTCOME = Object.freeze({ OK: 'ok', DENIED: 'denied', ERROR: 'error' })
+
+// Whom a row attributes its act to: this install, an identified peer, or the app acting on its
+// own. The renderer picks the sentence, the avatar and the name snapshot from it.
+export const ACTOR_TYPE = Object.freeze({ SELF: 'self', PEER: 'peer', SYSTEM: 'system' })
+
+export const CATEGORIES = Object.freeze(Object.values(CATEGORY))
+export const OUTCOMES = Object.freeze(Object.values(OUTCOME))
+export const ACTOR_TYPES = Object.freeze(Object.values(ACTOR_TYPE))
 
 export function isKnownKind(kind) {
   return Object.hasOwn(KINDS, kind)

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -45,6 +45,7 @@ import { mirrorMayFetch } from './mirror-reach.js'
 import { classifyMiss, isTerminalFault } from '../transfer/backends/overlay/fetch-policy.js'
 import { shortfall } from '../transfer/free-space.js'
 import { freeBytesFor } from '../transfer/free-space-probe.js'
+import { ACTOR_TYPE, OUTCOME } from '../contract/audit-kinds.js'
 
 const log = createLogger('foreign-folders')
 
@@ -334,7 +335,7 @@ function recordMirrorIntegrityFailure(mount, share, entry) {
   if (!integritySeen.admit(loopKey(mount.spaceId, mount.shareId), entry.relPath, entry.contentHash)) return
   getSpace(mount.spaceId).then((space) => {
     record('security.integrity_failure', {
-      actor: { type: 'self' },
+      actor: { type: ACTOR_TYPE.SELF },
       space: { id: mount.spaceId, name: space?.name ?? null },
       target: { kind: 'file', id: entry.relPath ?? null, name: path.basename(entry.relPath || '') || null },
       subject: {
@@ -343,7 +344,7 @@ function recordMirrorIntegrityFailure(mount, share, entry) {
         folder: share?.displayName || share?.name || null,
         shareId: mount.shareId ?? null,
       },
-      outcome: 'error',
+      outcome: OUTCOME.ERROR,
       code: 'TRANSFER_CHECKSUM',
     })
   }).catch((err) => log.debug('mirror integrity audit failed:', err.message))

--- a/src/shared/spaces/member-registry.js
+++ b/src/shared/spaces/member-registry.js
@@ -8,6 +8,7 @@ import { tombstoneActive, observedLeavers } from './member-set.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record } from '../audit/audit-log.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 // Set by the worker. A hook, not an import: the overlay reaches back into spaces/ for the
 // membership gate, so importing it here would close the cycle.
@@ -262,7 +263,7 @@ async function applyObservedLeave (spaceId, key, leaveTs) {
   // our own vouch being withdrawn as a consequence of their departure — not a removal.
   getSpace(spaceId).then((space) => {
     record('membership.approval_revoked', {
-      actor: { type: 'system', key: null, name: null },
+      actor: { type: ACTOR_TYPE.SYSTEM, key: null, name: null },
       space: { id: spaceId, name: space?.name ?? null },
       target: {
         kind: 'member',

--- a/src/shared/spaces/space.js
+++ b/src/shared/spaces/space.js
@@ -18,6 +18,7 @@ import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record } from '../audit/audit-log.js'
 import { prefixRange } from '../core/bee-keys.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 const log = createLogger('space')
 const { store: keysStore, core: keysCore } = keysMod
@@ -298,7 +299,7 @@ function auditArrivals(spaceId, space, added) {
     // arrival row seconds later is noise.
     if (await hasOwnApproval(spaceId, m.publicKey)) return
     record('member.joined', {
-      actor: { type: 'peer', key: m.publicKey, name: m.displayName || null },
+      actor: { type: ACTOR_TYPE.PEER, key: m.publicKey, name: m.displayName || null },
       space: { id: spaceId, name: space.name ?? null },
       target: { kind: 'member', id: m.publicKey, name: m.displayName || null },
     })

--- a/src/shared/transfer/backends/overlay/overlay-instance.js
+++ b/src/shared/transfer/backends/overlay/overlay-instance.js
@@ -22,6 +22,7 @@ import { getOverlayServeLimit, isSeparateContentPlaneEnabled, getBandwidthLimits
 import { createBandwidthLimiter } from '../../bandwidth-limiter.js'
 import { createChunkMapCache } from '../../chunk-map-cache.js'
 import { createLogger } from '../../../core/logger.js'
+import { ACTOR_TYPE, OUTCOME } from '../../../contract/audit-kinds.js'
 
 const log = createLogger('overlay')
 
@@ -195,14 +196,14 @@ function recordServeDenial(reason, { from, contentHash }) {
   Promise.resolve(spaceId ? getSpace(spaceId) : null).then((space) => {
     record('security.serve_denied', {
       actor: {
-        type: 'peer',
+        type: ACTOR_TYPE.PEER,
         key: from || null,
         name: (space?.members || []).find((m) => m.publicKey === from)?.displayName || null,
       },
       space: space ? { id: space.spaceId, name: space.name ?? null } : null,
       target: { kind: 'file', id: contentHash || null, name: relPath ? relPath.split('/').pop() : null },
       subject: { reason, requester: from ? from.slice(0, 12) : null },
-      outcome: 'denied',
+      outcome: OUTCOME.DENIED,
     })
   }).catch(() => {})
 }

--- a/src/shared/transfer/leave-protocol.js
+++ b/src/shared/transfer/leave-protocol.js
@@ -23,6 +23,7 @@ import { record } from '../audit/audit-log.js'
 import { peerLeft } from '../audit/network-watch.js'
 import { markLeft } from '../spaces/member-registry.js'
 import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers } from './swarm-registries.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 let presence = null
 let log = null
@@ -63,7 +64,7 @@ function memberSnapshot (space, publicKey) {
 
 function recordMemberLeft (spaceId, profileKey, snapshot) {
   record('member.left', {
-    actor: { type: 'peer', key: profileKey, name: snapshot.memberName },
+    actor: { type: ACTOR_TYPE.PEER, key: profileKey, name: snapshot.memberName },
     space: { id: spaceId, name: snapshot.spaceName },
     target: { kind: 'member', id: profileKey, name: snapshot.memberName },
   })

--- a/src/shared/transfer/serve-ledger.js
+++ b/src/shared/transfer/serve-ledger.js
@@ -13,6 +13,7 @@ import { LOOSE_SHARE_ID } from './transfer-id.js'
 import { getSpace } from '../spaces/space.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
+import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 const log = createLogger('serve-ledger')
 
@@ -98,7 +99,7 @@ function recordServeSession(session) {
     const live = getConnectedMemberMeta(meta.spaceId, meta.from)
     const persisted = (space?.members || []).find((m) => m.publicKey === meta.from)
     record('serve.completed', {
-      actor: { type: 'peer', key: meta.from ?? null, name: live?.displayName || persisted?.displayName || null },
+      actor: { type: ACTOR_TYPE.PEER, key: meta.from ?? null, name: live?.displayName || persisted?.displayName || null },
       space: { id: meta.spaceId, name: space?.name ?? null },
       target: { kind: 'file', id: meta.contentHash ?? null, name: meta.fileName ?? null },
       subject: { bytes: session.bytes, total: session.total || null, durationMs: session.durationMs, path: meta.path ?? null },

--- a/src/shared/transfer/transfer-audit.js
+++ b/src/shared/transfer/transfer-audit.js
@@ -10,6 +10,7 @@ import path from 'bare-path'
 import { record } from '../audit/audit-log.js'
 import { getSpace } from '../spaces/space.js'
 import { createLogger } from '../core/logger.js'
+import { ACTOR_TYPE, OUTCOME } from '../contract/audit-kinds.js'
 
 const log = createLogger('transfer-audit')
 
@@ -25,14 +26,14 @@ const INTEGRITY_CODES = new Set(['TRANSFER_CHECKSUM', 'EHASHMISMATCH'])
 
 function kindFor(outcome, errorCode) {
   if (INTEGRITY_CODES.has(errorCode)) return 'security.integrity_failure'
-  return outcome === 'ok' ? 'transfer.completed' : 'transfer.failed'
+  return outcome === OUTCOME.OK ? 'transfer.completed' : 'transfer.failed'
 }
 
 export function recordTransferOutcome(job, outcome, errorCode) {
   const fileName = path.basename(job.relPath || job.path || '')
   const write = getSpace(job.spaceId).then((space) => {
     record(kindFor(outcome, errorCode), {
-      actor: { type: 'self' },
+      actor: { type: ACTOR_TYPE.SELF },
       space: { id: job.spaceId, name: space?.name ?? null },
       target: { kind: 'file', id: job.path ?? null, name: fileName || null },
       // `folder` is null for a loose file and is what lets the viewer name the folder without a
@@ -43,7 +44,7 @@ export function recordTransferOutcome(job, outcome, errorCode) {
         folder: job.folderName ?? null,
         shareId: job.shareId ?? null,
       },
-      outcome: outcome === 'ok' ? 'ok' : 'error',
+      outcome: outcome === OUTCOME.OK ? OUTCOME.OK : OUTCOME.ERROR,
       code: errorCode || null,
     })
   }).catch((err) => log.debug('transfer audit failed:', err.message))

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -189,6 +189,7 @@ import {
   recordMirrorScanFault,
 } from '../shared/folders/foreign-folders.js'
 import { createForeignMount as persistForeignMount, getForeignMount, listForeignMounts } from '../shared/folders/mount-store.js'
+import { ACTOR_TYPE, OUTCOME } from '../shared/contract/audit-kinds.js'
 
 const ipc = createIPC(Bare.IPC)
 const log = createLogger('worklet')
@@ -275,14 +276,14 @@ function refreshAuditSelfName(displayName) {
 }
 
 function selfActor() {
-  return { type: 'self', key: null, name: null }
+  return { type: ACTOR_TYPE.SELF, key: null, name: null }
 }
 
 function peerActor(space, publicKey) {
   const live = space ? getConnectedMemberMeta(space.spaceId, publicKey) : null
   const persisted = (space?.members || []).find((m) => m.publicKey === publicKey)
   return {
-    type: 'peer',
+    type: ACTOR_TYPE.PEER,
     key: publicKey,
     name: displayNameOrNull(live?.displayName) || displayNameOrNull(persisted?.displayName) || null,
   }
@@ -471,7 +472,7 @@ function auditJoinRequest(spaceId, publicKey, displayName) {
   recordedJoinRequests.add(key)
   getSpace(spaceId).then((space) => {
     record('membership.requested', {
-      actor: { type: 'peer', key: publicKey, name: displayName || null },
+      actor: { type: ACTOR_TYPE.PEER, key: publicKey, name: displayName || null },
       space: spaceRef(space),
       target: { kind: 'member', id: publicKey, name: displayName || null },
     })
@@ -503,11 +504,11 @@ async function reconcileGrantCreator(spaceId, space, asserted) {
   }
   if (decision === 'refuse') {
     record('security.creator_divergence', {
-      actor: { type: 'system', key: null, name: null },
+      actor: { type: ACTOR_TYPE.SYSTEM, key: null, name: null },
       space: spaceRef(space),
       target: { kind: 'space', id: spaceId, name: space?.name ?? null },
       subject: { pinned: space.creatorKey ?? null, asserted: asserted ?? null },
-      outcome: 'denied',
+      outcome: OUTCOME.DENIED,
     })
     log.warn('membership:grant creator divergence — confirmed', space.creatorKey?.slice(0, 12) + '...', 'vs granter', asserted?.slice(0, 12) + '...')
     await markCreatorDivergence(spaceId)
@@ -1542,7 +1543,7 @@ ipc.handle('space:deny-member', async (msg) => {
       actor: selfActor(),
       space: spaceRef(space),
       target: { kind: 'member', id: msg.publicKey, name: peerActor(space, msg.publicKey).name },
-      outcome: 'denied',
+      outcome: OUTCOME.DENIED,
     })
   }
   return denied

--- a/test/flow/audit-coverage.test.js
+++ b/test/flow/audit-coverage.test.js
@@ -5,7 +5,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir, writeTmpFile, patternedBytes } from '../helpers/fixtures.js'
-import { KINDS } from '../../src/shared/contract/audit-kinds.js'
+import { KINDS, OUTCOMES } from '../../src/shared/contract/audit-kinds.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -209,7 +209,7 @@ test('every recorded row is well formed and renderable without a join', { timeou
     t.ok(Object.hasOwn(KINDS, row.kind), row.kind + ' is a declared kind')
     t.is(row.category, KINDS[row.kind].category, row.kind + ' stamps its category at write time')
     t.is(row.tier, KINDS[row.kind].tier, row.kind + ' stamps its tier at write time')
-    t.ok(['ok', 'denied', 'error'].includes(row.outcome), row.kind + ' has a known outcome')
+    t.ok(OUTCOMES.includes(row.outcome), row.kind + ' has a known outcome')
     t.ok(row.device, row.kind + ' names the device, for the future multi-device grouping')
     // The zero-joins rule: anything the row references must be named IN the row, because the
     // space record is deleted on leave and a peer may be unreachable.

--- a/test/unit/audit-coverage.test.js
+++ b/test/unit/audit-coverage.test.js
@@ -2,7 +2,7 @@ import test from 'brittle'
 import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
-import { KINDS, CATEGORIES } from '../../src/shared/contract/audit-kinds.js'
+import { KINDS, CATEGORIES, OUTCOME, OUTCOMES } from '../../src/shared/contract/audit-kinds.js'
 
 const here = path.dirname(fileURLToPath(import.meta.url))
 const ROOT = path.join(here, '..', '..')
@@ -53,6 +53,28 @@ test('every kind the data layer records is declared', (t) => {
   t.ok(called.size > 20, 'found the record() call sites')
   for (const kind of called) {
     t.ok(Object.hasOwn(KINDS, kind), kind + ' is declared in audit-kinds.js')
+  }
+})
+
+// The files that write audit rows. An outcome is what the viewer badges the row on, so the spelling
+// has to come from the frozen vocabulary rather than a literal: buildRecord refuses an unknown one,
+// but record() is fire-and-forget, so a misspelling costs the row instead of failing the operation.
+const auditCallSites = dataLayerFiles.filter((f) => /from '[^']*audit\/audit-log\.js'/.test(readFileSync(f, 'utf8')))
+
+test('every audit call site names its outcome through the frozen vocabulary', (t) => {
+  t.ok(auditCallSites.length > 5, `found ${auditCallSites.length} audit call sites`)
+  for (const file of auditCallSites) {
+    const code = readFileSync(file, 'utf8').replace(/^\s*\/\/.*$/gm, '')
+    const literals = [...code.matchAll(/outcome:\s*'([^']+)'/g)].map((m) => m[1])
+    t.alike(literals, [], path.relative(ROOT, file) + ' spells its outcome as OUTCOME.X, not a literal')
+  }
+})
+
+test('every OUTCOME reference in the data layer resolves to a member', (t) => {
+  const refs = new Set([...dataLayerSource.matchAll(/OUTCOME\.([A-Z_]+)/g)].map((m) => m[1]))
+  t.ok(refs.size > 0, 'found the OUTCOME references')
+  for (const key of refs) {
+    t.ok(OUTCOMES.includes(OUTCOME[key]), 'OUTCOME.' + key + ' is a member of the outcome vocabulary')
   }
 })
 

--- a/test/unit/audit-record.test.js
+++ b/test/unit/audit-record.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
 import { buildRecord, SCHEMA_VERSION } from '../../src/shared/audit/audit-record.js'
-import { KINDS } from '../../src/shared/contract/audit-kinds.js'
+import { KINDS, OUTCOME, OUTCOMES } from '../../src/shared/contract/audit-kinds.js'
 
 const base = { seq: 1, ts: 1754236800000, kind: 'space.created' }
 
@@ -63,8 +63,16 @@ test('a space without an id yields no space ref, so no by-space index entry is w
 })
 
 test('outcome is constrained to the known set', (t) => {
-  t.is(buildRecord({ ...base, outcome: 'denied' }).outcome, 'denied')
-  t.is(buildRecord({ ...base, outcome: 'weird' }).outcome, 'ok', 'an unknown outcome degrades to ok')
+  for (const outcome of OUTCOMES) t.is(buildRecord({ ...base, outcome }).outcome, outcome)
+  t.is(buildRecord({ ...base }).outcome, OUTCOME.OK, 'a row without an outcome records a success')
+})
+
+// REGRESSION (FIX-AUDIT-OUTCOME: a misspelt outcome was coerced to 'ok', so a security row
+// recording a denial claimed an approval — the one thing an audit log may not do.)
+test('REGRESSION (FIX-AUDIT-OUTCOME): an unknown outcome is refused, not coerced to ok', (t) => {
+  t.exception(() => buildRecord({ ...base, outcome: 'denyed' }), /unknown outcome/)
+  t.exception(() => buildRecord({ ...base, outcome: 'DENIED' }), /unknown outcome/)
+  t.exception(() => buildRecord({ ...base, outcome: null }), /unknown outcome/)
 })
 
 test('every kind in the table builds a valid record', (t) => {

--- a/test/unit/contract-declarations.test.js
+++ b/test/unit/contract-declarations.test.js
@@ -51,9 +51,9 @@ test('REGRESSION (FIX-CONTRACT-DRIFT): every declaration file matches the module
 })
 
 // The modules whose exports are pure vocabulary. Deliberately a list, not every file in the
-// package: audit-kinds.js and scope.js export objects that are not frozen today, and
-// invite-envelope.js exports a RegExp — widening this is a code change, not a test change.
-const FROZEN = ['errors', 'requests', 'events', 'limits', 'statuses', 'exit-codes', 'frames', 'main-requests', 'workers']
+// package: scope.js exports objects that are not frozen today, and invite-envelope.js exports a
+// RegExp — widening this is a code change, not a test change.
+const FROZEN = ['errors', 'requests', 'events', 'limits', 'statuses', 'exit-codes', 'frames', 'main-requests', 'workers', 'audit-kinds']
 
 test('every vocabulary is frozen', async (t) => {
   for (const name of FROZEN) {


### PR DESCRIPTION
Closes #225

**Bug.** `buildRecord` coerced any outcome outside `['ok','denied','error']` to `'ok'`, so a misspelt `'denied'` at a `security.serve_denied` / `membership.denied` / `security.creator_divergence` call site recorded a security row claiming an approval. Demonstrated before the fix: `buildRecord({kind:'security.serve_denied', outcome:'denyed'}).outcome === 'ok'`.

**Root cause.** The outcome vocabulary lived as a local array in `audit-record.js` with a silent fallback, while an unknown `kind` two lines above throws. It was spelled three times (that array, `renderer/types.ts`, a flow-test literal) and the actor types sixteen more.

**Fix.** Throw on an unknown outcome, matching the `kind` policy. `OUTCOME` and `ACTOR_TYPE` are frozen objects in `contract/audit-kinds.js` (with `OUTCOMES` / `ACTOR_TYPES` tuples derived from them); the 16 actor-type literals and all three outcome spellings import them, and `types.ts` derives its unions with `(typeof X)[number]`. `CATEGORY`/`KINDS` are frozen too, so `audit-kinds` joins the `FROZEN` list in `contract-declarations.test.js`. Actor *helpers* are out of scope (#233).

**Tests.** Unit (pure logic). Red-first `REGRESSION (FIX-AUDIT-OUTCOME)` in `test/unit/audit-record.test.js` — a misspelt, mis-cased or null outcome now throws; the old assertion that it "degrades to ok" is gone. `test/unit/audit-coverage.test.js` adds two call-site guards: no audit-writing file spells an outcome as a literal, and every `OUTCOME.X` reference in the data layer resolves to a member. SKIP `test:fe` — no rendered UI changes (types only).

**Security audit.** No injection, deserialization, secret, dep or auth surface. The throw is not remotely reachable: all six outcome-passing call sites use a constant from the frozen object or a local ternary over an engine-produced error code — none derive from peer frames, and `buildRecord` is called only from `audit-log.append`, inside `record()`'s fire-and-forget `writeChain` whose `.catch` logs a warn. Blast radius is identical to the pre-existing unknown-kind throw: no worker crash, no failure propagated into the audited operation. Fail-mode is a dropped row plus a warn (a visible gap) rather than a mislabelled one (an active lie).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wtnbw81zAL4wbxkoH6q2Yd