### PR TITLE
[fix] Run the quit teardown once, in a stated order

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1104,6 +1104,7 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/main/feature-flags.js` | Boot-cached `feature-flags.json` from the package root + env override |
 | `src/main/identity-kek.js` | The os-keychain unlock provider's host side: the identity KEK at rest under `safeStorage` (§16) |
 | `src/main/ipc-frame.js` | Byte-level NDJSON splitter for worker→main control frames, with a 64 KB per-frame gate |
+| `src/main/lifecycle.js` | The quit teardown: one ordered `before-quit` sequence (mark-quitting → owned watchers → loose watchers → config flush → workers → apply update), run at most once per process so the update-apply deferral cannot tear the app down twice |
 | `src/main/log-ring.js` | Bounded in-memory ring of recent log lines from all three processes, for the diagnostics bundle; never written to disk |
 | `src/main/loose-file-watchers.js` | Individual watched paths for in-place loose-file shares, over the watch host; path → `Set<spaceId>` fan-out (§2 step 12) |
 | `src/main/main-requests.js` | The worker→main command router — a null-prototype table keyed off `contract/main-requests.js`, capped unknown-command warnings |

--- a/src/main/lifecycle.js
+++ b/src/main/lifecycle.js
@@ -1,0 +1,82 @@
+// The main process's quit teardown: one ordered sequence behind a single
+// `before-quit` listener. Electron emits `before-quit` to every listener on every
+// `app.quit()`, so a listener that defers the quit (preventDefault → async work →
+// quit again) makes each of its siblings run once per pass. Sequencing the steps
+// here — and running them at most once per process — is what keeps a deferred
+// update-apply quit from tearing the app down twice.
+
+// The teardown order a quit runs, and the only order it runs in.
+//
+// - `mark-quitting` first: the window close handler hides to tray unless the flag
+//   is set, and the worker frame writer only stays quiet about a failed write once
+//   it is — so every later step has to run behind it.
+// - both watchers before `flush-config`: a live watcher can dirty the config
+//   store, and a write landing after the flush is lost.
+// - `stop-workers` before `apply-update`: the update swaps the files this process
+//   runs from, so the worker is asked to exit before the swap starts rather than
+//   racing it.
+// - `apply-update` last, and the only step that may defer the quit.
+const QUIT_STEPS = Object.freeze([
+  'mark-quitting',
+  'stop-owned-watchers',
+  'stop-loose-watchers',
+  'flush-config',
+  'stop-workers',
+  'apply-update',
+])
+
+/**
+ * Builds the ordered `before-quit` handler.
+ *
+ * Each step is independent, so a step that throws is recorded and the sequence
+ * continues: aborting would skip `stop-workers` and leave an orphaned worker
+ * subprocess holding the store, which is a worse outcome than the error that
+ * preceded it.
+ *
+ * `applyUpdate` returns a promise when a staged update is being applied and a
+ * falsy value when there is nothing to apply. A promise defers the quit
+ * (`event.preventDefault()`) and re-issues it once the apply settles; the
+ * re-issued quit re-enters this handler, which has already run and does nothing.
+ *
+ * @param {object} steps
+ * @param {() => void} steps.markQuitting
+ * @param {() => void} steps.stopOwnedWatchers
+ * @param {() => void} steps.stopLooseWatchers
+ * @param {() => void} steps.flushConfig
+ * @param {() => void} steps.stopWorkers
+ * @param {() => Promise<void> | null | undefined} steps.applyUpdate
+ * @param {() => void} steps.quit — re-issues the deferred quit.
+ * @param {(step: string, err: Error) => void} [steps.onStepError]
+ */
+function createQuitSequence ({ markQuitting, stopOwnedWatchers, stopLooseWatchers, flushConfig, stopWorkers, applyUpdate, quit, onStepError }) {
+  const runners = {
+    'mark-quitting': markQuitting,
+    'stop-owned-watchers': stopOwnedWatchers,
+    'stop-loose-watchers': stopLooseWatchers,
+    'flush-config': flushConfig,
+    'stop-workers': stopWorkers,
+  }
+  let ran = false
+
+  function report (step, err) {
+    if (onStepError) onStepError(step, err)
+  }
+
+  return function onBeforeQuit (event) {
+    if (ran) return
+    ran = true
+    for (const step of QUIT_STEPS) {
+      if (step === 'apply-update') continue
+      try { runners[step]() } catch (err) { report(step, err) }
+    }
+    let pending = null
+    try { pending = applyUpdate() } catch (err) { report('apply-update', err) }
+    if (!pending) return
+    event.preventDefault()
+    pending
+      .catch((err) => report('apply-update', err))
+      .finally(() => quit())
+  }
+}
+
+module.exports = { QUIT_STEPS, createQuitSequence }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -11,6 +11,7 @@ const fs = require('fs')
 const os = require('os')
 const { StringDecoder } = require('node:string_decoder')
 const { logRing } = require('./log-ring')
+const { createQuitSequence } = require('./lifecycle.js')
 
 // Custom app:// scheme. Registered as standard+secure so the renderer
 // document gets a stable origin across webContents.reload — file://
@@ -634,6 +635,23 @@ function validateDownloadFolder(folder) {
 
 // === Worker spawn + renderer⇄worker IPC relay ===
 
+// Asks every live worker to exit. Called once, from the quit sequence.
+//
+// 1. The shutdown frame lets the worker close the swarm and Bare.exit on its own.
+// 2. Escalation covers a worker that cannot. The bare-sidecar Duplex has no kill(): destroy()
+//    sends SIGTERM via the sidecar; a worker whose loop is starved cannot process the shutdown
+//    frame OR a SIGTERM bare dispatches on that loop, so follow up with SIGKILL on the child.
+//    Timers are unref'd so they never delay a clean exit; process.on('exit') is the backstop
+//    when main exits before these fire.
+function stopWorkers() {
+  for (const worker of workers.values()) {
+    sendToWorker(worker, { type: 'shutdown' })
+    const child = worker._process
+    setTimeout(() => { try { worker.destroy() } catch {} ; try { child?.kill('SIGTERM') } catch {} }, 3000).unref?.()
+    setTimeout(() => { try { child?.kill('SIGKILL') } catch {} }, 5000).unref?.()
+  }
+}
+
 function getWorker(specifier) {
   if (workers.has(specifier)) return workers.get(specifier)
   const p = getPear()
@@ -764,20 +782,6 @@ function getWorker(specifier) {
     logRing.push('worker', 'error', text)
   })
 
-  const onBeforeQuit = () => {
-    // 1. Ask the worker to exit cleanly (it closes the swarm, then Bare.exit).
-    sendToWorker(worker, { type: 'shutdown' })
-    // 2. Escalate if it is still alive. The bare-sidecar Duplex has no kill(): destroy() sends
-    //  SIGTERM via the sidecar; a worker whose loop is starved cannot process the shutdown frame
-    //  OR a SIGTERM bare dispatches on that loop, so follow up with SIGKILL on the child. Timers
-    //  are unref'd so they never delay a clean exit; process.on('exit') is the backstop when main
-    //  exits before these fire.
-    const child = worker._process
-    setTimeout(() => { try { worker.destroy() } catch {} ; try { child?.kill('SIGTERM') } catch {} }, 3000).unref?.()
-    setTimeout(() => { try { child?.kill('SIGKILL') } catch {} }, 5000).unref?.()
-  }
-  app.on('before-quit', onBeforeQuit)
-
   worker.once('exit', (code) => {
     // A partial character at process death would otherwise be dropped along with the line it
     // belongs to — and a worker's LAST line is the one worth having.
@@ -785,7 +789,6 @@ function getWorker(specifier) {
     if (stdoutTail) logRing.push('worker', 'log', stdoutTail)
     const stderrTail = stderrDecoder.end()
     if (stderrTail) logRing.push('worker', 'error', stderrTail)
-    app.removeListener('before-quit', onBeforeQuit)
     // Replace the writeHandler with a no-op instead of removing it. Late
     // renderer messages (common during shutdown) would otherwise hit
     // "No handler registered" and surface as Uncaught Promise rejections.
@@ -998,13 +1001,6 @@ ipcMain.handle('pear:startWorker', (_evt, specifier) => {
   return true
 })
 
-// before-quit fires before any window's close event. Setting isQuitting here
-// covers system-initiated quits (Cmd-Q, OS shutdown, app menu Quit) so the
-// close handler doesn't hide-to-tray instead of quitting. Tray-menu Quit
-// also sets this directly before calling app.quit — idempotent re-set is
-// harmless.
-app.on('before-quit', () => { isQuitting = true })
-
 // Backstop against orphaned worker subprocesses. When the main process exits for
 // any reason (clean quit, OTA relaunch, an uncaught crash), synchronously
 // hard-kill any worker child still alive. A healthy worker has already exited via
@@ -1015,22 +1011,6 @@ process.on('exit', () => {
   for (const worker of workers.values()) {
     try { worker._process?.kill('SIGKILL') } catch {}
   }
-})
-
-// Promote any staged OTA bundle on the user's next clean quit. Defer the quit
-// (preventDefault → await applyUpdate → re-quit) because Electron does not
-// await async listeners and the swap must finish before the process exits —
-// macOS/Linux: fsx.swap (fast); Windows: MSIXManager.addPackage (seconds).
-let updateApplyAttempted = false
-app.on('before-quit', (event) => {
-  if (updateApplyAttempted) return
-  if (!updatesEnabled) return
-  if (!pear?.updater?.updated || pear.updater.applied) return
-  updateApplyAttempted = true
-  event.preventDefault()
-  pear.updater.applyUpdate()
-    .catch((err) => console.error('apply update on quit failed:', err))
-    .finally(() => app.quit())
 })
 
 ipcMain.handle('window:getBounds', (evt) => {
@@ -1110,11 +1090,31 @@ ipcMain.handle('downloads:browse', (evt, defaultPath) => pickDirectory(
 
 ipcMain.handle('share:browseFolder', (evt) => pickDirectory(evt))
 
-app.on('before-quit', () => {
-  try { ownedFolderWatchers.stopAllWatchers() } catch {}
-  try { looseFileWatchers.stopLooseWatchers() } catch {}
-  try { configStore?.flush() } catch {}
-})
+// The one quit teardown. Electron re-emits before-quit to every listener on every
+// app.quit(), so the update-apply step's deferral (preventDefault → apply → quit
+// again) would run every sibling twice if they were separate listeners; the
+// sequence runs once per process and the re-issued quit passes straight through.
+// Step order and the continue-on-error rule live in lifecycle.js.
+app.on('before-quit', createQuitSequence({
+  // Read by the window close handler, which hides to tray unless the app is
+  // quitting. Tray-menu Quit sets it directly before calling app.quit.
+  markQuitting: () => { isQuitting = true },
+  stopOwnedWatchers: () => ownedFolderWatchers.stopAllWatchers(),
+  stopLooseWatchers: () => looseFileWatchers.stopLooseWatchers(),
+  flushConfig: () => configStore?.flush(),
+  stopWorkers,
+  // Promote any staged OTA bundle on the user's next clean quit. Returning the
+  // promise defers the quit, because Electron does not await async listeners and
+  // the swap must finish before the process exits — macOS/Linux: fsx.swap (fast);
+  // Windows: MSIXManager.addPackage (seconds).
+  applyUpdate: () => {
+    if (!updatesEnabled) return null
+    if (!pear?.updater?.updated || pear.updater.applied) return null
+    return pear.updater.applyUpdate()
+  },
+  quit: () => app.quit(),
+  onStepError: (step, err) => console.error('quit teardown step failed:', step, err),
+}))
 
 // === Theme, app menu, window creation ===
 

--- a/test/unit/main-quit-sequence.test.js
+++ b/test/unit/main-quit-sequence.test.js
@@ -1,0 +1,148 @@
+import test from 'brittle'
+import { QUIT_STEPS, createQuitSequence } from '../../src/main/lifecycle.js'
+
+// Electron's contract: app.quit() emits before-quit to every listener; a listener may
+// preventDefault() to abort that quit, and a later app.quit() re-emits to all of them.
+function fakeApp (handler) {
+  const app = { quits: 0, deferred: 0, exited: 0 }
+  app.quit = () => {
+    app.quits += 1
+    let prevented = false
+    handler({ preventDefault () { prevented = true } })
+    if (prevented) app.deferred += 1
+    else app.exited += 1
+  }
+  return app
+}
+
+function recorder (overrides = {}) {
+  const calls = []
+  const step = (name) => () => {
+    calls.push(name)
+    if (overrides[name]) return overrides[name]()
+  }
+  return {
+    calls,
+    steps: {
+      markQuitting: step('mark-quitting'),
+      stopOwnedWatchers: step('stop-owned-watchers'),
+      stopLooseWatchers: step('stop-loose-watchers'),
+      flushConfig: step('flush-config'),
+      stopWorkers: step('stop-workers'),
+      applyUpdate: step('apply-update'),
+    },
+  }
+}
+
+test('QUIT_STEPS is the declared teardown order', (t) => {
+  t.alike([...QUIT_STEPS], [
+    'mark-quitting',
+    'stop-owned-watchers',
+    'stop-loose-watchers',
+    'flush-config',
+    'stop-workers',
+    'apply-update',
+  ], 'watchers stop before the config flush; the worker stops before the update is applied')
+  t.ok(Object.isFrozen(QUIT_STEPS))
+})
+
+test('a plain quit runs every step once, in order, and does not defer', (t) => {
+  const rec = recorder()
+  const app = fakeApp(createQuitSequence({ ...rec.steps, quit: () => app.quit() }))
+  app.quit()
+  t.alike(rec.calls, [...QUIT_STEPS], 'every step ran exactly once, in QUIT_STEPS order')
+  t.is(app.deferred, 0)
+  t.is(app.exited, 1)
+})
+
+test('REGRESSION (FIX-220): an update-apply quit runs each teardown exactly once', async (t) => {
+  let applyDone = false
+  const rec = recorder({
+    'apply-update': async () => { await Promise.resolve(); applyDone = true },
+  })
+  let prevents = 0
+  const handler = createQuitSequence({ ...rec.steps, quit: () => app.quit() })
+  const app = fakeApp((event) => handler({ preventDefault () { prevents += 1; event.preventDefault() } }))
+
+  app.quit()
+  // The deferred quit lands when the apply settles.
+  await new Promise((resolve) => setTimeout(resolve, 20))
+
+  for (const step of QUIT_STEPS) {
+    t.is(rec.calls.filter((c) => c === step).length, 1, `${step} ran exactly once`)
+  }
+  t.alike(rec.calls, [...QUIT_STEPS], 'and in order — the re-issued quit adds nothing')
+  t.is(prevents, 1, 'the quit was deferred exactly once')
+  t.is(app.quits, 2, 'the deferral re-issued the quit')
+  t.is(app.exited, 1, 'the re-issued quit was not deferred again')
+  t.ok(applyDone, 'the update was applied before the process was allowed to exit')
+})
+
+test('the worker is asked to exit before the update apply starts', (t) => {
+  const order = []
+  const handler = createQuitSequence({
+    markQuitting: () => {},
+    stopOwnedWatchers: () => {},
+    stopLooseWatchers: () => {},
+    flushConfig: () => order.push('flush-config'),
+    stopWorkers: () => order.push('stop-workers'),
+    applyUpdate: () => { order.push('apply-update'); return Promise.resolve() },
+    quit: () => {},
+  })
+  handler({ preventDefault () {} })
+  t.alike(order, ['flush-config', 'stop-workers', 'apply-update'])
+})
+
+test('a step that throws is reported and does not skip the steps after it', (t) => {
+  const errors = []
+  const rec = recorder({
+    'stop-owned-watchers': () => { throw new Error('watcher boom') },
+    'flush-config': () => { throw new Error('flush boom') },
+  })
+  const handler = createQuitSequence({
+    ...rec.steps,
+    quit: () => {},
+    onStepError: (step, err) => errors.push([step, err.message]),
+  })
+  handler({ preventDefault () {} })
+  t.alike(rec.calls, [...QUIT_STEPS], 'every later step still ran')
+  t.alike(errors, [['stop-owned-watchers', 'watcher boom'], ['flush-config', 'flush boom']])
+})
+
+test('a synchronous throw from applyUpdate is reported and the quit is not deferred', (t) => {
+  const errors = []
+  let prevented = false
+  const rec = recorder({ 'apply-update': () => { throw new Error('apply boom') } })
+  const handler = createQuitSequence({
+    ...rec.steps,
+    quit: () => {},
+    onStepError: (step, err) => errors.push([step, err.message]),
+  })
+  handler({ preventDefault () { prevented = true } })
+  t.absent(prevented, 'a quit that cannot apply an update still exits')
+  t.alike(errors, [['apply-update', 'apply boom']])
+})
+
+test('a rejected apply still lets the quit through', async (t) => {
+  const errors = []
+  const rec = recorder({ 'apply-update': () => Promise.reject(new Error('swap failed')) })
+  const handler = createQuitSequence({
+    ...rec.steps,
+    quit: () => app.quit(),
+    onStepError: (step, err) => errors.push([step, err.message]),
+  })
+  const app = fakeApp(handler)
+  app.quit()
+  await new Promise((resolve) => setTimeout(resolve, 20))
+  t.is(app.exited, 1, 'the process exits rather than hanging on a failed swap')
+  t.alike(errors, [['apply-update', 'swap failed']])
+})
+
+test('a quit issued after the sequence has run is a no-op', (t) => {
+  const rec = recorder()
+  const handler = createQuitSequence({ ...rec.steps, quit: () => {} })
+  handler({ preventDefault () {} })
+  handler({ preventDefault () {} })
+  handler({ preventDefault () {} })
+  t.alike(rec.calls, [...QUIT_STEPS], 'the teardown is run at most once per process')
+})

--- a/test/unit/main-worker-writes.test.js
+++ b/test/unit/main-worker-writes.test.js
@@ -19,6 +19,7 @@ function fnBody(name) {
 const code = (text) => text.split('\n').filter((line) => !line.trim().startsWith('//')).join('\n')
 
 const getWorker = code(mainSrc.match(/function getWorker\s*\([\s\S]*?\n\}/)?.[0] ?? '')
+const stopWorkers = code(mainSrc.match(/function stopWorkers\s*\([\s\S]*?\n\}/)?.[0] ?? '')
 
 test('REGRESSION (FIX-BOOTSTRAP-1): every frame main puts on the worker pipe is written through one guarded path', (t) => {
   // The bootstrap write was the only one of four with no try/catch. A worker that died between
@@ -29,8 +30,9 @@ test('REGRESSION (FIX-BOOTSTRAP-1): every frame main puts on the worker pipe is 
 
   t.ok(/sendToWorker\(worker,\s*bootstrap\)/.test(getWorker),
     'the bootstrap frame goes through sendToWorker')
-  t.ok(/sendToWorker\(worker,\s*\{\s*type:\s*'shutdown'\s*\}\)/.test(getWorker),
-    'and so does the shutdown frame')
+  t.ok(stopWorkers, 'stopWorkers() exists in src/main/main.js')
+  t.ok(/sendToWorker\(worker,\s*\{\s*type:\s*'shutdown'\s*\}\)/.test(stopWorkers),
+    'and so does the quit sequence\'s shutdown frame')
 
   // The raw relay is the one legitimate exception: the renderer has already serialised its own
   // NDJSON envelope, so there is no frame object to hand over.


### PR DESCRIPTION
Fixes #220

> Was stacked on #253; #253 has merged and this branch is rebased onto `staging` @ `4141bd1`, so the diff below is this branch alone.

## Bug

Four `before-quit` listeners were registered in file order with nothing stating the order. The updater's listener calls `event.preventDefault()` and re-issues `app.quit()` in its `finally`, and Electron re-emits `before-quit` to *every* listener on that second quit — so the watchers were stopped, the config flushed and the worker `shutdown` frame sent twice, the first pass racing the update apply.

Reproduced with a harness reproducing Electron's `quit()`/`before-quit`/`preventDefault` contract over the four listener bodies verbatim: `stopAllWatchers=2 stopLooseWatchers=2 config.flush=2 worker:shutdown=2`, with the shutdown frame sent before the apply finished.

## Fix — the double fire is removed, not made idempotent

New `src/main/lifecycle.js` owns one ordered `before-quit` handler that runs at most once per process:

`mark-quitting → stop-owned-watchers → stop-loose-watchers → flush-config → stop-workers → apply-update`

The deferral stays (Electron does not await async listeners), but the re-issued quit re-enters a latched sequence and passes straight through. Removing the second pass was chosen over documenting it: nothing needs the teardown twice, and "idempotent by contract" would mean pinning idempotency for a chokidar close, an atomic config write and a worker `shutdown` frame — three contracts to hold instead of one latch.

Ordering rationale is in the module header: watchers stop before the flush (a live watcher can dirty the store after it is written); the worker is asked to exit before the apply starts, where previously the apply began in the same tick as the teardown.

The per-worker `before-quit` listener is replaced by a single `stopWorkers()` over the live `workers` map; the map is the ownership, so the `worker.once('exit')` `removeListener` is gone. Escalation timers and the `process.on('exit')` SIGKILL backstop are unchanged.

**Error policy: wrap and continue.** Each step is independent; aborting at the first throw would skip `stop-workers` (orphaned worker holding the store) and `flush-config` (lost preferences), both worse than the error that preceded them. Errors now go to `onStepError` → `console.error` → log ring instead of the three empty `catch {}` blocks they replaced.

## Tests

`test/unit/main-quit-sequence.test.js` — 8 tests: `QUIT_STEPS` order pinned; a plain quit runs every step once in order; `REGRESSION (FIX-220)` asserts an update-apply quit runs each step **exactly once** with exactly one `preventDefault` and one exit; worker-before-apply ordering; a throwing step reports and does not skip its successors; a sync throw and a rejected apply both still let the quit through; a repeat quit is a no-op.

`test/unit/main-worker-writes.test.js` — the shutdown-frame assertion follows the frame into `stopWorkers()`; the "one guarded write path" guarantee is unchanged.

Layers: **Unit** only. Main-process lifecycle logic — no data layer, no P2P, no renderer surface, so integration/flow/frontend are `SKIP` per the coverage matrix (`test:bare` was run anyway and is green).

## Security audit

- **Worker left running?** No. `stopWorkers()` iterates the same live `workers` map the `process.on('exit')` SIGKILL backstop does; a worker spawned after the sequence latched is covered by that backstop exactly as before.
- **Config half-flushed?** No. `configStore.flush()` is synchronous over `config-store.js`'s atomic temp+rename, and now runs once, after both watchers stop — no watcher write can land behind it.
- **Update applied over a live process?** Strictly improved: the apply now starts only after mark-quitting, both watchers, the flush and the worker shutdown request, where it previously started in the same tick as all of them. It still does not *block* on the worker's exit — unchanged behaviour; adding a wait would put a new timeout on the update path and is out of scope here.
- **Teardown skippable by a throw?** No — continue-on-error, argued above, and failures are now reported rather than swallowed.
- **`preventDefault` + re-quit window?** Narrowed, not widened: the old `updateApplyAttempted` flag latched only the updater listener, the new latch covers the whole sequence, so no teardown can run concurrently with an in-flight apply. The apply itself (`pear.updater.applyUpdate()`) is untouched; update authenticity remains the key-verified Pear drive. The sequence takes no arguments and is reachable from no IPC path.
- **Standard checks:** no secrets, no dependency change, no new IPC channel, handler or preload surface.

## Gates

`typecheck` clean · `lint` 0 errors / 19 warnings (ceiling 21, unchanged) · `lint:ci` clean incl. comment-hygiene · `test:node:core` 2184/2184 · `test:bare` 1100/1100. `test:fe` not run — no renderer surface.
