### PR TITLE
[fix] Await the app's real exit before quit() resolves

### DIFF
--- a/test/frontend/instance.mjs
+++ b/test/frontend/instance.mjs
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { spawn, execFileSync } from 'node:child_process'
 import { rmSync, openSync, closeSync } from 'node:fs'
 import path from 'node:path'
 import { ad, withRetry, RETRYABLE } from './agent.mjs'
@@ -31,6 +31,25 @@ const POLL_MS = 150
 // clock on the happy path. See nativeChoosePath.
 const PANEL_TRIES = 3
 const PANEL_WAIT_MS = 7000
+
+// How long to wait, after the `npx electron-forge` wrapper has exited, for the Electron process it
+// spawned to actually let go of the store. The graceful path already allows 6s before SIGKILL, so
+// this only has to cover the kernel reaping a killed process.
+const STORE_RELEASE_TIMEOUT_MS = 10000
+
+// True while an Electron process still holds `store`. Electron main carries `--storage <store>` in
+// its argv; the helper processes (renderer, GPU, utility) do not, so this matches exactly the one
+// process that writes config.json.
+function storeHeldByApp(store) {
+  const pattern = `Electron.*${store.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`
+  try {
+    execFileSync('pgrep', ['-f', pattern], { stdio: 'pipe' })
+    return true
+  } catch {
+    return false
+  }
+}
+
 async function mirallWindows() {
   const { data } = await ad(['list-windows'])
   return data
@@ -680,12 +699,35 @@ export class Instance {
     if (hard) {
       try { process.kill(-proc.pid, 'SIGKILL') } catch {}
       await exited
+      await this._awaitStoreRelease(proc.pid)
       return
     }
     try { process.kill(-proc.pid, 'SIGTERM') } catch {}
     const sigkill = setTimeout(() => { try { process.kill(-proc.pid, 'SIGKILL') } catch {} }, 6000)
     await exited
     clearTimeout(sigkill)
+    await this._awaitStoreRelease(proc.pid)
+  }
+
+  // The wrapper's `exit` says nothing about the Electron process it spawned, which is still running
+  // before-quit at that point. That matters because main's ConfigStore is debounced and flushed on
+  // quit, and the flush rewrites the WHOLE config.json from main's in-memory object — window bounds
+  // are written as the window closes, so the flush is armed even when the scenario changed nothing.
+  // Resolving here while that is in flight lets a caller's edit be silently replaced. Wait until no
+  // process holds the store, SIGKILLing the group once more if one is wedged.
+  async _awaitStoreRelease(groupPid) {
+    if (!storeHeldByApp(this.store)) return
+    const deadline = Date.now() + STORE_RELEASE_TIMEOUT_MS
+    let escalated = false
+    while (Date.now() < deadline) {
+      await new Promise((r) => setTimeout(r, POLL_MS))
+      if (!storeHeldByApp(this.store)) return
+      if (!escalated && Date.now() > deadline - STORE_RELEASE_TIMEOUT_MS / 2) {
+        escalated = true
+        try { process.kill(-groupPid, 'SIGKILL') } catch {}
+      }
+    }
+    throw new Error(`${this.name}: Electron still holds ${this.store} ${STORE_RELEASE_TIMEOUT_MS}ms after exit`)
   }
 
   async kill() {

--- a/test/frontend/scenarios/s15-appearance.mjs
+++ b/test/frontend/scenarios/s15-appearance.mjs
@@ -1,4 +1,3 @@
-import { execFileSync } from 'node:child_process'
 import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { Instance } from '../instance.mjs'
@@ -18,23 +17,11 @@ async function pressedZoomTiles (A) {
   return pressed
 }
 
-function storeHeldByApp (store) {
-  try {
-    execFileSync('pgrep', ['-f', `Electron.*${store}`], { stdio: 'pipe' })
-    return true
-  } catch {
-    return false
-  }
-}
-
-// Editing a stopped instance's store is only safe once the app is really gone: quit() resolves on
-// the `npx electron-forge` wrapper, whose Electron child can still be shutting down, and main's
-// config store is debounced and flushed on before-quit — a flush that rewrites the WHOLE file, so
-// an early edit is silently replaced by the factor the dying app held. Wait the app out, then read
-// the edit back, so a clobber fails here by name instead of as a mystery timeout further down.
-// The wait belongs in the harness's own stop; this is local until quit() awaits the real process.
+// quit() guarantees the app has released the store before it resolves, so the edit below lands on a
+// file nobody will rewrite. Read it back anyway: main's config flush rewrites the WHOLE file, so if
+// that guarantee ever regresses the clobber fails here by name instead of as a mystery timeout
+// further down.
 async function seedPersistedZoom (A, factor) {
-  await waitFor(async () => !storeHeldByApp(A.store), 20000, 'the quit app released its store')
   const configPath = join(A.store, 'config.json')
   const config = JSON.parse(readFileSync(configPath, 'utf8'))
   config.window.zoom = factor


### PR DESCRIPTION
Fixes #256.

## Bug
`Instance._stopProcess` resolved on the `npx electron-forge` wrapper's `exit`, not on the exit of the Electron process that wrapper spawned. Main's `ConfigStore` is debounced (`config-store.js:222`) and flushed on quit, and the flush rewrites the *whole* `config.json` from main's in-memory object — and `win.on('close')` writes window bounds, so a flush is armed on every graceful quit even when the scenario changed nothing. Any scenario editing the store between `quit()` and `launch()` could have its edit silently replaced, surfacing much later as an unrelated UI timeout.

## Fix
`_stopProcess` now awaits `_awaitStoreRelease` on both the graceful and `hard` paths: returns immediately when the store is already free (the normal case), otherwise polls `pgrep -f "Electron.*<store>"` on the existing `POLL_MS`, SIGKILLs the group once at 5s, and throws a named error at 10s rather than letting the next scenario inherit a live writer. Only Electron main carries `--storage` in its argv, so the match is exactly the process that writes `config.json`.

`kill()` inherits the guarantee, which makes its existing "Only now is nothing still writing the store" comment true for the first time.

`s15-appearance`'s local workaround is removed; its read-back assertion stays as the regression guard.

## Tests
Harness-only change, so the covering layer is the FE suite itself — `test:fe s15` fails by name if the guarantee regresses. The `pgrep` matcher was verified directly: a path with regex metacharacters escapes correctly, a live holder is detected, and release is detected after SIGKILL.

## Local runs
`typecheck` and `eslint` on both files green. `test:fe` not run in this session (local-only gate).