### PR TITLE
[docs] State the data-layer contracts nothing stated

### DIFF
--- a/src/shared/audit/audit-record.js
+++ b/src/shared/audit/audit-record.js
@@ -5,6 +5,11 @@
 // must be in the row itself. Live state cannot be joined against — leaving a space deletes its
 // record, and a peer's name needs that peer online or replicated — so a row holding only ids
 // would render raw hex forever. Hence a name snapshot on every participant, taken at write time.
+//
+// buildRecord below IS the v1 row schema — every `audit-log` bee row is one of its results, and
+// nothing else writes one. The renderer carries a hand-written copy of the shape in its types, so a
+// field added here has to be added there too; bumping SCHEMA_VERSION without doing so leaves the
+// two disagreeing with no gate between them.
 import { isKnownKind, categoryOf, tierOf, OUTCOME, OUTCOMES } from '../contract/audit-kinds.js'
 import { NAME_MAX } from '../contract/limits.js'
 

--- a/src/shared/contract/statuses.js
+++ b/src/shared/contract/statuses.js
@@ -46,6 +46,22 @@ export const SHARE_FILE_STATUS = Object.freeze([
 // A mount's durable status, per role. Two vocabularies rather than one: 'idle' is a mirror-only
 // state, and the two roles mean different things by a fault — a mirror's pause stops its loop,
 // while an owner's fault only labels the last pass and the ordinary cadence keeps retrying.
+//
+// The transitions the tuples alone do not give:
+//
+//   mirror  idle → scanning → active, and back to scanning on each poll tick. active → paused is
+//           the user's decision and only an explicit resume lifts it; active → paused-enospc /
+//           paused-error / mount-point-gone is a local I/O fault, which also stops the poll loop.
+//           A resume or a relocate re-enters at scanning.
+//   owner   scanning → active on a clean pass, scanning → paused-* when the pass hit a fault. The
+//           cadence keeps retrying either way.
+//
+// Three fields sit beside `status`, and none is derivable from it: `enabled` is the mirror's loop
+// switch (false plus an auto-pause status is what isAutoPaused reads), `indexPaused` is the owner's
+// durable pause — a field rather than a status, because four writers overwrite status and a pause
+// recorded there would be lost at the next settle — and `lastError` is the code a fault status
+// names itself by. folders/mount-store.js is the only write path; folders/foreign-folders.js and
+// worker/mounts-runtime.js are the callers that decide.
 export const OWNED_MOUNT_STATUS = Object.freeze([
   'scanning',
   'active',

--- a/src/shared/folders/mount-store.js
+++ b/src/shared/folders/mount-store.js
@@ -1,6 +1,13 @@
 // Persistence for mount records in the local `mounts-meta` bee: which disk path
 // backs which share (a "mount"), on both the owned and the foreign/mirror side,
 // plus per-mount sync state (enabled, status, syncedPaths, renamedPaths).
+//
+// Two key namespaces, one record shape: `owned-folder-mount/<spaceId>/<shareId>` and
+// `foreign-folder-mount/<spaceId>/<shareId>`. A record is created whole with spaceId, shareId,
+// mountPath, enabled and status, and every later writer patches it — which is why no single site
+// shows the shape. What the patches add: `lastError` and `indexPaused` (contract/statuses.js states
+// what the three status fields mean together), `syncedPaths` and `renamedPaths` from the mirror's
+// pass, and `lastScanCompletedAt` from the owner's.
 import { createLocalBee, storeEpoch } from '../core/store.js'
 import { createRecordWriter } from '../core/bee-writer.js'
 import { createLogger } from '../core/logger.js'

--- a/src/shared/shares/shares.js
+++ b/src/shared/shares/shares.js
@@ -1,5 +1,11 @@
 // Share records — the `share/<spaceId>/<shareId>` rows in profile bees. A record points
 // at a catalog (key + content mode); the file listings themselves live in share-catalog.js.
+//
+// The five words this domain is built from, in dependency order: a SHARE RECORD says a share exists,
+// who owns it and which catalog carries it; a CATALOG is the per-(owner, space) bee of
+// `file/<shareId>/<relPath>` rows; a REGISTRY is own plus member share records merged for one
+// space; a LISTING is the display rows of one share; and a CATALOG BATCH is the writer that buffers
+// catalog rows during a scan.
 // Own records are written to the local profile bee (under the `caps/folder-shares`
 // capability flag); peers' records are read from their replicated profile bees with
 // bounded reads, so an offline member can't stall a caller.

--- a/src/shared/spaces/space.js
+++ b/src/shared/spaces/space.js
@@ -3,6 +3,20 @@
 // shared core-purge primitive), the invite-code format, serialized member-roster mutation,
 // durable leave tombstones, pending join requests, and pinning of the creator root the
 // membership fold trusts.
+//
+// The `spaces-meta` bee's key layout, all three namespaces:
+//   space/<spaceId>            the space record (below)
+//   left/<spaceId>/<memberKey> a leave tombstone: { leaveTs }
+//   pendingleave/<spaceId>     an interrupted leave boot must finish: { topic, ts }
+//
+// A space record is written whole by createSpace and joinSpace and patched through mutateSpace
+// thereafter. Seven fields are always present — name, icon, topic, created, members, driveSuffix,
+// schemaVersion. The rest are latches, each owned by one writer: `status: 'pending'` until the
+// grant arrives, `sckDerivable` and `creatorKey` stamped at creation (or pre-seeded from an invite
+// and marked `creatorUnverified` until onGrant pins it), `inviteId` from the invite we joined
+// through, `leaving` while a leave runs, `left`/`joined`/`updated` as timestamps, `favorite` and
+// `downloadFolder` as user choices, and `creatorDivergence`, `creatorMigrated`, `legacyWarning`
+// and `driveLoadError` as diagnoses a later pass records.
 import { createLocalBee, createDrive, getStore, storeEpoch, hasMasterSecret, deriveSpaceContentKey, isStorageInconsistency } from '../core/store.js'
 import { getContentKey, putContentKey } from './space-keys.js'
 import { isInPlaceFilesEnabled } from '../core/runtime-config.js'

--- a/src/shared/transfer/backends/overlay/overlay-download.js
+++ b/src/shared/transfer/backends/overlay/overlay-download.js
@@ -87,6 +87,30 @@ function discardPartial(finalPath) {
 // }
 // job: { spaceId, pendingKey, path, relPath, transferId, contentHash, size, sourceSeq,
 //        ownerPublicKey, verifyKey, finalPath, prevBytes, ...channel-specific }
+//
+// A download's slot IS its registry entry: start() reserves it synchronously, before any await, so
+// a duplicate trigger cannot open a second fetch on the same hash; the fetch task holds it; settling
+// deletes it. Four memories deliberately outlive the slot, each declared with its reason below —
+// pausedHashes (the user's pause), terminalCodes (a terminal verdict whose durable write failed),
+// stallRetries (a retry in flight) and the durable pending row.
+//
+// When several intents land during start()'s awaits they do not queue: a supersede restarts on the
+// new hash, a plain cancel drops, a pause parks, and a republish park waits for the owner's
+// re-hash. A parked or interrupted row is re-driven by a reconcile, which runs on the owner
+// reconnecting (shallow — a manually paused or terminally errored row costs no I/O) and on a
+// catalog append (deep, which also honours a removal), plus the user's own resume and the stall
+// retry.
+//
+// The durable-write policy is deliberately not uniform, and each case is a decision:
+//   recordPending at start      throws. The slot is released and start() fails, because without the
+//                               row a crash loses the transfer entirely.
+//   clearPending on completion  tolerated, with a warn. The claim already decides the status, so a
+//                               surviving row costs one extra read at the next reconcile.
+//   clearPending on discard     fatal, and rethrown. Everything after it is destructive and
+//                               in-memory only: a live row whose partial and pause marker are gone
+//                               auto-resumes from zero a transfer the user discarded.
+//   recordPendingError          never throws. The verdict is kept in terminalCodes instead, which
+//                               suppresses auto-resume only until the next restart.
 export function createOverlayDownloadEngine(channel, { fetchImpl = fetchContentToFile, hasOverlay = () => !!getOverlay(), freeBytes = freeBytesFor, stallRetry = {}, dirExists = defaultDirExists } = {}) {
   const registry = new Map() // transferId -> { contentHash, finalPath, paused, cancelled, fetching, spaceId, pendingKey, ownerPublicKey, restartJob }
   // Paused-transfer markers whose single-flight slot was released (the fetch IIFE deletes it on

--- a/src/shared/transfer/files.js
+++ b/src/shared/transfer/files.js
@@ -3,6 +3,12 @@
 // loose files, the aggregated file listing (rows folded by file-dedupe), and
 // reveal-in-file-manager. "On your device" is always re-verified against
 // the disk before it is reported — the bee rows are claims, the file is the truth.
+//
+// The `downloads-meta` bee holds three namespaces, distinguished by prefix rather than by
+// separator, so a scan of one must not see another:
+//   <spaceId>:<filePath>            the downloaded-copy claim
+//   verified:<spaceId>:<key>        a hash-verified record: { hash, at }
+//   src:<spaceId>:<filePath>        the owned source path of a loose file: { sourcePath, addedAt }
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { getDrive, getSpace } from '../spaces/space.js'

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -445,6 +445,30 @@ function registerPendingRequester(socket, remoteKey, msg) {
 }
 
 // Route a verified inbound frame to its handler. reply sends back over THIS connection's channel.
+// The mirall/handshake frame vocabulary, in one place. Every frame is one JSON line on the
+// per-space handshake channel, and validFrameShape gates all of them before any property is read;
+// an unrecognised type is counted and dropped.
+//
+//   handshake               any peer, once per shared space on connect. Carries the sender's drive
+//                           key and, optionally, its asserted creator root.
+//   membership:request      a joiner asking to be admitted.
+//   membership:grant        the approver's answer, carrying the space content key.
+//   membership:deny         the approver's refusal.
+//   membership:cancel       either side withdrawing a pending request.
+//   membership:cancel-ack   the receipt for that withdrawal.
+//   presence                liveness — both the heartbeat and the offline farewell.
+//   share-index-progress    an owner's index progress for one share.
+//   share-prepare-progress  an owner's prepare progress for one share.
+//   leave                   a member announcing it has left the space.
+//   leave-ack               the receipt that lets the leaver stop announcing.
+//
+// Exactly two assert the SENDER's identity — handshake and membership:request — because they are
+// the two a peer uses to claim a profileKey; both must pass validSenderFrame and the signature
+// binding that key to this connection's Noise key before anything is registered, which is why the
+// check sits above rather than in a per-type branch. membership:grant asserts the GRANTER's
+// identity instead, and the membership control handler verifies it, because a grant arrives on the
+// connection the joiner opened. The content plane runs its own channel with one frame,
+// content-hello (content-swarm.js).
 function dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler) {
   const reply = (payload) => { try { msgHandler.send(JSON.stringify(payload)) } catch {} }
   if (msg.type === 'handshake') {


### PR DESCRIPTION
Row 1.9 of the codebase quality report (#232), items 1-5. Third of five, stacked on #273.
Comment-only — no code diff.

Five contracts a reader had to reconstruct from many sites:

- **The peer frame protocol** — 11 frame types plus `content-hello`, who sends each, and which two
  assert the sender's identity (and why `membership:grant` asserts the granter's instead). Written as
  a doc block above `dispatchFrame` rather than as a new `contract/peer-frames.js`, because Tier 2
  row 2.2 (#233) proposes that file as *code* and creating it here would pre-empt it.
- **The mount state machine** — the transitions per role, and the three fields beside `status`
  (`enabled`, `indexPaused`, `lastError`), none derivable from it.
- **The download-slot lifecycle** — and the durable-write policy, which was stated nowhere. Each of
  the four rules was verified at its call site before being written down: `recordPending` throws,
  `clearPending` is tolerated on completion but **fatal on discard**, `recordPendingError` never
  throws.
- **The bee key layouts** — `spaces-meta`, `downloads-meta`, the mount record, and the bootstrap
  frame's 20 hand-built fields.
- **The shares vocabulary** — share record → catalog → registry → listing → catalog batch.

The audit row got a pointer, not a field table: `buildRecord` is fully legible at one site, so what
is stated is that it IS the schema and that the renderer carries a hand copy.

Coverage: SKIP — comments only. `lint:ci` (incl. comment-hygiene) and `tsc` clean.
