### PR TITLE
[docs] State the renderer contracts nothing stated

### DIFF
--- a/src/renderer/components/primitives/Avatar.tsx
+++ b/src/renderer/components/primitives/Avatar.tsx
@@ -1,3 +1,8 @@
+// Peer/space avatar: an image when there is one, initials otherwise.
+//
+// `decorative` means a label sits next to it, so the avatar leaves the accessibility tree rather
+// than reading the name twice. `ring='status'` requires a statusVariant — the ring IS the status,
+// and without one it renders the neutral ring and says nothing.
 import type { CSSProperties } from 'react'
 import { useTranslation } from 'react-i18next'
 import { getInitials } from '../../utils.js'

--- a/src/renderer/components/primitives/Badge.tsx
+++ b/src/renderer/components/primitives/Badge.tsx
@@ -1,3 +1,6 @@
+// Small inline label. `classes` carries the whole tone — background AND text colour — because the
+// component has no tone vocabulary of its own yet; passing only a background leaves the text at the
+// inherited colour, which is the one way to make it unreadable.
 interface BadgeProps {
   label: string
   classes: string

--- a/src/renderer/components/primitives/Button.tsx
+++ b/src/renderer/components/primitives/Button.tsx
@@ -1,3 +1,7 @@
+// The text-button contract, two axes and nothing else. `variant` is what the button MEANS —
+// primary for the one affirmative action, secondary for the rest, and the destructive variants for
+// an action that deletes — and `size` is 'sm' everywhere except a hero call to action. Anything a
+// variant cannot express belongs in the variant table below, not in a className at the call site.
 import type { MouseEvent, ReactNode, Ref } from 'react'
 import Icon, { type IconName } from './Icon.js'
 

--- a/src/renderer/components/primitives/Icon.tsx
+++ b/src/renderer/components/primitives/Icon.tsx
@@ -1,3 +1,10 @@
+// The app's whole icon set, inlined as Material Symbols path data — one OUTLINED entry per name,
+// plus a FILLED variant for the names that have one. Adding an icon means adding its name to the
+// union and its path to the map(s), never an <img> or a font.
+//
+// Decorative by default: with no ariaLabel the svg is aria-hidden and the control around it carries
+// the name. Passing ariaLabel flips it to role="img" and makes it the named element, which is right
+// only when the icon IS the content.
 export type IconName =
   | 'add_circle'
   | 'architecture'

--- a/src/renderer/components/primitives/IconButton.tsx
+++ b/src/renderer/components/primitives/IconButton.tsx
@@ -1,3 +1,8 @@
+// A bare icon control: circular hit area, no background until hover, and `ariaLabel` REQUIRED —
+// there is no text to name it, so the type makes the accessible name non-optional.
+//
+// It inherits its colour rather than choosing one, so a button that needs a non-inherited ink (the
+// destructive ones) passes it through iconClassName.
 import type { MouseEvent } from 'react'
 import Icon, { type IconName } from './Icon.js'
 

--- a/src/renderer/components/primitives/Modal.tsx
+++ b/src/renderer/components/primitives/Modal.tsx
@@ -1,6 +1,10 @@
 // Base dialog shell: react-aria focus trap, and the one place the dialog keyboard contract lives —
 // Escape to dismiss, Enter (plain, or Cmd/Ctrl+Enter from a textarea) to confirm. See modalKeys.ts.
 // Also owns the window-level event that closes every open modal at once.
+//
+// forwardRef hands out the WRAPPER — the element carrying the keydown handler, not the inner panel.
+// That is what the two consumers need: ScanPreviewModal focuses it on open so the keyboard contract
+// is live before the first keystroke, and FeedbackModal screenshots the dialog as displayed.
 import { forwardRef, useEffect, useRef, type ForwardedRef, type KeyboardEvent, type ReactNode } from 'react'
 import { useDialog, FocusScope } from 'react-aria'
 import CrystalBackdrop from '../widgets/CrystalBackdrop.js'

--- a/src/renderer/components/widgets/ConnectivityToastBridge.tsx
+++ b/src/renderer/components/widgets/ConnectivityToastBridge.tsx
@@ -1,5 +1,14 @@
 // Renderless bridge turning connectivity transitions into toasts: sticky
 // offline/connecting warnings and a brief back-online notice.
+//
+// Three rules every toast bridge holds to. It fires on TRANSITIONS only, never on a level, so a
+// steady degraded state does not re-toast; every toast carries the one sticky TOAST_ID, so the
+// newest replaces the last rather than stacking; and a warning carries an action to the screen that
+// can fix it, with a success toast on recovery.
+//
+// Two effects can both speak, so the precedence is explicit: the verdict effect owns every degraded
+// case, os-offline included, and the state effect returns early whenever the verdict is blocked or
+// at-risk — it exists for the boot and recovery transitions the verdict does not cover.
 import { useEffect, useRef } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useToast } from '../toast/ToastProvider.js'
@@ -68,8 +77,6 @@ export default function ConnectivityToastBridge({ onShowDetails, onShowHelp }: P
     if (previous === state) return
     if (previous === null && state !== 'offline') return
 
-    // The verdict effect above owns every degraded case, os-offline included; this one
-    // keeps the boot and recovery transitions it does not cover.
     if (verdict === 'blocked' || verdict === 'at-risk') return
 
     if (state === 'offline') {

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -1,6 +1,11 @@
 // Folder-share screen. One skeleton for all three roles: header (one primary + More), a work strip
 // band that exists only while the folder is doing something, a controls row pinned on the listing,
 // and two read-only tiles. Tiles state, the header acts, the strip acts for now.
+//
+// The role picks the hooks, and each is called unconditionally with an empty id when it does not
+// apply — hooks cannot be called in a branch: `mine` reads useOwnedMount plus useIndexProgress,
+// `mirrored` reads useForeignMount, and `browse` reads neither, because a browsed folder has no
+// local mount at all.
 import { useState, useEffect, useMemo, useRef, useDeferredValue } from 'react'
 import { useTranslation } from 'react-i18next'
 import { useShareFiles } from '../hooks/useShareFiles.js'

--- a/src/renderer/screens/SpaceView.tsx
+++ b/src/renderer/screens/SpaceView.tsx
@@ -1,4 +1,14 @@
 // Space screen: loose files and folder shares with drag-drop adding, transfer controls, member presence, and invites.
+//
+// Eight modals, each its own piece of state rather than one union, and nothing enforces that only
+// one is open: they are mutually exclusive because every path that opens one runs from a closed
+// screen. `busy` holds the public keys with an approve or deny in flight.
+//
+// Two inboxes carry actions from outside the screen — 'mirall:open-mirror-modal' from a share row
+// anywhere in the tree, and SPACE_ACTION_EVENT from the title bar. They are window events rather
+// than props because the senders are not this screen's ancestors. The action inbox re-reads the
+// space's gates on every event: `leave` is the only action a legacy or pending space keeps, because
+// every other one writes and the data layer refuses it.
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import type { FileEntry } from '../types.js'

--- a/src/renderer/store/query-store.js
+++ b/src/renderer/store/query-store.js
@@ -8,6 +8,13 @@ import { CODES } from '../../shared/contract/errors.js'
 //
 // Plain JS with an injected transport so it unit-tests under brittle-node, like the other
 // renderer modules that carry a .d.ts.
+//
+// The model, once: one entry per keyOf(type, params). invalidate(hint) selects entries by scope
+// PREDICATE rather than by key — it bumps `seq` so a late response is discarded, aborts the read in
+// flight, keeps the cached value so a view paints instantly, and refetches only entries that have
+// subscribers, coalesced per entry. setQueryData lands a pushed value in that same entry.
+// invalidateKey forgets values but keeps any entry that still has subscribers, dropping the rest.
+// An entry keeps the scopes it was FIRST registered with.
 const entries = new Map()
 
 let send = () => Promise.reject(new Error('query store: no transport configured'))
@@ -53,6 +60,8 @@ function entryFor(key, scopes) {
     }
     entries.set(key, entry)
   }
+  // First registration wins: an entry re-requested with narrower scopes must keep the wider set, or
+  // it would stop matching the hints the original view still depends on.
   if (scopes && scopes.length && entry.scopes.length === 0) entry.scopes = scopes
   return entry
 }
@@ -133,9 +142,6 @@ export function fetchQuery(type, params = {}, scopes = null, { coalesceMs } = {}
   return inFlight
 }
 
-// Invalidation is by predicate, not by key: one hint may match many entries, which is exactly what
-// the Scope vocabulary already expresses. The cached value SURVIVES so a view can paint instantly
-// while the refetch runs.
 export function invalidate(hint) {
   const touched = []
   for (const [key, entry] of entries) {


### PR DESCRIPTION
Row 1.9 of the codebase quality report (#232), items 6, 9, 10, 11. Fourth of five, stacked on #274.
Comment-only — no code diff.

- **The query-store invalidation model** in one header. The model existed only as nine per-function
  blocks, with the first-scopes rule stated in `scopes.ts` and `hooks/README.md` but not at
  `entryFor`, where it is implemented. The header replaces the block it subsumes, so this lands
  **net-negative on comment lines** — the risk here was writing a fourth restatement, not a first.
- **The toast-bridge contract** — transition-only, one sticky id, an action to the fixing screen,
  success on recovery — and which of `ConnectivityToastBridge`'s two effects wins. the design doc
  cannot be cited from `src/` (the hygiene gate blocks those paths), so the contract is restated.
- **`SpaceView`** — eight modals, why nothing enforces exclusivity, what `busy` holds, and the two
  `window`-event inboxes and why they are events rather than props. **`FolderView`** — the
  role→hook mapping, and why each hook is called unconditionally with an empty id.
- **Six primitives** that opened on code with no contract: `Icon` (fan-in 51; `ariaLabel` flips it to
  `role="img"`), `Avatar` (`decorative`, and `ring='status'` needing a `statusVariant`), `Badge`
  (`classes` must carry both halves of the tone), `Button`, `IconButton`, and `Modal`'s `forwardRef`.

One correction to the report: `Modal`'s `forwardRef` has **two** consumers, not one, and it hands out
the **wrapper**, not the content element — the wrapper is what carries the keydown handler, which is
why `ScanPreviewModal` focusing it is what makes the keyboard contract live.

Coverage: SKIP — comments only. 5 frontend scenarios and 5 layout harnesses run locally, all green.
