### PR TITLE
[fix] Associate dialog field errors with their fields

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -133,7 +133,10 @@ export const pureFolderPolicyModules = [
 export default [
   // Vendored hyper-overlay v2 subset — third-party code kept re-diffable
   // against upstream (PROVENANCE.md), so our complexity/style rules don't apply.
-  { ignores: ['assets/dist/**', 'node_modules/**', 'src/shared/transfer/backends/overlay/vendor/**'] },
+  // Both dist trees are generated bundles: assets/dist is the app's, test/frontend-layout/dist is
+// whatever the layout harnesses last built. Neither is source, and linting a 2MB bundle drowns the
+// run in tens of thousands of findings.
+{ ignores: ['assets/dist/**', 'test/frontend-layout/dist/**', 'node_modules/**', 'src/shared/transfer/backends/overlay/vendor/**'] },
 
   // Renderer — sandboxed React UI. Accessibility rules stay ERRORS (the a11y gate); complexity
   // is advisory on top.

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "test:layout:stickyheader": "node test/frontend-layout/run-stickyheader.mjs",
     "test:layout:focusring": "node test/frontend-layout/run-focusring.mjs",
     "test:layout:truncation": "node test/frontend-layout/run-truncation.mjs",
-    "test:layout:segments": "node test/frontend-layout/run-segments.mjs"
+    "test:layout:segments": "node test/frontend-layout/run-segments.mjs",
+    "test:layout:errorassoc": "node test/frontend-layout/run-errorassoc.mjs"
   },
   "devDependencies": {
     "@axe-core/react": "^4.13.0",

--- a/src/renderer/components/modals/EditFolderModal.tsx
+++ b/src/renderer/components/modals/EditFolderModal.tsx
@@ -57,6 +57,9 @@ export default function EditFolderModal({
   // divergent copy here would either block a name the worker accepts or promise one it rejects.
   const nameValid = !isOwner || trimmed.length > 0
   const canSave = nameValid && (nameChanged || pathChanged) && !saving
+  // The non-owner note and the rename failure are both descriptions of the same field, so the
+  // error joins the note rather than replacing it.
+  const nameDescribedBy = [!isOwner && 'edit-folder-name-note', nameError && 'edit-folder-name-error'].filter(Boolean).join(' ')
 
   async function handleBrowse() {
     setPathError(null)
@@ -111,7 +114,8 @@ export default function EditFolderModal({
               id="edit-folder-name"
               autoFocus={isOwner}
               disabled={!isOwner}
-              aria-describedby={isOwner ? undefined : 'edit-folder-name-note'}
+              aria-invalid={nameError ? true : undefined}
+              aria-describedby={nameDescribedBy || undefined}
               className="w-full bg-surface-container-low border-none focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30 rounded-xl px-6 py-4 text-accent font-medium placeholder:text-outline/50 transition-all disabled:opacity-60"
               placeholder={t('editFolder.namePlaceholder')}
               value={isOwner ? draftName : name}
@@ -122,7 +126,7 @@ export default function EditFolderModal({
                 {t('editFolder.nameOwnedBy', { owner: ownerName })}
               </p>
             )}
-            {nameError && <p className="text-sm text-error px-1" role="alert">{nameError}</p>}
+            {nameError && <p id="edit-folder-name-error" className="text-sm text-error px-1" role="alert">{nameError}</p>}
           </div>
 
           <div className="space-y-3">
@@ -138,9 +142,9 @@ export default function EditFolderModal({
             <PathRow
               path={effectivePath}
               onAction={canRelocate ? handleBrowse : undefined}
-              ariaDescribedBy="edit-folder-path-label edit-folder-path-desc"
+              ariaDescribedBy={`edit-folder-path-label edit-folder-path-desc${pathError ? ' edit-folder-path-error' : ''}`}
             />
-            {pathError && <p className="text-sm text-error px-1" role="alert">{pathError}</p>}
+            {pathError && <p id="edit-folder-path-error" className="text-sm text-error px-1" role="alert">{pathError}</p>}
           </div>
 
           <div className="pt-4">

--- a/src/renderer/components/modals/EditSpaceModal.tsx
+++ b/src/renderer/components/modals/EditSpaceModal.tsx
@@ -33,7 +33,10 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   const [saving, setSaving] = useState(false)
   // undefined = untouched, null = reset to the global default, string = new override.
   const [folderEdit, setFolderEdit] = useState<string | null | undefined>(undefined)
-  const [error, setError] = useState<string | null>(null)
+  // Two errors, two homes: a screen reader must not be told the name field is at fault for a
+  // folder the app could not resolve, so each is associated with the control it belongs to.
+  const [nameError, setNameError] = useState<string | null>(null)
+  const [folderError, setFolderError] = useState<string | null>(null)
   const browseRef = useRef<HTMLButtonElement>(null)
 
   const { data: defaultFolder, error: defaultError } = useMainQuery('main:download-folder')
@@ -41,7 +44,7 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   // global default — so an unresolved read is a path still loading, not the absence of one. A read
   // that FAILED resolves to "no default available" instead, or the field would sit on its skeleton.
   const globalDefault = defaultFolder ?? (defaultError ? '' : null)
-  const shownError = error ?? (defaultError ? errorText(defaultError) : null)
+  const shownFolderError = folderError ?? (defaultError ? errorText(defaultError) : null)
 
   // Only the fallback to the global default can be pending; a picked folder or the space's own
   // override is already in hand.
@@ -54,7 +57,7 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   const isValid = name.trim().length >= 2
 
   const handleBrowse = useCallback(async () => {
-    setError(null)
+    setFolderError(null)
     const picked = await window.bridge.browseDownloadFolder(effectiveFolder || undefined)
     if (picked) setFolderEdit(picked)
   }, [effectiveFolder])
@@ -63,7 +66,7 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   // back to the control the user is most likely to want next, and let the status paragraph
   // below (a live region) announce what changed.
   const handleUseDefault = useCallback(() => {
-    setError(null)
+    setFolderError(null)
     setFolderEdit(null)
     browseRef.current?.focus()
   }, [])
@@ -71,16 +74,16 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
   async function handleSave() {
     if (!isValid || !hasChanges || saving) return
     setSaving(true)
-    setError(null)
+    setNameError(null)
+    setFolderError(null)
     try {
       await onSave(space.spaceId, name.trim(), icon, folderEdit)
       onClose()
     } catch (err) {
       const code = (err as { code?: string } | null)?.code
       const detail = errorText(err)
-      setError(code && FOLDER_ERROR_CODES.has(code)
-        ? t('editSpace.folderError', { error: detail })
-        : t('editSpace.saveError', { error: detail }))
+      if (code && FOLDER_ERROR_CODES.has(code)) setFolderError(t('editSpace.folderError', { error: detail }))
+      else setNameError(t('editSpace.saveError', { error: detail }))
     } finally {
       setSaving(false)
     }
@@ -102,11 +105,14 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
             <input
               id="edit-space-name"
               autoFocus
+              aria-invalid={nameError ? true : undefined}
+              aria-describedby={nameError ? 'edit-space-name-error' : undefined}
               className="w-full bg-surface-container-low border-none focus:outline-none focus-visible:ring-2 focus-visible:ring-secondary/30 rounded-xl px-6 py-4 text-accent font-medium placeholder:text-outline/50 transition-all"
               placeholder={t('createSpace.namePlaceholder')}
               value={name}
               onChange={(e) => setName(e.target.value)}
             />
+            {nameError && <p id="edit-space-name-error" className="text-sm text-error px-1" role="alert">{nameError}</p>}
           </div>
 
           <div className="space-y-3">
@@ -127,9 +133,12 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
               path={effectiveFolder || null}
               loading={awaitingDefault}
               onAction={handleBrowse}
-              ariaDescribedBy="edit-space-folder-label edit-space-folder-desc"
+              ariaDescribedBy={`edit-space-folder-label edit-space-folder-desc${shownFolderError ? ' edit-space-folder-error' : ''}`}
               actionRef={browseRef}
             />
+            {shownFolderError && (
+              <p id="edit-space-folder-error" className="text-sm text-error px-1" role="alert">{shownFolderError}</p>
+            )}
             <div className="flex items-center min-h-5">
               {isOverridden && (
                 <button
@@ -147,10 +156,6 @@ export default function EditSpaceModal({ space, onSave, onClose }: EditSpaceModa
               </p>
             </div>
           </div>
-
-          {shownError && (
-            <p className="text-sm text-error" role="alert">{shownError}</p>
-          )}
 
           <div className="pt-4">
             <Button size="lg" fullWidth onClick={handleSave} disabled={!isValid || !hasChanges || saving}>

--- a/src/renderer/components/widgets/MountPathField.tsx
+++ b/src/renderer/components/widgets/MountPathField.tsx
@@ -14,8 +14,8 @@ export default function MountPathField({ id, label, path, error, onBrowse }: Mou
   return (
     <div className="space-y-3">
       <span id={id} className="block font-headline text-sm font-bold text-accent px-1">{label}</span>
-      <PathRow path={path} onAction={onBrowse} ariaDescribedBy={id} />
-      {error && <p role="alert" className="text-xs text-error px-1">{error}</p>}
+      <PathRow path={path} onAction={onBrowse} ariaDescribedBy={error ? `${id} ${id}-error` : id} />
+      {error && <p id={`${id}-error`} role="alert" className="text-xs text-error px-1">{error}</p>}
     </div>
   )
 }

--- a/test/frontend-layout/README.md
+++ b/test/frontend-layout/README.md
@@ -25,6 +25,7 @@ components run unmodified. `harness-bootstrap.ts` gives every harness the query 
 | `test:layout:focusring` | `run-focusring.mjs` | `<FolderView>` | every focusable control's ring is unclipped |
 | `test:layout:truncation` | `run-truncation.mjs` | `<PathRow>` + `<FileName>` in a narrow field | exactly one run truncates; nothing overflows |
 | `test:layout:segments` | `run-segments.mjs` | `<SegmentedControl>` in its three shapes | the track and every segment keep their size across selections |
+| `test:layout:errorassoc` | `run-errorassoc.mjs` | `<EditSpaceModal>`, `<EditFolderModal>`, `<MountPathField>` in failure | each field marks itself invalid and describes itself with its OWN error |
 
 Append `--no-build` to any runner to reuse the existing bundle. Exit `0` = the invariant held; on
 failure each runner prints the measured metrics. **Local/dev-machine only** — they spawn a real

--- a/test/frontend-layout/build.mjs
+++ b/test/frontend-layout/build.mjs
@@ -110,4 +110,9 @@ await build({
   entryPoints: [path.join(HERE, 'harness-stickyheader-entry.tsx')],
   outfile: path.join(HERE, 'dist/harness-stickyheader.js'),
 })
+await build({
+  ...common,
+  entryPoints: [path.join(HERE, 'harness-errorassoc-entry.tsx')],
+  outfile: path.join(HERE, 'dist/harness-errorassoc.js'),
+})
 console.error('[build] harness bundled')

--- a/test/frontend-layout/harness-bootstrap.ts
+++ b/test/frontend-layout/harness-bootstrap.ts
@@ -1,12 +1,16 @@
-// What main.tsx does before the first render, minus the app shell: the query store's transport and
-// the one reconcile subscription. Without it every query rejects ("no transport configured") and a
-// mounted screen renders its empty state, so the harness fails looking for a control that was never
-// going to exist. Imported for side effect by EVERY harness entry: the failure is silent, arrives
+// What main.tsx does before the first render, minus the app shell: the query store's transport, the
+// main-store bridge, and the reconcile subscriptions. Without it every query rejects ("no transport
+// configured") and a mounted screen renders its empty state, so the harness fails looking for a
+// control that was never going to exist; a main fact never settles at all, so the control that
+// reads one sits on its loading shape forever. Imported for side effect by EVERY harness entry: the failure is silent, arrives
 // whenever a harness later grows a real hook, and CI never runs these.
 import { request } from './../../src/renderer/ipc.js'
 import { configureQueryStore } from './../../src/renderer/store/query-store.js'
+import { configureMainStore, installMainPushBridge } from './../../src/renderer/store/main-store.js'
 import { installPushBridges, installReconcileBridge } from './../../src/renderer/store/reconcile.js'
 
 configureQueryStore({ request: (type, params, opts) => request(type, params, undefined, opts) })
+configureMainStore(window.bridge)
+installMainPushBridge()
 installReconcileBridge()
 installPushBridges()

--- a/test/frontend-layout/harness-errorassoc-entry.tsx
+++ b/test/frontend-layout/harness-errorassoc-entry.tsx
@@ -1,0 +1,200 @@
+// REGRESSION harness for dialog error association (LOCAL/dev-machine only — spawns a real Electron
+// GUI process, like the agent-desktop frontend suite). A validation error that is only announced
+// once, with nothing tying it to the control it is about, leaves the field presenting as valid: a
+// person who tabs back to it, or reviews the form before resubmitting, gets nothing. The macOS AX
+// tree exposes neither `aria-invalid` nor `aria-describedby`, so the agent-desktop suite cannot see
+// this at all — the real DOM is the only layer that can.
+//
+// Drives the REAL <EditSpaceModal>, <EditFolderModal> and <MountPathField> into their failure
+// states and resolves each field's description the way assistive tech does.
+import './harness-bootstrap.js'
+import { createRoot, type Root } from 'react-dom/client'
+import './../../src/renderer/i18n.js'
+import EditSpaceModal from './../../src/renderer/components/modals/EditSpaceModal.js'
+import EditFolderModal from './../../src/renderer/components/modals/EditFolderModal.js'
+import MountPathField from './../../src/renderer/components/widgets/MountPathField.js'
+import type { Space } from './../../src/renderer/types.js'
+
+// The download-folder read fails for the whole page, so the space dialog carries BOTH a folder
+// error and a name error at once — the case where pointing the name field at "the error" would
+// name the wrong control.
+window.bridge.getDownloadFolder = () => Promise.reject(new Error('no default folder'))
+window.bridge.browseShareFolder = () => Promise.resolve('/tmp/relocated')
+
+const SPACE: Space = {
+  spaceId: 'space1',
+  name: 'Aurora',
+  icon: 'folder',
+  topic: 't'.repeat(64),
+  created: '2026-01-01',
+  members: [],
+  favorite: false,
+  schemaVersion: 2,
+}
+
+interface FieldProbe {
+  found: boolean
+  invalid: boolean
+  describedBy: string
+}
+
+interface HarnessResults {
+  pass: boolean
+  error: string | null
+  spaceName: FieldProbe
+  spaceFolder: FieldProbe
+  folderName: FieldProbe
+  folderPath: FieldProbe
+  mirrorName: FieldProbe
+  mountPath: FieldProbe
+}
+
+declare global {
+  interface Window { __results: HarnessResults }
+}
+
+const MISSING: FieldProbe = { found: false, invalid: false, describedBy: '' }
+const sleep = (ms: number) => new Promise<void>((r) => setTimeout(r, ms))
+
+// What a screen reader reads off the control: its invalid state, and the text of every element its
+// aria-describedby points at, in order.
+function probe(el: Element | null): FieldProbe {
+  if (!el) return MISSING
+  const ids = (el.getAttribute('aria-describedby') ?? '').split(/\s+/).filter(Boolean)
+  const described = ids.map((id) => document.getElementById(id)?.textContent ?? `«${id} missing»`)
+  return {
+    found: true,
+    invalid: el.getAttribute('aria-invalid') === 'true',
+    describedBy: described.join(' '),
+  }
+}
+
+// A controlled React input ignores a plain `.value =`; go through the native setter so React's
+// onChange fires and the draft state actually moves.
+function typeInto(el: HTMLInputElement, text: string): void {
+  const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+  setter?.call(el, text)
+  el.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+// The path row's button is the only one whose whole label is its text; a <Button> carries an icon
+// child, so it is matched on a substring.
+function pathButton(label: string): HTMLButtonElement | null {
+  return Array.from(document.querySelectorAll('button')).find((b) => b.textContent === label) ?? null
+}
+
+function saveButton(): HTMLButtonElement | null {
+  return Array.from(document.querySelectorAll('button')).find((b) => b.textContent?.includes('Save Changes')) ?? null
+}
+
+// A mapped code, so the save failure reads as its own sentence rather than the generic one the
+// folder read falls back to — the two must stay distinguishable from the field they hang off.
+const rejects = () => Promise.reject(Object.assign(new Error('boom'), { code: 'SHARE_NAME_COLLISION' }))
+const noop = () => {}
+
+async function run(root: Root): Promise<HarnessResults> {
+  const results: HarnessResults = {
+    pass: false,
+    error: null,
+    spaceName: MISSING,
+    spaceFolder: MISSING,
+    folderName: MISSING,
+    folderPath: MISSING,
+    mirrorName: MISSING,
+    mountPath: MISSING,
+  }
+
+  root.render(<EditSpaceModal space={SPACE} onSave={rejects} onClose={noop} />)
+  await sleep(300)
+  const spaceName = document.getElementById('edit-space-name') as HTMLInputElement
+  typeInto(spaceName, 'Aurora Renamed')
+  await sleep(50)
+  saveButton()?.click()
+  await sleep(300)
+  results.spaceName = probe(document.getElementById('edit-space-name'))
+  // With the read failed there is no path to show, so the row offers a first pick.
+  results.spaceFolder = probe(pathButton('Browse…'))
+
+  root.render(
+    <EditFolderModal
+      key="owner"
+      isOwner
+      canRelocate
+      name="Photos"
+      ownerName="Vhinz"
+      mountPath="/tmp/photos"
+      onRename={rejects}
+      onRelocate={rejects}
+      onClose={noop}
+    />,
+  )
+  await sleep(300)
+  typeInto(document.getElementById('edit-folder-name') as HTMLInputElement, 'Pictures')
+  pathButton('Change')?.click()
+  await sleep(200)
+  saveButton()?.click()
+  await sleep(300)
+  results.folderName = probe(document.getElementById('edit-folder-name'))
+  results.folderPath = probe(pathButton('Change'))
+
+  // A mirror's name belongs to the owner: the field is read-only and its note is the only
+  // description it has, so the joined value must not have swallowed it.
+  root.render(
+    <EditFolderModal
+      key="mirror"
+      isOwner={false}
+      canRelocate
+      name="Photos"
+      ownerName="Vhinz"
+      mountPath="/tmp/photos"
+      onRename={rejects}
+      onRelocate={rejects}
+      onClose={noop}
+    />,
+  )
+  await sleep(300)
+  results.mirrorName = probe(document.getElementById('edit-folder-name'))
+
+  root.render(
+    <div className="p-4">
+      <MountPathField id="mount-path" label="Folder on this Mac" path="/tmp/pick" error="That folder is inside another share." onBrowse={noop} />
+    </div>,
+  )
+  await sleep(300)
+  results.mountPath = probe(pathButton('Change'))
+
+  results.pass =
+    results.spaceName.invalid &&
+    results.spaceName.describedBy.includes('Could not save changes') &&
+    results.spaceName.describedBy.includes('already uses that name') &&
+    !results.spaceName.describedBy.includes('Something went wrong') &&
+    results.spaceFolder.describedBy.includes('Download Folder') &&
+    results.spaceFolder.describedBy.includes('Something went wrong') &&
+    results.folderName.invalid &&
+    results.folderName.describedBy.includes('rename this folder') &&
+    !results.folderName.describedBy.includes('change the location') &&
+    results.folderPath.describedBy.includes('change the location') &&
+    !results.mirrorName.invalid &&
+    results.mirrorName.describedBy.includes('Vhinz') &&
+    results.mountPath.describedBy.includes('Folder on this Mac') &&
+    results.mountPath.describedBy.includes('inside another share')
+
+  return results
+}
+
+const root = createRoot(document.getElementById('root') as HTMLElement)
+run(root).then(
+  (results) => { window.__results = results },
+  (e: unknown) => {
+    window.__results = {
+      pass: false,
+      error: String(e),
+      spaceName: MISSING,
+      spaceFolder: MISSING,
+      folderName: MISSING,
+      folderPath: MISSING,
+      mirrorName: MISSING,
+      mountPath: MISSING,
+    }
+  },
+)

--- a/test/frontend-layout/harness-errorassoc.html
+++ b/test/frontend-layout/harness-errorassoc.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Mirall dialog error-association harness</title>
+  <!-- The REAL built stylesheet, so the harness uses the app's actual CSS. -->
+  <link rel="stylesheet" href="../../assets/dist/app.css" />
+  <!-- Classic script: installs window.bridge BEFORE the ESM bundle imports ipc.ts. -->
+  <script src="./fake-bridge.js"></script>
+</head>
+<body style="background: var(--color-background);">
+  <div id="root"></div>
+  <script type="module" src="./dist/harness-errorassoc.js"></script>
+</body>
+</html>

--- a/test/frontend-layout/run-errorassoc.mjs
+++ b/test/frontend-layout/run-errorassoc.mjs
@@ -1,0 +1,26 @@
+// REGRESSION (dialog error association): a field that reports a validation error must mark itself
+// invalid and describe itself with that error's text — LOCAL/dev-machine only (spawns a real
+// Electron GUI process, like the agent-desktop frontend suite). The macOS AX tree carries neither
+// attribute, so this is the only layer that can assert them.
+//
+//   node test/frontend-layout/run-errorassoc.mjs            (builds, then runs)
+//   node test/frontend-layout/run-errorassoc.mjs --no-build (reuse existing bundle)
+import { runHarness } from './run-harness.mjs'
+
+const out = await runHarness({ html: 'harness-errorassoc.html', width: 900, height: 900 })
+
+const line = (label, probe) =>
+  `${label.padEnd(12)}: ${probe.found ? '' : 'NOT FOUND '}invalid ${probe.invalid} · described "${probe.describedBy}"`
+
+console.log('\n──────── Dialog error-association harness ────────')
+console.log(line('space name', out.spaceName))
+console.log(line('space path', out.spaceFolder))
+console.log(line('folder name', out.folderName))
+console.log(line('folder path', out.folderPath))
+console.log(line('mirror name', out.mirrorName))
+console.log(line('mount path', out.mountPath))
+if (out.error) console.log(`error: ${out.error}`)
+
+const pass = out.pass === true
+console.log(`\n${pass ? 'ok  ' : 'FAIL'} every dialog field reports invalid and resolves to its own error text`)
+process.exit(pass ? 0 : 1)


### PR DESCRIPTION
## What & why

Two dialogs announced a validation error once and then left the field presenting as valid: the Edit
Space name, the Edit Folder name, and the path row inside `MountPathField` carried neither
`aria-invalid` nor an id for `aria-describedby` to point at. Edit Space also folded a name-save
failure and a download-folder failure into one message; the two are now separate state and hang off
the controls they belong to, so the name field never claims a folder's fault. Edit Folder's name
field joins its error onto the non-owner note rather than replacing it.

Closes #278.

## Coverage

Renderer UI + accessibility. The regression test is a **layout harness**, not a `test:fe` scenario:
measured with a probe page, the macOS AX tree exposes neither `aria-invalid` nor `aria-describedby`,
so an agent-desktop scenario passes identically before and after the fix. `test:layout:errorassoc`
reads the real DOM — red on the parent commit, green with the fix.

Two incidentals: `harness-bootstrap.ts` never called `configureMainStore`, so no layout harness could
settle a main-process fact; and `test/frontend-layout/dist` was gitignored but still linted, which
fails `npm run build` on any machine that has run a layout harness.

## Ran locally

- `test:layout:errorassoc` — red before, green after; `truncation`, `segments`, `focusring` still
  pass (`modaltitle` fails identically on the parent commit — pre-existing).
- `test:fe s13` (edit-space rename + icon) 3/3, `test:fe s124` (folder acts) 6/6.
- VoiceOver spot-check of both dialogs still outstanding.