### PR TITLE
[fix] Make three robustness edges honest

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1101,6 +1101,7 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/main/config-store.js` | The single owner of `config.json` — atomic writes, merge-over-defaults, the legacy-file fold, validated setters, migration seam (§2 step 5) |
 | `src/main/debug-gate.js` | The live logging gate (`baseDebug` / `debug` / `verbose`) — one reader/writer seam for the five sections that consult it |
 | `src/main/deeplink.js` | `parseDeepLink(url)` — validates `mirall://join/<code>`, decodes the envelope (dynamic import, since main is CJS) |
+| `src/main/env-json.js` | `envJson(name)` — the JSON-valued env knobs (test/debug overrides): parses one, ignores a malformed or scalar value with a warning that never repeats it |
 | `src/main/feature-flags.js` | Boot-cached `feature-flags.json` from the package root + env override |
 | `src/main/identity-kek.js` | The os-keychain unlock provider's host side: the identity KEK at rest under `safeStorage` (§16) |
 | `src/main/ipc-frame.js` | Byte-level NDJSON splitter for worker→main control frames, with a 64 KB per-frame gate |

--- a/src/main/env-json.js
+++ b/src/main/env-json.js
@@ -1,0 +1,28 @@
+// JSON-valued environment knobs (test/debug overrides). A knob is optional by definition, so a
+// value this cannot use is ignored with a warning rather than thrown: these are set by hand and by
+// the test harness, and a parse that throws takes its reader down with it.
+//
+// The value never reaches the warning. Main's console is mirrored into the log ring a diagnostics
+// bundle ships, and JSON.parse's own message quotes a fragment of the input — which for these knobs
+// is a bootstrap host/port list.
+//
+// Only a JSON object or array is accepted: a scalar parses fine but is not a shape any knob
+// declares, and handing one on gives the consumer a value it cannot use.
+function envJson (name) {
+  const raw = process.env[name]
+  if (!raw) return null
+  let parsed
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    console.warn('[mirall] ignoring malformed ' + name + ': not valid JSON')
+    return null
+  }
+  if (parsed === null || typeof parsed !== 'object') {
+    console.warn('[mirall] ignoring ' + name + ': expected a JSON object or array')
+    return null
+  }
+  return parsed
+}
+
+module.exports = { envJson }

--- a/src/main/main.js
+++ b/src/main/main.js
@@ -50,6 +50,7 @@ const { buildAppMenuTemplate } = require('./menu.js')
 const { matchWindowShortcut } = require('./window-shortcuts.js')
 const { ConfigStore } = require('./config-store.js')
 const { primeFeatureFlags, readFeatureFlags } = require('./feature-flags.js')
+const { envJson } = require('./env-json.js')
 const relaySecret = require('./relay-secret.js')
 const { initDebugGate, isDebug, isVerbose, setVerbose } = require('./debug-gate.js')
 const { integrateXdgLinux } = require('./xdg-integration.js')
@@ -679,7 +680,7 @@ function getWorker(specifier) {
     verbose: isVerbose(),
     downloadFolder: readDownloadFolder(),
     ...readBandwidth(),
-    dhtBootstrap: process.env.MIRALL_DHT_BOOTSTRAP ? JSON.parse(process.env.MIRALL_DHT_BOOTSTRAP) : null,
+    dhtBootstrap: envJson('MIRALL_DHT_BOOTSTRAP'),
     // Test/debug override for the share:list-files row cap (undefined → omitted by JSON →
     // the runtime-config default). Lets the frontend suite exercise the truncation banner
     // with a handful of files; a bad value is caught by getListFilesCap's fail-safe.

--- a/src/renderer/errorMessages.js
+++ b/src/renderer/errorMessages.js
@@ -44,6 +44,10 @@ export const ERROR_I18N_KEY_BY_CODE = {
   NOT_A_MEMBER: 'notAMember',
   EOWNERSHIP: 'notApprovedForSpace',
   CREATOR_DIVERGENCE_UNRESOLVED: 'approveBlockedDivergence',
+  // The renderer's own channel failures. Without copy of their own they render the generic
+  // sentence, which is the one outcome that makes a stalled or dead worker undiagnosable.
+  TIMEOUT: 'requestTimedOut',
+  WORKER_UNAVAILABLE: 'workerUnavailable',
 }
 
 export function errorI18nKey (code, fallbackKey) {

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -123,9 +123,9 @@ function handleLine(line: string): void {
   }
 }
 
-function failAllPending(reason: string): void {
+function failAllPending(reason: string, code: string): void {
   for (const [id, entry] of pending) {
-    entry.reject(new Error(reason))
+    entry.reject(codedError(reason, code))
     pending.delete(id)
   }
 }
@@ -171,7 +171,7 @@ function onWorkerExit(code: number): void {
   decoder = new TextDecoder('utf-8')
   stdoutDecoder = new TextDecoder('utf-8')
   stderrDecoder = new TextDecoder('utf-8')
-  failAllPending('Worker exited with code ' + code)
+  failAllPending('Worker exited with code ' + code, CODES.WORKER_UNAVAILABLE)
   scheduleRespawn(code)
 }
 
@@ -256,10 +256,17 @@ if (typeof window !== 'undefined') {
   ensureWorker().catch((err) => console.error('worker start failed:', err))
 }
 
-function cancelledError(type: RequestName): Error & { code: string } {
-  const err = new Error(`cancelled: ${type}`) as Error & { code: string }
-  err.code = ECANCELLED
+// Every rejection this module raises itself carries a code: errorTextFor keys on `.code`, and one
+// without it renders the generic sentence — the outcome that makes a stalled or dead worker
+// indistinguishable from any other failure in the UI.
+function codedError(message: string, code: string): Error & { code: string } {
+  const err = new Error(message) as Error & { code: string }
+  err.code = code
   return err
+}
+
+function cancelledError(type: RequestName): Error & { code: string } {
+  return codedError(`cancelled: ${type}`, ECANCELLED)
 }
 
 export async function request(
@@ -276,7 +283,7 @@ export async function request(
   // (which re-arms it) wakes us onto the new worker instead of stranding us on a stale promise.
   // Fail fast if the respawn policy has given up rather than hanging until the IPC timeout.
   while (!workerReady) {
-    if (permanentlyDown) throw new Error('Worker is unavailable (respawn limit reached)')
+    if (permanentlyDown) throw codedError('Worker is unavailable (respawn limit reached)', CODES.WORKER_UNAVAILABLE)
     await readyPromise
   }
 
@@ -292,7 +299,7 @@ export async function request(
           if (pending.has(id)) {
             pending.delete(id)
             detach()
-            reject(new Error(`IPC timeout: ${type} (${timeout}ms)`))
+            reject(codedError(`IPC timeout: ${type} (${timeout}ms)`, CODES.TIMEOUT))
           }
         }, timeout)
       : null
@@ -332,7 +339,11 @@ export async function request(
       pending.delete(id)
       if (timer) clearTimeout(timer)
       detach()
-      reject(err instanceof Error ? err : new Error(String(err)))
+      // The write reaches main, not the worker, so its failure means no worker is behind the
+      // channel — the same thing a request has to tell the user as an exit does. The bridge's own
+      // message goes to the console; the sentence a person reads comes from the code.
+      console.error('worker write failed:', type, err)
+      reject(codedError(`worker write failed: ${type}`, CODES.WORKER_UNAVAILABLE))
     })
   })
 }

--- a/src/renderer/locales/de/errors.json
+++ b/src/renderer/locales/de/errors.json
@@ -42,6 +42,8 @@
   "leaveInProgress": "Mirall schließt gerade dein letztes Verlassen dieses Space ab. Versuche es gleich noch einmal.",
   "notAMember": "Du kannst andere erst einladen, wenn du für diesen Space freigegeben wurdest.",
   "notApprovedForSpace": "Du wurdest für diesen Space noch nicht freigegeben und kannst daher nichts darin teilen.",
+  "requestTimedOut": "Mirall hat zu lange für eine Antwort gebraucht. Versuche es gleich noch einmal.",
+  "workerUnavailable": "Der Hintergrunddienst von Mirall ist nicht verfügbar. Starte Mirall neu, wenn das weiterhin auftritt.",
   "unexpected": "Etwas ist schiefgelaufen. Versuche es erneut — wenn es weiterhin auftritt, sende Feedback über die Einstellungen.",
   "approveBlockedDivergence": "Solange der Eigentümer-Konflikt ungelöst ist, sind Genehmigungen pausiert."
 }

--- a/src/renderer/locales/en/errors.json
+++ b/src/renderer/locales/en/errors.json
@@ -42,6 +42,8 @@
   "leaveInProgress": "Mirall is still finishing your last leave of this space. Try again in a moment.",
   "notAMember": "You can only invite others once you've been approved for this space.",
   "notApprovedForSpace": "You haven't been approved for this space yet, so you can't share into it.",
+  "requestTimedOut": "Mirall took too long to answer. Try again in a moment.",
+  "workerUnavailable": "Mirall's background service isn't available. Restart Mirall if this keeps happening.",
   "unexpected": "Something went wrong. Try again — if it keeps happening, send feedback from Settings.",
   "approveBlockedDivergence": "Approvals are paused while the owner identity conflict is unresolved."
 }

--- a/src/renderer/locales/es/errors.json
+++ b/src/renderer/locales/es/errors.json
@@ -42,6 +42,8 @@
   "leaveInProgress": "Mirall todavía está terminando tu última salida de este espacio. Inténtalo de nuevo en un momento.",
   "notAMember": "Solo puedes invitar a otros cuando tengas la aprobación en este espacio.",
   "notApprovedForSpace": "Todavía no tienes la aprobación en este espacio, así que no puedes compartir en él.",
+  "requestTimedOut": "Mirall ha tardado demasiado en responder. Inténtalo de nuevo en un momento.",
+  "workerUnavailable": "El servicio en segundo plano de Mirall no está disponible. Reinicia Mirall si sigue ocurriendo.",
   "unexpected": "Algo ha ido mal. Inténtalo de nuevo — si sigue ocurriendo, envía tus comentarios desde Ajustes.",
   "approveBlockedDivergence": "Las aprobaciones están en pausa mientras el conflicto de identidad del propietario no se resuelva."
 }

--- a/src/renderer/locales/fr/errors.json
+++ b/src/renderer/locales/fr/errors.json
@@ -42,6 +42,8 @@
   "leaveInProgress": "Mirall termine encore votre dernier départ de cet espace. Réessayez dans un instant.",
   "notAMember": "Vous pouvez inviter d'autres personnes une fois votre adhésion approuvée dans cet espace.",
   "notApprovedForSpace": "Votre adhésion à cet espace n'est pas encore approuvée, vous ne pouvez donc rien y partager.",
+  "requestTimedOut": "Mirall a mis trop de temps à répondre. Réessayez dans un instant.",
+  "workerUnavailable": "Le service en arrière-plan de Mirall n'est pas disponible. Redémarrez Mirall si cela persiste.",
   "unexpected": "Une erreur s'est produite. Réessayez — si cela persiste, envoyez un commentaire depuis les Réglages.",
   "approveBlockedDivergence": "Les approbations sont suspendues tant que le conflit d'identité du propriétaire n'est pas résolu."
 }

--- a/src/renderer/locales/it/errors.json
+++ b/src/renderer/locales/it/errors.json
@@ -42,6 +42,8 @@
   "leaveInProgress": "Mirall sta ancora completando la tua ultima uscita da questo spazio. Riprova tra un momento.",
   "notAMember": "Puoi invitare altri solo dopo l'approvazione in questo spazio.",
   "notApprovedForSpace": "Non hai ancora l'approvazione per questo spazio, quindi non puoi condividerci nulla.",
+  "requestTimedOut": "Mirall ha impiegato troppo tempo a rispondere. Riprova tra un momento.",
+  "workerUnavailable": "Il servizio in background di Mirall non è disponibile. Riavvia Mirall se il problema persiste.",
   "unexpected": "Qualcosa è andato storto. Riprova — se continua, invia un feedback dalle Impostazioni.",
   "approveBlockedDivergence": "Le approvazioni sono sospese finché il conflitto sull'identità del proprietario non è risolto."
 }

--- a/src/shared/contract/errors.js
+++ b/src/shared/contract/errors.js
@@ -62,6 +62,7 @@ export const CODES = Object.freeze({
   TRANSFER_RENAME_FAILED: 'TRANSFER_RENAME_FAILED',
   UNKNOWN: 'UNKNOWN',
   UPLOAD_FAILED: 'UPLOAD_FAILED',
+  WORKER_UNAVAILABLE: 'WORKER_UNAVAILABLE',  // the renderer's channel has no worker behind it
 })
 
 export const CODE_NAMES = Object.freeze(Object.keys(CODES))
@@ -97,7 +98,6 @@ export const UNUSED_CODES = Object.freeze([
   'PREPARE_FAILED',
   'SOURCE_CHANGED',
   'SPACE_EXISTS',
-  'TIMEOUT',
   'TRANSFER_IN_PROGRESS',
   'TRANSFER_NOT_FOUND',
   'TRANSFER_RENAME_FAILED',

--- a/src/worker/mounts-runtime.js
+++ b/src/worker/mounts-runtime.js
@@ -313,12 +313,12 @@ export class MountsRuntime extends Subsystem {
   }
 
   async probeMountPoints() {
-    const fsMod = await import('bare-fs')
     const all = await listAllMounts()
     for (const mount of all) {
       const key = mount.role + ':' + mount.shareId
-      let exists = true
-      try { fsMod.default.statSync(mount.mountPath) } catch { exists = false }
+      // The same question the resume passes ask — is a DIRECTORY there — so a path replaced by a
+      // file cannot read present here and absent to them.
+      const exists = mountRootAvailable(mount.mountPath)
       const prev = this.lastMountPointStatus.get(key)
       if (prev === exists) continue
       const wasGone = prev === false

--- a/test/integration/owned-mount-probe.test.js
+++ b/test/integration/owned-mount-probe.test.js
@@ -1,0 +1,45 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { freshPeer } from '../helpers/store.js'
+import { createOwnedMount, getOwnedMount } from '../../src/shared/folders/mount-store.js'
+
+async function plantedMount (t, { makePath }) {
+  const ctx = await freshPeer(t)
+  const mountPath = path.join(ctx.tmpDir('owned'), 'Docs')
+  makePath(mountPath)
+  const mount = { spaceId: 'space1', shareId: 'share1', mountPath, ignore: [], createdAt: Date.now() }
+  await createOwnedMount(mount)
+  // The probe reports a TRANSITION, so it needs a baseline saying the path was there.
+  ctx.root.mounts.lastMountPointStatus.set('owned-folder:' + mount.shareId, true)
+  return { ctx, mount }
+}
+
+// REGRESSION (FIX-MOUNTPROBE-1: the 60 s probe asked statSync whether ANYTHING existed at the
+// mount path while every resume pass asks mountRootAvailable whether a DIRECTORY does. A path
+// replaced by a file read present to the probe and absent to the resume, so the folder kept a
+// durable 'active' status that nothing could publish into.)
+test('REGRESSION (FIX-MOUNTPROBE-1): a mount path replaced by a file reads as gone', async (t) => {
+  const { ctx, mount } = await plantedMount(t, {
+    makePath: (p) => fs.writeFileSync(p, 'not a directory'),
+  })
+
+  await ctx.root.mounts.probeMountPoints()
+
+  const read = await getOwnedMount(mount.spaceId, mount.shareId)
+  t.is(read.status, 'mount-point-gone', 'the probe agrees with the resume passes')
+  t.is(ctx.root.mounts.lastMountPointStatus.get('owned-folder:' + mount.shareId), false,
+    'and the probe baseline records the absence')
+})
+
+test('a mount path that is still a directory is left alone', async (t) => {
+  const { ctx, mount } = await plantedMount(t, {
+    makePath: (p) => fs.mkdirSync(p, { recursive: true }),
+  })
+
+  await ctx.root.mounts.probeMountPoints()
+
+  const read = await getOwnedMount(mount.spaceId, mount.shareId)
+  t.not(read.status, 'mount-point-gone', 'a healthy mount is not torn down by the probe')
+  t.is(ctx.root.mounts.lastMountPointStatus.get('owned-folder:' + mount.shareId), true)
+})

--- a/test/unit/contract-errors.test.js
+++ b/test/unit/contract-errors.test.js
@@ -48,7 +48,7 @@ test('the unused list is honest and only shrinks', (t) => {
   const stillThrown = UNUSED_CODES.filter((c) => thrown.has(c))
   t.alike(stillThrown, [], 'a code listed as unused is actually thrown — move it out of the list')
   for (const c of UNUSED_CODES) t.ok(CODES[c], `${c} is declared`)
-  t.ok(UNUSED_CODES.length <= 11, 'no code was added to the unused list')
+  t.ok(UNUSED_CODES.length <= 10, 'no code was added to the unused list')
 })
 
 // REGRESSION (FIX-CODES-1: this was a ratchet at 17 while INVITE_INVALID, INVITE_EXPIRED and

--- a/test/unit/env-json.test.js
+++ b/test/unit/env-json.test.js
@@ -1,0 +1,73 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { envJson } from '../../src/main/env-json.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSrc = readFileSync(path.join(here, '..', '..', 'src', 'main', 'main.js'), 'utf8')
+
+function captureWarnings (fn) {
+  const warnings = []
+  const orig = console.warn
+  console.warn = (...args) => { warnings.push(args.map(String).join(' ')) }
+  try { return { result: fn(), warnings } } finally { console.warn = orig }
+}
+
+function withEnv (t, name, value) {
+  const prev = process.env[name]
+  if (value === undefined) delete process.env[name]
+  else process.env[name] = value
+  t.teardown(() => {
+    if (prev === undefined) delete process.env[name]
+    else process.env[name] = prev
+  })
+}
+
+test('an unset knob reads as absent', (t) => {
+  withEnv(t, 'MIRALL_TEST_JSON', undefined)
+  t.is(envJson('MIRALL_TEST_JSON'), null)
+})
+
+test('a well-formed object or array is parsed', (t) => {
+  withEnv(t, 'MIRALL_TEST_JSON', '[{"host":"127.0.0.1","port":49737}]')
+  t.alike(envJson('MIRALL_TEST_JSON'), [{ host: '127.0.0.1', port: 49737 }])
+})
+
+// REGRESSION (FIX-ENVJSON-1: MIRALL_DHT_BOOTSTRAP was JSON.parse'd bare inside the worker
+// bootstrap build, so a malformed value threw there and pear:startWorker rejected with a JSON
+// syntax error — the app came up with no worker at all.)
+test('REGRESSION (FIX-ENVJSON-1): a malformed value is ignored, not thrown', (t) => {
+  withEnv(t, 'MIRALL_TEST_JSON', 'not json at all')
+  const { result, warnings } = captureWarnings(() => envJson('MIRALL_TEST_JSON'))
+  t.is(result, null, 'the caller sees an absent knob')
+  t.is(warnings.length, 1, 'and is told why')
+  t.ok(warnings[0].includes('MIRALL_TEST_JSON'), 'the warning names the variable')
+})
+
+// The warning reaches the main log ring, which a diagnostics bundle ships. JSON.parse's own
+// message quotes a fragment of the input, and these knobs carry host/port lists.
+test('REGRESSION (FIX-ENVJSON-1): the warning never repeats the value', (t) => {
+  withEnv(t, 'MIRALL_TEST_JSON', '[{"host":"203.0.113.9","port":49737},') // truncated → malformed
+  const { warnings } = captureWarnings(() => envJson('MIRALL_TEST_JSON'))
+  t.absent(warnings[0].includes('203.0.113.9'), 'no address in the log')
+  t.absent(warnings[0].includes('49737'), 'no port in the log')
+})
+
+// A JSON scalar parses fine but is not a shape any knob declares, and passing it on hands the
+// consumer (hyperswarm's bootstrap list, the flag merge) a value it cannot use.
+test('a scalar is refused like a malformed value', (t) => {
+  withEnv(t, 'MIRALL_TEST_JSON', '5')
+  const { result, warnings } = captureWarnings(() => envJson('MIRALL_TEST_JSON'))
+  t.is(result, null)
+  t.is(warnings.length, 1, 'and it warns rather than failing silently')
+})
+
+// main.js only runs inside Electron, so the wiring is pinned by source — the
+// renderer-cancellation-wiring.test.js pattern.
+test('REGRESSION (FIX-ENVJSON-1): the worker bootstrap reads the DHT knob through envJson', (t) => {
+  t.ok(mainSrc.includes("dhtBootstrap: envJson('MIRALL_DHT_BOOTSTRAP')"),
+    'the bootstrap field goes through the swallow-and-warn helper')
+  t.absent(/JSON\.parse\(process\.env\.MIRALL_DHT_BOOTSTRAP\)/.test(mainSrc),
+    'and no bare parse is left to throw inside getWorker')
+})

--- a/test/unit/renderer-ipc-error-codes.test.js
+++ b/test/unit/renderer-ipc-error-codes.test.js
@@ -1,0 +1,60 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { CODES } from '../../src/shared/contract/errors.js'
+import { ERROR_I18N_KEY_BY_CODE } from '../../src/renderer/errorMessages.js'
+import { errorTextFor, FALLBACK_KEY } from '../../src/renderer/errorText.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const root = path.join(here, '..', '..')
+const src = readFileSync(path.join(root, 'src', 'renderer', 'ipc.ts'), 'utf8')
+const enErrors = JSON.parse(readFileSync(path.join(root, 'src', 'renderer', 'locales', 'en', 'errors.json'), 'utf8'))
+
+const tr = (key) => 'T:' + key
+const withCode = (message, code) => Object.assign(new Error(message), { code })
+
+// src/renderer/ipc.ts reaches window.bridge and only runs inside Electron, so its wiring is pinned
+// structurally — the renderer-cancellation-wiring.test.js pattern. The copy half below is driven
+// through the real display boundary.
+
+// REGRESSION (FIX-IPCCODE-1: a request that timed out, and one rejected because the worker was
+// gone, carried no .code. errorTextFor keys on .code, so every one of them rendered the generic
+// "Something went wrong" sentence — indistinguishable from an unrelated failure.)
+test('REGRESSION (FIX-IPCCODE-1): a timed-out request carries the timeout code', (t) => {
+  const timer = src.slice(src.indexOf('const timer = timeout > 0'), src.indexOf('function onAbort'))
+  t.ok(/codedError\(`IPC timeout: \$\{type\} \(\$\{timeout\}ms\)`, CODES\.TIMEOUT\)/.test(timer),
+    'the timeout rejects with CODES.TIMEOUT, not a bare Error')
+})
+
+test('REGRESSION (FIX-IPCCODE-1): a request with no worker behind it carries the worker code', (t) => {
+  t.ok(src.includes("failAllPending('Worker exited with code ' + code, CODES.WORKER_UNAVAILABLE)"),
+    'in-flight requests killed by a worker exit are coded')
+  t.ok(/throw codedError\('Worker is unavailable \(respawn limit reached\)', CODES\.WORKER_UNAVAILABLE\)/.test(src),
+    'and so is the fail-fast after the respawn policy gives up')
+  const write = src.slice(src.indexOf('window.bridge.writeWorkerIPC(WORKER_SPEC, encoder.encode(envelope))'))
+  t.ok(/CODES\.WORKER_UNAVAILABLE/.test(write), 'and a failed write to a worker that never spawned')
+})
+
+test('both codes are declared in the contract', (t) => {
+  t.is(CODES.TIMEOUT, 'TIMEOUT')
+  t.is(CODES.WORKER_UNAVAILABLE, 'WORKER_UNAVAILABLE')
+})
+
+test('REGRESSION (FIX-IPCCODE-1): each code renders its own sentence, not the generic one', (t) => {
+  const timeout = errorTextFor(withCode('IPC timeout: share:list (30000ms)', CODES.TIMEOUT), tr)
+  const gone = errorTextFor(withCode('Worker exited with code 1', CODES.WORKER_UNAVAILABLE), tr)
+  t.not(timeout, 'T:' + FALLBACK_KEY, 'a timeout is diagnosable in the UI')
+  t.not(gone, 'T:' + FALLBACK_KEY, 'so is a dead worker')
+  t.not(timeout, gone, 'and the two read differently')
+  t.is(timeout, 'T:' + ERROR_I18N_KEY_BY_CODE.TIMEOUT)
+  t.is(gone, 'T:' + ERROR_I18N_KEY_BY_CODE.WORKER_UNAVAILABLE)
+})
+
+// The message these errors carry is written for a log; only the code becomes text a person reads.
+test('neither sentence exposes the internal message', (t) => {
+  for (const key of [ERROR_I18N_KEY_BY_CODE.TIMEOUT, ERROR_I18N_KEY_BY_CODE.WORKER_UNAVAILABLE]) {
+    t.ok(Object.hasOwn(enErrors, key), `errors.${key} exists`)
+    t.absent(/\bIPC\b|worker|\d+ms/i.test(enErrors[key]), `errors.${key} is user language, not wire detail`)
+  }
+})


### PR DESCRIPTION
## What & why

Three unrelated robustness edges from the codebase quality report (D18, D19, D23). All three
re-verified on current `origin/staging` before editing. D24 (sticky-toast eviction) is out of
scope — it is a decision, not a defect.

**D18 — mount probe (`src/worker/mounts-runtime.js`).** The 60 s probe asked `statSync` whether
anything existed at the mount path while every resume pass asks `mountRootAvailable` whether a
*directory* does, so a path replaced by a file read present to one and absent to the other. The
probe now asks the same question; the local `await import('bare-fs')` it needed is gone.

**D19 — IPC error codes (`src/renderer/ipc.ts`).** Timeouts and the worker-unavailable rejections
carried no `.code`, and `errorTextFor` keys on `.code` — so every one of them rendered the generic
"Something went wrong" sentence. A `codedError()` helper (which `cancelledError` now uses) attaches
`CODES.TIMEOUT` to a timeout and the new `CODES.WORKER_UNAVAILABLE` to the three no-worker paths
(exit-kills-in-flight, respawn-limit fail-fast, failed channel write). `errorMessages.js` maps both
to new copy in all five locales. `TIMEOUT` leaves `UNUSED_CODES` (ratchet 11 → 10).

**D23 — DHT bootstrap parse (`src/main/main.js`).** `JSON.parse(process.env.MIRALL_DHT_BOOTSTRAP)`
was unguarded, so a malformed value threw inside `getWorker` and `pear:startWorker` rejected with a
JSON syntax error. New `src/main/env-json.js` carries the swallow-and-warn policy the sibling knob
(`MIRALL_FEATURE_FLAGS`) already uses; only that knob is routed through it.

## Coverage

- **Integration** (D18): `test/integration/owned-mount-probe.test.js` — a mount path replaced by a
  file reads as gone; a directory is left alone. Red-first (1/2 before the fix).
- **Unit** (D19): `test/unit/renderer-ipc-error-codes.test.js` — the wiring pinned by source (the
  `renderer-cancellation-wiring.test.js` pattern, since `ipc.ts` needs Electron), plus both codes
  driven through the real display boundary. Red-first (0/5 before the fix).
- **Unit** (D23): `test/unit/env-json.test.js` — malformed and scalar values ignored, the warning
  never repeats the value, and main's bootstrap field pinned by source. Red-first (module absent).
- Flow: SKIP — no P2P behavior changes. Frontend: the D19 renderer half is exercised locally (see
  below); no UI markup, control or a11y surface changed.

## Security audit

- **Unsafe deserialization (D23):** the parse is now contained; only a JSON object or array is
  accepted, so a scalar cannot reach hyperswarm's `bootstrap` option (`transfer/swarm.js` is the
  sole consumer and only spreads it). The warning names the variable and never the value —
  `JSON.parse`'s own message quotes a fragment of the input, and main's console feeds the log ring
  a diagnostics bundle ships, so an address list would otherwise land there.
- **New IPC codes leaking internals into UI text:** no. `errorTextFor` returns `t(key)`; the raw
  message never reaches a display boundary. The two new sentences are static copy with no path,
  request name or timing in them. The failed-write path no longer forwards the bridge's own message
  into the rejected error (it logs it instead), so nothing carries an Electron-internal path toward
  the UI.
- **Injection:** none — no shell, SQL or HTML construction; copy renders as i18next text.
- **Unsafe user input:** the probe change strictly narrows what counts as present; no new path
  handling.
- **Secrets:** none in the diff; the test fixture uses `127.0.0.1` and an RFC 5737 documentation
  address.
- **Dependencies:** none added — `package.json` / lockfile untouched.
- **Permission/auth:** no change to admission, handshake, grants, or the IPC request surface (no
  new channel or request name).

## Ran locally

`test:fe` — **not run**; it could not be executed in this environment. The D19 half is covered by
`npm run test:fe s128 s118 s140` (localized error copy, the never-blank fold's surfaced error, and
the modal failure escape routes); evidence lands in `test/frontend/evidence/`. No axe/VoiceOver
delta is expected — no markup, control or accessible name changed, only the sentence behind an
error code — but that verification is genuinely unrun.

Run locally: typecheck, `lint:ci` (ceiling unchanged, 19 warnings against 21), `test:node:core`
2205/2205, `test:bare` 1102/1102, `test:flow` 202/202 (`# flow accounting: 202/202`).

Closes #231

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R2tBf3Bb7K59LWPMbpaJ6d
