### PR TITLE
[fix] Stop the republish park logging a false WARN

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1323,6 +1323,7 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/shared/transfer/backends/overlay/fetch-claims.js` | The process-wide "who is fetching this transferId" registry — engine probes + mirror claims |
 | `src/shared/transfer/backends/overlay/fetch-slots.js` | The one fetch semaphore for the process (`downloadConcurrency`, §2), reset per lifetime |
 | `src/shared/transfer/backends/overlay/fetch-policy.js` | `isTerminalFault`, `classifyMiss`, `nextRetryDelay` — one rule set for every producer. Pure |
+| `src/shared/transfer/backends/overlay/fetch-outcome.js` | `FETCH_OUTCOME` — the closed vocabulary every `diag.finish()` accepts, and the `DELIBERATE_STOPS` derived from it. Pure |
 | `src/shared/transfer/backends/overlay/paused-holders.js` | The paused-transfer markers a producer leaves behind, and the "tell the holder we stopped" primitives |
 | `src/shared/transfer/backends/overlay/migrate-overlay-index-encrypt.js` | One-shot copy of the plaintext file-index bee into the encrypted namespace, then purge |
 | `src/shared/transfer/backends/overlay/vendor/` | The vendored `hyper-overlay` v2 subset (8 files) + `PROVENANCE.md`, which records every local modification (§7.7) |

--- a/src/shared/transfer/backends/overlay/fetch-outcome.js
+++ b/src/shared/transfer/backends/overlay/fetch-outcome.js
@@ -1,0 +1,27 @@
+// The closed vocabulary of fetch outcomes — every value `diag.finish()` accepts, in one place.
+//
+// It lives in its own module, and imports nothing, for two reasons: `fetch-policy.js` produces
+// outcomes and must stay free of `bare-*` so test/unit can load it under Node, and `makeFetchDiag`
+// (overlay-backend.js) consumes them, so a shared home is the only one that is not a cycle.
+//
+// Before this existed the producers spelled their outcomes as literals and the diag kept a
+// hand-written set of the ones it recognised. The two drifted: 'awaiting-republish' — a normal,
+// documented park while the owner re-hashes a source — was never added to the set, so every park
+// logged a WARN "INCOMPLETE … gave up" into the user's log and every diagnostics bundle.
+export const FETCH_OUTCOME = Object.freeze({
+  DONE: 'done',
+  FAILED: 'failed',
+  PAUSED: 'paused',
+  CANCELLED: 'cancelled',
+  SUPERSEDED: 'superseded',
+  NO_HOLDER: 'no-holder',
+  AWAITING_REPUBLISH: 'awaiting-republish',
+})
+
+// Derived, never re-listed: exactly two outcomes are terminal for the intent — the success and the
+// give-up — and everything else is control flow the user or the owner asked for. An outcome added
+// to the vocabulary above is therefore a deliberate stop by default; if a future one is a genuine
+// give-up, it belongs beside FAILED here rather than in a second list.
+export const DELIBERATE_STOPS = new Set(
+  Object.values(FETCH_OUTCOME).filter((o) => o !== FETCH_OUTCOME.DONE && o !== FETCH_OUTCOME.FAILED),
+)

--- a/src/shared/transfer/backends/overlay/fetch-policy.js
+++ b/src/shared/transfer/backends/overlay/fetch-policy.js
@@ -2,6 +2,7 @@
 // asserted directly rather than through a live engine — the same shape as mirror-walk.js, and no
 // bare-* imports so it unit-tests under Node.
 import { CODES } from '../../../contract/errors.js'
+import { FETCH_OUTCOME } from './fetch-outcome.js'
 
 // A fault the user must clear before ANY retry can succeed: the same holder serves the same bad
 // bytes, a full disk is still full, an ejected volume is still gone. One set because it is one
@@ -21,7 +22,7 @@ export function isTerminalFault(code) {
 // false means no holder was ever reachable — a process-global fact, so a caller walking a list may
 // stop. True means a holder WAS asked and the transfer died, which is a fact about this file alone.
 export function classifyMiss({ attempted }) {
-  return attempted ? 'failed' : 'no-holder'
+  return attempted ? FETCH_OUTCOME.FAILED : FETCH_OUTCOME.NO_HOLDER
 }
 
 // How long before attempt N+1, and when to stop. `dry` counts consecutive attempts that banked no

--- a/src/shared/transfer/backends/overlay/overlay-backend.js
+++ b/src/shared/transfer/backends/overlay/overlay-backend.js
@@ -47,25 +47,24 @@ import { getPendingFor } from '../../pending-transfers.js'
 import { LOOSE_SHARE_ID, transferIdFor } from '../../transfer-id.js'
 import { getDownloadDir } from '../../../core/paths.js'
 import { createLogger } from '../../../core/logger.js'
+import { DELIBERATE_STOPS, FETCH_OUTCOME } from './fetch-outcome.js'
 
 const log = createLogger('overlay')
 
 // === fetch diagnostics ===
-
-// finish()'s deliberate stops — see makeFetchDiag; anything else is a give-up and WARNs.
-const DELIBERATE_STOPS = new Set(['paused', 'cancelled', 'superseded', 'no-holder'])
 
 // Download instrumentation: logs fetch start, throttled mid-download progress
 // (every 5s), the scheduler's terminal reason (timeout vs complete, with
 // bytes/chunks transferred), and the final outcome — so a stalled large-file
 // transfer reveals exactly where and why it stopped.
 //
-// finish(outcome): 'done' on success; a deliberate stop ('paused' / 'cancelled' /
-// 'superseded' / 'no-holder') is normal control flow and logs at debug — NOT a
-// WARN "gave up", which would make a user pausing a download read as a failure.
-// Only a genuine give-up ('failed' — timeout / stall / no live holder / hash
-// mismatch) warrants the WARN. An unrecognized outcome (caller bug) is fail-safe:
-// it WARNs rather than silently logging at debug.
+// finish(outcome): a member of FETCH_OUTCOME. 'done' on success; a deliberate stop
+// (fetch-outcome.js — a pause, a cancel, a supersede, no holder, a republish park)
+// is normal control flow and logs at debug — NOT a WARN "gave up", which would make
+// a user pausing a download read as a failure. Only a genuine give-up ('failed' —
+// timeout / stall / no live holder / hash mismatch) warrants the WARN. An outcome
+// outside the vocabulary (caller bug) is fail-safe: it WARNs rather than silently
+// logging at debug.
 export function makeFetchDiag(label, relPath, total, contentHash) {
   const t0 = Date.now()
   let lastLog = 0
@@ -90,12 +89,12 @@ export function makeFetchDiag(label, relPath, total, contentHash) {
     },
     finish(outcome) {
       const elapsed = ((Date.now() - t0) / 1000).toFixed(0)
-      if (outcome === 'done') {
+      if (outcome === FETCH_OUTCOME.DONE) {
         log.info(`${label} done:`, relPath, `${total} bytes in ${elapsed}s`)
       } else if (DELIBERATE_STOPS.has(outcome)) {
         log.debug(`${label} ${outcome}:`, relPath, `at ${lastBytes}/${total} bytes after ${elapsed}s`)
       } else {
-        const tag = outcome !== 'failed' ? ` [outcome='${outcome}']` : ''
+        const tag = outcome !== FETCH_OUTCOME.FAILED ? ` [outcome='${outcome}']` : ''
         log.warn(`${label} INCOMPLETE:`, relPath, `gave up after ${elapsed}s at ${lastBytes}/${total} bytes${tag}`)
       }
     },

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -26,6 +26,7 @@ import { CODES } from '../../../contract/errors.js'
 import { createLogger } from '../../../core/logger.js'
 
 import { isTerminalFault, nextRetryDelay } from './fetch-policy.js'
+import { FETCH_OUTCOME } from './fetch-outcome.js'
 import { makeFetchInstruments } from './fetch-run.js'
 import { shortfall } from '../../free-space.js'
 import { freeBytesFor } from '../../free-space-probe.js'
@@ -241,7 +242,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
   // failure (disk-full / checksum / permission → record + surface the error).
   async function settleFailed (job, r, diag) {
     if (!r.code) {
-      diag.finish('no-holder')
+      diag.finish(FETCH_OUTCOME.NO_HOLDER)
       log.debug('overlay fetch interrupted — holder gone or throttled:', job.relPath, 'at', job.prevBytes || 0, 'bytes')
       // `retrying` withholds the OS notification only — the paused emit still fires, because it
       // also terminates the decoration, and withholding it strands a progress bar that then
@@ -251,7 +252,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       channel.emitUpdated(job.spaceId)
       return
     }
-    diag.finish('failed')
+    diag.finish(FETCH_OUTCOME.FAILED)
     const code = terminalCodeFor(r, job, dirExists)
     if (code === CODES.TRANSFER_CHECKSUM) log.warn('overlay integrity failure — holder served bytes that do not match the content hash:', job.relPath)
     else if (code === CODES.TRANSFER_DISK_FULL) log.warn('overlay fetch failed — disk full:', job.relPath)
@@ -320,7 +321,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     // fetch settled (a no-holder stall, a checksum failure, or even a lucky completion of the OLD
     // bytes) — and let the status derive 'preparing' + the materialized-hash append restart it.
     const parkForRepublish = s?.republishing && !restartJob && !wasCancelled && !wasPaused
-    if (parkForRepublish) { diag.finish('awaiting-republish'); cancelStallRetry(transferId); finishRepublishRelease(transferId, s); return }
+    if (parkForRepublish) { diag.finish(FETCH_OUTCOME.AWAITING_REPUBLISH); cancelStallRetry(transferId); finishRepublishRelease(transferId, s); return }
     registry.delete(transferId)
     // Only a code-less stall keeps its retry history; every other outcome (done, cancelled,
     // superseded, terminal error) ends the intent this record belongs to.
@@ -330,7 +331,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       // and its partial discarded. Re-enter on the NEW contentHash now that the
       // stable transferId's slot is free — start() re-reserves it synchronously,
       // so has()/looseTransferActive never observes a gap.
-      diag.finish('superseded')
+      diag.finish(FETCH_OUTCOME.SUPERSEDED)
       restartAfterSupersede(restartJob)
       return
     }
@@ -338,7 +339,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       // A cancel raced the fetch to completion (the abort couldn't reach it in
       // time). cancelByKey already cleared the row + emitted, so just drop any
       // bytes that landed — never re-mark a cancelled file as downloaded.
-      diag.finish('cancelled')
+      diag.finish(FETCH_OUTCOME.CANCELLED)
       try { fs.unlinkSync(job.finalPath) } catch {}
       discardPartial(job.finalPath)
       // Settle-time re-derive: cancelByKey's emit fired while the slot was still
@@ -348,14 +349,14 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
       return
     }
     if (r.code === 'ECANCELLED') {
-      diag.finish(wasPaused ? 'paused' : 'cancelled')
+      diag.finish(wasPaused ? FETCH_OUTCOME.PAUSED : FETCH_OUTCOME.CANCELLED)
       // Pause keeps the pending row + partial → re-list so the row derives a
       // paused state. A discard already cleared the row + emitted in cancelByKey.
       if (wasPaused) { channel.emitUpdated(job.spaceId); channel.emitDecorationDone?.(job) }
       return
     }
     if (!r.ok) { await settleFailed(job, r, diag); return }
-    diag.finish('done')
+    diag.finish(FETCH_OUTCOME.DONE)
     // Durable positive fact FIRST: a crash inside this window must re-derive
     // 'downloaded' (a lingering resume row is masked by the downloaded status),
     // never 'remote' — which would re-download and duplicate the file.

--- a/test/integration/download-completion-ordering.test.js
+++ b/test/integration/download-completion-ordering.test.js
@@ -20,7 +20,7 @@ const engineSrc = fs.readFileSync(
 // the write order in the engine's done block structurally; the behavior half below pins
 // the masking that makes a lingering pending row harmless.
 test("REGRESSION (FIX-D2: completion records the durable downloaded fact before clearing the resume row)", (t) => {
-  const done = engineSrc.indexOf("diag.finish('done')")
+  const done = engineSrc.indexOf('diag.finish(FETCH_OUTCOME.DONE)')
   t.ok(done > -1, 'completion block found')
   const block = engineSrc.slice(done, engineSrc.indexOf('emitComplete', done))
   const downloadedAt = block.indexOf('markDownloaded')

--- a/test/integration/overlay-fetch-diag.test.js
+++ b/test/integration/overlay-fetch-diag.test.js
@@ -1,5 +1,6 @@
 import test from 'brittle'
 import { makeFetchDiag } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
+import { DELIBERATE_STOPS } from '../../src/shared/transfer/backends/overlay/fetch-outcome.js'
 import { setRuntimeConfig, getRuntimeConfig } from '../../src/shared/core/runtime-config.js'
 
 // Capture console.{log,warn,error} around a body. The logger maps debug/info →
@@ -23,7 +24,9 @@ function setVerbose(t, value) {
   t.teardown(() => setRuntimeConfig(prev))
 }
 
-const STOPS = ['paused', 'cancelled', 'superseded', 'no-holder']
+// Read from the shared vocabulary, so an outcome added there is covered here without an edit —
+// a hand-kept copy is how 'awaiting-republish' went a whole release warning at every user.
+const STOPS = [...DELIBERATE_STOPS]
 
 // REGRESSION (FIX-1: a deliberate pause logged as a WARN "INCOMPLETE … gave up").
 // Pausing an in-flight overlay download cancels the chunk scheduler, which the
@@ -37,6 +40,16 @@ test('REGRESSION: a deliberate-stop outcome never warns (at the default log leve
     t.is(out.warn.length, 0, `finish('${outcome}') emits no WARN`)
     t.absent(out.log.join('\n').includes('gave up'), `finish('${outcome}') never says "gave up"`)
   }
+})
+
+// REGRESSION (FIX-368: the republish park logged a false WARN). The owner re-hashing a source
+// parks the in-flight fetch — normal, documented control flow — but 'awaiting-republish' was
+// missing from the diag's stop set, so every park printed "INCOMPLETE … gave up" into the user's
+// log and into every diagnostics bundle.
+test('REGRESSION: a republish park never warns', (t) => {
+  setVerbose(t, false)
+  const out = capture(() => makeFetchDiag('loose download', 'big.mp4', 100, 'abc').finish('awaiting-republish'))
+  t.is(out.warn.length, 0, 'parking for a republish emits no WARN')
 })
 
 test('a genuine give-up still warns "INCOMPLETE … gave up"', (t) => {

--- a/test/unit/audit-coverage.test.js
+++ b/test/unit/audit-coverage.test.js
@@ -70,8 +70,10 @@ test('every audit call site names its outcome through the frozen vocabulary', (t
   }
 })
 
+// The lookbehind keeps the audit vocabulary's own name: a qualified sibling (FETCH_OUTCOME, the
+// overlay's fetch outcomes) is a different vocabulary and must not be judged against this one.
 test('every OUTCOME reference in the data layer resolves to a member', (t) => {
-  const refs = new Set([...dataLayerSource.matchAll(/OUTCOME\.([A-Z_]+)/g)].map((m) => m[1]))
+  const refs = new Set([...dataLayerSource.matchAll(/(?<![A-Z_])OUTCOME\.([A-Z_]+)/g)].map((m) => m[1]))
   t.ok(refs.size > 0, 'found the OUTCOME references')
   for (const key of refs) {
     t.ok(OUTCOMES.includes(OUTCOME[key]), 'OUTCOME.' + key + ' is a member of the outcome vocabulary')

--- a/test/unit/fetch-outcome.test.js
+++ b/test/unit/fetch-outcome.test.js
@@ -1,0 +1,76 @@
+import test from 'brittle'
+import { readFileSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import { FETCH_OUTCOME, DELIBERATE_STOPS } from '../../src/shared/transfer/backends/overlay/fetch-outcome.js'
+import { classifyMiss } from '../../src/shared/transfer/backends/overlay/fetch-policy.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const read = (p) => readFileSync(path.resolve(here, '../../src', p), 'utf8')
+
+// Every module that settles a fetch diag. Source-scanned rather than imported: they pull in bare-*,
+// which a Node runner cannot load — the same technique and rationale as fetch-policy-parity.test.js.
+const EMITTERS = [
+  'shared/transfer/backends/overlay/overlay-download.js',
+  'shared/transfer/backends/overlay/fetch-run.js',
+  'shared/folders/foreign-folders.js',
+]
+
+const VALUES = new Set(Object.values(FETCH_OUTCOME))
+
+// REGRESSION (FIX-368: 'awaiting-republish' logged a false WARN "INCOMPLETE … gave up" on every
+// republish park). The engine emitted an outcome the diag's set had never heard of, so finish()
+// took its fail-safe caller-bug branch on a normal, documented flow. One vocabulary closes it: an
+// outcome that is not a member is the bug this test is looking for.
+test('REGRESSION: every outcome a producer emits is a member of FETCH_OUTCOME', (t) => {
+  let emitted = 0
+  for (const f of EMITTERS) {
+    for (const call of read(f).matchAll(/\.finish\(([^)]*)\)/g)) {
+      for (const lit of call[1].matchAll(/'([^']*)'/g)) {
+        emitted++
+        t.ok(VALUES.has(lit[1]), `${f} emits '${lit[1]}', a known outcome`)
+      }
+    }
+  }
+  t.ok(emitted > 0, 'the scan found the emitters (a silent zero would pass vacuously)')
+})
+
+// `FETCH_OUTCOME.TYPO` is `undefined`, which finish() would report as an unknown outcome at runtime
+// rather than at build time — so the reference itself has to be checked.
+test('every FETCH_OUTCOME reference names a real member', (t) => {
+  let refs = 0
+  for (const f of [...EMITTERS, 'shared/transfer/backends/overlay/overlay-backend.js', 'shared/transfer/backends/overlay/fetch-policy.js']) {
+    for (const m of read(f).matchAll(/FETCH_OUTCOME\.([A-Z_]+)/g)) {
+      refs++
+      t.ok(m[1] in FETCH_OUTCOME, `${f} references FETCH_OUTCOME.${m[1]}`)
+    }
+  }
+  t.ok(refs > 0, 'at least one producer reads the vocabulary')
+})
+
+// The WARN branch of finish() is `not done && not a deliberate stop`. A member that satisfies both
+// halves is a false alarm in every user's log — which is exactly what 'awaiting-republish' was.
+test('the WARN branch is unreachable for every outcome but a genuine give-up', (t) => {
+  for (const outcome of VALUES) {
+    const warns = outcome !== FETCH_OUTCOME.DONE && !DELIBERATE_STOPS.has(outcome)
+    t.is(warns, outcome === FETCH_OUTCOME.FAILED, `finish('${outcome}') warns only if it is the give-up`)
+  }
+})
+
+test('DELIBERATE_STOPS is derived from the vocabulary, not re-listed beside it', (t) => {
+  t.alike(
+    [...DELIBERATE_STOPS].sort(),
+    [...VALUES].filter((o) => o !== FETCH_OUTCOME.DONE && o !== FETCH_OUTCOME.FAILED).sort(),
+    'every non-terminal member is a deliberate stop',
+  )
+  t.ok(DELIBERATE_STOPS.has(FETCH_OUTCOME.AWAITING_REPUBLISH), 'a republish park is a deliberate stop')
+})
+
+test('the vocabulary is frozen', (t) => {
+  t.ok(Object.isFrozen(FETCH_OUTCOME), 'no producer can extend it at runtime')
+})
+
+test('classifyMiss returns members of the vocabulary', (t) => {
+  t.is(classifyMiss({ attempted: true }), FETCH_OUTCOME.FAILED)
+  t.is(classifyMiss({ attempted: false }), FETCH_OUTCOME.NO_HOLDER)
+})


### PR DESCRIPTION
Closes #218 (by hand — a PR merging to `staging` never auto-closes).

**Bug.** Every republish park logged `WARN [overlay] … INCOMPLETE: … gave up after Ns [outcome='awaiting-republish']` — a normal, documented flow reported as a failure in every user's log and diagnostics bundle.

**Root cause.** `overlay-download.js` emitted `'awaiting-republish'`, but `DELIBERATE_STOPS` in `overlay-backend.js` was a hand-kept literal set of four. `makeFetchDiag.finish` therefore fell through to its fail-safe "unrecognized outcome" branch.

**Fix.** New pure module `src/shared/transfer/backends/overlay/fetch-outcome.js` holds a frozen `FETCH_OUTCOME` (`done | failed | paused | cancelled | superseded | no-holder | awaiting-republish`); `DELIBERATE_STOPS` is derived from it (everything but the success and the give-up). `overlay-backend.js`, `overlay-download.js` and `fetch-policy.js` read the vocabulary instead of literals.

The constant lives in its own module rather than beside `makeFetchDiag`: `fetch-policy.js` produces outcomes and must stay free of `bare-*` (asserted by `fetch-policy-parity.test.js`), and `fetch-run.js` already imports the diag — a shared home is the only placement that is neither a cycle nor a purity break.

**Tests.** Reproduced first (the WARN fires on `finish('awaiting-republish')` at HEAD).
- `test/unit/fetch-outcome.test.js` — REGRESSION (FIX-368): every outcome a producer emits is a member; every `FETCH_OUTCOME.X` reference resolves; the WARN branch is unreachable for every member but `failed`; `DELIBERATE_STOPS` is derived, not re-listed.
- `test/integration/overlay-fetch-diag.test.js` — REGRESSION: a republish park emits no WARN; the stop list now reads from the shared set.
- Follow-ons from the new file/spelling: a §11 row in `solution-architecture.md`, the audit-vocabulary guard's `OUTCOME\.` regex narrowed with a lookbehind so it no longer claims the qualified `FETCH_OUTCOME`, and `download-completion-ordering.test.js`'s source scan updated to the constant.

**Security audit.** Injection: none — no interpolation into a shell/query/path. Deserialization: none. Secrets: none added; the diff adds no credential or key material. User input: outcomes are internal enum values, never user-supplied; the WARN still prints only the outcome string it was handed, unchanged. Dependencies: none added. Permissions/auth: untouched. Net effect on logging is strictly fewer WARN lines for one known-benign outcome; a genuine give-up and an unknown outcome still WARN.

**Local runs.** `typecheck` clean · `test:node` 2216/2216 + flow 202/202 · `test:bare` 1104/1104 · `lint:ci` 0 errors, 19 warnings (cap 21), hygiene scripts clean. `test:fe` not run — no renderer change.