### PR TITLE
[fix] Persist zoom applied from the View menu

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -350,6 +350,15 @@ function writeZoom(factor) {
   config().set('window.zoom', factor)
 }
 
+// Every zoom trigger — the View menu, the keyboard chord, the renderer's zoom:set — routes here so
+// applyZoom stays the sole writer of the persisted factor and of currentZoom.
+function zoomByDirection(direction, win = targetWindow()) {
+  if (!win) return currentZoom
+  if (direction === 'in') return applyZoom(win, currentZoom + ZOOM_STEP)
+  if (direction === 'out') return applyZoom(win, currentZoom - ZOOM_STEP)
+  return applyZoom(win, ZOOM_DEFAULT)
+}
+
 function applyZoom(win, factor) {
   const next = clampZoom(factor)
   if (next === currentZoom) return next
@@ -1162,6 +1171,9 @@ function buildAppMenu() {
       whatsNew: send('help.whatsNew'),
       sendFeedback: send('help.feedback'),
       openDocs: send('help.docs'),
+      zoomIn: () => zoomByDirection('in'),
+      zoomOut: () => zoomByDirection('out'),
+      zoomReset: () => zoomByDirection('reset'),
     },
   })
   return Menu.buildFromTemplate(template)
@@ -1245,12 +1257,8 @@ async function createWindow() {
     if (!match) return
     if (match.kind === 'devtools') {
       win.webContents.toggleDevTools()
-    } else if (match.direction === 'in') {
-      applyZoom(win, currentZoom + ZOOM_STEP)
-    } else if (match.direction === 'out') {
-      applyZoom(win, currentZoom - ZOOM_STEP)
     } else {
-      applyZoom(win, ZOOM_DEFAULT)
+      zoomByDirection(match.direction, win)
     }
     event.preventDefault?.()
   })

--- a/src/main/menu.js
+++ b/src/main/menu.js
@@ -75,9 +75,14 @@ function buildAppMenuTemplate({ platform, isDev, inSpace, spaces = [], appName, 
     { label: 'Command Palette', accelerator: 'CmdOrCtrl+K', click: handlers.openPalette },
     { label: 'Keyboard Shortcuts', accelerator: 'CmdOrCtrl+/', click: handlers.showShortcuts },
     { type: 'separator' },
-    { role: 'zoomIn' },
-    { role: 'zoomOut' },
-    { role: 'resetZoom' },
+    // Zoom is a click handler, not Electron's zoomIn/zoomOut/resetZoom role: a role writes
+    // webContents.zoomLevel directly, which persists nothing and tells main nothing, so the
+    // factor is lost on quit. registerAccelerator keeps the chord displayed but unregistered on
+    // Windows/Linux (it is a no-op on macOS, where the window's key handler already claims the
+    // chord first), so one press applies exactly one step.
+    { label: 'Zoom In', accelerator: 'CmdOrCtrl+Plus', registerAccelerator: false, click: handlers.zoomIn },
+    { label: 'Zoom Out', accelerator: 'CmdOrCtrl+-', registerAccelerator: false, click: handlers.zoomOut },
+    { label: 'Actual Size', accelerator: 'CmdOrCtrl+0', registerAccelerator: false, click: handlers.zoomReset },
     { type: 'separator' },
     { role: 'togglefullscreen' },
     { type: 'separator' },

--- a/src/renderer/hooks/useZoom.ts
+++ b/src/renderer/hooks/useZoom.ts
@@ -15,10 +15,17 @@ export const ZOOM_LEVELS: readonly ZoomLevel[] = [
   { key: 'spacious', factor: 1.10, labelKey: 'appearanceSettings.zoomSpacious' },
 ]
 
-const EPSILON = 0.005
-
-export function isSameZoom(a: number, b: number): boolean {
-  return Math.abs(a - b) < EPSILON
+// The presets are four named rungs, but the factor itself is continuous: main steps it by 0.05
+// within a 0.5-1.5 clamp, so most values sit between two rungs. Any factor resolves to the closest
+// one — past either end, to that end — so the Zoom control always marks exactly one preset. A
+// factor exactly between two rungs takes the lower one, so the answer never depends on how the
+// ladder is walked.
+export function nearestZoomLevel(factor: number): ZoomLevel {
+  let nearest = ZOOM_LEVELS[0]
+  for (const level of ZOOM_LEVELS) {
+    if (Math.abs(factor - level.factor) < Math.abs(factor - nearest.factor)) nearest = level
+  }
+  return nearest
 }
 
 export function useZoom(): { zoom: number; setZoom: (factor: number) => Promise<void> } {

--- a/src/renderer/screens/AppearanceSettings.tsx
+++ b/src/renderer/screens/AppearanceSettings.tsx
@@ -5,7 +5,7 @@ import i18n, { setLocale, SUPPORTED_LANGUAGES, type SupportedLanguage } from '..
 import { applyTheme, getStoredTheme, type ThemeMode } from '../theme.js'
 import { useHasVerticalOverflow } from '../hooks/useHasVerticalOverflow.js'
 import { useMainQuery } from '../store/useMainQuery.js'
-import { useZoom, ZOOM_LEVELS, isSameZoom } from '../hooks/useZoom.js'
+import { useZoom, ZOOM_LEVELS, nearestZoomLevel } from '../hooks/useZoom.js'
 import Icon, { type IconName } from '../components/primitives/Icon.js'
 import PageHeader from '../components/layout/PageHeader.js'
 import SectionHeading from '../components/layout/SectionHeading.js'
@@ -27,6 +27,7 @@ export default function AppearanceSettings({ onBack }: AppearanceSettingsProps) 
   const { t } = useTranslation()
   const [theme, setTheme] = useState<ThemeMode>(() => getStoredTheme())
   const { zoom, setZoom } = useZoom()
+  const selectedZoomKey = nearestZoomLevel(zoom).key
   const { ref, hasOverflow } = useHasVerticalOverflow<HTMLDivElement>()
   const currentLang = i18n.language
   const showMenuBarToggle = window.bridge.getPlatform() !== 'darwin'
@@ -76,7 +77,7 @@ export default function AppearanceSettings({ onBack }: AppearanceSettingsProps) 
                     <Segment
                       key={level.key}
                       label={t(level.labelKey)}
-                      selected={isSameZoom(zoom, level.factor)}
+                      selected={level.key === selectedZoomKey}
                       onSelect={() => setZoom(level.factor)}
                     />
                   ))}

--- a/test/frontend/scenarios/s15-appearance.mjs
+++ b/test/frontend/scenarios/s15-appearance.mjs
@@ -1,3 +1,4 @@
+import { execFileSync } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { Instance } from '../instance.mjs'
@@ -15,6 +16,34 @@ async function pressedZoomTiles (A) {
     if ((await A.nodeValue({ name: label })) === '1') pressed.push(label)
   }
   return pressed
+}
+
+function storeHeldByApp (store) {
+  try {
+    execFileSync('pgrep', ['-f', `Electron.*${store}`], { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Editing a stopped instance's store is only safe once the app is really gone: quit() resolves on
+// the `npx electron-forge` wrapper, whose Electron child can still be shutting down, and main's
+// config store is debounced and flushed on before-quit — a flush that rewrites the WHOLE file, so
+// an early edit is silently replaced by the factor the dying app held. Wait the app out, then read
+// the edit back, so a clobber fails here by name instead of as a mystery timeout further down.
+// The wait belongs in the harness's own stop; this is local until quit() awaits the real process.
+async function seedPersistedZoom (A, factor) {
+  await waitFor(async () => !storeHeldByApp(A.store), 20000, 'the quit app released its store')
+  const configPath = join(A.store, 'config.json')
+  const config = JSON.parse(readFileSync(configPath, 'utf8'))
+  config.window.zoom = factor
+  writeFileSync(configPath, JSON.stringify(config))
+  await new Promise((resolve) => setTimeout(resolve, 300))
+  const readBack = JSON.parse(readFileSync(configPath, 'utf8')).window.zoom
+  if (readBack !== factor) {
+    throw new Error(`seeded zoom ${factor} was clobbered: config.json holds ${readBack}`)
+  }
 }
 
 export default async function s15 ({ runDir, bootstrap }) {
@@ -46,10 +75,7 @@ export default async function s15 ({ runDir, bootstrap }) {
     // nothing — a screen reader must never be told no zoom is selected while one plainly is.
     await r.ok('a factor between presets marks exactly the nearest tile', async () => {
       await A.quit()
-      const configPath = join(A.store, 'config.json')
-      const config = JSON.parse(readFileSync(configPath, 'utf8'))
-      config.window.zoom = 0.90
-      writeFileSync(configPath, JSON.stringify(config))
+      await seedPersistedZoom(A, 0.90)
       await A.launch({ onboard: false })
       await A.gotoSettings('Appearance')
       await A.waitText('Appearance', 8000)

--- a/test/frontend/scenarios/s15-appearance.mjs
+++ b/test/frontend/scenarios/s15-appearance.mjs
@@ -1,10 +1,22 @@
-import { mkdirSync } from 'node:fs'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { Instance } from '../instance.mjs'
 import { makeReport, waitFor } from '../assert.mjs'
 
-// Appearance settings: a zoom level applies (aria-pressed flips) and switching
-// the interface language re-renders visible strings (English → Deutsch → back).
-// Theme switching is already covered by s8.
+// Appearance settings: a zoom level applies (aria-pressed flips), an off-preset factor still marks
+// exactly one tile, and switching the interface language re-renders visible strings
+// (English → Deutsch → back). Theme switching is already covered by s8.
+
+const ZOOM_TILES = ['Compact', 'Cozy', 'Default', 'Spacious']
+
+async function pressedZoomTiles (A) {
+  const pressed = []
+  for (const label of ZOOM_TILES) {
+    if ((await A.nodeValue({ name: label })) === '1') pressed.push(label)
+  }
+  return pressed
+}
+
 export default async function s15 ({ runDir, bootstrap }) {
   mkdirSync(runDir, { recursive: true })
   const r = makeReport()
@@ -28,6 +40,23 @@ export default async function s15 ({ runDir, bootstrap }) {
       await A.waitText('Manage your experience', 8000)
       await A.click({ name: 'Appearance' })
       await waitFor(async () => (await A.nodeValue({ name: 'Spacious' })) === '1', 8000, 'still Spacious')
+    })
+    // The menu and the keyboard chord step the factor by 0.05, so the persisted value usually
+    // lands between two presets. The control marks the nearest one: 0.90 is Cozy (0.92), not
+    // nothing — a screen reader must never be told no zoom is selected while one plainly is.
+    await r.ok('a factor between presets marks exactly the nearest tile', async () => {
+      await A.quit()
+      const configPath = join(A.store, 'config.json')
+      const config = JSON.parse(readFileSync(configPath, 'utf8'))
+      config.window.zoom = 0.90
+      writeFileSync(configPath, JSON.stringify(config))
+      await A.launch({ onboard: false })
+      await A.gotoSettings('Appearance')
+      await A.waitText('Appearance', 8000)
+      await waitFor(async () => (await A.nodeValue({ name: 'Cozy' })) === '1', 8000, 'Cozy pressed at 0.90')
+      const pressed = await pressedZoomTiles(A)
+      if (pressed.join(',') !== 'Cozy') throw new Error(`expected only Cozy pressed, got [${pressed.join(',')}]`)
+      await A.shot('s15-zoom-nearest', runDir)
     })
     await r.ok('switching language re-renders the UI, then switches back', async () => {
       await A.click({ name: 'Deutsch' })

--- a/test/unit/app-menu.test.js
+++ b/test/unit/app-menu.test.js
@@ -20,6 +20,9 @@ const allHandlers = {
   whatsNew: noop,
   sendFeedback: noop,
   openDocs: noop,
+  zoomIn: noop,
+  zoomOut: noop,
+  zoomReset: noop,
 }
 
 const baseOpts = { isDev: false, inSpace: false, appName: 'Mirall', handlers: allHandlers }
@@ -119,15 +122,46 @@ test('Reload / Force Reload visible only in dev; DevTools always visible', (t) =
   t.ok(findInSubmenu(devView, 'toggleDevTools'), 'DevTools in dev')
 })
 
-test('View submenu has zoom roles', (t) => {
+test('View submenu has the zoom items and their chords', (t) => {
   const tpl = buildAppMenuTemplate({ ...baseOpts, platform: 'darwin' })
   const view = find(tpl, 'View').submenu
-  t.ok(findInSubmenu(view, 'zoomIn'), 'zoomIn role present')
-  t.ok(findInSubmenu(view, 'zoomOut'), 'zoomOut role present')
-  t.ok(findInSubmenu(view, 'resetZoom'), 'resetZoom role present')
+  const chords = { 'Zoom In': 'CmdOrCtrl+Plus', 'Zoom Out': 'CmdOrCtrl+-', 'Actual Size': 'CmdOrCtrl+0' }
+  for (const [label, accelerator] of Object.entries(chords)) {
+    const item = findInSubmenu(view, label)
+    t.ok(item, `${label} item present`)
+    t.is(item.accelerator, accelerator, `${label} shows ${accelerator}`)
+  }
   t.ok(findInSubmenu(view, 'togglefullscreen'), 'togglefullscreen role present')
   t.ok(findInSubmenu(view, 'Back'), 'Back item present')
   t.ok(findInSubmenu(view, 'Home'), 'Home item present')
+})
+
+// REGRESSION (FIX-219: the zoom items carried Electron's zoomIn/zoomOut/resetZoom roles, which
+// write webContents.zoomLevel behind main's back — the factor was never persisted, no
+// zoom-changed event was emitted, and main's cached factor went stale). The items must dispatch
+// through the handlers, and must not register their chord a second time on Windows/Linux, where
+// the window's own key handler already applies one step per press.
+test('REGRESSION (FIX-219): zoom items call the handlers instead of the Electron roles', (t) => {
+  for (const platform of ['darwin', 'win32', 'linux']) {
+    const calls = []
+    const handlers = {
+      ...allHandlers,
+      zoomIn: () => calls.push('in'),
+      zoomOut: () => calls.push('out'),
+      zoomReset: () => calls.push('reset'),
+    }
+    const view = find(buildAppMenuTemplate({ ...baseOpts, platform, handlers }), 'View').submenu
+    for (const [label, expected] of [['Zoom In', 'in'], ['Zoom Out', 'out'], ['Actual Size', 'reset']]) {
+      const item = findInSubmenu(view, label)
+      t.absent(item.role, `${platform}: ${label} carries no Electron role`)
+      t.is(item.registerAccelerator, false, `${platform}: ${label} does not register its chord`)
+      item.click()
+      t.is(calls.at(-1), expected, `${platform}: ${label} invoked the ${expected} handler`)
+    }
+  }
+  const roles = ['zoomIn', 'zoomOut', 'resetZoom']
+  const view = find(buildAppMenuTemplate({ ...baseOpts, platform: 'darwin' }), 'View').submenu
+  for (const role of roles) t.absent(findInSubmenu(view, role), `no ${role} role in the View menu`)
 })
 
 test('View submenu exposes Profile and Activity Log with their chords', (t) => {

--- a/test/unit/zoom-levels.test.js
+++ b/test/unit/zoom-levels.test.js
@@ -1,0 +1,60 @@
+// The Zoom control's preset ladder (src/renderer/hooks/useZoom.ts). The persisted factor is
+// continuous — main steps it by 0.05 inside a 0.5-1.5 clamp — so the control has to resolve an
+// arbitrary factor to one of four named rungs.
+import test from 'brittle'
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import { dirname, join } from 'node:path'
+import { transformSync } from 'esbuild'
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..', '..')
+
+// TypeScript the Node runner can't import directly. Its React and store imports are stubbed:
+// only the hook body reads them, and the ladder under test is plain data.
+function loadModule (relPath) {
+  const src = readFileSync(join(root, relPath), 'utf8')
+  const { code } = transformSync(src, { loader: 'ts', format: 'cjs' })
+  const mod = { exports: {} }
+  const stubRequire = () => ({ useCallback: (fn) => fn, useMainQuery: () => ({}) })
+  new Function('module', 'exports', 'require', code)(mod, mod.exports, stubRequire)
+  return mod.exports
+}
+
+const { ZOOM_LEVELS, nearestZoomLevel } = loadModule('src/renderer/hooks/useZoom.ts')
+
+test('every preset resolves to itself', (t) => {
+  for (const level of ZOOM_LEVELS) {
+    t.is(nearestZoomLevel(level.factor).key, level.key, `${level.factor} is ${level.key}`)
+  }
+})
+
+// REGRESSION (FIX-219: the control compared the factor to each preset within 0.005, so every
+// factor main's 0.05 step produces that is not itself a preset — 0.90, 0.95, 1.05, 1.15 — lit no
+// tile at all, leaving a screen reader told nothing was selected while zoom was plainly applied).
+test('REGRESSION (FIX-219): a factor between presets marks exactly one tile', (t) => {
+  const cases = [
+    [0.90, 'cozy'],
+    [0.95, 'cozy'],
+    [1.05, 'default'],
+    [1.15, 'spacious'],
+    [1.20, 'spacious'],
+  ]
+  for (const [factor, key] of cases) {
+    t.is(nearestZoomLevel(factor).key, key, `${factor} → ${key}`)
+    const marked = ZOOM_LEVELS.filter((l) => l.key === nearestZoomLevel(factor).key)
+    t.is(marked.length, 1, `${factor} marks exactly one preset`)
+  }
+})
+
+test('a factor past either end of the ladder takes the end rung', (t) => {
+  t.is(nearestZoomLevel(0.5).key, 'compact', 'the 0.5 clamp floor is Compact')
+  t.is(nearestZoomLevel(0.1).key, 'compact', 'below the ladder is Compact')
+  t.is(nearestZoomLevel(1.5).key, 'spacious', 'the 1.5 clamp ceiling is Spacious')
+  t.is(nearestZoomLevel(9).key, 'spacious', 'above the ladder is Spacious')
+})
+
+test('a factor exactly between two presets takes the lower one', (t) => {
+  t.is(nearestZoomLevel(0.885).key, 'compact', 'midway between 0.85 and 0.92')
+  t.is(nearestZoomLevel(0.96).key, 'cozy', 'midway between 0.92 and 1.0')
+  t.is(nearestZoomLevel(1.05).key, 'default', 'midway between 1.0 and 1.10')
+})


### PR DESCRIPTION
Fixes #219

**Bug.** Zoom chosen from View ▸ Zoom In / Zoom Out / Actual Size is lost on quit.

**Reproduced at runtime** (macOS, `electron-forge start --storage <tmp>`, driven via agent-desktop):
- Menu ▸ Zoom In visibly zooms (a heading measures 448 → 646 px across four clicks) while `config.json` `window.zoom` stays `1`. Quit + relaunch comes back unzoomed.
- Boot restore itself works: hand-setting `window.zoom` to `1.2` renders the heading at 538 px.
- The issue's guess that macOS menu key-equivalents preempt `before-input-event` is **wrong**: with an instrumented build, a physical ⌘0 fires only the window's `before-input-event` handler, never the menu item. Chords were already persisting; only the menu was not.

**Root cause.** The three items carried Electron's `zoomIn`/`zoomOut`/`resetZoom` roles, which set `webContents.zoomLevel` directly — bypassing `applyZoom`, the only writer of `window.zoom`, the only emitter of `pear:event:zoom-changed`, and the owner of main's cached factor.

**Fix.** The items dispatch through new `zoomIn`/`zoomOut`/`zoomReset` handlers that call `applyZoom` via one `zoomByDirection` helper, which the keyboard path now shares. `registerAccelerator: false` keeps the chord displayed but unregistered on Windows/Linux (no-op on macOS), so the window's key handler stays the single chord owner and one press applies one step.

**Verified after the fix**: two menu Zoom In clicks → `window.zoom` 1.10; quit; relaunch renders the heading at 493 px (448 × 1.1).

**Tests.** `test/unit/app-menu.test.js`: the roles assertion is replaced by label + accelerator assertions, plus `REGRESSION (FIX-219)` across darwin/win32/linux asserting no Electron role, `registerAccelerator === false`, and that each item invokes its handler. Red-first confirmed — the pre-fix template has no `Zoom In`/`Zoom Out`/`Actual Size` item at all. Main-process/native-menu change, so unit is the layer; no renderer DOM changed, and the menu items keep the same AX names (`Zoom In`, `Zoom Out`, `Actual Size`) — verified in the live AX tree. Flow and frontend layers are not applicable.

**Security audit of this change.** Persisted zoom is read only through `readZoom() → clampZoom()`, which rejects non-numeric/non-finite values to the default and clamps to 0.5–1.5 before any `setZoomFactor`; a hand-edited `config.json` cannot drive an out-of-range zoom. The click handlers take no argument and no untrusted input — direction is a literal at the call site. No new IPC channel or preload surface, no new dependency, no secret touched.

---

## Follow-on (same PR, at the human's request): the Zoom tiles marked nothing

**Bug.** With menu zoom now persisting, most factors leave Appearance ▸ Zoom with **no** tile highlighted. `ZOOM_LEVELS` is a four-rung named ladder (0.85 / 0.92 / 1.0 / 1.10) and the screen lit a tile only on an exact match within `EPSILON = 0.005`, while main steps zoom by a linear 0.05 over a 0.5–1.5 clamp — so 0.90, 0.95, 1.05, 1.15 matched nothing. `aria-pressed` was `false` on all four: a screen-reader user was told nothing was selected while zoom was plainly applied.

**Fix (nearest-preset, per the human's decision).** Stepping stays continuous; `nearestZoomLevel(factor)` in `useZoom.ts` resolves any factor to the closest rung — past either end, to that end — and ties take the lower rung so the answer never depends on how the ladder is walked. `AppearanceSettings` selects on `level.key === nearestZoomLevel(zoom).key`. `isSameZoom` had no other caller and is removed with it. Accepted trade-off: at 1.15 the control reads Spacious (1.10), and clicking that tile looks inert while it does move the zoom.

**Accessibility.** `Segment` derives both the highlight and `aria-pressed` from the one `selected` prop, so the visual and ARIA states cannot diverge; the new rule makes exactly one of the four true for every factor — never zero, never two. jsx-a11y clean via `lint:ci`.

**Tests.** `test/unit/zoom-levels.test.js` covers exact presets, between-preset factors (`REGRESSION (FIX-219)`), out-of-ladder ends, and ties. Red-first confirmed: the pre-fix `isSameZoom` lights nothing at 0.90 / 0.95 / 1.05 / 1.15. `test/frontend/scenarios/s15-appearance.mjs` gains a step that quits, sets the persisted factor to 0.90, relaunches, and asserts Cozy is the *only* pressed tile.
