### PR TITLE
[fix] Match the `**/` prefix in the ignore matcher

### DIFF
--- a/src/shared/folders/path-keys.js
+++ b/src/shared/folders/path-keys.js
@@ -137,7 +137,17 @@ export function shouldIgnore (rel, ignorePatterns) {
 // configuration and are matched against every path of every scan, where a backtracking pattern
 // would be a stall the user cannot explain.
 function matchPattern (input, pattern) {
-  if (pattern === input) return true
+  // `**/x` is the gitignore spelling of "x wherever it sits in the tree" — the form a user is
+  // likeliest to type. It names one segment, so it is answered per segment: any path holding a
+  // matching segment is covered, which withholds a matching directory's contents too. A `**/`
+  // prefix on a multi-segment pattern only widens where that pattern may sit, which is already
+  // what the rest of this matcher does, so the remainder is answered on its own terms.
+  if (pattern.startsWith('**/')) {
+    const rest = pattern.slice(3)
+    if (rest === '') return false
+    if (rest.includes('/')) return matchPattern(input, rest)
+    return input.split('/').some((segment) => matchSegment(segment, rest))
+  }
   // `dir/**` covers that directory WHEREVER it sits in the tree, plus everything beneath it at
   // any depth. Anchoring it to the mount root would publish a nested `node_modules` or `.git`
   // while the same glob withheld the one at the top.
@@ -146,12 +156,15 @@ function matchPattern (input, pattern) {
     return input === prefix || input.startsWith(prefix + '/') ||
       input.endsWith('/' + prefix) || input.includes('/' + prefix + '/')
   }
-  if (pattern.startsWith('*')) {
-    return input.endsWith(pattern.slice(1))
-  }
-  if (pattern.endsWith('*')) {
-    return input.startsWith(pattern.slice(0, -1))
-  }
+  return matchSegment(input, pattern)
+}
+
+// Exact name, leading-`*` suffix glob, or trailing-`*` prefix glob — the whole vocabulary a
+// pattern without a `**` has.
+function matchSegment (input, pattern) {
+  if (pattern === input) return true
+  if (pattern.startsWith('*')) return input.endsWith(pattern.slice(1))
+  if (pattern.endsWith('*')) return input.startsWith(pattern.slice(0, -1))
   return false
 }
 

--- a/test/unit/path-keys.test.js
+++ b/test/unit/path-keys.test.js
@@ -241,14 +241,37 @@ test('REGRESSION (FIX-221: watcher and reconcile disagree on ignore-glob semanti
   t.ok(shouldIgnore('a/b/dist', ['dist']), 'anywhere in the tree')
   t.absent(shouldIgnore('dist/app.js', ['dist']), 'a bare name is not a directory glob')
 
-  // `**/` is not a supported prefix in either matcher: the answer is the same on both sides.
-  t.absent(shouldIgnore('node_modules/pkg/index.js', ['**/node_modules']))
-  t.absent(shouldIgnore('a/node_modules', ['**/node_modules']))
-
   // Look-alikes stay publishable now that the glob reaches into the tree.
   t.absent(shouldIgnore('src/.gitignore', DEFAULT_IGNORE))
   t.absent(shouldIgnore('my-node_modules-notes.md', DEFAULT_IGNORE))
   t.absent(shouldIgnore('rebuild/x.js', ['build/**']), 'a name-suffix sibling directory')
+})
+
+// The gitignore spelling of "anywhere in the tree". It reaches the matcher from a share's
+// configuration, so a pattern that matches nothing withholds nothing — silently.
+test('REGRESSION (FIX-245: a `**/` pattern matches nothing)', (t) => {
+  t.ok(shouldIgnore('node_modules', ['**/node_modules']), 'the dir at the root')
+  t.ok(shouldIgnore('a/node_modules', ['**/node_modules']), 'the dir nested')
+  t.ok(shouldIgnore('node_modules/pkg/index.js', ['**/node_modules']), 'content at the root')
+  t.ok(shouldIgnore('a/b/node_modules/pkg/index.js', ['**/node_modules']), 'content nested')
+
+  t.ok(shouldIgnore('debug.log', ['**/*.log']), 'a suffix glob at the root')
+  t.ok(shouldIgnore('a/b/debug.log', ['**/*.log']), 'a suffix glob nested')
+
+  t.ok(shouldIgnore('debug.log', ['*.log']), 'a bare suffix glob at the root')
+  t.ok(shouldIgnore('a/b/debug.log', ['*.log']), 'a bare suffix glob nested')
+
+  // Look-alikes stay publishable: the prefix widens where a name may sit, not what it matches.
+  t.absent(shouldIgnore('my-node_modules-notes.md', ['**/node_modules']))
+  t.absent(shouldIgnore('a/node_modules-old/x.js', ['**/node_modules']))
+  t.absent(shouldIgnore('a/log/x.txt', ['**/*.log']))
+
+  // A `**/` prefix on a pattern that already carries its own semantics keeps them.
+  t.ok(shouldIgnore('src/build/x.js', ['**/build/**']))
+  t.absent(shouldIgnore('rebuild/x.js', ['**/build/**']))
+
+  // A bare `**/` names nothing, so it withholds nothing.
+  t.absent(shouldIgnore('docs/readme.md', ['**/']))
 })
 
 test('shouldIgnore: ordinary files pass; empty/missing patterns ignore nothing', (t) => {


### PR DESCRIPTION
**Bug.** `**/node_modules` and `**/*.log` — the gitignore spellings a user is likeliest to type — matched nothing, with no error and no UI signal, so an owned folder published what the user asked to withhold.

**Root cause.** In `matchPattern`, a pattern beginning with `*` fell into the leading-star branch and was compared as a literal suffix, so `**/node_modules` was tested as "ends with `*/node_modules`" — true of no path.

**Decision: support the prefix, do not reject it.** Rejection would need an error channel the matcher does not have (it is a pure, import-free predicate called per path per scan) and a UI to surface it in — ignore lists are not user-editable in the app today, they arrive over `share:create-and-mount`. Supporting it is also what the spelling means everywhere else, and it lands on the anywhere-in-tree semantics `dir/**` already has after #242.

**Fix.** `**/x` names one segment and is answered per segment: any path holding a matching segment is covered, which withholds a matching directory's contents too. A remainder that still contains `/` (`**/build/**`) is answered on its own terms by the rest of the matcher. A bare `**/` names nothing and matches nothing. The exact/leading-`*`/trailing-`*` vocabulary moved verbatim into `matchSegment`; every other pattern shape takes the identical path it did before. Still one matcher for the watcher and the reconcile.

**Tests.** Unit (red-first): `REGRESSION (FIX-245: a `**/` pattern matches nothing)` over `**/node_modules` (dir + contents, root + nested), `**/*.log`, a bare `*.log`, `**/build/**`, look-alikes, and the empty `**/`. The FIX-221 test's two asserts that pinned the old no-op are replaced; the rest of that test — the non-regression of what #242 fixed — is untouched and green.

**Security audit** (this is a confidentiality control):
- *Match widening* — the new branch is reachable only for patterns starting `**/`, which previously matched nothing; no other shape changes behaviour, and the widening direction is over-ignoring (withholds more), never under-ignoring. `DEFAULT_IGNORE` contains no `**/` pattern, so defaults are unchanged.
- *ReDoS* — no regex is built from user input, here or anywhere in this matcher; cost stays linear in path × pattern length. Recursion strips ≥3 characters per hop, so it terminates.
- *Traversal / normalization* — the matcher receives already-normalized `/`-separated share-relative keys from both callers; no new normalization or case-folding assumption.
- No new dependencies, no secrets, no filesystem or eval access added.

Fixes #245