### PR TITLE
[fix] Count in the singular in the scan preview

### DIFF
--- a/src/renderer/components/modals/ScanPreviewModal.tsx
+++ b/src/renderer/components/modals/ScanPreviewModal.tsx
@@ -124,14 +124,14 @@ function ScanPreviewBody({ preview, loading, progress, readOnlyWarning }: ScanPr
       {preview.toUpload > 0 && (
         <SummaryCard
           tone="info"
-          title={t('scanPreview.toUpload_other', { count: preview.toUpload })}
+          title={t('scanPreview.toUpload', { count: preview.toUpload })}
           detail={t('scanPreview.uploadDetail', { size: formatSize(preview.totalBytes) })}
         />
       )}
       {preview.toDownload > 0 && (
         <SummaryCard
           tone="info"
-          title={t('scanPreview.toDownload_other', { count: preview.toDownload })}
+          title={t('scanPreview.toDownload', { count: preview.toDownload })}
           detail={t('scanPreview.downloadDetail', { size: formatSize(preview.totalBytes) })}
         />
       )}

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -138,6 +138,7 @@ import s137 from './scenarios/s137-relay-invite.mjs'
 import s138 from './scenarios/s138-mirror-offline-quiet.mjs'
 import s139 from './scenarios/s139-mirror-offline-incomplete.mjs'
 import s140 from './scenarios/s140-modal-failure-escape-routes.mjs'
+import s141 from './scenarios/s141-scan-preview-singular.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -197,7 +198,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140, s141 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s141-scan-preview-singular.mjs
+++ b/test/frontend/scenarios/s141-scan-preview-singular.mjs
@@ -1,0 +1,36 @@
+import { mkdirSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, assert } from '../assert.mjs'
+import { workDir } from '../paths.mjs'
+
+// REGRESSION (FIX-PLURAL-SUFFIX) — the Add-Folder preview counts in the singular. A folder holding
+// exactly one file reads "Upload 1 file"; naming i18next's `_other` suffix in the key pins the
+// plural form for every count, so the same card read "Upload 1 files".
+//
+// hasText is a case-folded WHOLE-WINDOW substring match, so the singular alone would also match
+// inside the plural. The plural string has to be asserted ABSENT for this to mean anything.
+export default async function s141 ({ runDir }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', slot: 0, total: 1 })
+
+  const ownDir = path.join(workDir('own-'), 'Solo')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'only.txt'), 'x'.repeat(64))
+
+  try {
+    await r.ok('A opens the Add Folder preview on a one-file folder', async () => {
+      await A.launch()
+      // Add-Folder (cmd+shift+u) is registered only in space-view, so enter a space first.
+      await A.createSpaceOnly('Aurora')
+      await A.openAddFolderPreview(ownDir)
+    })
+    await r.ok('the summary card counts in the singular', async () => {
+      await A.waitText('Upload 1 file', 30000)
+      assert(!(await A.hasText('Upload 1 files')), 'the plural form is NOT used at count 1')
+      await A.shot('s141-A-scan-preview-singular', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/unit/i18n-unreferenced-keys.test.js
+++ b/test/unit/i18n-unreferenced-keys.test.js
@@ -10,11 +10,7 @@ const PLURAL = /_(one|other|zero|two|few|many)$/
 
 // Keys the scan cannot see but which are live, each with the site that will consume it. A key
 // that merely stopped being used does not belong here — delete it from all five locales instead.
-const ALLOW = [
-  // ScanPreviewModal.tsx calls the `_other` form directly; switching it to
-  // t('scanPreview.toUpload', { count }) makes the `_one` forms live again. Remove then.
-  /^scanPreview\.to(Upload|Download)_one$/
-]
+const ALLOW = []
 
 function flatten (obj, prefix = '', out = []) {
   for (const [k, v] of Object.entries(obj)) {
@@ -84,4 +80,18 @@ test('the scan sees a literal, a plural base and a dotted-prefix template — an
   t.ok(literals.has('actions.cancel'), 'a plain t() key is a literal')
   t.ok(patterns.some((re) => re.test('leaveSpace.phases.finalizing')), 'a `prefix.${x}` template covers its family')
   t.absent(patterns.some((re) => re.test('zzz.never.defined')), 'no template matches everything')
+})
+
+// i18next picks the plural form from `count`; naming a suffix in the key pins one form for every
+// count, so the singular is unreachable and the locale key reads as dead to the scan above.
+test('REGRESSION (FIX-PLURAL-SUFFIX): no t() call names a plural suffix in its key', (t) => {
+  const files = SCAN.flatMap((d) => walk(path.join(root, d)))
+  const offenders = []
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8')
+    for (const m of src.matchAll(/\bt\(\s*['"`]([^'"`]+)['"`]/g)) {
+      if (PLURAL.test(m[1])) offenders.push(path.relative(root, file) + ': ' + m[1])
+    }
+  }
+  t.alike(offenders, [], 'pass the base key and { count } instead of a _one/_other key')
 })


### PR DESCRIPTION
**Bug.** The Add-Folder / Mirror-Folder scan preview read "Upload 1 files" (and "Download 1 files") at count 1, in all five locales.

**Root cause.** `ScanPreviewModal.tsx` passed `t('scanPreview.toUpload_other', { count })` and the same for `toDownload`. Naming i18next's `_other` suffix in the key pins that plural form for every count, so the `_one` forms were unreachable — and looked dead to the `i18n-unreferenced-keys` guard, which carried an ALLOW entry for them.

**Fix.** Pass the base key with `{ count }` at both sites. The `_one` forms are live again, so the guard's ALLOW entry is gone (now empty). No locale strings needed changing: all ten `_one`/`_other` values across en/de/es/fr/it read correctly (Italian `file` is invariant by design; German is generic-masculine and has no person nouns here).

**Scope check.** `git grep` over the whole renderer found the defect at exactly these two sites and nowhere else.

**Tests.**
- Red-first unit guard in `test/unit/i18n-unreferenced-keys.test.js`: `REGRESSION (FIX-PLURAL-SUFFIX)` fails on any `t()` call whose key ends in a plural suffix. Verified red before the fix (both sites reported), green after. It reuses the existing i18n corpus scan rather than adding new apparatus, and it closes the class, not just the instance.
- New frontend scenario `s141-scan-preview-singular.mjs`: opens the Add-Folder preview on a one-file folder, waits for "Upload 1 file" and asserts "Upload 1 files" is ABSENT — `hasText` is a case-folded whole-window substring match, so the singular alone would also match inside the plural.

Layers: renderer UI → Frontend + a11y (+ the unit guard for the pure rule). No data-layer surface.

**Accessibility.** No markup change — only the string passed to an existing `SummaryCard` title, which already renders as a plain text node. `eslint-plugin-jsx-a11y` passes via `npm run build`; the modal's controls (Cancel, the primary confirm, the header close) keep their accessible names and disabled state, which is what lets `s141` drive it.

**Security audit of this change.**
- *Injection / XSS:* the only interpolated value is `count`, a number derived from the worker's scan tally — not user-controlled text. `i18n.ts` sets `interpolation: { escapeValue: false }`, which is the standard React setting because React escapes text children; the strings land as JSX children of `<p>` in `SummaryCard`, never through `dangerouslySetInnerHTML` (the sole use of that in the renderer is `WhatsNewModal`, untouched). No filename or other user-controlled string reaches either translated string.
- *Unsafe deserialization:* none — no parsing added.
- *Secrets:* none committed; diff is three source files plus one test scenario.
- *Dependencies:* none added or changed; `package.json`/lockfile untouched.
- *Permissions / auth:* none touched — this is presentation only, no IPC, no gate.

Result: no findings.

**Local gate.** `typecheck` clean · `build` (incl. jsx-a11y) clean · `test:node` `# tests = 202/202 pass`, `# flow accounting: 202/202 registered test(s) executed` · `test:bare` `# tests = 1100/1100 pass`, `# asserts = 4149/4149 pass` · `lint` 0 errors / 19 warnings (all pre-existing, ceiling 21) · comment-hygiene clean.

`test:fe s141` has NOT been run — the sandbox denied the invocation. It needs a local run before this merges.

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2tBf3Bb7K59LWPMbpaJ6d
