### PR TITLE
[fix] Declare @react-types/shared as a dependency

### DIFF
--- a/.claude/dependency-updates.md
+++ b/.claude/dependency-updates.md
@@ -84,6 +84,14 @@ Before merging:
 
 There is **no** automated pin-guard test — nothing fails CI when the version changes. Any manual hyperdrive bump is therefore a `needs-smoke-test` candidate: re-read the release notes for replication/wire-format changes, run the two-window smoke test, and confirm end-to-end replication before merging.
 
+## `@react-types/shared` — pinned twin of `react-aria`
+
+`@react-types/shared` is pinned to an exact version in `package.json` (`"@react-types/shared": "3.36.1"`, no caret). It is not a dependency we chose: `src/renderer/components/widgets/ActionMenu.tsx` needs the `Node`, `CollectionElement` and `FocusStrategy` types, and `react-aria` re-exports only `Key` from that package. It must therefore stay on the exact version the installed `react-aria` resolves for it.
+
+**When Renovate bumps `react-aria` (or `@react-stately/*`), bump `@react-types/shared` in the same PR** to whatever the new `react-aria` resolves — `npm ls @react-types/shared` after the bump tells you. Leaving it behind gives the renderer types from one React Aria release against hooks from another.
+
+`test/unit/renderer-declared-dependencies.test.js` fails if the renderer imports a package that `package.json` does not declare, so a dropped declaration is caught; it does not pin the version, which is what this note is for.
+
 ## Security PRs
 
 Renovate's `vulnerabilityAlerts` rule bypasses the weekly schedule. When one shows up:

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@react-stately/collections": "^3.13.1",
         "@react-stately/menu": "^3.10.1",
         "@react-stately/tree": "^3.10.1",
+        "@react-types/shared": "3.36.1",
         "@tailwindcss/cli": "^4.3.3",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.18",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@react-stately/collections": "^3.13.1",
     "@react-stately/menu": "^3.10.1",
     "@react-stately/tree": "^3.10.1",
+    "@react-types/shared": "3.36.1",
     "@tailwindcss/cli": "^4.3.3",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.18",

--- a/test/unit/renderer-declared-dependencies.test.js
+++ b/test/unit/renderer-declared-dependencies.test.js
@@ -1,0 +1,68 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import tsParser from '@typescript-eslint/parser'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.join(here, '..', '..')
+const rendererDir = path.join(repoRoot, 'src', 'renderer')
+
+function walk (dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) { if (name !== 'locales') walk(p, out) }
+    else if (/\.(ts|tsx|js)$/.test(name)) out.push(p)
+  }
+  return out
+}
+
+// The package a bare specifier belongs to: '@scope/name/sub' -> '@scope/name', 'react-dom/client' -> 'react-dom'.
+function packageOf (specifier) {
+  const parts = specifier.split('/')
+  return specifier.startsWith('@') ? parts.slice(0, 2).join('/') : parts[0]
+}
+
+function bareSpecifiers (source) {
+  const ast = tsParser.parse(source, { ecmaFeatures: { jsx: true }, sourceType: 'module' })
+  const found = []
+  const visit = (node) => {
+    if (!node || typeof node !== 'object') return
+    if (Array.isArray(node)) { node.forEach(visit); return }
+    const carriesSource = node.type === 'ImportDeclaration' || node.type === 'ExportNamedDeclaration' ||
+      node.type === 'ExportAllDeclaration' || node.type === 'ImportExpression'
+    if (carriesSource && node.source?.type === 'Literal' && typeof node.source.value === 'string') {
+      const value = node.source.value
+      if (!value.startsWith('.') && !value.startsWith('/')) found.push(value)
+    }
+    for (const key of Object.keys(node)) visit(node[key])
+  }
+  visit(ast.body)
+  return found
+}
+
+// Every package the renderer names must be declared in package.json. A specifier that resolves only
+// because some other package hoisted it into node_modules is one dependency bump away from a build
+// that fails with no lockfile signal — `import type` included, since esbuild strips those but tsc
+// does not.
+test('every bare import in src/renderer names a declared dependency', (t) => {
+  t.alike(bareSpecifiers("import type { Node } from '@react-types/shared'\n").map(packageOf), ['@react-types/shared'], 'a type-only import counts')
+  t.alike(bareSpecifiers("import { createRoot } from 'react-dom/client'\n").map(packageOf), ['react-dom'], 'a subpath maps to its package')
+  t.alike(bareSpecifiers("import Icon from '../primitives/Icon.js'\n").map(packageOf), [], 'a relative import is not a dependency')
+  t.alike(bareSpecifiers("const m = await import('marked')\n").map(packageOf), ['marked'], 'a dynamic import counts')
+
+  const manifest = JSON.parse(readFileSync(path.join(repoRoot, 'package.json'), 'utf8'))
+  const declared = new Set([...Object.keys(manifest.dependencies ?? {}), ...Object.keys(manifest.devDependencies ?? {})])
+
+  const files = walk(rendererDir)
+  t.ok(files.length > 100, 'src/renderer was actually walked')
+
+  const undeclared = []
+  for (const file of files) {
+    for (const specifier of bareSpecifiers(readFileSync(file, 'utf8'))) {
+      const pkg = packageOf(specifier)
+      if (!declared.has(pkg)) undeclared.push(`${path.relative(repoRoot, file)}: ${specifier}`)
+    }
+  }
+  t.alike(undeclared, [], 'no renderer import relies on a transitively hoisted package')
+})


### PR DESCRIPTION
## Bug

`src/renderer/components/widgets/ActionMenu.tsx` imports `Node`, `Key`, `CollectionElement` and
`FocusStrategy` from `@react-types/shared`, a package `package.json` never declared. It is the only
undeclared import in the renderer (verified by `git grep` on current `staging`).

## Root cause

It resolves today only because `react-aria` / `@react-stately/*` hoist it into the root
`node_modules`. Nothing pins it, so a Renovate bump of `react-aria` that stops hoisting it removes
the package with no lockfile signal, and `tsc --noEmit` — i.e. `npm run build` — fails in CI.

## Option chosen: (a) declare it

Option (b) was checked first and does not work: `react-aria@3.51.0` re-exports exactly
`Key`, `Orientation` and `RangeValue` from `@react-types/shared`
(`dist/types/exports/index.d.ts:266`). `Node`, `CollectionElement` and `FocusStrategy` are not
re-exported by `react-aria`, nor by the declared `@react-stately/tree`, `/collections` or `/menu`.
The only alternative would be indexed-access gymnastics over `TreeState`/`MenuTriggerState`, which is
less readable than naming the dependency the code actually has.

Declared as a **devDependency** — the whole React stack lives there, because the renderer is bundled
by esbuild at build time and never ships as a runtime `node_modules` dep. Putting it in
`dependencies` would have flipped `react` from dev to prod in the lockfile.

Pinned exactly (`3.36.1`, no caret) as a twin of `react-aria`, and recorded in
`.claude/dependency-updates.md` with the instruction to bump it in the same PR as any `react-aria`
bump.

## Guard

`test/unit/renderer-declared-dependencies.test.js` walks `src/renderer`, parses every file with
`@typescript-eslint/parser`, and asserts every bare specifier (static, `export … from`, dynamic
`import()`, and `import type` — which esbuild erases but `tsc` does not) maps to a package declared
in `package.json`. It follows the `renderer-contract-only-imports.test.js` pattern and carries four
control assertions.

Red-first, verified: run against the pre-fix `package.json` it fails with
`src/renderer/components/widgets/ActionMenu.tsx: @react-types/shared`; green after.

## Security audit of this change

- **Vulnerabilities:** `npm audit` on the branch is identical to the `staging` baseline —
  30 dev (3 low / 26 high / 1 critical) and **0 prod**, before and after. No advisory touches
  `@react-types/*`, `react-aria` or `@react-stately/*`.
- **Supply-chain shape:** genuine Adobe React Spectrum package —
  `repository: git+https://github.com/adobe/react-spectrum.git`, maintainers `devongovett` /
  `aspro83`, registry tarball on registry.npmjs.org. Correct `@react-types` scope, not a typosquat;
  it is the same package already present transitively, at the same version, so no new code enters
  the tree.
- **Lockfile integrity:** the existing entry keeps its `sha512-Azsu…FUoag==` integrity hash; the only
  lockfile change is adding the name to the root `devDependencies` block (one line).
- **Secrets:** none added.
- **Permission/auth surface:** unchanged. The package is types-only, erased at build.

## Scope

No `src/` file changes at all, so the emitted bundle is byte-identical. Diff is
`package.json` +1, `package-lock.json` +1, plus the guard test and the doc note.

## Tests

- `npm run typecheck` — exit 0
- `npm run build` — exit 0
- `npm run lint` / `lint:ci` — exit 0, 19 warnings (pre-existing, ceiling 21)
- `npm run test:node` — `# tests = 2195/2195 pass` (unit), `# tests = 202/202 pass` (flow)
- `npm run test:bare` — `# tests = 1100/1100 pass # asserts = 4092/4092 pass`

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2tBf3Bb7K59LWPMbpaJ6d
