### PR TITLE
[chore] Build audit row participants in one place

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:css": "npx @tailwindcss/cli -i src/renderer/styles/tailwind.css -o assets/dist/app.css --minify",
     "build:clean": "node -e \"require('fs').rmSync('assets/dist',{recursive:true,force:true})\"",
     "lint": "eslint src test scripts",
-    "lint:ci": "eslint src test scripts --max-warnings 21 && bash scripts/check-comment-hygiene.sh && bash scripts/check-test-timing.sh && bash scripts/check-release-mime.sh",
+    "lint:ci": "eslint src test scripts --max-warnings 19 && bash scripts/check-comment-hygiene.sh && bash scripts/check-test-timing.sh && bash scripts/check-release-mime.sh",
     "knip": "knip",
     "build": "npm run build:clean && npm run lint && tsc --noEmit && npm run build:js && npm run build:css",
     "start": "npm run build && electron-forge start -- --no-updates",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "build:css": "npx @tailwindcss/cli -i src/renderer/styles/tailwind.css -o assets/dist/app.css --minify",
     "build:clean": "node -e \"require('fs').rmSync('assets/dist',{recursive:true,force:true})\"",
     "lint": "eslint src test scripts",
-    "lint:ci": "eslint src test scripts --max-warnings 19 && bash scripts/check-comment-hygiene.sh && bash scripts/check-test-timing.sh && bash scripts/check-release-mime.sh",
+    "lint:ci": "eslint src test scripts --max-warnings 21 && bash scripts/check-comment-hygiene.sh && bash scripts/check-test-timing.sh && bash scripts/check-release-mime.sh",
     "knip": "knip",
     "build": "npm run build:clean && npm run lint && tsc --noEmit && npm run build:js && npm run build:css",
     "start": "npm run build && electron-forge start -- --no-updates",

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -1,5 +1,5 @@
 import type { FILE_STATUS, BADGE_STATUS, SHARE_FILE_STATUS, OWNED_MOUNT_STATUS, FOREIGN_MOUNT_STATUS } from '../shared/contract/statuses.js'
-import type { OUTCOMES, ACTOR_TYPES } from '../shared/contract/audit-kinds.js'
+import type { CATEGORIES, OUTCOMES, ACTOR_TYPES, TARGET_KINDS } from '../shared/contract/audit-kinds.js'
 export interface Profile {
   displayName: string
   avatar: string | null
@@ -361,7 +361,7 @@ export interface NetworkStatus {
   }
 }
 
-export type AuditCategory = 'members' | 'files' | 'folders' | 'security' | 'network'
+export type AuditCategory = (typeof CATEGORIES)[number]
 type AuditTier = 'A' | 'B' | 'C'
 type AuditOutcome = (typeof OUTCOMES)[number]
 
@@ -377,7 +377,7 @@ export interface AuditSpaceRef {
 }
 
 interface AuditTargetRef {
-  kind: string | null
+  kind: (typeof TARGET_KINDS)[number]
   id: string | null
   name: string | null
 }

--- a/src/shared/audit/audit-log.js
+++ b/src/shared/audit/audit-log.js
@@ -22,7 +22,7 @@
 //   config                      -> retention settings — user preferences, kept by audit:purge.
 import { createLocalBee, getStore } from '../core/store.js'
 import { createLogger } from '../core/logger.js'
-import { buildRecord } from './audit-record.js'
+import { buildRecord, selfActor } from './audit-record.js'
 import { STATE_OFF } from './peer-observer.js'
 import { prefixRange } from '../core/bee-keys.js'
 import {
@@ -161,7 +161,7 @@ export function record(kind, fields = {}) {
 
 function withSelfIdentity(actor) {
   if (!actor || actor.type !== ACTOR_TYPE.SELF) return actor
-  return { type: ACTOR_TYPE.SELF, key: actor.key ?? selfIdentity.key, name: actor.name ?? selfIdentity.name }
+  return selfActor(actor.key ?? selfIdentity.key, actor.name ?? selfIdentity.name)
 }
 
 async function append(kind, fields, target = bee) {

--- a/src/shared/audit/audit-record.js
+++ b/src/shared/audit/audit-record.js
@@ -17,11 +17,9 @@ import { NAME_MAX } from '../contract/limits.js'
 // test seam
 export const SCHEMA_VERSION = 1
 
-// The participant shapes, built here or nowhere. Hand-written literals drifted: some omitted `key`
-// and `name` entirely, peer-watch.js shadowed the worker's own spaceRef with a second copy, and the
-// worker kept three of these as private functions no other caller could reach. A row's shape is not
-// a per-site decision — normalizeActor and friends below are the only readers, and they expect
-// exactly this.
+// The participant shapes every row is assembled from. A row's shape is not a per-site decision:
+// normalizeActor, normalizeSpace and normalizeTarget below are their only readers, and they read
+// exactly these fields.
 
 // The key and name default to null because most producers do not know them; audit-log fills them
 // from the live identity at write time and calls this with both.

--- a/src/shared/audit/audit-record.js
+++ b/src/shared/audit/audit-record.js
@@ -7,14 +7,45 @@
 // would render raw hex forever. Hence a name snapshot on every participant, taken at write time.
 //
 // buildRecord below IS the v1 row schema — every `audit-log` bee row is one of its results, and
-// nothing else writes one. The renderer carries a hand-written copy of the shape in its types, so a
-// field added here has to be added there too; bumping SCHEMA_VERSION without doing so leaves the
-// two disagreeing with no gate between them.
-import { isKnownKind, categoryOf, tierOf, OUTCOME, OUTCOMES } from '../contract/audit-kinds.js'
+// nothing else writes one. The renderer derives the vocabularies (category, outcome, actor type,
+// target kind) from the contract, but still hand-writes the FIELD LIST in its types, so a field
+// added here has to be added there too; bumping SCHEMA_VERSION without doing so leaves the two
+// disagreeing with no gate between them.
+import { isKnownKind, categoryOf, tierOf, ACTOR_TYPE, OUTCOME, OUTCOMES, TARGET_KINDS } from '../contract/audit-kinds.js'
 import { NAME_MAX } from '../contract/limits.js'
 
 // test seam
 export const SCHEMA_VERSION = 1
+
+// The participant shapes, built here or nowhere. Hand-written literals drifted: some omitted `key`
+// and `name` entirely, peer-watch.js shadowed the worker's own spaceRef with a second copy, and the
+// worker kept three of these as private functions no other caller could reach. A row's shape is not
+// a per-site decision — normalizeActor and friends below are the only readers, and they expect
+// exactly this.
+
+// The key and name default to null because most producers do not know them; audit-log fills them
+// from the live identity at write time and calls this with both.
+export function selfActor(key = null, name = null) {
+  return { type: ACTOR_TYPE.SELF, key: key ?? null, name: name ?? null }
+}
+
+// The name is resolved by the caller: it needs the live roster or the space record, which this
+// module deliberately cannot reach.
+export function peerActor(key, name) {
+  return { type: ACTOR_TYPE.PEER, key: key ?? null, name: name ?? null }
+}
+
+export function systemActor() {
+  return { type: ACTOR_TYPE.SYSTEM, key: null, name: null }
+}
+
+export function spaceRef(id, name) {
+  return id ? { id, name: name ?? null } : null
+}
+
+export function targetRef(kind, id, name) {
+  return { kind, id: id ?? null, name: name ?? null }
+}
 
 const SEARCH_MAX = 300
 const CODE_MAX = 64
@@ -33,9 +64,12 @@ function normalizeSpace(space) {
   return { id: space.id, name: clampName(space.name) }
 }
 
+// Refused rather than stored, exactly as an unknown kind or outcome is: the viewer groups and links
+// on this field, so a spelling it does not know is a row that no filter can ever surface.
 function normalizeTarget(target) {
   if (!target) return null
-  return { kind: target.kind || null, id: target.id || null, name: clampName(target.name) }
+  if (!TARGET_KINDS.includes(target.kind)) throw new Error('audit: unknown target kind ' + target.kind)
+  return { kind: target.kind, id: target.id || null, name: clampName(target.name) }
 }
 
 // Proper nouns only, deliberately language-independent. The kind is NOT included: the renderer

--- a/src/shared/audit/network-watch.js
+++ b/src/shared/audit/network-watch.js
@@ -11,7 +11,8 @@ import { createLogger } from '../core/logger.js'
 import { record, getNetworkState, setNetworkState } from './audit-log.js'
 import { createEpisodeTracker, evidenceFor } from './network-episodes.js'
 import { createPeerPresenceTracker } from './peer-episodes.js'
-import { ACTOR_TYPE } from '../contract/audit-kinds.js'
+import { TARGET_KIND } from '../contract/audit-kinds.js'
+import { peerActor, spaceRef, systemActor, targetRef } from './audit-record.js'
 
 const log = createLogger('network-watch')
 
@@ -98,7 +99,7 @@ async function pumpDevice() {
     if (!row) return
 
     const written = record(row.kind, {
-      actor: { type: ACTOR_TYPE.SYSTEM, key: null, name: null },
+      actor: systemActor(),
       code: row.code,
       subject: { ...row.subject, ...evidenceFor(row.kind, last.evidence) },
     })
@@ -161,15 +162,15 @@ const armPeerTimer = guarded(() => {
 
 function writePeerRow(row) {
   const name = row.meta?.memberName ?? null
-  const space = { id: row.spaceId, name: row.meta?.spaceName ?? null }
+  const space = spaceRef(row.spaceId, row.meta?.spaceName)
   if (row.suppressed) {
     record('audit.suppressed', { space, subject: { kind: row.kind, count: row.cap, windowMs: row.windowMs } })
     return
   }
   const written = record(row.kind, {
-    actor: { type: ACTOR_TYPE.PEER, key: row.publicKey, name },
+    actor: peerActor(row.publicKey, name),
     space,
-    target: { kind: 'member', id: row.publicKey, name },
+    target: targetRef(TARGET_KIND.MEMBER, row.publicKey, name),
     subject: row.subject,
   })
   if (written) emitUpdated?.()

--- a/src/shared/audit/peer-watch.js
+++ b/src/shared/audit/peer-watch.js
@@ -14,7 +14,8 @@ import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record, getSeenVersion, setSeenVersion, getPeerSubjectState, setPeerSubjectState } from './audit-log.js'
 import { classifyProfileChange, classifyCatalogChange, isTransition, readChangesSince, stateOf, subjectKey } from './peer-observer.js'
-import { ACTOR_TYPE } from '../contract/audit-kinds.js'
+import { TARGET_KIND } from '../contract/audit-kinds.js'
+import { peerActor, spaceRef, targetRef } from './audit-record.js'
 
 const log = createLogger('peer-watch')
 
@@ -81,16 +82,16 @@ async function applyProfileChange(peerKey, change) {
   const space = await getSpace(change.spaceId)
   // Not a space we are in — their records for it are none of our business.
   if (!space || space.leaving) return
-  const actor = { type: ACTOR_TYPE.PEER, key: peerKey, name: peerName(space, peerKey) }
-  const spaceRef = { id: space.spaceId, name: space.name ?? null }
+  const actor = peerActor(peerKey, peerName(space, peerKey))
+  const ref = spaceRef(space.spaceId, space.name)
 
   if (change.kind === 'share') {
     const commit = await transitioned('share', peerKey, change.spaceId, change.shareId, change.removed)
     if (!commit) return
     const written = record(change.removed ? 'peer.share_deleted' : 'peer.share_created', {
       actor,
-      space: spaceRef,
-      target: { kind: 'share', id: change.shareId, name: change.name },
+      space: ref,
+      target: targetRef(TARGET_KIND.SHARE, change.shareId, change.name),
     })
     if (written) await commit()
     return
@@ -103,8 +104,8 @@ async function applyProfileChange(peerKey, change) {
   const own = (await readOwnShares(change.spaceId)).find((s) => s.id === change.shareId)
   const written = record(change.removed ? 'mirror.peer_unmirrored' : 'mirror.peer_mirrored', {
     actor,
-    space: spaceRef,
-    target: { kind: 'share', id: change.shareId, name: own?.name ?? null },
+    space: ref,
+    target: targetRef(TARGET_KIND.SHARE, change.shareId, own?.name ?? null),
   })
   if (written) await commit()
 }
@@ -117,9 +118,9 @@ async function applyCatalogChange(peerKey, spaceId, change) {
   const commit = await transitioned('file', peerKey, spaceId, change.relPath, change.removed)
   if (!commit) return
   const written = record(change.removed ? 'peer.file_unshared' : 'peer.file_shared', {
-    actor: { type: ACTOR_TYPE.PEER, key: peerKey, name: peerName(space, peerKey) },
-    space: { id: space.spaceId, name: space.name ?? null },
-    target: { kind: 'file', id: change.relPath, name: change.relPath },
+    actor: peerActor(peerKey, peerName(space, peerKey)),
+    space: spaceRef(space.spaceId, space.name),
+    target: targetRef(TARGET_KIND.FILE, change.relPath, change.relPath),
   })
   if (written) await commit()
 }

--- a/src/shared/contract/audit-kinds.d.ts
+++ b/src/shared/contract/audit-kinds.d.ts
@@ -2,9 +2,13 @@ export declare const CATEGORY: Readonly<Record<string, string>>
 export declare const KINDS: Readonly<Record<string, { category: string; tier: string }>>
 export declare const OUTCOME: Readonly<{ OK: 'ok'; DENIED: 'denied'; ERROR: 'error' }>
 export declare const ACTOR_TYPE: Readonly<{ SELF: 'self'; PEER: 'peer'; SYSTEM: 'system' }>
-export declare const CATEGORIES: readonly string[]
+export declare const TARGET_KIND: Readonly<{ FILE: 'file'; INVITE: 'invite'; MEMBER: 'member'; SHARE: 'share'; SPACE: 'space' }>
+// Literal tuples, not string[]: types.ts derives its unions with (typeof X)[number], so a widened
+// declaration turns an exhaustive switch into `string`.
+export declare const CATEGORIES: readonly ['members', 'files', 'folders', 'security', 'network']
 export declare const OUTCOMES: readonly ['ok', 'denied', 'error']
 export declare const ACTOR_TYPES: readonly ['self', 'peer', 'system']
+export declare const TARGET_KINDS: readonly ['file', 'invite', 'member', 'share', 'space']
 export declare function isKnownKind (kind: string): boolean
 // Throws on an unknown kind — the vocabulary is closed, so a kind absent from it is a programming
 // error; `| null` would invite a guard that still crashes.

--- a/src/shared/contract/audit-kinds.js
+++ b/src/shared/contract/audit-kinds.js
@@ -102,10 +102,22 @@ export const OUTCOME = Object.freeze({ OK: 'ok', DENIED: 'denied', ERROR: 'error
 // own. The renderer picks the sentence, the avatar and the name snapshot from it.
 export const ACTOR_TYPE = Object.freeze({ SELF: 'self', PEER: 'peer', SYSTEM: 'system' })
 
+// What a row points AT, as distinct from whom it attributes the act to. Closed like the kinds and
+// the outcomes: the viewer groups and links rows on this field, so a spelling it does not know
+// renders as a row no filter can reach.
+export const TARGET_KIND = Object.freeze({
+  FILE: 'file',
+  INVITE: 'invite',
+  MEMBER: 'member',
+  SHARE: 'share',
+  SPACE: 'space',
+})
+
 // test seam — the audit-coverage guard's grouping
 export const CATEGORIES = Object.freeze(Object.values(CATEGORY))
 export const OUTCOMES = Object.freeze(Object.values(OUTCOME))
 export const ACTOR_TYPES = Object.freeze(Object.values(ACTOR_TYPE))
+export const TARGET_KINDS = Object.freeze(Object.values(TARGET_KIND))
 
 export function isKnownKind(kind) {
   return Object.hasOwn(KINDS, kind)

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -45,7 +45,8 @@ import { mirrorMayFetch } from './mirror-reach.js'
 import { classifyMiss, isTerminalFault } from '../transfer/backends/overlay/fetch-policy.js'
 import { shortfall } from '../transfer/free-space.js'
 import { freeBytesFor } from '../transfer/free-space-probe.js'
-import { ACTOR_TYPE, OUTCOME } from '../contract/audit-kinds.js'
+import { OUTCOME, TARGET_KIND } from '../contract/audit-kinds.js'
+import { selfActor, spaceRef, targetRef } from '../audit/audit-record.js'
 
 const log = createLogger('foreign-folders')
 
@@ -340,9 +341,9 @@ function recordMirrorIntegrityFailure(mount, share, entry) {
   if (!integritySeen.admit(loopKey(mount.spaceId, mount.shareId), entry.relPath, entry.contentHash)) return
   getSpace(mount.spaceId).then((space) => {
     record('security.integrity_failure', {
-      actor: { type: ACTOR_TYPE.SELF },
-      space: { id: mount.spaceId, name: space?.name ?? null },
-      target: { kind: 'file', id: entry.relPath ?? null, name: path.basename(entry.relPath || '') || null },
+      actor: selfActor(),
+      space: spaceRef(mount.spaceId, space?.name ?? null),
+      target: targetRef(TARGET_KIND.FILE, entry.relPath ?? null, path.basename(entry.relPath || '') || null),
       subject: {
         bytes: entry.size ?? null,
         ownerKey: mount.ownerKey ?? null,

--- a/src/shared/spaces/member-registry.js
+++ b/src/shared/spaces/member-registry.js
@@ -8,7 +8,8 @@ import { tombstoneActive, observedLeavers } from './member-set.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record } from '../audit/audit-log.js'
-import { ACTOR_TYPE } from '../contract/audit-kinds.js'
+import { TARGET_KIND } from '../contract/audit-kinds.js'
+import { systemActor, spaceRef, targetRef } from '../audit/audit-record.js'
 
 // Set by the worker. A hook, not an import: the overlay reaches back into spaces/ for the
 // membership gate, so importing it here would close the cycle.
@@ -264,13 +265,13 @@ async function applyObservedLeave(spaceId, key, leaveTs) {
   // our own vouch being withdrawn as a consequence of their departure — not a removal.
   getSpace(spaceId).then((space) => {
     record('membership.approval_revoked', {
-      actor: { type: ACTOR_TYPE.SYSTEM, key: null, name: null },
-      space: { id: spaceId, name: space?.name ?? null },
-      target: {
-        kind: 'member',
-        id: key,
-        name: (space?.members || []).find((m) => m.publicKey === key)?.displayName ?? null,
-      },
+      actor: systemActor(),
+      space: spaceRef(spaceId, space?.name ?? null),
+      target: targetRef(
+        TARGET_KIND.MEMBER,
+        key,
+        (space?.members || []).find((m) => m.publicKey === key)?.displayName ?? null,
+      ),
     })
   }).catch(() => {})
   log.info('observed leave via replication — revoked + tombstoned:', key.slice(0, 12) + '...', '→', spaceId)

--- a/src/shared/spaces/space.js
+++ b/src/shared/spaces/space.js
@@ -32,7 +32,8 @@ import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { record } from '../audit/audit-log.js'
 import { prefixRange } from '../core/bee-keys.js'
-import { ACTOR_TYPE } from '../contract/audit-kinds.js'
+import { TARGET_KIND } from '../contract/audit-kinds.js'
+import { peerActor, spaceRef, targetRef } from '../audit/audit-record.js'
 
 const log = createLogger('space')
 const { store: keysStore, core: keysCore } = keysMod
@@ -314,9 +315,9 @@ function auditArrivals(spaceId, space, added) {
     // arrival row seconds later is noise.
     if (await hasOwnApproval(spaceId, m.publicKey)) return
     record('member.joined', {
-      actor: { type: ACTOR_TYPE.PEER, key: m.publicKey, name: m.displayName || null },
-      space: { id: spaceId, name: space.name ?? null },
-      target: { kind: 'member', id: m.publicKey, name: m.displayName || null },
+      actor: peerActor(m.publicKey, m.displayName || null),
+      space: spaceRef(spaceId, space.name ?? null),
+      target: targetRef(TARGET_KIND.MEMBER, m.publicKey, m.displayName || null),
     })
   })).catch((err) => log.debug('arrival audit failed:', err.message))
 }

--- a/src/shared/transfer/backends/overlay/overlay-instance.js
+++ b/src/shared/transfer/backends/overlay/overlay-instance.js
@@ -22,7 +22,8 @@ import { getOverlayServeLimit, isSeparateContentPlaneEnabled, getBandwidthLimits
 import { createBandwidthLimiter } from '../../bandwidth-limiter.js'
 import { createChunkMapCache } from '../../chunk-map-cache.js'
 import { createLogger } from '../../../core/logger.js'
-import { ACTOR_TYPE, OUTCOME } from '../../../contract/audit-kinds.js'
+import { OUTCOME, TARGET_KIND } from '../../../contract/audit-kinds.js'
+import { peerActor, targetRef } from '../../../audit/audit-record.js'
 
 const log = createLogger('overlay')
 
@@ -195,13 +196,9 @@ function recordServeDenial(reason, { from, contentHash }) {
   const relPath = refs[0]?.relPath || null
   Promise.resolve(spaceId ? getSpace(spaceId) : null).then((space) => {
     record('security.serve_denied', {
-      actor: {
-        type: ACTOR_TYPE.PEER,
-        key: from || null,
-        name: (space?.members || []).find((m) => m.publicKey === from)?.displayName || null,
-      },
+      actor: peerActor(from || null, (space?.members || []).find((m) => m.publicKey === from)?.displayName || null),
       space: space ? { id: space.spaceId, name: space.name ?? null } : null,
-      target: { kind: 'file', id: contentHash || null, name: relPath ? relPath.split('/').pop() : null },
+      target: targetRef(TARGET_KIND.FILE, contentHash || null, relPath ? relPath.split('/').pop() : null),
       subject: { reason, requester: from ? from.slice(0, 12) : null },
       outcome: OUTCOME.DENIED,
     })

--- a/src/shared/transfer/leave-protocol.js
+++ b/src/shared/transfer/leave-protocol.js
@@ -23,7 +23,8 @@ import { record } from '../audit/audit-log.js'
 import { peerLeft } from '../audit/network-watch.js'
 import { markLeft } from '../spaces/member-registry.js'
 import { connectedPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, authorizedOn, detachPeerFromSpace, forgetPeerOnSocket } from './swarm-registries.js'
-import { ACTOR_TYPE } from '../contract/audit-kinds.js'
+import { TARGET_KIND } from '../contract/audit-kinds.js'
+import { peerActor, spaceRef, targetRef } from '../audit/audit-record.js'
 
 let presence = null
 let log = null
@@ -64,9 +65,9 @@ function memberSnapshot(space, publicKey) {
 
 function recordMemberLeft(spaceId, profileKey, snapshot) {
   record('member.left', {
-    actor: { type: ACTOR_TYPE.PEER, key: profileKey, name: snapshot.memberName },
-    space: { id: spaceId, name: snapshot.spaceName },
-    target: { kind: 'member', id: profileKey, name: snapshot.memberName },
+    actor: peerActor(profileKey, snapshot.memberName),
+    space: spaceRef(spaceId, snapshot.spaceName),
+    target: targetRef(TARGET_KIND.MEMBER, profileKey, snapshot.memberName),
   })
 }
 

--- a/src/shared/transfer/serve-ledger.js
+++ b/src/shared/transfer/serve-ledger.js
@@ -13,7 +13,8 @@ import { LOOSE_SHARE_ID } from './transfer-id.js'
 import { getSpace } from '../spaces/space.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
-import { ACTOR_TYPE } from '../contract/audit-kinds.js'
+import { TARGET_KIND } from '../contract/audit-kinds.js'
+import { peerActor, spaceRef, targetRef } from '../audit/audit-record.js'
 
 const log = createLogger('serve-ledger')
 
@@ -99,9 +100,9 @@ function recordServeSession(session) {
     const live = getConnectedMemberMeta(meta.spaceId, meta.from)
     const persisted = (space?.members || []).find((m) => m.publicKey === meta.from)
     record('serve.completed', {
-      actor: { type: ACTOR_TYPE.PEER, key: meta.from ?? null, name: live?.displayName || persisted?.displayName || null },
-      space: { id: meta.spaceId, name: space?.name ?? null },
-      target: { kind: 'file', id: meta.contentHash ?? null, name: meta.fileName ?? null },
+      actor: peerActor(meta.from ?? null, live?.displayName || persisted?.displayName || null),
+      space: spaceRef(meta.spaceId, space?.name ?? null),
+      target: targetRef(TARGET_KIND.FILE, meta.contentHash ?? null, meta.fileName ?? null),
       subject: { bytes: session.bytes, total: session.total || null, durationMs: session.durationMs, path: meta.path ?? null },
     })
   }).catch((err) => log.debug('serve audit failed:', err.message))

--- a/src/shared/transfer/transfer-audit.js
+++ b/src/shared/transfer/transfer-audit.js
@@ -10,7 +10,8 @@ import path from 'bare-path'
 import { record } from '../audit/audit-log.js'
 import { getSpace } from '../spaces/space.js'
 import { createLogger } from '../core/logger.js'
-import { ACTOR_TYPE, OUTCOME } from '../contract/audit-kinds.js'
+import { OUTCOME, TARGET_KIND } from '../contract/audit-kinds.js'
+import { selfActor, spaceRef, targetRef } from '../audit/audit-record.js'
 
 const log = createLogger('transfer-audit')
 
@@ -33,9 +34,9 @@ export function recordTransferOutcome(job, outcome, errorCode) {
   const fileName = path.basename(job.relPath || job.path || '')
   const write = getSpace(job.spaceId).then((space) => {
     record(kindFor(outcome, errorCode), {
-      actor: { type: ACTOR_TYPE.SELF },
-      space: { id: job.spaceId, name: space?.name ?? null },
-      target: { kind: 'file', id: job.path ?? null, name: fileName || null },
+      actor: selfActor(),
+      space: spaceRef(job.spaceId, space?.name ?? null),
+      target: targetRef(TARGET_KIND.FILE, job.path ?? null, fileName || null),
       // `folder` is null for a loose file and is what lets the viewer name the folder without a
       // join — a row outlives its share.
       subject: {

--- a/src/worker/ipc/space-leave.js
+++ b/src/worker/ipc/space-leave.js
@@ -1,5 +1,7 @@
 // The space:leave handler. Its teardown ORDER is shared with boot's interrupted-leave pass through
 // spaces/leave-flow.js (LEAVE_PHASES + runLeaveTeardown), so the two cannot drift.
+import { TARGET_KIND } from '../../shared/contract/audit-kinds.js'
+import { selfActor, spaceRef, targetRef } from '../../shared/audit/audit-record.js'
 import { record } from '../../shared/audit/audit-log.js'
 import { MAIN_REQUEST_FRAME, MAIN_REQUEST } from '../../shared/contract/main-requests.js'
 import { unmountForeignFolder } from '../../shared/folders/foreign-folders.js'
@@ -26,7 +28,7 @@ import {
   unmarkSpaceLeaving,
 } from '../../shared/transfer/swarm.js'
 
-export function registerSpaceLeave(ipc, { log, mounts, selfActor, spaceRef, discardPendingSpace, dropSpaceDownloadRoot }) {
+export function registerSpaceLeave(ipc, { log, mounts, discardPendingSpace, dropSpaceDownloadRoot }) {
   // Persist a pending-leave marker BEFORE the record purge erases the topic, so the swarm can
   // re-announce the leave to members who were offline at leave time (and boot re-joins the topic)
   // until they provably apply it — without this they keep us as a ghost member forever. Arm iff
@@ -78,8 +80,8 @@ export function registerSpaceLeave(ipc, { log, mounts, selfActor, spaceRef, disc
     if (pending) {
       record('space.left', {
         actor: selfActor(),
-        space: spaceRef(pending),
-        target: { kind: 'space', id: pending.spaceId, name: pending.name },
+        space: spaceRef(pending.spaceId, pending.name),
+        target: targetRef(TARGET_KIND.SPACE, pending.spaceId, pending.name),
         subject: { wasPending: pending.status === 'pending' },
       })
     }

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -189,7 +189,8 @@ import {
   recordMirrorScanFault,
 } from '../shared/folders/foreign-folders.js'
 import { createForeignMount as persistForeignMount, getForeignMount, listForeignMounts } from '../shared/folders/mount-store.js'
-import { ACTOR_TYPE, OUTCOME } from '../shared/contract/audit-kinds.js'
+import { OUTCOME, TARGET_KIND } from '../shared/contract/audit-kinds.js'
+import { selfActor, peerActor, systemActor, spaceRef, targetRef } from '../shared/audit/audit-record.js'
 
 const ipc = createIPC(Bare.IPC)
 const log = createLogger('worklet')
@@ -275,22 +276,18 @@ function refreshAuditSelfName(displayName) {
   setAuditIdentity({ key: getLocalPublicKeyHex(), name: displayName })
 }
 
-function selfActor() {
-  return { type: ACTOR_TYPE.SELF, key: null, name: null }
-}
-
-function peerActor(space, publicKey) {
+// Resolves the name, which needs the live roster and the persisted members — the two things
+// audit-record.js deliberately cannot reach. The shape itself comes from peerActor.
+function peerActorIn(space, publicKey) {
   const live = space ? getConnectedMemberMeta(space.spaceId, publicKey) : null
   const persisted = (space?.members || []).find((m) => m.publicKey === publicKey)
-  return {
-    type: ACTOR_TYPE.PEER,
-    key: publicKey,
-    name: displayNameOrNull(live?.displayName) || displayNameOrNull(persisted?.displayName) || null,
-  }
+  return peerActor(publicKey, displayNameOrNull(live?.displayName) || displayNameOrNull(persisted?.displayName) || null)
 }
 
-function spaceRef(space) {
-  return space ? { id: space.spaceId, name: space.name } : null
+// The worker holds space RECORDS, whose id field is `spaceId`; every other producer holds the id
+// and the name separately. One adapter, rather than a second shape in the shared builder.
+function spaceRefOf(space) {
+  return spaceRef(space?.spaceId, space?.name)
 }
 
 function fileNameOf(path) {
@@ -307,9 +304,9 @@ async function recordGrantReceived(spaceId, granterKey) {
   // this needs is exactly what those may have just filled in.
   const space = await getSpace(spaceId)
   record('membership.granted', {
-    actor: peerActor(space, granterKey || null),
-    space: spaceRef(space),
-    target: { kind: 'space', id: spaceId, name: space?.name ?? null },
+    actor: peerActorIn(space, granterKey || null),
+    space: spaceRefOf(space),
+    target: targetRef(TARGET_KIND.SPACE, spaceId, space?.name ?? null),
   })
 }
 
@@ -472,9 +469,9 @@ function auditJoinRequest(spaceId, publicKey, displayName) {
   recordedJoinRequests.add(key)
   getSpace(spaceId).then((space) => {
     record('membership.requested', {
-      actor: { type: ACTOR_TYPE.PEER, key: publicKey, name: displayName || null },
-      space: spaceRef(space),
-      target: { kind: 'member', id: publicKey, name: displayName || null },
+      actor: peerActor(publicKey, displayName || null),
+      space: spaceRefOf(space),
+      target: targetRef(TARGET_KIND.MEMBER, publicKey, displayName || null),
     })
   }).catch(() => {})
 }
@@ -504,9 +501,9 @@ async function reconcileGrantCreator(spaceId, space, asserted) {
   }
   if (decision === 'refuse') {
     record('security.creator_divergence', {
-      actor: { type: ACTOR_TYPE.SYSTEM, key: null, name: null },
-      space: spaceRef(space),
-      target: { kind: 'space', id: spaceId, name: space?.name ?? null },
+      actor: systemActor(),
+      space: spaceRefOf(space),
+      target: targetRef(TARGET_KIND.SPACE, spaceId, space?.name ?? null),
       subject: { pinned: space.creatorKey ?? null, asserted: asserted ?? null },
       outcome: OUTCOME.DENIED,
     })
@@ -761,8 +758,8 @@ async function publishOwnedShare(space, share) {
   await publishShare(space.spaceId, share)
   record('share.created', {
     actor: selfActor(),
-    space: spaceRef(space),
-    target: { kind: 'share', id: share.id, name: share.name },
+    space: spaceRefOf(space),
+    target: targetRef(TARGET_KIND.SHARE, share.id, share.name),
   })
   ipc.emit('event:shares-updated', { spaceId: space.spaceId })
 }
@@ -804,8 +801,8 @@ ipc.handle('share:create-and-mount', async (msg) => {
       await tombstoneShare(msg.spaceId, share.id)
       record('share.deleted', {
         actor: selfActor(),
-        space: spaceRef(space),
-        target: { kind: 'share', id: share.id, name: share.name },
+        space: spaceRefOf(space),
+        target: targetRef(TARGET_KIND.SHARE, share.id, share.name),
       })
       await intents.complete(intentId)
     } catch (tombstoneErr) {
@@ -846,8 +843,8 @@ ipc.handle('share:rename', async (msg) => {
   await publishShare(msg.spaceId, next)
   record('share.renamed', {
     actor: selfActor(),
-    space: spaceRef(space),
-    target: { kind: 'share', id: msg.shareId, name: displayName },
+    space: spaceRefOf(space),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, displayName),
     subject: { previousName },
   })
   ipc.emit('event:shares-updated', { spaceId: msg.spaceId })
@@ -860,8 +857,8 @@ ipc.handle('share:delete', async (msg) => {
   await tombstoneShare(msg.spaceId, msg.shareId)
   record('share.deleted', {
     actor: selfActor(),
-    space: spaceRef(space),
-    target: { kind: 'share', id: msg.shareId, name: share?.name ?? null },
+    space: spaceRefOf(space),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, share?.name ?? null),
   })
   ipc.emit('event:shares-updated', { spaceId: msg.spaceId })
   return { ok: true }
@@ -1057,8 +1054,8 @@ async function mountOwnedShare(spaceId, share, validated, requestedIgnore) {
       // reconcile deliberately records nothing — it is machine churn, not a user action.
       record('share.mounted', {
         actor: selfActor(),
-        space: spaceRef(await getSpace(spaceId)),
-        target: { kind: 'share', id: shareId, name: share?.name ?? null },
+        space: spaceRefOf(await getSpace(spaceId)),
+        target: targetRef(TARGET_KIND.SHARE, shareId, share?.name ?? null),
         subject: { fileCount: result?.totalOnDisk ?? null, uploaded: result?.uploaded ?? null, mountPath },
       })
       mounts.schedulePeriodicReconcile(spaceId, shareId, mountPath, ignore)
@@ -1153,8 +1150,8 @@ ipc.handle('owned-folder:relocate', async (msg) => {
 
   record('share.relocated', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'share', id: msg.shareId, name: null },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, null),
     subject: { from: previousMountPath, to: mountPath },
   })
   return { mount, advisories }
@@ -1185,8 +1182,8 @@ ipc.handle('owned-folder:delete', async (msg) => {
   await intents.complete(intentId)
   record('share.deleted', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'share', id: msg.shareId, name: share?.name ?? null },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, share?.name ?? null),
   })
   ipc.emit('event:shares-updated', { spaceId: msg.spaceId })
   ipc.emit('event:share-files-updated', { spaceId: msg.spaceId, shareId: msg.shareId })
@@ -1252,8 +1249,8 @@ ipc.handle('foreign-folder:mount', async (msg) => {
 
   record('mirror.created', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'share', id: msg.shareId, name: await shareNameOrNull(msg.spaceId, msg.ownerKey, msg.shareId) },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, await shareNameOrNull(msg.spaceId, msg.ownerKey, msg.shareId)),
     subject: { mountPath: mount.mountPath, ownerKey: msg.ownerKey },
   })
   return { mount, advisories }
@@ -1281,8 +1278,8 @@ ipc.handle('foreign-folder:relocate', async (msg) => {
   const next = await relocateForeignFolder(msg.spaceId, msg.shareId, mountPath)
   record('mirror.relocated', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'share', id: msg.shareId, name: await shareNameOrNull(msg.spaceId, mount.ownerKey, msg.shareId) },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, await shareNameOrNull(msg.spaceId, mount.ownerKey, msg.shareId)),
     subject: { mountPath, previousMountPath: mount.mountPath },
   })
   return { mount: next, advisories }
@@ -1297,8 +1294,8 @@ ipc.handle('foreign-folder:unmount', async (msg) => {
   await intents.complete(intentId)
   record('mirror.removed', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'share', id: msg.shareId, name: await shareNameOrNull(msg.spaceId, mount?.ownerKey, msg.shareId) },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.SHARE, msg.shareId, await shareNameOrNull(msg.spaceId, mount?.ownerKey, msg.shareId)),
     subject: { mountPath: mount?.mountPath ?? null },
   })
   return { ok: true }
@@ -1384,7 +1381,11 @@ ipc.handle('space:create', async (msg) => {
   await joinSpaceTopic(space.spaceId)
   await openMemberView(space.spaceId)   // the creator's own space derives its membership too
   log.info('space created:', space.spaceId)
-  record('space.created', { actor: selfActor(), space: spaceRef(space), target: { kind: 'space', id: space.spaceId, name: space.name } })
+  record('space.created', {
+    actor: selfActor(),
+    space: spaceRefOf(space),
+    target: targetRef(TARGET_KIND.SPACE, space.spaceId, space.name),
+  })
   return space
 })
 // Block a rejoin until a concurrent leave of the same space has fully torn down (the leaving flag
@@ -1456,8 +1457,8 @@ ipc.handle('space:join', async (msg) => {
   log.info('space joined:', space.spaceId)
   record('space.joined', {
     actor: selfActor(),
-    space: spaceRef(space),
-    target: { kind: 'space', id: space.spaceId, name: space.name },
+    space: spaceRefOf(space),
+    target: targetRef(TARGET_KIND.SPACE, space.spaceId, space.name),
     subject: { inviteId: decoded.inviteId || null, autoAdmit: !!decoded.autoAdmit },
   })
   return space
@@ -1494,8 +1495,8 @@ ipc.handle('space:invite', async (msg) => {
     await markInvite(space.spaceId, inviteId, { autoApprove: !!msg.autoAdmit, expiresAt })
     record('invite.minted', {
       actor: selfActor(),
-      space: spaceRef(space),
-      target: { kind: 'invite', id: inviteId, name: null },
+      space: spaceRefOf(space),
+      target: targetRef(TARGET_KIND.INVITE, inviteId, null),
       subject: { autoAdmit: !!msg.autoAdmit, expiresAt },
     })
   }
@@ -1525,8 +1526,8 @@ ipc.handle('space:approve-member', async (msg) => {
   if (approved) {
     record('membership.approved', {
       actor: selfActor(),
-      space: spaceRef(space),
-      target: { kind: 'member', id: msg.publicKey, name: peerActor(space, msg.publicKey).name },
+      space: spaceRefOf(space),
+      target: targetRef(TARGET_KIND.MEMBER, msg.publicKey, peerActorIn(space, msg.publicKey).name),
     })
   }
   return approved
@@ -1544,8 +1545,8 @@ ipc.handle('space:deny-member', async (msg) => {
   if (denied) {
     record('membership.denied', {
       actor: selfActor(),
-      space: spaceRef(space),
-      target: { kind: 'member', id: msg.publicKey, name: peerActor(space, msg.publicKey).name },
+      space: spaceRefOf(space),
+      target: targetRef(TARGET_KIND.MEMBER, msg.publicKey, peerActorIn(space, msg.publicKey).name),
       outcome: OUTCOME.DENIED,
     })
   }
@@ -1577,8 +1578,8 @@ ipc.handle('space:update', async (msg) => {
     }
     record('space.updated', {
       actor: selfActor(),
-      space: spaceRef(updated),
-      target: { kind: 'space', id: msg.spaceId, name: updated.name },
+      space: spaceRefOf(updated),
+      target: targetRef(TARGET_KIND.SPACE, msg.spaceId, updated.name),
       subject: { previousName: space?.name ?? null },
     })
   }
@@ -1587,7 +1588,7 @@ ipc.handle('space:update', async (msg) => {
 ipc.handle('space:toggle-favorite', async (msg) => {
   return await toggleFavorite(msg.spaceId)
 })
-registerSpaceLeave(ipc, { log, mounts, selfActor, spaceRef, discardPendingSpace, dropSpaceDownloadRoot })
+registerSpaceLeave(ipc, { log, mounts, discardPendingSpace, dropSpaceDownloadRoot })
 
 // === IPC: presence, file & transfer handlers ===
 
@@ -1614,8 +1615,8 @@ ipc.handle('files:remove', async (msg) => {
   await removeFile(msg.spaceId, msg.path)
   record('file.unshared', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'file', id: msg.path, name: fileNameOf(msg.path) },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.FILE, msg.path, fileNameOf(msg.path)),
   })
   ipc.emit('event:files-updated', { spaceId: msg.spaceId })
   return { ok: true }
@@ -1635,8 +1636,8 @@ ipc.handle('files:add', async (msg) => {
   await addFile(msg.spaceId, msg.filePath, msg.fileName)
   record('file.shared', {
     actor: selfActor(),
-    space: spaceRef(await getSpace(msg.spaceId)),
-    target: { kind: 'file', id: msg.fileName, name: msg.fileName },
+    space: spaceRefOf(await getSpace(msg.spaceId)),
+    target: targetRef(TARGET_KIND.FILE, msg.fileName, msg.fileName),
     subject: { size: msg.fileSize ?? null },
   })
   ipc.emit('event:files-updated', { spaceId: msg.spaceId })

--- a/test/unit/audit-record.test.js
+++ b/test/unit/audit-record.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
-import { buildRecord, SCHEMA_VERSION } from '../../src/shared/audit/audit-record.js'
-import { KINDS, OUTCOME, OUTCOMES } from '../../src/shared/contract/audit-kinds.js'
+import { buildRecord, SCHEMA_VERSION, selfActor, peerActor, systemActor, spaceRef, targetRef } from '../../src/shared/audit/audit-record.js'
+import { KINDS, OUTCOME, OUTCOMES, TARGET_KIND } from '../../src/shared/contract/audit-kinds.js'
 
 const base = { seq: 1, ts: 1754236800000, kind: 'space.created' }
 
@@ -81,4 +81,41 @@ test('every kind in the table builds a valid record', (t) => {
     t.ok(rec.category, kind + ' has a category')
     t.ok(rec.tier, kind + ' has a tier')
   }
+})
+
+test('an unknown target kind is refused, as an unknown kind and outcome already are', (t) => {
+  t.exception(() => buildRecord({ ...base, target: { kind: 'folder', id: 'x', name: 'x' } }), /unknown target kind/)
+  t.exception(() => buildRecord({ ...base, target: { id: 'x', name: 'x' } }), /unknown target kind/)
+  t.execution(() => buildRecord({ ...base, target: targetRef(TARGET_KIND.SPACE, 'x', 'x') }), 'a declared kind passes')
+})
+
+// The builders are the point of the module: a row's participant shapes were hand-written at 52
+// sites and drifted five ways. normalizeActor and normalizeTarget read exactly these fields.
+test('the builders produce the shapes buildRecord normalizes', (t) => {
+  t.alike(selfActor(), { type: 'self', key: null, name: null })
+  t.alike(peerActor('abc', 'Ada'), { type: 'peer', key: 'abc', name: 'Ada' })
+  t.alike(systemActor(), { type: 'system', key: null, name: null })
+  t.alike(spaceRef('s1', 'Space'), { id: 's1', name: 'Space' })
+  t.alike(targetRef(TARGET_KIND.FILE, 'f1', 'a.txt'), { kind: 'file', id: 'f1', name: 'a.txt' })
+})
+
+test('a missing id or name becomes null rather than undefined', (t) => {
+  t.alike(peerActor(undefined, undefined), { type: 'peer', key: null, name: null })
+  t.alike(targetRef(TARGET_KIND.SHARE, undefined, undefined), { kind: 'share', id: null, name: null })
+  t.is(spaceRef(null, 'Space'), null, 'a space with no id is no space')
+})
+
+// Round-trip: the builders' output is what the record actually carries, so a shape change here
+// cannot pass while leaving the row wrong.
+test('a record built entirely from the builders round-trips', (t) => {
+  const rec = buildRecord({
+    ...base,
+    actor: peerActor('key1', 'Ada'),
+    space: spaceRef('s1', 'Space'),
+    target: targetRef(TARGET_KIND.MEMBER, 'key1', 'Ada'),
+  })
+  t.alike(rec.actor, { type: 'peer', key: 'key1', name: 'Ada' })
+  t.alike(rec.space, { id: 's1', name: 'Space' })
+  t.alike(rec.target, { kind: 'member', id: 'key1', name: 'Ada' })
+  t.is(rec.search, 'ada space ada', 'every builder name reaches the search index')
 })

--- a/test/unit/audit-record.test.js
+++ b/test/unit/audit-record.test.js
@@ -89,8 +89,8 @@ test('an unknown target kind is refused, as an unknown kind and outcome already 
   t.execution(() => buildRecord({ ...base, target: targetRef(TARGET_KIND.SPACE, 'x', 'x') }), 'a declared kind passes')
 })
 
-// The builders are the point of the module: a row's participant shapes were hand-written at 52
-// sites and drifted five ways. normalizeActor and normalizeTarget read exactly these fields.
+// The builders' output is what the normalizers read, so their field names and null handling are
+// the contract between the two halves of this module.
 test('the builders produce the shapes buildRecord normalizes', (t) => {
   t.alike(selfActor(), { type: 'self', key: null, name: null })
   t.alike(peerActor('abc', 'Ada'), { type: 'peer', key: 'abc', name: 'Ada' })

--- a/test/unit/contract-declarations.test.js
+++ b/test/unit/contract-declarations.test.js
@@ -97,7 +97,7 @@ test('the declared status tuples match the runtime arrays exactly', (t) => {
 // exactly the twin this package exists to delete.
 test('the renderer derives its status unions instead of re-listing them', (t) => {
   const types = readFileSync(path.join(dir, '..', '..', 'renderer', 'types.ts'), 'utf8')
-  for (const [type, konst] of [['FileStatus', 'FILE_STATUS'], ['BadgeStatus', 'BADGE_STATUS'], ['ShareFileStatus', 'SHARE_FILE_STATUS']]) {
+  for (const [type, konst] of [['FileStatus', 'FILE_STATUS'], ['BadgeStatus', 'BADGE_STATUS'], ['ShareFileStatus', 'SHARE_FILE_STATUS'], ['AuditCategory', 'CATEGORIES']]) {
     t.ok(new RegExp(`export type ${type} = \\(typeof ${konst}\\)\\[number\\]`).test(types),
       `${type} is derived from the contract`)
   }

--- a/test/unit/no-hand-mirrored-vocabularies.test.js
+++ b/test/unit/no-hand-mirrored-vocabularies.test.js
@@ -1,5 +1,5 @@
 import test from 'brittle'
-import { readFileSync } from 'fs'
+import { readFileSync, readdirSync, statSync } from 'fs'
 import { fileURLToPath } from 'url'
 import path from 'path'
 
@@ -24,5 +24,38 @@ test('no module re-declares a vocabulary the contract package owns', (t) => {
 test('every mirrored module points at the contract package', (t) => {
   for (const [file] of MIRRORED) {
     t.ok(/from '[^']*contract\/[a-z-]+\.js'/.test(src(file)), `${file} imports from the contract`)
+  }
+})
+
+// The same rule one level up: the audit row's participant shapes. These were hand-written object
+// literals at 52 sites and drifted five ways — some omitted `key` and `name`, one module shadowed
+// the worker's own spaceRef with a second copy, and the worker kept three of them private so no
+// other producer could reach them. audit-record.js builds them or nothing does.
+const HAND_BUILT = [
+  [/type:\s*ACTOR_TYPE\./, 'builds an actor literal instead of calling selfActor/peerActor/systemActor'],
+  [/target:\s*\{\s*kind:/, 'builds a target literal instead of calling targetRef'],
+  [/space:\s*\{\s*id:/, 'builds a space literal instead of calling spaceRef'],
+]
+
+function walk(dir, out = []) {
+  for (const name of readdirSync(dir)) {
+    const p = path.join(dir, name)
+    if (statSync(p).isDirectory()) { if (name !== 'vendor') walk(p, out) }
+    else if (name.endsWith('.js')) out.push(p)
+  }
+  return out
+}
+
+test('no module hand-builds an audit row participant', (t) => {
+  const root = path.join(here, '..', '..', 'src')
+  const files = [...walk(path.join(root, 'shared')), ...walk(path.join(root, 'worker'))]
+    .filter((f) => !f.endsWith(path.join('audit', 'audit-record.js')))
+  t.ok(files.length > 50, `walked ${files.length} data-layer modules`)
+
+  for (const file of files) {
+    const body = readFileSync(file, 'utf8')
+    for (const [pattern, why] of HAND_BUILT) {
+      t.absent(pattern.test(body), `${path.relative(root, file)} ${why}`)
+    }
   }
 })

--- a/test/unit/no-hand-mirrored-vocabularies.test.js
+++ b/test/unit/no-hand-mirrored-vocabularies.test.js
@@ -27,10 +27,9 @@ test('every mirrored module points at the contract package', (t) => {
   }
 })
 
-// The same rule one level up: the audit row's participant shapes. These were hand-written object
-// literals at 52 sites and drifted five ways — some omitted `key` and `name`, one module shadowed
-// the worker's own spaceRef with a second copy, and the worker kept three of them private so no
-// other producer could reach them. audit-record.js builds them or nothing does.
+// The same rule one level up: the audit row's participant shapes. audit-record.js builds them, so
+// a producer that assembles one itself can omit a field the normalizers read, or diverge from the
+// shape the renderer is typed against.
 const HAND_BUILT = [
   [/type:\s*ACTOR_TYPE\./, 'builds an actor literal instead of calling selfActor/peerActor/systemActor'],
   [/target:\s*\{\s*kind:/, 'builds a target literal instead of calling targetRef'],


### PR DESCRIPTION
Box 2.5 of #233, at its corrected scope.

The actor, space and target shapes were hand-written object literals at **52 sites** and had drifted:
some omitted `key` and `name`, `peer-watch.js` shadowed the worker's own `spaceRef` with a second
copy, and the worker kept three of the builders private so no other producer could reach them.

- `audit-record.js` exports `selfActor` / `peerActor` / `systemActor` / `spaceRef` / `targetRef`.
  33 target, 12 actor and 7 space literals now call them.
- `contract/audit-kinds.js` gains `TARGET_KIND` (`file|invite|member|share|space` — the five in use).
  `buildRecord` refuses an unknown target kind, exactly as it already refuses an unknown kind (#240's
  precedent for outcomes). Safe to refuse: `buildRecord` runs only on the local write path, never on a
  replicated peer row.
- `types.ts` derives `AuditCategory` and the target kind from the contract instead of re-listing them;
  `CATEGORIES` / `TARGET_KINDS` are declared as literal tuples so the existing parity test pins them.
- Two adapters stay, each for a stated reason: `peerActorIn` resolves a name from the live roster
  (which `audit-record.js` cannot reach), and `spaceRefOf` adapts the worker's space *record*, whose
  id field is `spaceId`.
- `space-leave.js` no longer receives `selfActor`/`spaceRef` as injected parameters — both modules
  import them directly.

**Already shipped, so not redone:** `OUTCOME` and `ACTOR_TYPE` were already in the contract.

**Deliberately not done — a flat `KIND` enum for kind names.** A mistyped kind is *already* refused
at write time by `isKnownKind`, so unlike a mistyped event name it fails loudly today. The safety is
real but does not earn a ~50-site mechanical diff, which is the same call #236 A.5 made for events.
Worth confirming before #233 is closed.

A new ratchet fails any module that hand-builds a participant again. It earned itself immediately:
it caught `audit-log.js` filling in the self identity by hand, which I had previously judged
legitimate — `selfActor` now takes the optional key and name it needs.

Verified: `tsc` and `lint:ci` clean; the eight audit unit files plus the two leave-wiring ones pass
(120 new asserts); integration `network-watch`, `serve-ledger`, `shutdown-audit` and `member-view`
pass. The refactor also dropped the lint warning count to 19, so the `--max-warnings` ceiling is
tightened from 21.
