### PR TITLE
[fix] Key the verified fast path to where bytes landed

### DIFF
--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -491,12 +491,14 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
   let diskHash = null
   if (onDisk?.isFile() && entry.contentHash) {
     // Already-mirrored file: the verified record skips the full re-hash the poll
-    // would otherwise run over every file each tick; only hash on a cache miss.
+    // would otherwise run over every file each tick; only hash on a cache miss. No `expectLocal`
+    // is needed: `abs` is the path resolveLocalRelPath just chose for these bytes, so a record
+    // this mount wrote describes that same file.
     if (await isVerifiedUnchanged(mount.spaceId, verifyKey, entry.contentHash, entry.size, onDisk)) return 'present'
     try {
       diskHash = await hashOf(abs)
       if (diskHash === entry.contentHash) {
-        await markVerified(mount.spaceId, verifyKey, entry.contentHash)
+        await markVerified(mount.spaceId, verifyKey, entry.contentHash, { local: localRelPath })
         return 'present'
       }
     } catch (err) { log.debug('overlay hash skipped on disk:', err.message) }
@@ -519,7 +521,7 @@ async function materializeOverlayFile(mount, share, entry, opts = {}) {
     // Fall back to the LIVE generation rather than undefined: loops.stopped compares against it,
     // so an absent gen would read as 'stopped' and refuse every fetch. A caller without one still
     // gets the check it needs — a stop landing during the wait above.
-    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen: opts.gen ?? mirrorGen(streamKey), diskHash, localExists: !!onDisk || unreadable })
+    return await fetchOverlayEntry(mount, share, entry, { abs, verifyKey, localRelPath, streamKey, gen: opts.gen ?? mirrorGen(streamKey), diskHash, localExists: !!onDisk || unreadable })
   } finally {
     releaseSlot()
   }
@@ -545,7 +547,7 @@ async function acquireMirrorSlot(streamKey) {
 
 // The gated half of a materialize: everything past the slot owns a chunk scheduler, a watchdog,
 // an fd and a ticker.
-async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKey, gen, diskHash = null, localExists = false }) {
+async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, localRelPath, streamKey, gen, diskHash = null, localExists = false }) {
   // The wait for a slot is unbounded, so re-check the stop the catalog walk tests at every entry.
   if (mirrorStopped(streamKey, gen)) return 'missing'
   // Deliberately NOT re-checking reachability here, unlike the download engine past its own slot
@@ -632,7 +634,7 @@ async function fetchOverlayEntry(mount, share, entry, { abs, verifyKey, streamKe
   }
   // The transfer verified the content hash on landing — record it so the row can
   // surface a "verified" indicator without re-hashing.
-  await markVerified(mount.spaceId, verifyKey, entry.contentHash)
+  await markVerified(mount.spaceId, verifyKey, entry.contentHash, { local: localRelPath })
   attempts.succeed(loopKey(mount.spaceId, mount.shareId), entry.relPath, entry.contentHash)
   return 'present'
 }

--- a/src/shared/folders/foreign-preview.js
+++ b/src/shared/folders/foreign-preview.js
@@ -53,7 +53,11 @@ async function classifyForeignEntry(entry, mountPath, spaceId, shareId, hashOf) 
   }
   if (!stat.isFile()) return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
   if (stat.size !== entry.size) return { relPath: entry.relPath, size: entry.size, download: true, conflict: true }
-  if (entry.hash && await isVerifiedUnchanged(spaceId, shareId + '|' + entry.relPath, entry.hash, entry.size, stat)) {
+  // `expectLocal` is what makes the record evidence about THIS path: the mirror writes the same key
+  // when it lands the owner's bytes on a renamed sibling, and a manual download writes it for a
+  // file in the downloads folder. Either one would otherwise report a clean destination for a file
+  // the mount is about to download on top of the user's own.
+  if (entry.hash && await isVerifiedUnchanged(spaceId, shareId + '|' + entry.relPath, entry.hash, entry.size, stat, { expectLocal: entry.relPath })) {
     return { relPath: entry.relPath, size: entry.size, download: false }
   }
   try {

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -362,7 +362,7 @@ export function createOverlayDownloadEngine (channel, { fetchImpl = fetchContent
     // never 'remote' — which would re-download and duplicate the file.
     terminalCodes.delete(job.transferId)
     await markDownloaded(job.spaceId, job.pendingKey, job.finalPath, { hash: job.contentHash })
-    await markVerified(job.spaceId, job.verifyKey, job.contentHash)
+    await markVerified(job.spaceId, job.verifyKey, job.contentHash, { local: job.finalPath })
     // The claim above already decides the status; the row only matters to the resume scan,
     // which drops a claimed row itself (runReconcile). So a failed clear degrades to one extra
     // read at the next reconcile — but it has to be visible.

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -66,8 +66,13 @@ export async function getDownloadedPath(spaceId, filePath) {
 // (overlay downloads verify the content hash incrementally during the transfer).
 // `key` identifies the file within the space (e.g. `<shareId>|<relPath>`). Kept
 // under a `verified:` namespace; cleaned per-space by cleanupDownloadHistory.
-export async function markVerified(spaceId, key, hash) {
-  await downloadsBee.put('verified:' + spaceId + ':' + key, { hash, at: Date.now() })
+//
+// `local` is where the bytes actually landed, addressed the way the writer addresses them: the
+// mount-relative path for a mirror, the absolute final path for a manual download. The key names
+// the OWNER's path, and neither writer is obliged to use it — a mirror renames onto a free sibling
+// when a user file holds the natural name — so only `local` says which file the hash describes.
+export async function markVerified(spaceId, key, hash, { local = null } = {}) {
+  await downloadsBee.put('verified:' + spaceId + ':' + key, { hash, at: Date.now(), local })
 }
 
 export async function getVerifiedHash(spaceId, key) {
@@ -144,12 +149,19 @@ async function getVerifiedRecord(spaceId, key) {
 // still matches). It is an mtime proxy — a same-size in-place edit that does not
 // advance mtime (a backdated utimes, or a coarse-granularity FS) can slip past; the
 // deliberate cost of not hashing on every check. `key` = `<shareId>|<relPath>`.
-export async function isVerifiedUnchanged(spaceId, key, contentHash, expectedSize, stat) {
+//
+// `expectLocal` is the path the caller is asking about; pass it whenever the record's key does not
+// by itself prove which file the hash describes (see markVerified). A record written before the
+// landing path was recorded carries none, so it vouches for nothing and the caller falls back to a
+// hash — transient, and healed by the next landing or confirmation, which rewrites the record.
+export async function isVerifiedUnchanged(spaceId, key, contentHash, expectedSize, stat, { expectLocal = null } = {}) {
   if (!contentHash || !stat) return false
   if (typeof expectedSize === 'number' && stat.size !== expectedSize) return false
   let rec = null
   try { rec = await getVerifiedRecord(spaceId, key) } catch { return false }
-  return !!rec && rec.hash === contentHash && Math.floor(stat.mtimeMs) <= rec.at
+  if (!rec || rec.hash !== contentHash) return false
+  if (expectLocal !== null && rec.local !== expectLocal) return false
+  return Math.floor(stat.mtimeMs) <= rec.at
 }
 
 // A downloaded overlay file is "verified" when the hash recorded on landing (the

--- a/test/integration/files-ops.test.js
+++ b/test/integration/files-ops.test.js
@@ -15,6 +15,7 @@ import {
   isDownloadedFile,
   markVerified,
   getVerifiedHash,
+  isVerifiedUnchanged,
   cleanupDownloadHistory,
   listDownloadClaimsForShare,
   listVerifiedForShare,
@@ -195,6 +196,24 @@ test('verified marker round-trips and is cleared on space cleanup', async (t) =>
 
   await cleanupDownloadHistory(spaceId)
   t.is(await getVerifiedHash(spaceId, key), null, 'cleared with the space download history')
+})
+
+// The landing path is the half of the record the key cannot carry: the key names the owner's
+// path, and a mirror writes it even when the bytes went to a renamed sibling.
+test('isVerifiedUnchanged vouches only for the path the bytes landed at', async (t) => {
+  const { spaceId, tmpDir } = await setup(t)
+  const landed = path.join(tmpDir('v'), 'a.txt')
+  fs.writeFileSync(landed, 'bytes')
+  const stat = fs.statSync(landed)
+  const key = 'share1|a.txt'
+
+  await markVerified(spaceId, key, 'oid-AAA', { local: 'a (1).txt' })
+  t.is(await isVerifiedUnchanged(spaceId, key, 'oid-AAA', stat.size, stat), true, 'no expectation asked, hash and mtime decide')
+  t.is(await isVerifiedUnchanged(spaceId, key, 'oid-AAA', stat.size, stat, { expectLocal: 'a (1).txt' }), true, 'the recorded landing path matches')
+  t.is(await isVerifiedUnchanged(spaceId, key, 'oid-AAA', stat.size, stat, { expectLocal: 'a.txt' }), false, 'another path is not vouched for')
+
+  await markVerified(spaceId, key, 'oid-AAA')
+  t.is(await isVerifiedUnchanged(spaceId, key, 'oid-AAA', stat.size, stat, { expectLocal: 'a.txt' }), false, 'a record with no landing path vouches for nothing')
 })
 
 // The share listing reads every row's claim from one range scan instead of a point read per row,

--- a/test/integration/foreign-preview-verified-path.test.js
+++ b/test/integration/foreign-preview-verified-path.test.js
@@ -1,0 +1,70 @@
+import test from 'brittle'
+import fs from 'bare-fs'
+import path from 'bare-path'
+import { setupSelfMirror } from '../helpers/owned.js'
+import { initialMaterializeScan, unmountForeignFolder } from '../../src/shared/folders/foreign-folders.js'
+import { previewMaterializeScan } from '../../src/shared/folders/foreign-preview.js'
+import { initDownloads, markVerified } from '../../src/shared/transfer/files.js'
+import { overlayHashFile } from '../../src/shared/transfer/backends/overlay/overlay-backend.js'
+
+// The mount preview's verified-record fast path answers "is the file already here?". A record is
+// evidence only when the bytes it vouches for landed at the very path the preview is asking about:
+// the key alone names the OWNER's path, which the mirror is free not to write to.
+
+const listing = (dir) => fs.readdirSync(dir).sort()
+
+// A pre-existing user file of the same size as the share's copy: the size check cannot separate
+// them, so the verified record decides.
+function plantUserFile (abs, content) {
+  fs.writeFileSync(abs, content)
+  const past = new Date(Date.now() - 60000)
+  fs.utimesSync(abs, past, past)
+}
+
+test('REGRESSION (FIX-PREVIEW-LOCAL-1): a mirror that landed on a sibling does not clean the preview', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'aaaa' } })
+  await initDownloads()
+  // The user's own a.txt is already at the destination, so the first mount has to mint a sibling.
+  plantUserFile(path.join(ctx.mirrorPath, 'a.txt'), 'bbbb')
+
+  await initialMaterializeScan(ctx.mount)
+  t.alike(listing(ctx.mirrorPath), ['a (1).txt', 'a.txt'], 'precondition: the mirror landed on a sibling')
+
+  await unmountForeignFolder(ctx.spaceId, ctx.share.id)
+
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, ctx.mirrorPath)
+  t.is(preview.toDownload, 1, 're-mounting would download the file again')
+  t.is(preview.conflicts, 1, 'and it would collide with the user file at the natural name')
+})
+
+test('REGRESSION (FIX-PREVIEW-LOCAL-2): a manual-download record does not clean a mount preview', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'aaaa' } })
+  await initDownloads()
+  const dest = ctx.tmpDir('dst')
+  // The user downloaded this share file manually earlier: the record is keyed by the share's
+  // relPath but the bytes landed in the downloads folder.
+  const downloaded = path.join(ctx.tmpDir('downloads'), 'a.txt')
+  fs.writeFileSync(downloaded, 'aaaa')
+  await markVerified(ctx.spaceId, ctx.share.id + '|a.txt', await overlayHashFile(downloaded), { local: downloaded })
+  // An unrelated same-size file of the user's sits at the folder they now want to mount into.
+  plantUserFile(path.join(dest, 'a.txt'), 'bbbb')
+
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, dest)
+  t.is(preview.toDownload, 1, 'the download record says nothing about this destination')
+  t.is(preview.conflicts, 1, 'the user file at the natural name is still a conflict')
+})
+
+test('a legacy verified record (no landing path) is re-hashed rather than trusted', async (t) => {
+  const ctx = await setupSelfMirror(t, { files: { 'a.txt': 'aaaa' } })
+  await initDownloads()
+  const dest = ctx.mirrorPath
+  fs.writeFileSync(path.join(dest, 'a.txt'), 'aaaa')
+  await markVerified(ctx.spaceId, ctx.share.id + '|a.txt', await overlayHashFile(path.join(dest, 'a.txt')))
+
+  let hashed = 0
+  const preview = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, dest, {
+    hashOf: async (p) => { hashed += 1; return overlayHashFile(p) },
+  })
+  t.is(hashed, 1, 'the record without a landing path is not evidence on its own')
+  t.is(preview.toDownload, 0, 'the hash still proves the file is identical')
+})

--- a/test/integration/preview-scan.test.js
+++ b/test/integration/preview-scan.test.js
@@ -130,8 +130,8 @@ test('foreign preview: detail list omitted above the cap', async (t) => {
 })
 
 // The preview must not read a file it can decide on cheaply: a different SIZE proves a
-// conflict, and a verified-cache hit proves identity. Only a same-size, uncached file is
-// hashed. A counting hashOf asserts the read actually happened (or didn't).
+// conflict, and a verified-cache hit for THIS path proves identity. Only a same-size, uncached
+// file is hashed. A counting hashOf asserts the read actually happened (or didn't).
 function countingHash (real) {
   let calls = 0
   const fn = async (p) => { calls += 1; return real(p) }
@@ -156,7 +156,7 @@ test('foreign preview: a verified-cache hit is identical WITHOUT hashing', async
   const dest = ctx.mirrorPath
   fs.writeFileSync(path.join(dest, 'a.txt'), 'aaaa') // identical bytes
   await initDownloads()
-  await markVerified(ctx.spaceId, ctx.share.id + '|a.txt', await overlayHashFile(path.join(dest, 'a.txt')))
+  await markVerified(ctx.spaceId, ctx.share.id + '|a.txt', await overlayHashFile(path.join(dest, 'a.txt')), { local: 'a.txt' })
   const spy = countingHash(overlayHashFile)
   const p = await previewMaterializeScan(ctx.spaceId, ctx.share.owner, ctx.share.id, dest, { hashOf: spy })
   t.is(p.toDownload, 0, 'cached-identical file is not a download')
@@ -181,7 +181,7 @@ test('REGRESSION: a cached file edited (same size) after materialize is re-hashe
   const dest = ctx.mirrorPath
   fs.writeFileSync(path.join(dest, 'a.txt'), 'aaaa')
   await initDownloads()
-  await markVerified(ctx.spaceId, ctx.share.id + '|a.txt', await overlayHashFile(path.join(dest, 'a.txt')))
+  await markVerified(ctx.spaceId, ctx.share.id + '|a.txt', await overlayHashFile(path.join(dest, 'a.txt')), { local: 'a.txt' })
   // User edits the mirrored file in place (same size, different content) AFTER the record.
   fs.writeFileSync(path.join(dest, 'a.txt'), 'bbbb')
   const future = new Date(Date.now() + 60000)


### PR DESCRIPTION
Fixes #243.

## Bug
The mount preview reports `{toDownload: 0, conflicts: 0}` ("the destination is clean") for a share that is about to download a file and mint a numbered sibling next to the user's own.

## Root cause
`verified:<spaceId>:<shareId>|<relPath>` is keyed by the OWNER's relPath, but neither writer is obliged to write there: the mirror resolves a local path first and renames onto a free sibling when a user file holds the natural name, and the manual-download engine writes the same key for a file in the downloads folder. The preview's fast path trusted that record as proof about the natural path. `resolveLocalRelPath` explicitly refuses the same inference and re-hashes — the engine is correct, the preview's shortcut was not.

## Fix (option C1)
Widen the record's VALUE: `markVerified` now records `local`, the path the bytes landed at (mount-relative for the mirror, the absolute final path for a download). The preview passes `expectLocal` and trusts the fast path only when it matches.

Rejected alternatives: keying by the local path (the issue's "Preferred") needs a bee-row key-shape change plus a migration, four reader rewrites, and leaves one namespace holding two key meanings; dropping the shortcut re-hashes every destination file, which `preview-scan.test.js` deliberately pins at zero.

No key migration and no version bump — every other reader of the namespace keeps reading `.hash` untouched. A legacy row carries no `local` and is treated as untrusted, so those files fall back to a hash; self-healing, since the next landing or confirmation rewrites the record with the field.

Also fixed by the same guard, intentionally: a file the user once downloaded manually left a `shareId|relPath` record that cleaned the preview of an unrelated mount containing a same-size file at that path. A downloads-dir path cannot match a mount-relative `entry.relPath`.

Out of scope: the pre-existing mtime proxy in `isVerifiedUnchanged` (a backdated same-size replacement can still pass the fast path) is untouched.

## Tests
- `test/integration/foreign-preview-verified-path.test.js` — `FIX-PREVIEW-LOCAL-1` drives the measured sequence through the real paths (`setupSelfMirror` → `initialMaterializeScan` → `unmountForeignFolder` → `previewMaterializeScan`); `FIX-PREVIEW-LOCAL-2` pins the manual-download record; a third pins the legacy-row hash fallback. All three fail on staging.
- `files-ops.test.js` pins `expectLocal` at the helper layer.
- `preview-scan.test.js`: the two tests that plant a verified record now pass `local: 'a.txt'`. The 0-hash pin still holds for a record that vouches for the path being asked about — that is the honest form of what it was pinning.

## Security audit
Re-verified for this change: `local` is only ever compared with `===`, never used to build a path or a bee key; both paths still join through `pathFromMount`, so no path-escape surface is added. No key-shape change, so the existing no-collision argument (16-hex spaceId without `:`, base36 share ids without `|`) is unaffected. The stored value is a local path already persisted in the same bee by `markDownloaded`, is never serialized over IPC, and is not a secret. Unknown-field tolerance makes the row forward- and backward-compatible. The guard is fail-closed (unknown landing path → hash, never trust). No new deps, no auth/permission change, no deserialization or injection surface.

## Local runs
`typecheck`, `lint:ci`, `test:node` (202/202 flow + core) green. `test:bare` 1107/1108 — the one red is `invite-record-capture.test.js`, unrelated to this diff and green in isolation (known one-random-test flakiness).