### PR TITLE
[fix] Scale flow per-test deadlines; guard them

### DIFF
--- a/scripts/check-test-timing.sh
+++ b/scripts/check-test-timing.sh
@@ -47,4 +47,45 @@ if [ -n "$(printf '%s' "$own" | tr -d '[:space:]')" ]; then
   exit 1
 fi
 
+# The third face of the same rule, and the reason the other two are not enough: brittle's
+# per-test deadline is not a helper, so nothing scales it for the call site. A flow test whose
+# ceiling is a bare number — or absent, inheriting brittle's 30s default — keeps its dev-box
+# budget while every helper deadline inside it triples, so brittle kills the test before the
+# helper's diagnostic (which carries the worker stderr tail) can fire. Rule 1 cannot see it:
+# the defect is again the ABSENCE of scaled(. Every top-level test in test/flow therefore
+# declares its ceiling as `{ timeout: scaled(N) }`, or sets it as the first statement of the
+# body with `t.timeout(scaled(N))`.
+missing="$(
+  for f in test/flow/*.test.js; do
+    awk -v file="$f" '
+      # Accumulate a declaration head across lines until the body arrow, then judge it.
+      /^[ 	]*test(\.skip|\.solo)?\(/ { collecting = 1; head = ""; start = FNR }
+      collecting {
+        head = head $0
+        if (head ~ /=> \{/) {
+          collecting = 0
+          if (head ~ /timeout: scaled\(/) next
+          want_body = 1   # no ceiling in the options object; the first body line gets the chance
+          next
+        }
+        next
+      }
+      want_body {
+        want_body = 0
+        if ($0 !~ /^ *t\.timeout\(scaled\(/) print file ":" start ": " substr(head, 1, 100)
+      }
+    ' "$f"
+  done
+)"
+
+if [ -n "$(printf '%s' "$missing" | tr -d '[:space:]')" ]; then
+  echo "ERROR: flow test without a scaled per-test deadline — brittle's ceiling ignores MIRALL_TEST_TIMEOUT_SCALE:" >&2
+  printf '%s\n' "$missing" >&2
+  echo >&2
+  echo "  fix: test('…', { timeout: 150000 }, …)  ->  test('…', { timeout: scaled(150000) }, …)" >&2
+  echo "       test('…', async (t) => {           ->  add { timeout: scaled(N) }, sized above the" >&2
+  echo "                                              longest helper wait in the body" >&2
+  exit 1
+fi
+
 echo "test-timing: clean."

--- a/test/flow/_boot.test.js
+++ b/test/flow/_boot.test.js
@@ -1,17 +1,18 @@
 import test from 'brittle'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
+import { scaled } from '../helpers/timing.js'
 
 // Proves the two-peer harness foundation: the real worker boots as a bare
 // subprocess via bare-sidecar, completes bootstrap, and answers IPC.
-test('a worker boots under bare-sidecar and answers ping', async (t) => {
+test('a worker boots under bare-sidecar and answers ping', { timeout: scaled(60000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const peer = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const res = await peer.request('ping')
   t.ok(res && res.pong, 'ping answered with pong')
 })
 
-test('two workers boot independently on the same testnet', async (t) => {
+test('two workers boot independently on the same testnet', { timeout: scaled(60000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const a = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const b = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/approval-files.test.js
+++ b/test/flow/approval-files.test.js
@@ -4,6 +4,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir, writeTmpFile, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -13,7 +14,7 @@ const v2flags = () => ({ identityKEK: kekHex() })
 // approves a third peer — who must also see the owner's files. The owner's drive key now rides the
 // replicated records (markSpaceDriveKey), so a transitively-approved member can open the owner's
 // drive even without a direct handshake with the owner.
-test('a transitively-approved member sees the owner\'s files', { timeout: 150000 }, async (t) => {
+test('a transitively-approved member sees the owner\'s files', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })

--- a/test/flow/audit-attribution.test.js
+++ b/test/flow/audit-attribution.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
 import { mkTmpDir, writeTmpFile, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -20,7 +21,7 @@ const find = (entries, kind) => entries.find((e) => e.kind === kind)
 // The whole value of a tier-B row is that the peer identity in it was authenticated on the
 // socket, not merely claimed. This asserts the recorded actor key is the real remote profile
 // key — a two-peer test is the only layer that can prove it.
-test('a peer join and approval are recorded with the authenticated peer key', { timeout: 220000 }, async (t) => {
+test('a peer join and approval are recorded with the authenticated peer key', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -61,7 +62,7 @@ test('a peer join and approval are recorded with the authenticated peer key', { 
   t.is(granted.tier, 'B')
 })
 
-test('a denied join is recorded by the decider with a denied outcome', { timeout: 220000 }, async (t) => {
+test('a denied join is recorded by the decider with a denied outcome', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -82,7 +83,7 @@ test('a denied join is recorded by the decider with a denied outcome', { timeout
 // The log is a deliberate exception to §6's "leave removes everything space-scoped" rule. Without
 // the name snapshot the surviving rows would render a raw hex id forever, so both halves are
 // asserted together.
-test('audit rows survive a space leave, still naming the space', { timeout: 220000 }, async (t) => {
+test('audit rows survive a space leave, still naming the space', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -108,7 +109,7 @@ test('audit rows survive a space leave, still naming the space', { timeout: 2200
   t.ok(scoped.length > 0, 'the by-space index survives the leave too')
 })
 
-test('recording can be turned off and back on at runtime', { timeout: 220000 }, async (t) => {
+test('recording can be turned off and back on at runtime', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
 
@@ -130,7 +131,7 @@ test('recording can be turned off and back on at runtime', { timeout: 220000 }, 
 // every boot — so every already-known member re-registered as a fresh arrival on every app
 // start, and the log filled with duplicate "X joined the space" rows. The guard must be the
 // durable roster instead.
-test('REGRESSION (FIX-1): a member is recorded as joining once, not on every restart', { timeout: 220000 }, async (t) => {
+test('REGRESSION (FIX-1): a member is recorded as joining once, not on every restart', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const aStorage = idStore(t)
   const aDownloads = mkTmpDir(t)
@@ -158,7 +159,7 @@ test('REGRESSION (FIX-1): a member is recorded as joining once, not on every res
 // A co-member who did NOT approve the newcomer has no other signal that they arrived, so the row
 // must still be recorded there — including when they learn it purely through replication rather
 // than a direct handshake.
-test('a co-member records an arrival it did not approve, with the authenticated key', { timeout: 220000 }, async (t) => {
+test('a co-member records an arrival it did not approve, with the authenticated key', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -190,7 +191,7 @@ test('a co-member records an arrival it did not approve, with the authenticated 
 // session was closed only by the protocol's onServeEnd, which fires on channel close or grant
 // revocation — never on a successful transfer — and the idle sweep stops being scheduled once
 // the last live row is dropped. So a completed serve was never recorded at all.
-test('REGRESSION (FIX-3): the owner records a peer downloading their file', { timeout: 220000 }, async (t) => {
+test('REGRESSION (FIX-3): the owner records a peer downloading their file', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -227,7 +228,7 @@ test('REGRESSION (FIX-3): the owner records a peer downloading their file', { ti
 // The three peer-action events: a member publishing a file into a shared space, creating a
 // folder share there, and mirroring one of OUR folders. All three are read from that peer's own
 // replicated records (tier C) by diffing their bee's history against a durable watermark.
-test('a peer publishing a file into a shared space is recorded', { timeout: 220000 }, async (t) => {
+test('a peer publishing a file into a shared space is recorded', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -257,7 +258,7 @@ test('a peer publishing a file into a shared space is recorded', { timeout: 2200
   t.ok(find(await rows(B), 'file.shared'))
 })
 
-test('a peer creating a folder share, and mirroring ours, are both recorded', { timeout: 220000 }, async (t) => {
+test('a peer creating a folder share, and mirroring ours, are both recorded', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })

--- a/test/flow/audit-coverage.test.js
+++ b/test/flow/audit-coverage.test.js
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir, writeTmpFile, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 import { KINDS, OUTCOMES } from '../../src/shared/contract/audit-kinds.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
@@ -91,7 +92,7 @@ async function rows (peer) {
 
 const kindsOf = (entries) => new Set(entries.map((e) => e.kind))
 
-test('the expected-kind manifest accounts for the whole vocabulary, exactly', (t) => {
+test('the expected-kind manifest accounts for the whole vocabulary, exactly', { timeout: scaled(30000) }, (t) => {
   const claimed = new Set([...EXPECTED_KINDS.A, ...EXPECTED_KINDS.B, ...Object.keys(UNTRIGGERABLE)])
   for (const kind of Object.keys(KINDS)) {
     t.ok(claimed.has(kind), kind + ' is either driven by the session below or explicitly accounted for')
@@ -101,7 +102,7 @@ test('the expected-kind manifest accounts for the whole vocabulary, exactly', (t
   }
 })
 
-test('one realistic session produces every expected kind, and nothing else', { timeout: 300000 }, async (t) => {
+test('one realistic session produces every expected kind, and nothing else', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
@@ -191,7 +192,7 @@ test('one realistic session produces every expected kind, and nothing else', { t
   for (const kind of bKinds) t.ok(allowedB.has(kind), 'B recorded ONLY expected kinds — unexpected: ' + kind)
 })
 
-test('every recorded row is well formed and renderable without a join', { timeout: 300000 }, async (t) => {
+test('every recorded row is well formed and renderable without a join', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const space = await A.request('space:create', { name: 'Shapes' })

--- a/test/flow/audit-network-presence.test.js
+++ b/test/flow/audit-network-presence.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // Production waits five minutes before calling a peer gone; that is tuning, not a contract, and
 // five minutes of wall-clock is not a test. Everything else here is real: two peers, a real
@@ -25,7 +26,7 @@ async function rows (peer) {
   return (await peer.request('audit:list', { limit: 200 })).entries
 }
 
-test('a peer that really goes away is recorded once, and its return closes the row', { timeout: 220000 }, async (t) => {
+test('a peer that really goes away is recorded once, and its return closes the row', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const storageB = idStore(t)
   const downloadsB = mkTmpDir(t)
@@ -61,7 +62,7 @@ test('a peer that really goes away is recorded once, and its return closes the r
 })
 
 // member.left already tells that story; a second row seconds later reads as two separate events.
-test('leaving the space is a leave, not a disconnect', { timeout: 220000 }, async (t) => {
+test('leaving the space is a leave, not a disconnect', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })

--- a/test/flow/copy-file.test.js
+++ b/test/flow/copy-file.test.js
@@ -4,12 +4,13 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-6 (flow) — copying a file within a shared folder produces a second path
 // holding identical bytes. Both must replicate and the mirror must materialize
 // both. The collision-naming walk is unit-proven (path-keys); this is the byte /
 // blob path: two drive keys, identical content, both landing on the mirror.
-test('copying a file yields two byte-identical paths on the mirror', { timeout: 150000 }, async (t) => {
+test('copying a file yields two byte-identical paths on the mirror', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/downloaded-claim-reset.test.js
+++ b/test/flow/downloaded-claim-reset.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // FIX-21 — "downloaded / on your device" used to be a bare key in downloads-meta
 // (keyed by spaceId:filePath), never checked against disk. So the claim outlived
@@ -19,7 +20,7 @@ function localOf (list, rel) {
   return list?.entries?.find((f) => f.relPath === rel)?.localPath
 }
 
-test('REGRESSION (FIX-21): a kept copy stays on-device when the owner removes then re-shares the same content', { timeout: 150000 }, async (t) => {
+test('REGRESSION (FIX-21): a kept copy stays on-device when the owner removes then re-shares the same content', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const aDownloads = mkTmpDir(t)

--- a/test/flow/foreign-mirror-head-tracking.test.js
+++ b/test/flow/foreign-mirror-head-tracking.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // The safety premise of the mirror-walk skip, and the ONE property no single-peer test can reach.
 //
@@ -17,7 +18,7 @@ import { mkTmpDir } from '../helpers/fixtures.js'
 // The backstop is disabled here (foreignFullWalkEvery far beyond any tick this test will run) so it
 // cannot mask a failure. With a working probe the new file lands in seconds; with a broken one it
 // would wait for tick 5000 and this test would time out — which is exactly the signal wanted.
-test('a remote owner append advances the mirror\'s local catalog version', { timeout: 120000 }, async (t) => {
+test('a remote owner append advances the mirror\'s local catalog version', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, {

--- a/test/flow/foreign-mirror-progress.test.js
+++ b/test/flow/foreign-mirror-progress.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // Mirroring a foreign folder must surface per-file download progress the same
 // way an individual file download does — otherwise the receiving peer's folder
@@ -11,7 +12,7 @@ import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
 // event:decoration frames (channel 'transfer', keyed shareId:relPath) during
 // materialize with a correct total and monotonic byte counts, and that the
 // file still lands byte-exact.
-test('B sees per-file mirror progress with correct total and monotonic bytes', { timeout: 90000 }, async (t) => {
+test('B sees per-file mirror progress with correct total and monotonic bytes', { timeout: scaled(90000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/foreign-mirror.test.js
+++ b/test/flow/foreign-mirror.test.js
@@ -4,13 +4,14 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // Mirroring a foreign folder exercises the materialize engine's connectivity
 // gate (the deadlock fixed this session: a freshly-replicated drive has only
 // metadata, so the engine must stream the blob on demand while the owner is
 // online — it must NOT skip because the blob isn't cached yet). A successful
 // download here is the end-to-end regression for that fix.
-test('B mirrors A’s owned folder; files materialize to disk with matching bytes', { timeout: 90000 }, async (t) => {
+test('B mirrors A’s owned folder; files materialize to disk with matching bytes', { timeout: scaled(90000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/handshake-starvation.test.js
+++ b/test/flow/handshake-starvation.test.js
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, waitForCatalogEntry } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const v2flags = (extra = {}) => ({ identityKEK: kekHex(), ...extra })
@@ -33,7 +34,7 @@ async function approveAndConverge (t, A, B, spaceId, requestPromise) {
 // creator silently dropped the one frame that mattered, the membership:request, and no
 // banner ever appeared until a reconnect (the Egypt field failure). The two-lane limiter
 // admits it: the five unmatched frames ride their own generous lane.
-test('REGRESSION (FIX-1): join request survives a multi-space connection-open burst', { timeout: 120000 }, async (t) => {
+test('REGRESSION (FIX-1): join request survives a multi-space connection-open burst', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Creator', flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Joiner', flags: v2flags() })
@@ -53,7 +54,7 @@ test('REGRESSION (FIX-1): join request survives a multi-space connection-open bu
 // Pre-approval there is NO fold/readmit backstop — the request was never recorded anywhere —
 // so only the joiner's level-triggered re-announce can surface the banner. Red with the
 // convergence tick disabled; green with it on.
-test('REGRESSION (FIX-2): a dropped membership:request is re-announced until the banner appears', { timeout: 120000 }, async (t) => {
+test('REGRESSION (FIX-2): a dropped membership:request is re-announced until the banner appears', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Creator', flags: v2flags({ testDropIdentityFramesCount: 4 }) })
   const B = await launchPeer(t, { bootstrap, displayName: 'Joiner', flags: v2flags(fastTick) })
@@ -74,7 +75,7 @@ test('REGRESSION (FIX-2): a dropped membership:request is re-announced until the
 // no restart of either peer. (Post-approval the fold+readmit path can also converge this
 // state once records replicate — the deterministic pre-approval pin is FIX-2; this test
 // covers the ledger's handshake kind end-to-end under drops.)
-test('REGRESSION (FIX-3): joiner converges the creator although its post-grant handshakes were dropped', { timeout: 120000 }, async (t) => {
+test('REGRESSION (FIX-3): joiner converges the creator although its post-grant handshakes were dropped', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Creator', flags: v2flags({ testDropIdentityFramesAfter: 1, testDropIdentityFramesCount: 3 }) })
   const B = await launchPeer(t, { bootstrap, displayName: 'Joiner', flags: v2flags(fastTick) })
@@ -92,7 +93,7 @@ test('REGRESSION (FIX-3): joiner converges the creator although its post-grant h
 // With the tick running hot, a full approve → share → download-visible flow stays green and
 // both workers shut down cleanly (the teardown leak check enforces the timer lifecycle). A
 // converged swarm must make the tick a no-op — this is the smoke for that steady state.
-test('convergence tick smoke: hot tick does not disturb a healthy flow', { timeout: 120000 }, async (t) => {
+test('convergence tick smoke: hot tick does not disturb a healthy flow', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Creator', flags: v2flags(fastTick) })
   const B = await launchPeer(t, { bootstrap, displayName: 'Joiner', flags: v2flags(fastTick) })

--- a/test/flow/identity-binding.test.js
+++ b/test/flow/identity-binding.test.js
@@ -7,6 +7,7 @@ import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
 import { rawPeer } from '../helpers/raw-peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 import { decodeInvite } from '../../src/shared/contract/invite-envelope.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
@@ -27,7 +28,7 @@ async function topicFor (peer, spaceId) {
 
 // Positive path: with binding enforced, honest peers (each signing their own Noise key)
 // still approve and converge. If the capability/sig wiring were wrong this would hang.
-test('binding ON: honest peers approve and converge', { timeout: 220000 }, async (t) => {
+test('binding ON: honest peers approve and converge', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
@@ -43,7 +44,7 @@ test('binding ON: honest peers approve and converge', { timeout: 220000 }, async
 // REGRESSION (MIR-03): an attacker that knows a member's public profileKey cannot
 // impersonate them — a handshake without a valid Noise-key binding is rejected, so the
 // follow-up leave frame for the victim is not authenticated and the victim stays.
-test('REGRESSION (MIR-03): spoofed handshake cannot impersonate or evict a member', { timeout: 220000 }, async (t) => {
+test('REGRESSION (MIR-03): spoofed handshake cannot impersonate or evict a member', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
@@ -68,7 +69,7 @@ test('REGRESSION (MIR-03): spoofed handshake cannot impersonate or evict a membe
 // REGRESSION (MIR-03-A): a spoofed membership:request must not trigger an SCK re-grant.
 // A member that is a known member + currently offline would otherwise have its grant
 // routed (via the pendingRequesters fallback) to whoever sent the request.
-test('REGRESSION (MIR-03-A): spoofed join request gets no SCK grant', { timeout: 220000 }, async (t) => {
+test('REGRESSION (MIR-03-A): spoofed join request gets no SCK grant', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })

--- a/test/flow/identity-replication.test.js
+++ b/test/flow/identity-replication.test.js
@@ -5,13 +5,14 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace, waitForWorkerExit } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 // identity.enc is written beside the store (dirname(storage)), so each identity
 // peer needs its own store parent — mirror production's <userData>/app-storage.
 const identityStore = (t) => path.join(mkTmpDir(t), 'app-storage')
 
-test('explicit-keypair peers replicate a shared file', { timeout: 150000 }, async (t) => {
+test('explicit-keypair peers replicate a shared file', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: identityStore(t), downloads: mkTmpDir(t), flags: { identityKEK: kekHex() } })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: identityStore(t), downloads: mkTmpDir(t), flags: { identityKEK: kekHex() } })
@@ -35,7 +36,7 @@ test('explicit-keypair peers replicate a shared file', { timeout: 150000 }, asyn
   t.ok(fs.readFileSync(completed.localPath).equals(bytes), 'explicit-keypair drive replicated byte-exact')
 })
 
-test('migration through the real worker preserves the network identity', { timeout: 150000 }, async (t) => {
+test('migration through the real worker preserves the network identity', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const root = mkTmpDir(t)
   const storage = path.join(root, 'app-storage')

--- a/test/flow/invite-link-policy.test.js
+++ b/test/flow/invite-link-policy.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // Per-link invite policy end to end: auto-approve, review, expiry, and the load-bearing proof that
 // the per-link record is REPLICATED — a co-member enforces an auto-approve link the minter never
@@ -19,7 +20,7 @@ const memberKeys = async (peer, spaceId) => {
 const status = async (peer, spaceId) =>
   (await peer.request('spaces:list')).find((s) => s.spaceId === spaceId)?.status
 
-test('REGRESSION (FIX-1): an auto-approve link admits with no manual approval', { timeout: 150000 }, async (t) => {
+test('REGRESSION (FIX-1): an auto-approve link admits with no manual approval', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -37,7 +38,7 @@ test('REGRESSION (FIX-1): an auto-approve link admits with no manual approval', 
   t.absent(prompted, 'no manual approval was required')
 })
 
-test('a review link (auto-approve off) still requires manual approval', { timeout: 150000 }, async (t) => {
+test('a review link (auto-approve off) still requires manual approval', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -51,7 +52,7 @@ test('a review link (auto-approve off) still requires manual approval', { timeou
   t.is((await B.request('spaces:list')).find((s) => s.spaceId === space.spaceId)?.status, 'pending', 'review link leaves the joiner pending')
 })
 
-test('an expired link is refused at join', { timeout: 120000 }, async (t) => {
+test('an expired link is refused at join', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -66,7 +67,7 @@ test('an expired link is refused at join', { timeout: 120000 }, async (t) => {
 // REGRESSION (FIX-2, R1): the per-link record is replicated, so a co-member enforces an auto-approve
 // link the MINTER never resolves. A mints the link and goes offline; C (a member who learned the
 // record via replication) auto-admits B with no manual approval.
-test('REGRESSION (FIX-2): a co-member enforces an auto-approve link the offline minter did not resolve', { timeout: 300000 }, async (t) => {
+test('REGRESSION (FIX-2): a co-member enforces an auto-approve link the offline minter did not resolve', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const mk = (name) => launchPeer(t, { bootstrap, displayName: name, storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const A = await mk('Alice'); const B = await mk('Bob'); const C = await mk('Carol')

--- a/test/flow/leave-crash-recovery.test.js
+++ b/test/flow/leave-crash-recovery.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, waitForWorkerExit } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // REGRESSION (G4): a leave interrupted by a hard quit must COMPLETE at the next boot, not
 // silently reverse. Before the fix, the space record survived the crash (only the in-memory
@@ -16,7 +17,7 @@ const settle = (ms) => new Promise((r) => setTimeout(r, ms))
 const memberKeys = async (peer, spaceId) =>
   new Set(((await peer.request('spaces:list')).find((x) => x.spaceId === spaceId)?.members || []).map((m) => m.publicKey))
 
-test('REGRESSION (G4): a leave interrupted by a hard quit completes at the next boot', { timeout: 300000 }, async (t) => {
+test('REGRESSION (G4): a leave interrupted by a hard quit completes at the next boot', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const flags = () => ({ identityKEK: kekHex(), handshakeIdentityBindingEnabled: true })
   // B is relaunched, so its KEK + storage must stay fixed across boots.

--- a/test/flow/leave-drops-coapproved-member.test.js
+++ b/test/flow/leave-drops-coapproved-member.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // REGRESSION (FIX-240): a member approved by a CO-MEMBER (not the creator) leaves; BOTH the creator
 // and the approver must drop it. The leave frame is now identity-bound (accepted even if the
@@ -17,7 +18,7 @@ const hasMember = (l, spaceId, key) =>
 const memberKeys = async (peer, spaceId) =>
   new Set(((await peer.request('spaces:list')).find((x) => x.spaceId === spaceId)?.members || []).map((m) => m.publicKey))
 
-test('FIX-240: a co-member-approved leaver is dropped by the creator and the approver', { timeout: 300000 }, async (t) => {
+test('FIX-240: a co-member-approved leaver is dropped by the creator and the approver', { timeout: scaled(300000) }, async (t) => {
   const flags = () => ({ identityKEK: kekHex(), handshakeIdentityBindingEnabled: true })
   const bootstrap = await localTestnet(t)
   const mk = (name) => launchPeer(t, { bootstrap, displayName: name, storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })

--- a/test/flow/leave-identity-store.test.js
+++ b/test/flow/leave-identity-store.test.js
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -15,7 +16,7 @@ const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
 // closed" / "Cannot make sessions on a closing core"). The leave then never reached
 // the catalog-record delete, so the space was stranded in the list forever and every
 // subsequent worker op threw SESSION_CLOSED.
-test('leaving an identity-mode space leaves the root store intact and removes the record', { timeout: 150000 }, async (t) => {
+test('leaving an identity-mode space leaves the root store intact and removes the record', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, {
     bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t),

--- a/test/flow/leave-reconcile.test.js
+++ b/test/flow/leave-reconcile.test.js
@@ -1,8 +1,9 @@
 import test from 'brittle'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { scaled } from '../helpers/timing.js'
 
-test('when A leaves a shared space, B prunes A from membership', { timeout: 90000 }, async (t) => {
+test('when A leaves a shared space, B prunes A from membership', { timeout: scaled(90000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/leave-teardown.test.js
+++ b/test/flow/leave-teardown.test.js
@@ -4,13 +4,14 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // FIX-1 — leaving a space must tear down its folder machinery (watcher, loops,
 // periodic reconcile, cached views, mounts) BEFORE purging the drive. Without
 // it, the next fs event / timer tick writes to a closed-and-purged drive. We
 // assert the observable effect: the space's owned mount is gone after leave and
 // the worker stays healthy. RED before FIX-1 (the leave handler left mounts).
-test('REGRESSION (FIX-1): leaving a space tears down its folder mounts', { timeout: 60000 }, async (t) => {
+test('REGRESSION (FIX-1): leaving a space tears down its folder mounts', { timeout: scaled(60000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
 

--- a/test/flow/list-files-status.test.js
+++ b/test/flow/list-files-status.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // share:list-files derives a per-file status the UI renders as a badge. The
 // branches: own folder → 'synced'; foreign browse, owner online, not downloaded
@@ -14,7 +15,7 @@ function statusOf (list, rel) {
   return list?.entries?.find((f) => f.relPath === rel)?.status
 }
 
-test('status derivation: synced / remote / downloaded / unavailable', { timeout: 150000 }, async (t) => {
+test('status derivation: synced / remote / downloaded / unavailable', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -56,7 +57,7 @@ test('status derivation: synced / remote / downloaded / unavailable', { timeout:
   t.is(statusOf(offline, 'b.txt'), 'unavailable', 'un-cached file is unavailable while owner offline')
 })
 
-test('status derivation: a mirrored file present on disk reports synced', { timeout: 120000 }, async (t) => {
+test('status derivation: a mirrored file present on disk reports synced', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -83,7 +84,7 @@ test('status derivation: a mirrored file present on disk reports synced', { time
   t.ok(list.entries.find((f) => f.relPath === 'x.txt').localPath.startsWith(mirrorDir), 'localPath points into the mirror')
 })
 
-test('status derivation: a mirrored file not yet on disk reports remote/downloading', { timeout: 150000 }, async (t) => {
+test('status derivation: a mirrored file not yet on disk reports remote/downloading', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/loose-transfer.test.js
+++ b/test/flow/loose-transfer.test.js
@@ -6,6 +6,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpaceWithApproval, waitForCatalogEntry } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -19,7 +20,7 @@ function writeTmpFile (bytes) {
   return p
 }
 
-test('A shares a file, B sees and downloads it; bytes match end-to-end', { timeout: 120000 }, async (t) => {
+test('A shares a file, B sees and downloads it; bytes match end-to-end', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })

--- a/test/flow/member-identity-sync.test.js
+++ b/test/flow/member-identity-sync.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // Identity (displayName + avatar) and presence (online) must converge to the same authority the
 // roster uses — replicated records — not a live point-to-point handshake. Before the fix a derived
@@ -36,7 +37,7 @@ async function joinAndApprove (t, owner, joiner, sid, invite) {
   return jKey
 }
 
-test('approved joiner sees the approver name + avatar', { timeout: 180000 }, async (t) => {
+test('approved joiner sees the approver name + avatar', { timeout: scaled(180000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launch(t, 'Alice', bootstrap)
   const B = await launch(t, 'Bob', bootstrap)
@@ -53,7 +54,7 @@ test('approved joiner sees the approver name + avatar', { timeout: 180000 }, asy
   t.pass('approver identity (name + avatar) converged on the joiner')
 })
 
-test('a late joiner sees a pre-existing member name + avatar + online', { timeout: 240000 }, async (t) => {
+test('a late joiner sees a pre-existing member name + avatar + online', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launch(t, 'Alice', bootstrap)
   const B = await launch(t, 'Bob', bootstrap)
@@ -80,7 +81,7 @@ test('a late joiner sees a pre-existing member name + avatar + online', { timeou
   t.pass('late joiner sees pre-existing members with identity + online')
 })
 
-test('REGRESSION (FIX-MIR-12): an over-long peer display name arrives clamped', { timeout: 180000 }, async (t) => {
+test('REGRESSION (FIX-MIR-12): an over-long peer display name arrives clamped', { timeout: scaled(180000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launch(t, 'Alice', bootstrap)
   const B = await launch(t, 'Bob', bootstrap)

--- a/test/flow/membership-approval.test.js
+++ b/test/flow/membership-approval.test.js
@@ -5,12 +5,13 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
 const v2flags = () => ({ identityKEK: kekHex() })
 
-test('joiner is pending, member approves, then files converge', { timeout: 150000 }, async (t) => {
+test('joiner is pending, member approves, then files converge', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -59,7 +60,7 @@ test('joiner is pending, member approves, then files converge', { timeout: 15000
 // is recorded — it must NOT wait for the time-bounded joiner-membership capture. B is killed before
 // approval so captureJoinerMembership runs to its full timeout; the banner-clear hint must still land
 // almost immediately, while the approve RPC (which awaits the capture) stays outstanding.
-test('REGRESSION (FIX-APPROVE-LAG): approver pending clears without waiting for joiner capture', { timeout: 150000 }, async (t) => {
+test('REGRESSION (FIX-APPROVE-LAG): approver pending clears without waiting for joiner capture', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const CAPTURE_MS = 3000
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: { ...v2flags(), captureMemberRecordMs: CAPTURE_MS } })
@@ -92,7 +93,7 @@ test('REGRESSION (FIX-APPROVE-LAG): approver pending clears without waiting for 
   await approved
 })
 
-test('deny path: the requester is not admitted', { timeout: 150000 }, async (t) => {
+test('deny path: the requester is not admitted', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -120,7 +121,7 @@ test('deny path: the requester is not admitted', { timeout: 150000 }, async (t) 
 // REGRESSION: a pending space has no materialized own drive, so the heavyweight
 // leave teardown crashed on the closing cores (SESSION_CLOSED). Cancelling a
 // pending request must be a clean, lightweight removal.
-test('cancelling (leaving) a pending space removes it without crashing', { timeout: 150000 }, async (t) => {
+test('cancelling (leaving) a pending space removes it without crashing', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -140,7 +141,7 @@ test('cancelling (leaving) a pending space removes it without crashing', { timeo
 
 // SECURITY: member-only operations must be refused at the data layer for a peer
 // that holds no content key (pending), not merely hidden in the UI.
-test('a pending member cannot invite, approve, deny, or rename the space', { timeout: 150000 }, async (t) => {
+test('a pending member cannot invite, approve, deny, or rename the space', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -162,7 +163,7 @@ test('a pending member cannot invite, approve, deny, or rename the space', { tim
   t.is(await B.request('space:update', { spaceId: space.spaceId, name: 'Hijacked', icon: 'folder' }), null, 'rename refused while pending')
 })
 
-test('no approver online → joiner stays pending without failure', { timeout: 150000 }, async (t) => {
+test('no approver online → joiner stays pending without failure', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const space = await A.request('space:create', { name: 'Secret' })
@@ -177,7 +178,7 @@ test('no approver online → joiner stays pending without failure', { timeout: 1
 
 // Auto-approve links are reusable until expiry (not single-use): every redeemer is admitted with
 // no prompt. (Previously the nonce was consumed and the second joiner fell back to manual.)
-test('auto-approve invite is reusable — every redeemer is admitted with no prompt', { timeout: 150000 }, async (t) => {
+test('auto-approve invite is reusable — every redeemer is admitted with no prompt', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -206,7 +207,7 @@ test('auto-approve invite is reusable — every redeemer is admitted with no pro
 
 // REGRESSION (MIR-01): a member still pending approval holds no content key and must
 // never be asked to approve another joiner.
-test('a pending member does not receive join requests for other joiners', { timeout: 150000 }, async (t) => {
+test('a pending member does not receive join requests for other joiners', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -236,7 +237,7 @@ test('a pending member does not receive join requests for other joiners', { time
   t.alike(await B.request('space:pending-requests', { spaceId: space.spaceId }), [], 'pending member records no requests')
 })
 
-test("a pending joiner pulls the inviter's avatar onto the pre-seeded member", { timeout: 150000 }, async (t) => {
+test("a pending joiner pulls the inviter's avatar onto the pre-seeded member", { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })

--- a/test/flow/membership-cancel-convergence.test.js
+++ b/test/flow/membership-cancel-convergence.test.js
@@ -13,7 +13,7 @@ const showsB = (reqs, bKey) => Array.isArray(reqs) && reqs.some((r) => r.publicK
 
 // A withdrawing pending joiner must reach the member showing its request; that member writes a
 // durable denied tombstone. The member's banner must clear and STAY cleared (survive its restart).
-test('a withdrawn pending request clears on the member and stays cleared', { timeout: 200000 }, async (t) => {
+test('a withdrawn pending request clears on the member and stays cleared', { timeout: scaled(200000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const aStore = idStore(t)
   const aKek = kekHex()   // stable across Alice's restart so her identity re-unlocks
@@ -44,7 +44,7 @@ test('a withdrawn pending request clears on the member and stays cleared', { tim
 // REGRESSION: a single fire-and-forget cancel used to strand the banner if the member missed it.
 // The pending-cancel replay re-announces on every connection until acked, so a member OFFLINE at
 // withdrawal time still converges on the withdrawal when it returns.
-test('a withdrawal reaches a member offline at withdrawal time (pending-cancel replay)', { timeout: 200000 }, async (t) => {
+test('a withdrawal reaches a member offline at withdrawal time (pending-cancel replay)', { timeout: scaled(200000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const aStore = idStore(t)
   const aKek = kekHex()

--- a/test/flow/membership-convergence.test.js
+++ b/test/flow/membership-convergence.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -26,7 +27,7 @@ const seesMembers = (spaceId, keys) => (list) => {
 // REGRESSION: one member's approval must converge across ALL members. Before the fix,
 // a co-member who didn't perform the approval kept showing "wants to join" and never
 // admitted the joiner — member lists diverged across peers.
-test('an approval converges across all members (owner + two joiners)', { timeout: 220000 }, async (t) => {
+test('an approval converges across all members (owner + two joiners)', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -72,7 +73,7 @@ test('an approval converges across all members (owner + two joiners)', { timeout
 
 // REGRESSION: when a joiner withdraws (cancels) a pending request, the member who saw
 // it must stop showing "wants to join" — the withdrawal gossips like approval/deny.
-test('a cancelled join request clears on the member', { timeout: 150000 }, async (t) => {
+test('a cancelled join request clears on the member', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -96,7 +97,7 @@ test('a cancelled join request clears on the member', { timeout: 150000 }, async
 
 // REGRESSION: a member denying a request must clear it on co-members too — otherwise a
 // second member who saw the same request keeps a stale "wants to join".
-test('a deny clears the request on co-members too', { timeout: 220000 }, async (t) => {
+test('a deny clears the request on co-members too', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -127,7 +128,7 @@ test('a deny clears the request on co-members too', { timeout: 220000 }, async (
 
 // REGRESSION: an auto-admit approval must converge to co-members the same way a manual
 // approval does — they admit the joiner and drop the banner.
-test('an auto-admit approval converges to co-members', { timeout: 220000 }, async (t) => {
+test('an auto-admit approval converges to co-members', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -160,7 +161,7 @@ test('an auto-admit approval converges to co-members', { timeout: 220000 }, asyn
 
 // Approval is monotonic: once a co-member has approved a joiner (SCK handed out),
 // a different member's deny cannot revoke — it is a no-op (revocation needs key rotation).
-test('deny is a no-op once a co-member has approved', { timeout: 220000 }, async (t) => {
+test('deny is a no-op once a co-member has approved', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })

--- a/test/flow/membership-creator-root.test.js
+++ b/test/flow/membership-creator-root.test.js
@@ -5,6 +5,7 @@ import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpaceWithApproval } from '../helpers/peer.js'
 import { rawPeer } from '../helpers/raw-peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 import { encodeInvite, decodeInvite } from '../../src/shared/contract/invite-envelope.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
@@ -20,7 +21,7 @@ const memberKeys = async (peer, spaceId) => new Set(((await spaceOf(peer, spaceI
 // The headline attack: an invite for A's REAL topic but with a forged creator (c = mKey).
 // The victim pins mKey provisionally, but the authenticated grant from the real member
 // corrects it — the forger never becomes the root, so it can mint no members on the victim.
-test('REGRESSION (MIR-26: a forged-creator invite does NOT make the forger the root)', { timeout: 220000 }, async (t) => {
+test('REGRESSION (MIR-26: a forged-creator invite does NOT make the forger the root)', { timeout: scaled(220000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
@@ -60,7 +61,7 @@ test('REGRESSION (MIR-26: a forged-creator invite does NOT make the forger the r
 
 // Two honest peers, each granted by the real creator, pin the SAME root — so their member
 // folds agree. (Pre-MIR-26 a stray forged invite could have left them rooted differently.)
-test('REGRESSION (MIR-26: two honest peers never fork their root)', { timeout: 260000 }, async (t) => {
+test('REGRESSION (MIR-26: two honest peers never fork their root)', { timeout: scaled(260000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
@@ -86,7 +87,7 @@ test('REGRESSION (MIR-26: two honest peers never fork their root)', { timeout: 2
 
 // An unbound membership:grant (no valid MIR-03 binding) cannot pin a root or materialize the
 // space under enforcement — so a topic-squatter that races a grant is refused, not trusted.
-test('REGRESSION (MIR-26: an unbound grant is refused under enforcement)', { timeout: 240000 }, async (t) => {
+test('REGRESSION (MIR-26: an unbound grant is refused under enforcement)', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: bindFlags() })
 

--- a/test/flow/membership-flood.test.js
+++ b/test/flow/membership-flood.test.js
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const kekHex = () => crypto.randomBytes(32).toString('hex')
 const idStore = (t) => path.join(mkTmpDir(t), 'app-storage')
@@ -25,7 +26,7 @@ const tightFlags = () => ({
   maxMembersPerSpace: 8,
 })
 
-test('REGRESSION (MIR-04): honest membership flow converges with DoS bound-caps shrunk + limiter on', { timeout: 150000 }, async (t) => {
+test('REGRESSION (MIR-04): honest membership flow converges with DoS bound-caps shrunk + limiter on', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: tightFlags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: tightFlags() })

--- a/test/flow/membership-presence.test.js
+++ b/test/flow/membership-presence.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // New phase-(a) coverage (state-reconciliation §5): a late joiner derives the existing
 // roster purely from replicated records (the bespoke approval gossip is gone), and Tier-1
@@ -36,7 +37,7 @@ async function joinAndApprove (t, owner, joiner, sid, invite) {
   return jKey
 }
 
-test('a late joiner derives the pre-existing roster from records (no gossip)', { timeout: 240000 }, async (t) => {
+test('a late joiner derives the pre-existing roster from records (no gossip)', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launch(t, 'Alice', bootstrap)
   const B = await launch(t, 'Bob', bootstrap)
@@ -58,7 +59,7 @@ test('a late joiner derives the pre-existing roster from records (no gossip)', {
   t.ok((await memberSetOf(A, sid)).has(cKey), 'A sees the late joiner C')
 })
 
-test('a member that vanishes without leaving stays in the roster but shows offline', { timeout: 240000 }, async (t) => {
+test('a member that vanishes without leaving stays in the roster but shows offline', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launch(t, 'Alice', bootstrap)
   const B = await launch(t, 'Bob', bootstrap)
@@ -90,7 +91,7 @@ test('a member that vanishes without leaving stays in the roster but shows offli
 // of the onExpire departure emit) fires it — a changed-gated emit would strand the returning peer
 // offline in useMembers/useSpaces until an unrelated refresh. The waitFor is the guard: with a
 // conditional emit it times out.
-test('a reconnecting member re-emits members-updated even though its record is unchanged', { timeout: 240000 }, async (t) => {
+test('a reconnecting member re-emits members-updated even though its record is unchanged', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const bStore = idStore(t)
   // B is relaunched against the SAME storage, so it must reuse the SAME identity KEK — a fresh KEK

--- a/test/flow/membership.test.js
+++ b/test/flow/membership.test.js
@@ -1,8 +1,9 @@
 import test from 'brittle'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
+import { scaled } from '../helpers/timing.js'
 
-test('two peers converge on shared space membership after handshake', async (t) => {
+test('two peers converge on shared space membership after handshake', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/mirror-add.test.js
+++ b/test/flow/mirror-add.test.js
@@ -4,12 +4,13 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-4 (flow) — adding a brand-new file to a shared folder AFTER a mirror is
 // already active must propagate to the mirror. foreign-sync proves edit + delete
 // after mount; the single most common ongoing action — a fresh add (at the root
 // and inside a subfolder) — was never covered.
-test('files added after the mirror is active materialize on the mirror', { timeout: 150000 }, async (t) => {
+test('files added after the mirror is active materialize on the mirror', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/mirror-local-edit.test.js
+++ b/test/flow/mirror-local-edit.test.js
@@ -4,13 +4,14 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-7 (flow) — a mirror is owner-authoritative. If the user edits a file inside
 // their own mirror, the next materialize tick notices the on-disk hash no longer
 // matches the owner's drive hash and re-downloads, reverting the local edit. This
 // documents (and guards) that local edits to mirrored files are NOT preserved —
 // so the UI must steer users away from editing inside a mirror.
-test('a local edit to a mirrored file is reverted to the owner version on the next tick', { timeout: 150000 }, async (t) => {
+test('a local edit to a mirrored file is reverted to the owner version on the next tick', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/mirror-participation.test.js
+++ b/test/flow/mirror-participation.test.js
@@ -4,10 +4,11 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, mkStoreDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // End-to-end: the durable mirror-participation record lets a share's OWNER see who mirrors it,
 // and its state, across the wire — a fact the ephemeral serve ledger can't carry once bytes stop.
-test('owner sees a peer mount, pause and unmount a mirror of its share', { timeout: 90000 }, async (t) => {
+test('owner sees a peer mount, pause and unmount a mirror of its share', { timeout: scaled(90000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -45,7 +46,7 @@ test('owner sees a peer mount, pause and unmount a mirror of its share', { timeo
 
 // The durable half's whole point: an owner OFFLINE when the mirror is dropped still learns of it —
 // the tombstone replicates on reconnect. The ephemeral serve ledger cannot do this.
-test('a peer unmount reaches an owner who was offline at unmount time', { timeout: 120000 }, async (t) => {
+test('a peer unmount reaches an owner who was offline at unmount time', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const aStore = mkStoreDir(t)
   let A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: aStore })

--- a/test/flow/mirror-stop.test.js
+++ b/test/flow/mirror-stop.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, mkStoreDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 function countFiles(dir) {
   try { return fs.readdirSync(dir).filter((n) => !n.endsWith('.mirall.part')).length } catch { return 0 }
@@ -14,7 +15,7 @@ function countFiles(dir) {
 // scan over many files ran to completion (and its trailing createForeignMount even
 // recreated the unmounted mount, resuming it on the next launch).
 test('REGRESSION (mirror): unmount mid-sync stops it and does not resurrect the mount',
-  { timeout: 150000 }, async (t) => {
+  { timeout: scaled(150000) }, async (t) => {
     const bootstrap = await localTestnet(t)
     const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: mkStoreDir(t) })
     const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/move-file.test.js
+++ b/test/flow/move-file.test.js
@@ -4,12 +4,13 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-5 (flow) — moving a file from the folder root into a subfolder is an
 // unlink (old path) + add (new path) to the watcher. It must reach the mirror as
 // remove-old + create-new, byte-preserved, with no duplicate and no window where
 // the content is lost. Explicitly named ("moving files in subfolders").
-test('moving a file into a subfolder removes the old path and creates the new on the mirror', { timeout: 150000 }, async (t) => {
+test('moving a file into a subfolder removes the old path and creates the new on the mirror', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/multi-mirror.test.js
+++ b/test/flow/multi-mirror.test.js
@@ -4,12 +4,13 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace, addPeerToSpace } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-8 (flow) — two peers (B and C) both mirror the SAME owner folder. An owner
 // edit and an owner delete must reach BOTH mirrors independently. The suite's
 // first multi-mirror scenario: if one mirror diverges (misses an edit or delete),
 // the two peers silently disagree on the folder's contents.
-test('an owner edit and delete reach two independent mirrors of the same folder', { timeout: 240000 }, async (t) => {
+test('an owner edit and delete reach two independent mirrors of the same folder', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/nested-subfolders.test.js
+++ b/test/flow/nested-subfolders.test.js
@@ -4,13 +4,14 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-1 (flow) — every other folder test uses a flat folder. This is the base
 // case: a shared folder containing subfolders must publish its nested files
 // (relPath with `/`) and a mirror must recreate the directory tree byte-exact.
 // The relPath⇄key separator math is unit-proven (path-keys); this exercises the
 // real scan→replicate→materialize pipeline for nested paths across two workers.
-test('a nested folder tree publishes and materializes with structure intact', { timeout: 120000 }, async (t) => {
+test('a nested folder tree publishes and materializes with structure intact', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/offline-approver-revoke.test.js
+++ b/test/flow/offline-approver-revoke.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, waitForWorkerExit } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // REGRESSION (G6): an approver OFFLINE at leave time never receives the leave frame — the only
 // place the revoke used to run. Its grow-only approved/<S>/<leaver> vouch survived, so when the
@@ -20,7 +21,7 @@ const hasMember = (l, spaceId, key) =>
 const memberKeys = async (peer, spaceId) =>
   new Set(((await peer.request('spaces:list')).find((x) => x.spaceId === spaceId)?.members || []).map((m) => m.publicKey))
 
-test('REGRESSION (G6): an approver offline at leave time revokes on return; rejoin needs fresh approval', { timeout: 300000 }, async (t) => {
+test('REGRESSION (G6): an approver offline at leave time revokes on return; rejoin needs fresh approval', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const flags = () => ({ identityKEK: kekHex(), handshakeIdentityBindingEnabled: true })
   // A (the creator/approver) is relaunched, so its KEK + storage stay fixed across boots.

--- a/test/flow/offline-delete-guard.test.js
+++ b/test/flow/offline-delete-guard.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-3 (flow) — the offline deletion guard (FIX-6 negative) end-to-end. When the
 // owner goes offline, the materialize tick must NOT remove the user's mirrored
@@ -11,7 +12,7 @@ import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
 // never treated as "owner deleted everything." foreign-sync proves the online
 // positive and path-keys unit-tests the `shouldHonorDeletions` truth table; this
 // proves the genuine offline path across two workers — files survive offline ticks.
-test('an offline owner never causes the mirror to wipe already-synced files', { timeout: 180000 }, async (t) => {
+test('an offline owner never causes the mirror to wipe already-synced files', { timeout: scaled(180000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/over-limit-share-syncs.test.js
+++ b/test/flow/over-limit-share-syncs.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // FIX-360 (flow) — the share file limit is an ADMISSION gate, not a runtime ceiling. A folder
 // admitted at exactly the limit that then GROWS past it must keep syncing every file to a mirroring
@@ -11,7 +12,7 @@ import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
 // incomplete on every peer, which is a far worse failure than a truncated list: the owner sees a
 // folder they believe is shared, and the member is quietly missing files. This proves the publish
 // path (watcher add) never consults the limit, end to end across two real peers.
-test('a folder that grows past the file limit still syncs every file to a mirror', { timeout: 150000 }, async (t) => {
+test('a folder that grows past the file limit still syncs every file to a mirror', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   // Alice is admitted at exactly the limit (4 files), then grows to 6.
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', flags: { maxFilesPerShare: 4 } })

--- a/test/flow/owned-folder.test.js
+++ b/test/flow/owned-folder.test.js
@@ -4,8 +4,9 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
-test('A publishes an owned folder; the share + its files replicate to B', async (t) => {
+test('A publishes an owned folder; the share + its files replicate to B', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/rejoin-after-leave.test.js
+++ b/test/flow/rejoin-after-leave.test.js
@@ -5,6 +5,7 @@ import crypto from 'crypto'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, waitForWorkerExit } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // End-to-end regression for the leave→rejoin gate. A peer that shared a folder, left, and rejoins
 // must NOT have its previously-mirrored folder re-surface on the other peer before re-approval, and
@@ -71,7 +72,7 @@ async function mirrorFolder (t, mirrorer, spaceId, share, ownerKey) {
   return mirrorDir
 }
 
-test('REGRESSION (FIX-1+FIX-2): a non-creator member leaving and rejoining stays hidden until re-approval', { timeout: 300000 }, async (t) => {
+test('REGRESSION (FIX-1+FIX-2): a non-creator member leaving and rejoining stays hidden until re-approval', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -113,7 +114,7 @@ test('REGRESSION (FIX-1+FIX-2): a non-creator member leaving and rejoining stays
   t.absent(await hasShare(A, spaceId, share.id), 'FIX-1: the retired share does not auto-return after re-approval (must re-share)')
 })
 
-test('REGRESSION (FIX-1): the creator leaving and rejoining does not re-surface its stale folder', { timeout: 300000 }, async (t) => {
+test('REGRESSION (FIX-1): the creator leaving and rejoining does not re-surface its stale folder', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob', storage: idStore(t), downloads: mkTmpDir(t), flags: v2flags() })
@@ -146,7 +147,7 @@ test('REGRESSION (FIX-1): the creator leaving and rejoining does not re-surface 
   t.absent(await hasShare(B, spaceId, share.id), 'FIX-1: the creator’s stale share does not re-surface')
 })
 
-test('REGRESSION (FIX-2 guard): a transient reconnect (no leave) keeps membership and the mirror', { timeout: 300000 }, async (t) => {
+test('REGRESSION (FIX-2 guard): a transient reconnect (no leave) keeps membership and the mirror', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const bStorage = idStore(t)
   const bDownloads = mkTmpDir(t)
@@ -180,7 +181,7 @@ test('REGRESSION (FIX-2 guard): a transient reconnect (no leave) keeps membershi
 // outcome; the deterministic red-first guard for the "owner no longer a member" backstop specifically
 // is test/integration/foreign-owner-left.test.js (this flow timing is also covered by FIX-1's
 // share tombstone replicating during the leave flush). Short poll makes the teardown assert promptly.
-test('REGRESSION (FIX-4): the mirrorer unmounts an orphaned foreign folder when the owner leaves', { timeout: 300000 }, async (t) => {
+test('REGRESSION (FIX-4): the mirrorer unmounts an orphaned foreign folder when the owner leaves', { timeout: scaled(300000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   // Fast poll for prompt orphan teardown, but keep the DEFAULT peer-read budget: the overlay
   // mirror reads the owner's share record + catalog over peer bees (bounded by peerReadTimeoutMs),

--- a/test/flow/relocate.test.js
+++ b/test/flow/relocate.test.js
@@ -5,6 +5,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 const SYSTEM_PATH = {
   darwin: '/System/Library/x',
@@ -16,7 +17,7 @@ const SYSTEM_PATH = {
 // was moved/renamed). The hash-based reconcile must recognize identical content
 // at the new path and upload NOTHING — that "no churn" is the whole reason
 // relocate beats delete-and-re-add: mirror peers see no drive change.
-test('relocating to an identical copy uploads nothing (no mirror churn)', async (t) => {
+test('relocating to an identical copy uploads nothing (no mirror churn)', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const spaceId = (await A.request('space:create', { name: 'Aurora' })).spaceId
@@ -48,7 +49,7 @@ test('relocating to an identical copy uploads nothing (no mirror churn)', async 
   t.alike(files.entries.map((f) => f.relPath).sort(), ['one.txt', 'two.txt'], 'drive contents unchanged')
 })
 
-test('relocating to a forbidden path is rejected and the original mount is unchanged', async (t) => {
+test('relocating to a forbidden path is rejected and the original mount is unchanged', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const spaceId = (await A.request('space:create', { name: 'Aurora' })).spaceId

--- a/test/flow/remount-mirror.test.js
+++ b/test/flow/remount-mirror.test.js
@@ -4,12 +4,13 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-11 (flow) — unmounting a mirror reclaims its cached blobs (FIX-9). The
 // inverse must also hold: mounting it again re-materializes the files cleanly,
 // re-fetching from the owner since the cache was reclaimed. Guards against a
 // remount that errors or never re-downloads.
-test('remounting a previously-unmounted mirror re-materializes the files', { timeout: 150000 }, async (t) => {
+test('remounting a previously-unmounted mirror re-materializes the files', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/same-name-folders.test.js
+++ b/test/flow/same-name-folders.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-9 (flow) — two different owners each share a folder with the SAME name
 // ("Docs"). A member who sees both owners must treat them as two distinct shares
@@ -15,7 +16,7 @@ import { mkTmpDir } from '../helpers/fixtures.js'
 // the dedupe-by-owner logic needs. (A genuine *third* observer would additionally
 // depend on transitive membership propagation — a peer learning co-members it did
 // not directly invite — which is a separate, still-open convergence gap.)
-test('two owners sharing the same folder name stay distinct, each with its own files', { timeout: 150000 }, async (t) => {
+test('two owners sharing the same folder name stay distinct, each with its own files', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/share-content-conformance.test.js
+++ b/test/flow/share-content-conformance.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes, mkStoreDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // The content backend's observable status matrix: remote → downloaded → synced →
 // unavailable. Overlay is the only backend; a future one is validated by adding
@@ -20,7 +21,7 @@ function runContract(label, { flags, contentMode }) {
   }
 
   test(`[${label}] status matrix: remote → downloaded → synced → unavailable`,
-    { timeout: 150000 }, async (t) => {
+    { timeout: scaled(150000) }, async (t) => {
       const bootstrap = await localTestnet(t)
       const A = await launchPeer(t, { bootstrap, displayName: 'Alice', storage: mkStoreDir(t), flags })
       const B = await launchPeer(t, { bootstrap, displayName: 'Bob', downloads: mkTmpDir(t), flags })

--- a/test/flow/share-create-and-mount.test.js
+++ b/test/flow/share-create-and-mount.test.js
@@ -4,8 +4,9 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
-test('one command creates a folder and mounts it, and both halves reach the other peer', async (t) => {
+test('one command creates a folder and mounts it, and both halves reach the other peer', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -38,7 +39,7 @@ test('one command creates a folder and mounts it, and both halves reach the othe
 //
 // maxFilesPerShare makes the failure deterministic AND puts it where the defect lives: the
 // admission gate runs after the replicated publish, behind the folder walk.
-test('REGRESSION (FIX-R05-9): a mount that fails leaves nothing advertised to the space', async (t) => {
+test('REGRESSION (FIX-R05-9): a mount that fails leaves nothing advertised to the space', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice', flags: { maxFilesPerShare: 1 } })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -58,7 +59,7 @@ test('REGRESSION (FIX-R05-9): a mount that fails leaves nothing advertised to th
   t.alike(await B.request('share:list', { spaceId }), [], 'and no co-member was ever told about one')
 })
 
-test('a refused mount path publishes nothing at all', async (t) => {
+test('a refused mount path publishes nothing at all', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/share-folder-two-spaces.test.js
+++ b/test/flow/share-folder-two-spaces.test.js
@@ -4,12 +4,13 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // REGRESSION (FIX: multi-space owned share) — the same on-disk folder shared into
 // two different spaces must (1) mount in both without MOUNT_OVERLAPS, and (2)
 // publish + propagate edits/deletes to each space's mirror independently. Before
 // the mount-validate relaxation, step (1) threw "already being shared or mirrored".
-test('one folder shared into two spaces reaches a mirror in each, independently', { timeout: 240000 }, async (t) => {
+test('one folder shared into two spaces reaches a mirror in each, independently', { timeout: scaled(240000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/share-visibility.test.js
+++ b/test/flow/share-visibility.test.js
@@ -18,7 +18,7 @@ const v2flags = () => ({ overlayEnabled: true, inPlaceFilesEnabled: true, identi
 // replicates but the UI is stuck on "Nothing shared yet". The membership refactor deleted
 // the reconcilePeerAcrossSpaces that carried this emission; the flow suite poll-checks data
 // so it never caught it. This asserts the EVENT fires (the thing the frontend tests need).
-test('REGRESSION: a peer\'s new share refreshes the other peer (event:shares-updated + list)', async (t) => {
+test('REGRESSION: a peer\'s new share refreshes the other peer (event:shares-updated + list)', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })
@@ -44,7 +44,7 @@ test('REGRESSION: a peer\'s new share refreshes the other peer (event:shares-upd
 // REGRESSION (companion): when a sharing member leaves, the other peer's share list must
 // refresh so the gone owner's shares drop out. The fold's member-set change now drives the
 // shares-updated emission (the old reconcile prune used to).
-test('REGRESSION: a leaving member\'s shares drop from the other peer\'s list', { timeout: 120000 }, async (t) => {
+test('REGRESSION: a leaving member\'s shares drop from the other peer\'s list', { timeout: scaled(120000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/space-storage-summary.test.js
+++ b/test/flow/space-storage-summary.test.js
@@ -4,13 +4,14 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, patternedBytes } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // The space-storage widget's two-peer contract: both peers agree on the space
 // TOTAL (owner's folder + loose file), while on-device tracks what each peer
 // actually holds — the owner everything, the consumer nothing until it mirrors
 // the folder, then exactly the folder's bytes (the un-downloaded loose file
 // keeps counting toward the total only).
-test('space storage summary: shared total on both peers; on-device follows the mirror', { timeout: 90000 }, async (t) => {
+test('space storage summary: shared total on both peers; on-device follows the mirror', { timeout: scaled(90000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/subfolder-delete.test.js
+++ b/test/flow/subfolder-delete.test.js
@@ -4,13 +4,14 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, connectInSpace } from '../helpers/peer.js'
 import { mkTmpDir, waitForFile } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // CRIT-2 (flow) — deleting a whole subfolder (several files) from a shared folder
 // while a mirror is active (owner online) must remove that subtree from the mirror
 // and nothing else. Recursive deletes are where "deleted the wrong thing" bugs
 // live; foreign-sync covers only a single-file delete. The watcher fires one
 // unlink per file under the removed subfolder, which we inject directly here.
-test('deleting a subfolder removes its whole subtree from an online mirror, leaving siblings', { timeout: 150000 }, async (t) => {
+test('deleting a subfolder removes its whole subtree from an online mirror, leaving siblings', { timeout: scaled(150000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const A = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const B = await launchPeer(t, { bootstrap, displayName: 'Bob' })

--- a/test/flow/three-peer-approval.test.js
+++ b/test/flow/three-peer-approval.test.js
@@ -4,6 +4,7 @@ import path from 'path'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer } from '../helpers/peer.js'
 import { mkTmpDir } from '../helpers/fixtures.js'
+import { scaled } from '../helpers/timing.js'
 
 // Repro for the reported 3-peer regression: owner A invites B and C; A approves B; C stays
 // waiting. Symptoms to catch: (D) B hangs in "waiting for approval"; (C) a co-member B lists
@@ -52,11 +53,11 @@ async function runScenario (t, flags) {
   t.is(await status(C, spaceId), 'pending', 'C is still waiting for approval')
 }
 
-test('3-peer approval — binding ON + identity (shipped config)', { timeout: 300000 }, async (t) => {
+test('3-peer approval — binding ON + identity (shipped config)', { timeout: scaled(300000) }, async (t) => {
   await runScenario(t, () => ({ identityKEK: kekHex(), handshakeIdentityBindingEnabled: true }))
 })
 
-test('3-peer approval — binding OFF + identity', { timeout: 300000 }, async (t) => {
+test('3-peer approval — binding OFF + identity', { timeout: scaled(300000) }, async (t) => {
   await runScenario(t, () => ({ identityKEK: kekHex(), handshakeIdentityBindingEnabled: false }))
 })
 
@@ -64,7 +65,7 @@ test('3-peer approval — binding OFF + identity', { timeout: 300000 }, async (t
 // the owner's request record), not a direct request banner. To seal the grant, B must recover C's
 // bound signer key from C's live connection (boundSignerKeys) — C is connected to B in the mesh —
 // rather than from the request-record copy; else B's approval silently fails and C hangs forever.
-test('3-peer: a co-member can approve a joiner learned via replication', { timeout: 300000 }, async (t) => {
+test('3-peer: a co-member can approve a joiner learned via replication', { timeout: scaled(300000) }, async (t) => {
   const flags = () => ({ identityKEK: kekHex(), handshakeIdentityBindingEnabled: true })
   const bootstrap = await localTestnet(t)
   const mk = (name) => launchPeer(t, { bootstrap, displayName: name, storage: idStore(t), downloads: mkTmpDir(t), flags: flags() })

--- a/test/flow/worker-shutdown.test.js
+++ b/test/flow/worker-shutdown.test.js
@@ -1,6 +1,7 @@
 import test from 'brittle'
 import { localTestnet } from '../helpers/testnet.js'
 import { launchPeer, waitForWorkerExit } from '../helpers/peer.js'
+import { scaled } from '../helpers/timing.js'
 
 // Regression guard for the orphaned-worker bug. In production the main process
 // reaps the worker on quit by sending a `shutdown` IPC and escalating to a signal;
@@ -9,7 +10,7 @@ import { launchPeer, waitForWorkerExit } from '../helpers/peer.js'
 // it orphans itself at ~100% CPU. These prove both rungs of the escalation make
 // the worker process actually exit.
 
-test('a worker exits cleanly on graceful shutdown — no orphaned subprocess', { timeout: 30000 }, async (t) => {
+test('a worker exits cleanly on graceful shutdown — no orphaned subprocess', { timeout: scaled(30000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const peer = await launchPeer(t, { bootstrap, displayName: 'Alice' })
   const pid = peer.sidecar._process.pid
@@ -23,7 +24,7 @@ test('a worker exits cleanly on graceful shutdown — no orphaned subprocess', {
     'worker process exited within 8s of graceful shutdown (no orphan)')
 })
 
-test('a worker is reaped by destroy() (SIGTERM) — the force-kill rung', { timeout: 30000 }, async (t) => {
+test('a worker is reaped by destroy() (SIGTERM) — the force-kill rung', { timeout: scaled(30000) }, async (t) => {
   const bootstrap = await localTestnet(t)
   const peer = await launchPeer(t, { bootstrap, displayName: 'Bob' })
   const pid = peer.sidecar._process.pid


### PR DESCRIPTION
Closes #258

## Bug

Helpers scale the `ms` they receive; brittle's per-test `{ timeout }` is not a helper and must
be scaled at the call site. 94 `test/flow` sites passed a bare number and 11 tests set no
ceiling at all, inheriting brittle's unscaled `DEFAULT_TIMEOUT = 30000`. Under CI's
`MIRALL_TEST_TIMEOUT_SCALE=3` the ceiling kept its dev-box value while every helper deadline
inside it tripled, so brittle killed the test before the helper's diagnostic — which carries
the worker stderr tail — could fire.

## Fix

- 94 sites across 47 files become `timeout: scaled(N)`; 45 files gain the `timing.js` import.
- The 11 option-less tests get an explicit ceiling: 150000 for a two-peer convergence test,
  120000 for `share-visibility`'s (matching its siblings, above its two 60000 waits), 60000
  for the two `_boot` cases, 30000 for `audit-coverage`'s pure-sync manifest check.
- `check-test-timing.sh` gains a third rule, scoped to `test/flow` and allowlist-free: every
  declaration carries `{ timeout: scaled(N) }` or sets the ceiling as its first body statement
  with `t.timeout(scaled(N))`.

## Notes

- 94 sites, not the issue's ~93: one declaration is generated inside a loop and is indented, so
  a line-anchored grep misses it. The guard's anchor allows leading whitespace for that reason.
- `storage-observability.test.js` is not defective — it already sets `t.timeout(scaled(120000))`
  in its body. That is the third legal form and the suite's only instance; the guard accepts it.
- Scoping the rule to `test/flow` is what keeps it allowlist-free:
  `test/unit/overlay-vendor-scheduler.test.js` and `test/frontend/layout.mjs` carry legitimate
  bare `timeout:` option values.

## Verification

The guard was proven to fail on all five defect shapes (bare single-line head, bare
continuation line, no ceiling, de-scaled `t.timeout`, bare indented declaration) and to pass
clean after each restore. Gates: typecheck, `lint:ci`, `eslint test/flow` for unused imports,
`test:node:core` 2216/2216. At `MIRALL_TEST_TIMEOUT_SCALE=3`, all 7 hand-edited files and 5
sampled swept files pass. The full flow suite is left to CI, which shards it 6 ways.