### PR TITLE
[fix] Keep failed remove and leave dialogs honest

### DIFF
--- a/src/renderer/components/modals/FeedbackModal.tsx
+++ b/src/renderer/components/modals/FeedbackModal.tsx
@@ -135,6 +135,7 @@ export default function FeedbackModal({ isOpen, onClose }: FeedbackModalProps) {
               description={t('feedback.intro')}
               descriptionSize="sm"
               onClose={handleClose}
+              closeDisabled={sending}
             />
             <div className="px-10 pb-10 space-y-6">
               <div className="space-y-3">

--- a/src/renderer/components/modals/LeaveSpaceModal.tsx
+++ b/src/renderer/components/modals/LeaveSpaceModal.tsx
@@ -2,8 +2,10 @@
 // leave-progress events while local data is cleaned up and compacted.
 import { useState, useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useErrorText } from '../../hooks/useErrorText.js'
 import { subscribe } from '../../ipc.js'
 import { formatSize } from '../../utils.js'
+import { useToast } from '../toast/ToastProvider.js'
 import Modal from '../primitives/Modal.js'
 import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
@@ -32,6 +34,8 @@ const PHASES_WITH_SIZE = new Set(['compactingPeerCache', 'compactingLocalCache']
 
 export default function LeaveSpaceModal({ isOpen, spaceName, spaceId, onClose, onLeave, onComplete }: LeaveSpaceModalProps) {
   const { t } = useTranslation()
+  const toast = useToast()
+  const errorText = useErrorText()
   const [leaving, setLeaving] = useState(false)
   const [done, setDone] = useState(false)
   const [progress, setProgress] = useState<LeaveProgress | null>(null)
@@ -63,15 +67,24 @@ export default function LeaveSpaceModal({ isOpen, spaceName, spaceId, onClose, o
     return unsub
   }, [leaving, spaceId])
 
+  // Leaving a space is destructive and irreversible, so the completion half — the bar filled to
+  // 100% and the navigation away from the space — runs on RESOLVE only. A rejection reports and
+  // returns the dialog to its confirm step, where the space is still joined and the leave can be
+  // retried.
   async function handleLeave() {
     if (leaving) return
     setLeaving(true)
     try {
       await onLeave()
-    } finally {
-      setDone(true)
-      setTimeout(() => { onComplete() }, COMPLETION_HOLD_MS)
+    } catch (err) {
+      toast.error(errorText(err))
+      setLeaving(false)
+      setProgress(null)
+      totalBytesRef.current = 0
+      return
     }
+    setDone(true)
+    setTimeout(() => { onComplete() }, COMPLETION_HOLD_MS)
   }
 
   const computedPercent = progress

--- a/src/renderer/components/modals/RemoveFileModal.tsx
+++ b/src/renderer/components/modals/RemoveFileModal.tsx
@@ -1,6 +1,8 @@
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
+import { useErrorText } from '../../hooks/useErrorText.js'
 import { fileName as getFileName } from '../../utils.js'
+import { useToast } from '../toast/ToastProvider.js'
 import Modal from '../primitives/Modal.js'
 import ModalHeader from '../layout/ModalHeader.js'
 import Button from '../primitives/Button.js'
@@ -10,18 +12,24 @@ interface RemoveFileModalProps {
   isOpen: boolean
   filePath: string
   onClose: () => void
-  onRemove: () => void
+  onRemove: () => void | Promise<void>
 }
 
 export default function RemoveFileModal({ isOpen, filePath, onClose, onRemove }: RemoveFileModalProps) {
   const { t } = useTranslation()
+  const toast = useToast()
+  const errorText = useErrorText()
   const [removing, setRemoving] = useState(false)
 
+  // A rejected removal reports and leaves the dialog on its confirm step: the busy flag is what
+  // makes the dialog undismissable, so clearing it is the only thing that gives the escape routes
+  // (Escape, the backdrop, the close button) back.
   async function handleRemove() {
     if (removing) return
     setRemoving(true)
-    await onRemove()
-    setRemoving(false)
+    try { await onRemove() }
+    catch (err) { toast.error(errorText(err)) }
+    finally { setRemoving(false) }
   }
 
   return (
@@ -30,6 +38,7 @@ export default function RemoveFileModal({ isOpen, filePath, onClose, onRemove }:
         <ModalHeader
           titleNode={<FilenameTitle i18nKey="removeFile.titleConfirm" name={getFileName(filePath)} />}
           onClose={onClose}
+          closeDisabled={removing}
         />
 
         <div className="px-10 pb-10 space-y-6">
@@ -42,6 +51,7 @@ export default function RemoveFileModal({ isOpen, filePath, onClose, onRemove }:
               variant="secondary"
               autoFocus
               onClick={onClose}
+              disabled={removing}
               className="flex-1 h-14"
             >
               {t('actions.cancel')}

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -137,6 +137,7 @@ import s136 from './scenarios/s136-screen-header-parity.mjs'
 import s137 from './scenarios/s137-relay-invite.mjs'
 import s138 from './scenarios/s138-mirror-offline-quiet.mjs'
 import s139 from './scenarios/s139-mirror-offline-incomplete.mjs'
+import s140 from './scenarios/s140-modal-failure-escape-routes.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -196,7 +197,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s140-modal-failure-escape-routes.mjs
+++ b/test/frontend/scenarios/s140-modal-failure-escape-routes.mjs
@@ -1,0 +1,106 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, waitFor, assert } from '../assert.mjs'
+import { allText, findNode } from '../tree.mjs'
+import { workDir } from '../paths.mjs'
+
+// REGRESSION (FIX-D8 / FIX-D9): the two confirm dialogs whose busy flag gates every exit.
+//
+// FIX-D8 — RemoveFileModal held `removing` true forever when the removal rejected, so Escape and
+// the backdrop were refused while the header ✕ stayed live: the only way out was the one click the
+// busy flag claimed was unsafe. FIX-D9 — LeaveSpaceModal completed from a `finally`, painting the
+// bar to 100% and navigating away from a space the user was still in.
+//
+// The rejection itself is not reachable from the UI: `space:leave` answers ok even when its
+// teardown throws, and the only other rejection source — the worker dying — reloads the renderer.
+// The shape of both fixes is pinned at the unit layer (test/unit/modal-busy-recovery.test.js);
+// what this scenario holds is the property a person experiences: each dialog keeps a named,
+// reachable way out when it is not busy, exposes no live close button while it is, and its
+// happy path still lands.
+export default async function s140 ({ runDir, bootstrap }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', bootstrap, slot: 0, total: 1 })
+
+  const file = path.join(workDir('modalexit-'), 'draft.txt')
+  writeFileSync(file, 'a file the remove confirm must let go of')
+
+  async function openRemoveConfirm() {
+    await A.click({ role: 'button', name: 'Unshare from Space', last: true })
+    await A.waitText('Remove File', 8000)
+  }
+
+  async function openLeaveConfirm() {
+    await A.click({ name: 'More' })
+    await new Promise((res) => setTimeout(res, 400))
+    await A.click({ name: 'Leave Space' })
+    // The dialog's body, not its title: the menu item that opened it is named "Leave Space" too.
+    await A.waitText('stop syncing with members', 8000)
+  }
+
+  try {
+    await r.ok('launch, create a space, share a file', async () => {
+      await A.launch()
+      await A.createSpaceOnly('Aurora')
+      await A.addFile(file)
+      await A.waitText('draft.txt', 30000)
+    })
+
+    await r.ok('the remove confirm carries a named close button and answers Escape', async () => {
+      await openRemoveConfirm()
+      assert(await A.has({ role: 'button', name: 'Close' }), 'the confirm exposes a close button by name')
+      assert(!(await A.isDisabled({ role: 'button', name: 'Close' })), 'and it is live while nothing is running')
+      await A.press('escape')
+      await waitFor(async () => !(await A.hasText('Remove File')), 8000, 'the confirm to close on Escape')
+      assert(await A.hasText('draft.txt'), 'the file survived the dismissal')
+    })
+
+    await r.ok('and the close button itself dismisses it', async () => {
+      await openRemoveConfirm()
+      await A.click({ role: 'button', name: 'Close' })
+      await waitFor(async () => !(await A.hasText('Remove File')), 8000, 'the confirm to close on ✕')
+      assert(await A.hasText('draft.txt'), 'the file survived the dismissal')
+      await A.shot('s140-remove-dismissed', runDir)
+    })
+
+    await r.ok('the remove still removes', async () => {
+      await openRemoveConfirm()
+      await A.click({ role: 'button', name: 'Remove File', last: true })
+      await waitFor(async () => !(await A.hasText('draft.txt')), 15000, 'the file to go')
+    })
+
+    await r.ok('the leave confirm answers Escape before it is busy', async () => {
+      await openLeaveConfirm()
+      assert(await A.has({ role: 'button', name: 'Close' }), 'the leave confirm exposes a close button by name')
+      await A.press('escape')
+      await waitFor(async () => !(await A.hasText('stop syncing with members')), 8000, 'the leave confirm to close on Escape')
+      assert(await A.hasText('Aurora'), 'still in the space')
+      await A.shot('s140-leave-dismissed', runDir)
+    })
+
+    await r.ok('leaving reports progress with no live close button, and lands on the list', async () => {
+      await openLeaveConfirm()
+      await A.click({ role: 'button', name: 'Leave Space', last: true })
+      let sawProgress = false
+      await waitFor(async () => {
+        const tree = await A.snap()
+        const text = allText(tree)
+        // The progress step is undismissable by design; a close button there would be the one exit
+        // the busy state refuses everywhere else.
+        if (text.includes('Leaving...')) {
+          sawProgress = true
+          assert(!findNode(tree, { role: 'button', name: 'Close' }), 'no close button on the progress step')
+        }
+        return text.includes('Create Space')
+      }, 60000, 'the leave to finish and land on the spaces list')
+      // A solo space can tear down faster than one snapshot round trip, so seeing the progress
+      // step is an observation, not a precondition.
+      console.error(sawProgress ? 'observed the leave progress step' : 'leave completed before a snapshot caught the progress step')
+      assert(!(await A.hasText('Aurora')), 'the space is gone from the list')
+      await A.shot('s140-left', runDir)
+    })
+  } catch {}
+
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/unit/modal-busy-recovery.test.js
+++ b/test/unit/modal-busy-recovery.test.js
@@ -1,0 +1,111 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const RENDERER = path.resolve(here, '../../src/renderer')
+
+function tsxFiles (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) tsxFiles(p, out)
+    else if (name.endsWith('.tsx')) out.push(p)
+  }
+  return out
+}
+
+const files = tsxFiles(RENDERER).map((f) => ({
+  rel: path.relative(RENDERER, f).split(path.sep).join('/'),
+  src: readFileSync(f, 'utf8'),
+}))
+
+// The bodies of every `catch`/`finally` clause in a source, by brace matching. A regex cannot see
+// where a clause ends, and "the setter is somewhere in the file" is exactly the assertion that
+// passed while the setter sat on the resolve-only path.
+function guardBlocks (src) {
+  const blocks = []
+  for (const m of src.matchAll(/\b(catch|finally)\b/g)) {
+    const open = src.indexOf('{', m.index)
+    if (open === -1) continue
+    let depth = 0
+    for (let i = open; i < src.length; i++) {
+      if (src[i] === '{') depth++
+      else if (src[i] === '}') {
+        depth--
+        if (depth === 0) { blocks.push(src.slice(open, i + 1)); break }
+      }
+    }
+  }
+  return blocks
+}
+
+// A dialog that refuses Escape and the backdrop while an operation runs (`isDismissable={!busy}`)
+// holds every exit route behind that one flag. The flag therefore has to be cleared on the
+// REJECTION path too — from a catch or a finally — or a failed confirm strands the dialog with no
+// way out at all.
+test('REGRESSION (FIX-D8/FIX-D9: a busy dialog clears its busy flag when the operation rejects)', (t) => {
+  const dialogs = files.filter((f) => /isDismissable=\{!\w+\}/.test(f.src))
+  t.ok(dialogs.length >= 4, `found ${dialogs.length} dialogs that gate dismissal on a busy flag`)
+  for (const f of dialogs) {
+    const flag = f.src.match(/isDismissable=\{!(\w+)\}/)[1]
+    const clear = `set${flag[0].toUpperCase()}${flag.slice(1)}(false)`
+    t.ok(f.src.includes(clear), `${f.rel}: ${clear} exists`)
+    t.ok(guardBlocks(f.src).some((b) => b.includes(clear)),
+      `${f.rel}: ${clear} runs from a catch/finally, so a rejection cannot strand the dialog`)
+  }
+})
+
+// The other half of the same trap: while the busy flag refuses Escape and the backdrop, the header
+// ✕ must not stay live — it is the one exit the busy state claims is unsafe. Every close button a
+// busy dialog renders is therefore disabled from the flag, except where the header is on the
+// dialog's non-busy branch and so is not on screen at all while the operation runs.
+const CLOSE_OFF_BUSY_BRANCH = new Map([
+  // LeaveSpaceModal renders two headers: the progress step's carries no close button, and the one
+  // below is the confirm step, which `leaving` has already replaced by the time it could matter.
+  ['components/modals/LeaveSpaceModal.tsx', 1],
+])
+
+function modalHeaderElements (src) {
+  const els = []
+  for (const m of src.matchAll(/<ModalHeader\b/g)) {
+    // Scan to the element's own closing `>`, tracking `{}` depth: the first `/>` in the source
+    // usually belongs to a nested element inside a prop (`titleNode={<FilenameTitle … />}`).
+    let depth = 0
+    for (let i = m.index; i < src.length; i++) {
+      if (src[i] === '{') depth++
+      else if (src[i] === '}') depth--
+      else if (src[i] === '>' && depth === 0) { els.push(src.slice(m.index, i + 1)); break }
+    }
+  }
+  return els
+}
+
+test('REGRESSION (FIX-D8: a busy dialog disables every close button it renders while busy)', (t) => {
+  const dialogs = files.filter((f) => /isDismissable=\{!\w+\}/.test(f.src))
+  for (const f of dialogs) {
+    const flag = f.src.match(/isDismissable=\{!(\w+)\}/)[1]
+    const closable = modalHeaderElements(f.src).filter((el) => el.includes('onClose'))
+    const exempt = CLOSE_OFF_BUSY_BRANCH.get(f.rel) || 0
+    const guarded = closable.filter((el) => el.includes(`closeDisabled={${flag}}`)).length
+    t.is(guarded, closable.length - exempt,
+      `${f.rel}: ${closable.length - exempt} of ${closable.length} close button(s) disabled while ${flag}`)
+  }
+})
+
+// A `finally` runs on rejection as well as on resolve, so a completion callback placed there
+// reports success for an operation that failed — and for a leave, navigates the user out of a
+// space they are still in.
+test('REGRESSION (FIX-D9: no dialog reports completion from a finally block)', (t) => {
+  const COMPLETION = ['onComplete', 'onCreated', 'onMounted', 'onSaved', 'onDone', 'onSuccess']
+  for (const f of files) {
+    for (const block of guardBlocks(f.src)) {
+      for (const cb of COMPLETION) {
+        if (block.includes(`${cb}(`)) {
+          t.fail(`${f.rel}: ${cb}() runs from a catch/finally — it would report a failed operation as done`)
+        }
+      }
+    }
+  }
+  t.pass('no completion callback runs from a catch/finally')
+})


### PR DESCRIPTION
## What & why

Closes #223.

**D8 — `RemoveFileModal`.** `await onRemove()` had no `try/finally`, so a rejected removal left
`removing` true forever. `isDismissable={!removing}` then refused Escape and the backdrop while the
header ✕ stayed live — the only exit was the one click the busy flag claimed was unsafe.

**D9 — `LeaveSpaceModal`.** `finally { setDone(true); setTimeout(onComplete, 350) }` ran on rejection
too: a failed leave painted the bar to 100% and navigated the user out of a space they were still in.

Fix: `RemoveFileModal` gets `try/catch/finally` + `closeDisabled` on the header (the shape
`DeleteFolderShareModal` already had); `LeaveSpaceModal` catches, reports, and clears `leaving`, with
the completion half running only on resolve. Both report through the existing toast +
`useErrorText` (a localized message keyed by error code — never the worker's `err.message`).
`FeedbackModal` gets the same `closeDisabled`: it was the third instance of D8's live-✕ half, and the
guard test below would otherwise need an allowlist entry for it.

The call chain surfaces the rejection: `SpaceView.handleLeave` → `useSpaces.leaveSpace` →
`request('space:leave')` has no catch anywhere, and same for `handleUnshareFile` → `files:remove`.

## Coverage

- **Unit (red-first)** — `test/unit/modal-busy-recovery.test.js`, three `REGRESSION (FIX-D8/FIX-D9…)`
  guards over the dialog sources: a busy flag is cleared from a `catch`/`finally`, every close button
  a busy dialog renders is disabled from that flag, and no dialog reports completion from a
  `finally`. All three fail on `staging` (verified) and pass here.
- **Frontend** — `s140-modal-failure-escape-routes`: the remove confirm exposes a close button by
  role+name and is dismissed by both Escape and that button, the remove still removes, the leave
  confirm answers Escape, and the leave progress step renders no live close button and lands on the
  spaces list. Also re-ran `s11`, `s133` (remove confirm) and `s1` (feedback dialog).
- Not covered at the FE layer: the **rejection itself**. `space:leave` answers `{ok:true}` even when
  its teardown throws, and the only other rejection source — the worker dying — reloads the renderer,
  so a rejecting handler is not reachable through the real UI without adding a fault seam to the
  worker. The rejection paths are pinned at the unit layer instead; the scenario holds the
  user-facing property.

## Ran locally

`test:fe s140` (green, 6/6 — remove-confirm dismissal, remove happy path, leave confirm + progress),
plus `s11 s133 s1` green. a11y: jsx-a11y clean; every control the change touches is AX-targetable by
role+name (that is what s140 asserts); no new DOM nodes or roles — the change adds `disabled` state
to existing controls and reuses the existing toast. `typecheck`, `lint:ci`, `test:unit`, `test:bare`
and `test:node` (incl. flow) all green locally, re-run after rebasing onto `staging`.

Security: no new deps, no secrets; the toast renders a localized string as a React text child (no
`dangerouslySetInnerHTML`, no path/key/`err.message` leak); the destructive `space:leave` can no
longer report success on failure, and a second leave is blocked by the busy guard, the disabled
button and the worker's own `isSpaceLeaving` short-circuit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wtnbw81zAL4wbxkoH6q2Yd
