### PR TITLE
[fix] Scale flow wait deadlines; hex temp-dir suffixes

### DIFF
--- a/scripts/check-test-timing.sh
+++ b/scripts/check-test-timing.sh
@@ -29,4 +29,22 @@ if [ -n "$(printf '%s' "$hits" | tr -d '[:space:]')" ]; then
   exit 1
 fi
 
+# The silent twin of the rule above: a flow test that declares its OWN poll/sleep helper
+# owns the scaling that test/helpers would have done for it. A bare millisecond parameter
+# default there never grows under MIRALL_TEST_TIMEOUT_SCALE, so the deadline stays at its
+# dev-box value on a CI runner three times slower and the wait expires before the work can
+# land. Such a helper carries no `scaled(` for the check above to see, so match the
+# declaration instead: in test/flow a millisecond parameter default is written
+# `ms = scaled(60000)` (or `unscaled(...)` where the bound must stay absolute).
+own="$(grep -rnE "\([^()]*\b[A-Za-z_]*([Mm]s|[Tt]imeout|[Dd]eadline)\b *= *[0-9]{3,}" test/flow/ || true)"
+
+if [ -n "$(printf '%s' "$own" | tr -d '[:space:]')" ]; then
+  echo "ERROR: un-scaled deadline default in a flow helper — it ignores MIRALL_TEST_TIMEOUT_SCALE:" >&2
+  printf '%s\n' "$own" | sort -u >&2
+  echo >&2
+  echo "  fix: (ms = 90000)  ->  (ms = scaled(90000))" >&2
+  echo "       or drop the local copy and import the helper from test/helpers/" >&2
+  exit 1
+fi
+
 echo "test-timing: clean."

--- a/test/flow/foreign-sync.test.js
+++ b/test/flow/foreign-sync.test.js
@@ -3,23 +3,15 @@ import fs from 'fs'
 import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
-import { mkTmpDir, patternedBytes, mkStoreDir } from '../helpers/fixtures.js'
-
-async function waitForFile (p, { present = true, ms = 90000, every = 500 } = {}) {
-  const start = Date.now()
-  for (;;) {
-    if (fs.existsSync(p) === present) return
-    if (Date.now() - start > ms) throw new Error(`timeout waiting for ${p} present=${present}`)
-    await new Promise((r) => setTimeout(r, every))
-  }
-}
+import { mkTmpDir, patternedBytes, mkStoreDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // The materialize engine streams a blob from the owner on demand. If the owner
 // is offline and the blob isn't cached, it must DEFER (try again next tick) —
 // not skip forever (the old has()-only deadlock) and not error/pause. When the
 // owner returns, the poll loop completes the download.
 test('REGRESSION (connectivity gate): mirror defers while owner offline+uncached, then materializes on return',
-  { timeout: 180000 }, async (t) => {
+  { timeout: scaled(180000) }, async (t) => {
     const bootstrap = await localTestnet(t)
     const aStore = mkStoreDir(t)
     const aDownloads = mkTmpDir(t)
@@ -64,7 +56,7 @@ test('REGRESSION (connectivity gate): mirror defers while owner offline+uncached
 // listing, an owner-side edit propagates to the mirror and an owner-side delete
 // removes the mirrored file.
 test('REGRESSION (FIX-6): owner edit and delete propagate to an online mirror',
-  { timeout: 180000 }, async (t) => {
+  { timeout: scaled(180000) }, async (t) => {
     const bootstrap = await localTestnet(t)
     const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
     const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -115,7 +107,7 @@ test('REGRESSION (FIX-6): owner edit and delete propagate to an online mirror',
 // sibling — never B's pre-existing file at the natural name. (An anchor file
 // keeps the owner listing non-empty so the deletion gate honors the removal.)
 test('REGRESSION (MIR-07): a peer delete removes only the mirror copy, never the user\'s conflicting file',
-  { timeout: 180000 }, async (t) => {
+  { timeout: scaled(180000) }, async (t) => {
     const bootstrap = await localTestnet(t)
     const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
     const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/loose-transfer.test.js
+++ b/test/flow/loose-transfer.test.js
@@ -14,7 +14,7 @@ const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
 const v2flags = () => ({ overlayEnabled: true, inPlaceFilesEnabled: true, identityKEK: kekHex() })
 
 function writeTmpFile (bytes) {
-  const p = path.join(os.tmpdir(), `mirall-src-${Date.now()}-${Math.random().toString(36).slice(2, 8)}.bin`)
+  const p = path.join(os.tmpdir(), `mirall-src-${Date.now()}-${Math.random().toString(16).slice(2, 8)}.bin`)
   fs.writeFileSync(p, bytes)
   return p
 }

--- a/test/flow/overlay-no-store-growth.test.js
+++ b/test/flow/overlay-no-store-growth.test.js
@@ -15,7 +15,7 @@ import { scaled } from '../helpers/timing.js'
 const FLAGS = { overlayEnabled: true }
 const SIZE = 8 * 1024 * 1024 // dwarfs RocksDB WAL/compaction + catalog/chunk-map metadata
 
-const flush = (ms = 1500) => new Promise((r) => setTimeout(r, ms))
+const flush = (ms = scaled(1500)) => new Promise((r) => setTimeout(r, ms))
 
 test('overlay: publish imports no blob; download writes no content blocks into the consumer store',
   { timeout: scaled(180000) }, async (t) => {

--- a/test/flow/share-delete.test.js
+++ b/test/flow/share-delete.test.js
@@ -3,16 +3,8 @@ import fs from 'fs'
 import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
-import { mkTmpDir } from '../helpers/fixtures.js'
-
-async function waitForFile (p, { present = true, ms = 90000, every = 500 } = {}) {
-  const start = Date.now()
-  for (;;) {
-    if (fs.existsSync(p) === present) return
-    if (Date.now() - start > ms) throw new Error(`timeout waiting for ${p} present=${present}`)
-    await new Promise((r) => setTimeout(r, every))
-  }
-}
+import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // owned-folder:delete is the owner's full teardown: it stops the watcher +
 // reconcile, dels every drive entry under the share prefix, removes the owned
@@ -21,7 +13,7 @@ async function waitForFile (p, { present = true, ms = 90000, every = 500 } = {})
 // is the FIX-6 "treat as transient" case) — those files persist as orphans,
 // exactly like an unmount.
 test('owner deletes a share: it vanishes from the peer registry and the mirror files orphan (not wiped)',
-  { timeout: 150000 }, async (t) => {
+  { timeout: scaled(150000) }, async (t) => {
     const bootstrap = await localTestnet(t)
     const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
     const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/helpers/peer-bee.js
+++ b/test/helpers/peer-bee.js
@@ -6,7 +6,8 @@ import Corestore from 'corestore'
 import Hyperbee from 'hyperbee'
 
 function tmpDir () {
-  const dir = path.join(os.tmpdir(), `pb-peer-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  // Hex, not base36 — a base36 suffix can spell a cloud-sync hint (see test/helpers/fixtures.js).
+  const dir = path.join(os.tmpdir(), `pb-peer-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`)
   fs.mkdirSync(dir, { recursive: true })
   return dir
 }

--- a/test/helpers/peer.js
+++ b/test/helpers/peer.js
@@ -24,7 +24,8 @@ function kekFor (storage) {
 }
 
 function tmp (label) {
-  const dir = path.join(os.tmpdir(), `mirall-peer-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  // Hex, not base36 — a base36 suffix can spell a cloud-sync hint (see test/helpers/fixtures.js).
+  const dir = path.join(os.tmpdir(), `mirall-peer-${label}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`)
   fs.mkdirSync(dir, { recursive: true })
   return dir
 }

--- a/test/helpers/store.js
+++ b/test/helpers/store.js
@@ -9,7 +9,8 @@ import { createFakeIpc } from './fake-ipc.js'
 
 let seq = 0
 function tmpDir (label) {
-  const rand = Math.random().toString(36).slice(2, 8)
+  // Hex, not base36 — a base36 suffix can spell a cloud-sync hint (see test/helpers/fixtures.js).
+  const rand = Math.random().toString(16).slice(2, 8)
   const dir = path.join(os.tmpdir(), `mirall-test-${label}-${Date.now()}-${rand}-${seq++}`)
   fs.mkdirSync(dir, { recursive: true })
   return dir

--- a/test/raw/_holepunch.js
+++ b/test/raw/_holepunch.js
@@ -6,7 +6,8 @@ import Corestore from 'corestore'
 import Hyperswarm from 'hyperswarm'
 
 export function tmpDir(label) {
-  const dir = path.join(os.tmpdir(), `mirall-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  // Hex, not base36 — a base36 suffix can spell a cloud-sync hint (see test/helpers/fixtures.js).
+  const dir = path.join(os.tmpdir(), `mirall-test-${label}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`)
   fs.mkdirSync(dir, { recursive: true })
   return dir
 }

--- a/test/raw/holepunch-integration.test.js
+++ b/test/raw/holepunch-integration.test.js
@@ -10,7 +10,7 @@ import Hyperswarm from 'hyperswarm'
 import createTestnet from 'hyperdht/testnet.js'
 
 function tmpDir(label) {
-  const dir = path.join(os.tmpdir(), `mirall-test-${label}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`)
+  const dir = path.join(os.tmpdir(), `mirall-test-${label}-${Date.now()}-${Math.random().toString(16).slice(2, 8)}`)
   fs.mkdirSync(dir, { recursive: true })
   return dir
 }

--- a/test/unit/tmp-dir-suffix-hygiene.test.js
+++ b/test/unit/tmp-dir-suffix-hygiene.test.js
@@ -1,0 +1,57 @@
+import test from 'brittle'
+import { readFileSync, readdirSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { cloudSyncHint } from '../../src/shared/folders/path-keys.js'
+
+// A test peer's temp dir is handed to the app as a mount root, so it crosses
+// mount-validate. A base36 random suffix draws from [0-9a-z] and can therefore spell
+// a cloud-sync hint ("box", "mega"), which mount-validate rejects with
+// MOUNT_FORBIDDEN_CLOUD_SYNC — a rare, unreproducible red with no relation to the
+// behavior under test. Hex is safe by construction, and that is what these pin.
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const testRoot = path.join(here, '..')
+
+// Every dir whose names reach the app as a mount root or a download destination.
+const SCANNED = ['flow', 'helpers', 'raw']
+const HEX = /^[0-9a-f]*$/
+
+function scannedFiles () {
+  const out = []
+  for (const dir of SCANNED) {
+    for (const name of readdirSync(path.join(testRoot, dir))) {
+      if (name.endsWith('.js')) out.push(path.join(dir, name))
+    }
+  }
+  return out
+}
+
+test('no cloud-sync hint is spellable in hex', (t) => {
+  // The whole guarantee: every rejected substring carries at least one character
+  // outside the hex alphabet, so no hex suffix of any length can contain one.
+  const hints = ['dropbox', 'onedrive', 'google drive', 'icloud', 'box', 'nextcloud', 'mega', 'proton drive', 'pcloud']
+  for (const hint of hints) {
+    t.ok(cloudSyncHint(hint), `${hint} is a rejected substring`)
+    t.absent(HEX.test(hint), `${hint} cannot be spelled in hex`)
+  }
+})
+
+test('the generated suffix is hex, long enough to isolate concurrent runs, and hint-free', (t) => {
+  let shortest = Infinity
+  for (let i = 0; i < 50000; i++) {
+    const suffix = Math.random().toString(16).slice(2, 8)
+    if (!HEX.test(suffix)) return t.fail(`non-hex suffix ${suffix}`)
+    if (cloudSyncHint(`/tmp/mirall-peer-a-1700000000000-${suffix}`)) return t.fail(`hint in ${suffix}`)
+    shortest = Math.min(shortest, suffix.length)
+  }
+  t.ok(shortest >= 5, `>= 20 bits of suffix entropy (shortest sample: ${shortest} hex chars)`)
+})
+
+test('REGRESSION: no base36 temp-dir suffix under test/flow, test/helpers or test/raw', (t) => {
+  // Nothing in these dirs has a legitimate use for base36, so the whole call is the tell —
+  // the suffix and the tmpdir() join are not always on the same line.
+  const offenders = scannedFiles().filter((rel) =>
+    readFileSync(path.join(testRoot, rel), 'utf8').includes('toString(36)'))
+  t.alike(offenders, [], 'temp-dir suffixes are hex')
+})


### PR DESCRIPTION
Closes #229

## Bug

**D16** — `test/flow/foreign-sync.test.js` and `share-delete.test.js` each kept a private
copy of `waitForFile` with a bare `ms = 90000` default. `test/helpers/fixtures.js`'s copy
runs `scaled(ms)`; these did not, so under CI's `MIRALL_TEST_TIMEOUT_SCALE=3` they gave up
at a third of the intended budget. `check-test-timing.sh` could not see it: the defect is
the *absence* of `scaled(`, and the guard only grepped for its presence.

**D17** — four temp-dir makers built their random suffix with `Math.random().toString(36)`.
Base36 draws from `[0-9a-z]`, so a suffix can spell a cloud-sync hint (`box`, `mega`);
`mount-validate` rejects such a path with `MOUNT_FORBIDDEN_CLOUD_SYNC`, flaking any test
that mounts the dir. `fixtures.js` documented the hazard and used hex; these did not.

## Fix

- Both flow tests import `fixtures.waitForFile`; the local copies are gone. Their own
  per-test `{ timeout }` is now `scaled(...)` too, so the brittle deadline can't fire
  before the (now correctly scaled) wait does.
- `check-test-timing.sh` gained a second rule: in `test/flow`, a millisecond parameter
  default must be wrapped in `scaled(`/`unscaled(`.
- Hex suffixes in `test/helpers/{peer,store,peer-bee}.js` and `test/raw/_holepunch.js`,
  plus two the issue missed (`test/raw/holepunch-integration.test.js`,
  `test/flow/loose-transfer.test.js`). One line each points at the rule's canonical
  statement in `fixtures.js` rather than restating it five times.
- `test/unit/tmp-dir-suffix-hygiene.test.js` pins both halves.

## Beyond the issue's list

- A third un-scaled flow deadline the widened guard found on its own:
  `overlay-no-store-growth.test.js`'s `flush(ms = 1500)` settle sleep — now `scaled(1500)`.
- Two more base36 makers, listed above.
- No other local `waitForFile` copies exist. `overlay-mirror-sync.test.js`'s
  `waitForContent` and `mirror-pause.test.js`'s `waitForSize` already default to
  `scaled(...)` and are the pattern the widened rule encodes.
- **Not fixed, out of scope:** ~100 flow `test(..., { timeout: N })` per-test deadlines
  are un-scaled repo-wide, and `test/integration` still has ~25 base36 temp-dir makers —
  including `mount-validate.test.js`, which actually mounts them. Filed separately.

## Guard: fires before, passes after

Widened guard against the pre-fix tree:

```
ERROR: un-scaled deadline default in a flow helper — it ignores MIRALL_TEST_TIMEOUT_SCALE:
test/flow/foreign-sync.test.js:8:async function waitForFile (p, { present = true, ms = 90000, every = 500 } = {}) {
test/flow/overlay-no-store-growth.test.js:18:const flush = (ms = 1500) => new Promise((r) => setTimeout(r, ms))
test/flow/share-delete.test.js:8:async function waitForFile (p, { present = true, ms = 90000, every = 500 } = {}) {
EXIT=1
```

After: `test-timing: clean.` (exit 0).

D17, same shape — the regression test run against the pre-fix `test/helpers/store.js`:

```
not ok 3 - REGRESSION: no base36 temp-dir suffix under test/flow, test/helpers or test/raw
# tests = 2/3 pass
```

After: `# tests = 3/3 pass  # asserts = 20/20 pass`.

## Security audit

Test-only change; `src/` is untouched, so there is no auth, permission or deserialization
surface to regress.

- **Injection** — the new `check-test-timing.sh` rule is a fixed `grep -rnE` over a
  literal path, no interpolation of any external value; `set -euo pipefail` retained.
- **Deps / secrets** — `package.json` and the lockfile are untouched, no new dependency,
  no credential added (diff scanned for key/token/secret patterns: none).
- **Temp-dir entropy** — the suffix stays 6 characters, so the alphabet change lowers it
  from ~31 to 24 bits. Collision between two concurrent runs additionally requires the
  same `Date.now()` millisecond (and, in `store.js`, the same in-process sequence
  number), which makes it negligible; the sampled generator is asserted never to emit a
  suffix under 5 characters, so the entropy floor can't silently erode. This matches the
  already-shipped `fixtures.js` precedent rather than introducing a weaker one.
- **Path escape** — the suffix alphabet is now strictly `[0-9a-f]`, asserted over 50k
  samples, so it cannot contain `/`, `..` or NUL; every generated path stays under
  `os.tmpdir()`. Strictly narrower than the base36 alphabet it replaces.

## Test layers

Unit (new hygiene guard) + the flow files themselves. No UI surface, so `test:fe` is `SKIP`.

- `npm run typecheck` — clean
- `npm run lint` — 0 errors, 19 warnings (all pre-existing, all in `src/`; 0 in `test/`)
- `bash scripts/check-comment-hygiene.sh` — `comment-hygiene: clean.`
- `npm run test:node:core` — `# tests = 2197/2197 pass  # asserts = 17037/17037 pass`
- `npm run test:bare` — `# tests = 1100/1100 pass  # asserts = 4083/4083 pass`
- flow (the four touched files) — `# tests = 6/6 pass  # asserts = 26/26 pass`,
  `# flow accounting: 6/6 registered test(s) executed`
- `scripts/check-test-timing.sh` — `test-timing: clean.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2tBf3Bb7K59LWPMbpaJ6d
