### PR TITLE
[fix] Continue the catalog migration past a bad space

### DIFF
--- a/src/shared/shares/migrate-catalog-encrypt.js
+++ b/src/shared/shares/migrate-catalog-encrypt.js
@@ -37,6 +37,7 @@ async function run (flagBee) {
 
   let migrated = 0
   let deferred = 0
+  let failed = 0
   for (const space of await listSpaces()) {
     // A pre-encryption space can never obtain an SCK, so letting it fall into the deferred bucket
     // below would hold the global flag open and re-run this whole pass on every boot, forever.
@@ -50,28 +51,34 @@ async function run (flagBee) {
       migrated += 1
       log.info('migrated space catalog to SCK-encrypted:', spaceId)
     } catch (err) {
+      failed += 1
       log.warn('catalog encrypt migration failed for', spaceId, '-', err.message)
-      return { skipped: false, migrated, retry: true }
     }
   }
-  // Only close out the migration once no space is still waiting on its SCK.
-  if (deferred === 0) await flagBee.put(FLAG, { completedAt: Date.now(), migrated })
+  // Only close out the migration once every space is done: one that failed, and one still waiting
+  // on its SCK, are both retried on a later boot — and neither costs the spaces after it, whose
+  // own markers make the retry a no-op for them.
+  if (deferred === 0 && failed === 0) await flagBee.put(FLAG, { completedAt: Date.now(), migrated })
   if (migrated) log.info('SCK-encrypted', migrated, 'space catalog(s)')
-  return { skipped: false, migrated, deferred }
+  if (failed) log.warn(failed, 'space catalog(s) failed to encrypt — retrying on the next boot')
+  return { skipped: false, migrated, deferred, failed }
 }
 
 async function migrateOneCatalog (space, spaceId) {
   const enc = await ownCatalog(spaceId)
   const legacy = openLegacyPlaintextCatalog(space, spaceId)
-  await legacy.core.ready()
-  if (legacy.core.length > 0) {
-    const batch = enc.batch()
-    for await (const { key, value } of legacy.createReadStream()) await batch.put(key, value)
-    await batch.flush()
-  } else {
-    log.info('no legacy plaintext catalog to copy for', spaceId)
+  try {
+    await legacy.core.ready()
+    if (legacy.core.length > 0) {
+      const batch = enc.batch()
+      for await (const { key, value } of legacy.createReadStream()) await batch.put(key, value)
+      await batch.flush()
+    } else {
+      log.info('no legacy plaintext catalog to copy for', spaceId)
+    }
+  } finally {
+    try { await legacy.close() } catch {}
   }
-  try { await legacy.close() } catch {}
 
   const encKey = await ownCatalogKeyHex(spaceId)
   await markSpaceLooseCatalogKeyEnc(spaceId, encKey)

--- a/test/integration/catalog-encrypt-migration.test.js
+++ b/test/integration/catalog-encrypt-migration.test.js
@@ -2,7 +2,7 @@ import test from 'brittle'
 import b4a from 'b4a'
 import { freshDurableWithIdentity } from '../helpers/store.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
-import { createSpace, joinSpace, mutateSpace } from '../../src/shared/spaces/space.js'
+import { createSpace, joinSpace, mutateSpace, listSpaces } from '../../src/shared/spaces/space.js'
 import { getLocalPublicKeyHex, readProfileRecord } from '../../src/shared/spaces/profile.js'
 import { publishShare, readOwnShares } from '../../src/shared/shares/shares.js'
 import { createBee, getStore } from '../../src/shared/core/store.js'
@@ -96,4 +96,37 @@ test('a legacy space is skipped, not deferred — the migration still closes out
   const res = await migrateCatalogsToEncrypted()
   t.is(res.deferred, 0, 'the legacy space is not deferred')
   t.ok((await migrateCatalogsToEncrypted()).skipped, 'the global flag closed out, so later boots no-op')
+})
+
+// REGRESSION (FIX-MIGRATE-CONTINUE): a space whose catalog copy throws must not end the pass —
+// every space after it stayed plaintext until the next boot, where it failed the same way.
+test('REGRESSION (FIX-MIGRATE-CONTINUE): a failing space is counted and the rest still migrate', async (t) => {
+  await v2Peer(t)
+  for (const name of ['Aurora', 'Borealis', 'Corona']) await createSpace(name)
+  const spaces = await listSpaces()
+  t.is(spaces.length, 3, 'precondition: three v2 spaces')
+
+  // The FIRST space in the pass order is the poisoned one, so a runner that stops on a failure
+  // migrates nothing at all.
+  const poisoned = spaces[0].spaceId
+  for (const space of spaces) {
+    const legacy = createBee(await legacyPlaintextCatalogName(space.spaceId))
+    await legacy.ready()
+    await legacy.put(fileKey(SHARE, 'a.txt'), { size: 3, mtime: 1, contentHash: 'hf' })
+    // An unreadable legacy catalog: the copy throws where a corrupt core would.
+    if (space.spaceId === poisoned) await legacy.core.append(b4a.from('not-a-hyperbee-node'))
+    await legacy.close()
+  }
+
+  const res = await migrateCatalogsToEncrypted()
+  t.is(res.failed, 1, 'the failing space is counted')
+  t.is(res.migrated, 2, 'the two healthy spaces migrated anyway')
+
+  for (const space of spaces) {
+    if (space.spaceId === poisoned) continue
+    const folder = await collectOwnShare(space.spaceId, SHARE)
+    t.alike(folder.entries.map((e) => e.relPath), ['a.txt'], 'healthy space copied into its encrypted core')
+  }
+
+  t.absent((await migrateCatalogsToEncrypted()).skipped, 'not marked complete while a space failed (retries next boot)')
 })


### PR DESCRIPTION
Closes #227

**Bug.** The catalog-encrypt migration returned `{ retry: true }` on the first space whose copy threw, so every space after it stayed plaintext until the next boot — where the same space failed the same way, indefinitely. The runner's own policy (`storage/migrations.js`) is that a failure must not stop the stage.

**Fix.** `migrate-catalog-encrypt.js` counts a failing space and continues. The result now carries `failed`, a summary line is logged when any space failed, and the global marker is written only when `deferred === 0 && failed === 0`, so a failed space is retried next boot while the per-space markers make that retry a no-op for the ones that succeeded. The legacy plaintext bee is now closed in a `finally` — on the throwing path it was left as an open store session, which now happens once per failed space per boot.

No on-disk schema, encryption format, or API change; a failing space keeps its plaintext catalog exactly as before (the purge still runs only after a successful copy).

**Tests.** Integration (red-first): `REGRESSION (FIX-MIGRATE-CONTINUE)` in `test/integration/catalog-encrypt-migration.test.js` — three v2 spaces, the first in pass order poisoned with an unreadable legacy catalog; asserts `failed === 1`, `migrated === 2`, both healthy catalogs copied into their encrypted cores, and that the pass is not marked complete. Fails on staging (`migrated 0`), passes with the fix. UI: none — `test:fe` not applicable.

**Security audit.** No user input, deserialization, dep, or auth surface is touched. No secrets in the diff. The per-space failure is not swallowed: it is logged per space, summarised, returned as `failed`, and the pass stays open so it retries every boot — a corruption or tampering signal is louder than before, not quieter, since a poisoned space previously masked every later space's state as "not yet migrated". No key material is logged (the warn line carries the space id and the error message; the SCK and the catalog key are not printed). Continuing does not weaken the plaintext-leak closure: purge still runs only after a successful copy, and later spaces now get closed out instead of remaining plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2tBf3Bb7K59LWPMbpaJ6d