### PR TITLE
[docs] State the boundary contracts, constants and asymmetries

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -671,6 +671,19 @@ function getWorker(specifier) {
   // before re-registering, otherwise ipcMain.handle throws.
   try { ipcMain.removeHandler('pear:worker:writeIPC:' + specifier) } catch {}
 
+  // Every MIRALL_* test hook the app reads, in one list: MIRALL_DEBUG and MIRALL_VERBOSE (log
+  // level), MIRALL_DHT_BOOTSTRAP (a hermetic testnet instead of the public DHT),
+  // MIRALL_DOWNLOAD_FOLDER and MIRALL_WINDOW_BOUNDS (start from a known state),
+  // MIRALL_FEATURE_FLAGS (flags without a build), MIRALL_FORCE_A11Y (the AX tree the frontend suite
+  // drives), MIRALL_NO_DEVTOOLS, and the three caps below — MIRALL_LIST_FILES_CAP,
+  // MIRALL_MAX_FILES_PER_SHARE and MIRALL_FOREIGN_FULL_WALK_EVERY. None is read in a shipped run.
+  //
+  // The worker's whole starting state: it is sent once, before any request, and the worker never
+  // asks main for these again. Three sources are mixed here on purpose — the packaged app (storage,
+  // version, upgrade key), the user's stored preferences, and the MIRALL_* test overrides, each of
+  // which is undefined unless its variable is set so JSON drops it and the worker's own default
+  // stands. shared/core/runtime-config.js is what reads the result, and is the authority on what
+  // each field means once it lands.
   const bootstrap = {
     type: 'bootstrap',
     storage: p.storage,
@@ -1496,11 +1509,18 @@ if (!lock) {
       fs.mkdirSync(storagePath, { recursive: true })
       if (!isWindows) fs.chmodSync(storagePath, 0o700)
     } catch (err) {
+      // Survivable, unlike the KEK failure below, and the difference is what each one protects. The
+      // mode is defence in depth over a file that is already encrypted; the KEK is the secret that
+      // encrypts it, so starting without one would write an unprotected identity.
       console.error('[identity] storage perms failed:', err.message)
     }
     try {
       const identityKek = require('./identity-kek.js')
       identityKEKHex = identityKek.resolveKEKHex(storagePath)
+      // 'weak' means safeStorage fell back to basic_text: the key is still encrypted, but with no
+      // OS keyring behind it, so anyone with the file can read it and the user's protection is
+      // whatever full-disk encryption they have. 'protected' means a real keyring holds the KEK.
+      // An unavailable safeStorage is neither — it is fatal, below.
       identityProtection = identityKek.storageBackend() === 'basic_text' ? 'weak' : 'protected'
       if (identityProtection === 'weak') {
         console.warn('[identity] safeStorage backend is basic_text (no OS keyring); identity.enc is only weakly protected — rely on full-disk encryption')

--- a/src/preload/preload.js
+++ b/src/preload/preload.js
@@ -4,6 +4,16 @@
 // updater control, worker spawn + raw NDJSON pipe access) plus event
 // subscriptions that return their own unsubscribe function. No ipcRenderer,
 // Node, or Electron API leaks past this file by design.
+//
+// Four of these are SYNCHRONOUS (sendSync): pkg, isDev, getLocale and getConfig. They block the
+// renderer, which is only acceptable because each is read once during first render and a promise
+// there would mean painting the wrong thing first — a wrong locale, or the light theme before the
+// stored one arrives. Every other method is async, and a new one should be too.
+//
+// The non-obvious per-channel contracts: zoom:set returns the CLAMPED factor, so the caller must
+// render what came back rather than what it sent; prefs:set has side effects beyond storing
+// (applying the value is part of the call); downloads:set throws on a path it cannot use instead of
+// reporting failure in its result; and relay:set answers with a code the renderer translates.
 const { contextBridge, ipcRenderer, webUtils } = require('electron')
 
 // Main refuses anything else outright (worker-entrypoints.js), so this is a boundary annotation and

--- a/src/renderer/components/modals/ApprovalModal.tsx
+++ b/src/renderer/components/modals/ApprovalModal.tsx
@@ -36,6 +36,9 @@ export default function ApprovalModal({ isOpen, requests, busyKeys, onApprove, o
     })
   }
 
+  // Approve closes rather than waiting, and busyKeys gates Deny alone. The asymmetry is
+  // deliberate: approving is the expected outcome and its progress is visible on the space screen
+  // the modal closes onto, while a deny is destructive and must not be issued twice.
   function approveAll() {
     requests.forEach((r) => onApprove(r.publicKey))
     onClose()

--- a/src/renderer/components/modals/CreateSpaceModal.tsx
+++ b/src/renderer/components/modals/CreateSpaceModal.tsx
@@ -42,6 +42,8 @@ export default function CreateSpaceModal({
     }
   }
 
+  // onCreated fires AFTER onClose, and on the captured space: it navigates to the new space, and
+  // running it first would leave this modal open over the screen it navigated to.
   function handleClose() {
     const justCreated = createdSpace;
     setName("");

--- a/src/renderer/components/modals/JoinSpaceModal.tsx
+++ b/src/renderer/components/modals/JoinSpaceModal.tsx
@@ -38,6 +38,9 @@ export default function JoinSpaceModal({ isOpen, initialCode, initialName, onClo
     }
   }, [isOpen, initialCode, initialName])
 
+  // Auto-fill the name from the invite, but only while the field is still the machine's: empty, or
+  // exactly the last value this effect wrote. Once the user has typed anything of their own, a
+  // pasted invite must not overwrite it.
   useEffect(() => {
     const decoded = decodeInvite(inviteCode)
     const suggested = decoded && decoded.v === 1 ? decoded.name : undefined

--- a/src/renderer/components/modals/LeaveSpaceModal.tsx
+++ b/src/renderer/components/modals/LeaveSpaceModal.tsx
@@ -27,7 +27,10 @@ interface LeaveProgress {
   data?: Record<string, string>
 }
 
+// The teardown reports steps, but the reclaim that follows reports nothing, so the bar holds at
+// half and switches to a stripe rather than showing a percentage it cannot honour.
 const PROGRESS_CAP = 50
+// Long enough for the bar to reach 100 and be seen there before the modal closes.
 const COMPLETION_HOLD_MS = 350
 
 const PHASES_WITH_SIZE = new Set(['compactingPeerCache', 'compactingLocalCache'])

--- a/src/renderer/components/widgets/DropZone.tsx
+++ b/src/renderer/components/widgets/DropZone.tsx
@@ -37,6 +37,8 @@ export default function DropZone({
       label: t('dropZone.folder'),
       icon: 'folder',
       onAction: () => {
+        // '' means "no path chosen yet" — the handler opens the native picker. A real path here
+        // would skip it and share that folder immediately.
         if (folderEnabled && onFolderSelected) onFolderSelected('')
       },
     },

--- a/src/renderer/components/widgets/NetworkStatusIndicator.tsx
+++ b/src/renderer/components/widgets/NetworkStatusIndicator.tsx
@@ -6,6 +6,9 @@ interface Props {
   className?: string
 }
 
+// 'limited' is the one state without a semantic colour of its own: it is not a fault, so warning
+// would overstate it, and it is not healthy either. The neutral container reads as "something to
+// know" without competing with the two states the user must act on.
 const COLOR: Record<ConnectivityState, string> = {
   online: 'bg-online',
   limited: 'bg-secondary-container',

--- a/src/renderer/hooks/useConnectionStatus.tsx
+++ b/src/renderer/hooks/useConnectionStatus.tsx
@@ -22,6 +22,9 @@ interface ConnectionStatusContextValue {
 
 const ConnectionStatusContext = createContext<ConnectionStatusContextValue | null>(null)
 
+// Only reached when nothing authoritative has answered yet. A fresh start looks online while the
+// DHT is still coming up, degrades to connecting once that is slow enough to notice, and is called
+// offline only after long enough that a working network would have answered.
 const BOOT_GRACE_MS = 15000
 const DHT_FAILURE_MS = 45000
 

--- a/src/renderer/hooks/usePreviewFlow.ts
+++ b/src/renderer/hooks/usePreviewFlow.ts
@@ -39,6 +39,9 @@ export function usePreviewFlow(cancelPreview: (previewId: string) => void): Prev
     setProgress(null)
   }, [cancelPreview])
 
+  // A cancelled preview rejects, and run RETHROWS it: the caller knows whether it cancelled, this
+  // hook does not, and swallowing it here would leave a modal waiting on a result that never comes.
+  // Callers catch PREVIEW_CANCELLED and close quietly.
   const run = useCallback(async (start: (onProgress: (p: PreviewProgress) => void) => PreviewHandle) => {
     setPreview(null)
     setProgress(null)

--- a/src/renderer/ipc.ts
+++ b/src/renderer/ipc.ts
@@ -3,6 +3,17 @@ import { FRAME } from '../shared/contract/frames.js'
 import { MAIN_WORKER_SPEC } from '../shared/contract/workers.js'
 import { CODES } from '../shared/contract/errors.js'
 // The renderer's worker channel: NDJSON request/response with timeouts over window.bridge, event:* fan-out, and crash-respawn recovery.
+//
+// One JSON object per line, in both directions. A request is { id, type, ...payload } and its answer
+// is { id, data } or { id, error, code }; { id, type: 'ping' } is the readiness probe and is answered
+// the same way. { type: 'cancel', id } is a control frame rather than a request, so it cannot queue
+// behind the request it cancels. Any other line carrying a string `type` is an event, fanned out to
+// subscribe()'s listeners — except event:worker-ready, which the channel consumes itself and which
+// arrives once per worker boot.
+//
+// subscribe() takes an unchecked name and allows any number of listeners per name. They are called
+// synchronously, each inside its own try: a throwing subscriber must not starve the listeners after
+// it, nor abort the chunk loop — which would drop the request responses sharing that read.
 const WORKER_SPEC = MAIN_WORKER_SPEC
 
 const ECANCELLED = CODES.ECANCELLED

--- a/src/renderer/keyboard/KeyboardProvider.tsx
+++ b/src/renderer/keyboard/KeyboardProvider.tsx
@@ -155,6 +155,10 @@ export function useKeyboard(): KeyboardApi {
   return v
 }
 
+// `deps` governs RE-REGISTRATION, not freshness: `run` and `when` are read through a ref, so they
+// are always current whatever deps say. Only the fields copied into `stable` below — labelKey,
+// labelParams, group, accelerator, hiddenInPalette — need a change here, which is why most callers
+// pass [] and only one passes the values its label interpolates.
 export function useRegisterCommand(cmd: Command, deps: DependencyList): void {
   const { registerCommand } = useKeyboard()
   const cmdRef = useRef(cmd)

--- a/src/renderer/screens/NetworkStatus.tsx
+++ b/src/renderer/screens/NetworkStatus.tsx
@@ -17,6 +17,8 @@ interface Props {
 }
 
 const DASH = '—'
+// A revealed key re-masks itself: the value is shoulder-surfable and the screen is one a user
+// leaves open while working through a connectivity problem.
 const REVEAL_AUTO_HIDE_MS = 30000
 
 function formatRelativeTime(ms: number | null, now: number): string {

--- a/src/shared/core/identity-keys.js
+++ b/src/shared/core/identity-keys.js
@@ -28,6 +28,9 @@ export function deriveKeyPair(masterSecret, name, namespace = DEFAULT_NAMESPACE)
   return crypto.keyPair(deriveSeed(masterSecret, namespace, name))
 }
 
+// 'db' and the per-drive namespace are not ours to choose: they reproduce Hyperdrive's own
+// derivation, so a drive opened by name lands on the key it already has. A pin test holds the
+// output; changing either argument would silently orphan every existing drive.
 export function deriveDriveKeyPair(masterSecret, driveName) {
   return deriveKeyPair(masterSecret, 'db', generateNamespace(DEFAULT_NAMESPACE, driveName))
 }

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -414,7 +414,6 @@ async function readBothSides(spaceId, shareId, mountPath, ignore, pass, signal) 
     const bail = await bailIfAborted(spaceId, shareId, signal)
     return bail ? { bail } : { walk, known }
   } catch (err) {
-    // walk-disk raises PREVIEW_CANCELLED for any aborted walk, preview or not.
     if (err?.code !== 'PREVIEW_CANCELLED') throw err
     // The `??` is load-bearing: an aborted walk has no result to hand back, so a null bail here
     // would fall through to the caller destructuring an undefined walk.

--- a/src/shared/folders/walk-disk.js
+++ b/src/shared/folders/walk-disk.js
@@ -7,6 +7,10 @@ import { createLogger } from '../core/logger.js'
 
 const log = createLogger('walk-disk')
 
+// Every aborted walk raises this, not just a cancelled preview: the code is named for the first
+// caller and kept because it is the on-the-wire value a catch already tests for. A caller that
+// aborts a scan, a reconcile or a preview sees PREVIEW_CANCELLED and must treat it as "the walk
+// stopped because I asked", never as a failure.
 export class AbortError extends Error {
   constructor() {
     super('preview cancelled')

--- a/src/shared/spaces/profile.js
+++ b/src/shared/spaces/profile.js
@@ -473,6 +473,9 @@ export async function capturePeerBee(profileKeyHex, {
     await bee.ready()
     const core = bee.core
     try {
+      // At most a second waiting for the peer's head, however much of the budget is left: the
+      // sweep below is the part that needs the time, and a peer that has not answered by now is
+      // offline rather than slow.
       await boundedUpdate(core, Math.min(1000, Math.max(0, deadline - Date.now())))
       const target = Math.min(core.length, maxBlocks)
       await sweepBlocks(core, target, parallel, deadline)

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1163,6 +1163,9 @@ ipc.handle('owned-folder:relocate', async (msg) => {
 ipc.handle('owned-folder:delete', async (msg) => {
   const own = await readOwnShares(msg.spaceId)
   const share = own.find((s) => s.id === msg.shareId)
+  // An unknown share warns but does not stop: the teardown below is idempotent, and a delete is
+  // most needed exactly when the record is already half-gone — a crash between the two writes, or a
+  // repeated click. Refusing here would strand the mount, the watcher and the tombstone.
   if (!share) {
     log.warn('delete requested for unknown share:', msg.shareId)
   }

--- a/test/flow-shard.mjs
+++ b/test/flow-shard.mjs
@@ -2,6 +2,11 @@
 // longest-processing-time) so heavy files land in different shards and the suite
 // parallelises evenly. Weights are coarse CI-second hints; unmapped files use
 // DEFAULT_WEIGHT. Usage: node test/flow-shard.mjs <1-based shardIndex> <shardTotal>
+//
+// The weights are read off a CI run's per-file times and rounded; they only have to rank the heavy
+// files correctly, since the partition is greedy. They go stale silently — a file that grows heavy
+// keeps its old weight and unbalances a shard — so re-read them when one shard starts timing out
+// while the others finish early.
 import { readdirSync } from 'fs'
 import path from 'path'
 

--- a/test/frontend/layout.mjs
+++ b/test/frontend/layout.mjs
@@ -21,6 +21,12 @@ function screen() {
 // Split the screen into `cols` equal columns and center each instance's window
 // within its column, both horizontally and vertically. Windows stay fully
 // on-screen (off-screen windows yield an empty AX tree in Chromium).
+// The four numbers are the app's own layout thresholds, not display maths: 920 is the narrowest
+// column a Mirall window can occupy and still lay out at desktop width (below it, columns collapse
+// and the scenarios stop finding what they target), 900/1200 bound the window so it neither drops
+// to the narrow layout nor stretches past the point the app stops filling it, and 1040 keeps the
+// whole window on a laptop screen. A scenario failing to find an element on a small display is
+// usually one of these, not the assertion.
 export function tile(slot, total = 2) {
   const { w, h } = screen()
   const gap = 24


### PR DESCRIPTION
Row 1.9 of the codebase quality report (#232), items 7, 8, 12, 13. Last of five, stacked on #275.
Comment-only — no code diff.

- **The renderer↔worker wire format**, both directions: request/response/event envelopes, `cancel` as
  a control frame rather than a request, `event:worker-ready` once per boot, and `subscribe()`'s
  contract (unchecked names, N listeners, per-listener catch).
- **The renderer↔main surface**: the four synchronous `sendSync` methods and why they may block, the
  non-obvious per-channel contracts (`zoom:set` returns clamped, `downloads:set` throws, …), the
  `MIRALL_*` hook index, and `identityProtection` `'weak'` vs `'protected'` — which lived only in a
  `console.warn` string.
- **Eight constants** that named no reason, including `deriveDriveKeyPair`'s `'db'` namespace, which
  reproduces Hyperdrive's own derivation: a pin test held the output, nothing held the reason.
- **Ten deliberate asymmetries** that read as bugs until explained — approve-all closing while deny
  is gated, `onCreated` after `onClose`, the bar holding at 50%, `chmod 0o700` survivable while the
  KEK failure is fatal, and `walk-disk`'s `AbortError` moved from its catch site to the class, since
  every aborted walk raises `PREVIEW_CANCELLED`, not just a preview.

**Left undone, deliberately.** §4.7 also asks why `storage.js`, `leftover.js` and `sweeps.js`
lazy-import the overlay. There is no import cycle, no unit test loading them under Node, and two of
the three predate the initial commit — the report asked it as an open question and the code does not
answer it. A confidently-worded wrong contract is worse than none, so those three are uncommented and
need whoever knows.

Coverage: SKIP — comments only. Full stack verified: `lint:ci`, `tsc`, core, bare (1110/1110), flow
(202/202), 5 frontend scenarios, 5 layout harnesses.
