### PR TITLE
[chore] Give the swarm registries a read and detach API

### DIFF
--- a/.claude/lessons.md
+++ b/.claude/lessons.md
@@ -533,3 +533,19 @@ be characterised by isolation runs instead of read off the log.
 **The rule:** a local flow "green" is only trustworthy up to the first throw. Compare planned
 against executed count before believing a pass, and prefer CI's sharded result — it is the
 stronger evidence, not the weaker one. Tracked as #246.
+
+## A refactor's commit message is not its comments
+
+A comment that explains why a refactor was needed dates the instant the refactor lands. "These
+were hand-written at 52 sites and drifted five ways", "peer-watch.js shadowed the worker's own
+copy", "the copies had already begun to disagree" — all true, all worthless to the next reader,
+who needs to know what the function guarantees, not what the tree looked like before it existed.
+
+**The rule:** state what the code does and the constraint that makes it so. Two things earn a
+"why": a non-obvious invariant a reader would otherwise break (`authorizedOn` is per socket
+because a draining socket must stay authorized through a reconnect), and a divergence that looks
+like an oversight but is deliberate (the two detach paths do not share their follow-through). The
+history of the refactor belongs in the commit body and the PR, where it is dated by construction.
+
+Applies to test comments too: say what the test protects, not which bug motivated writing it —
+unless it is a `REGRESSION` test, whose whole contract is naming the defect it pins.

--- a/src/shared/transfer/leave-protocol.js
+++ b/src/shared/transfer/leave-protocol.js
@@ -22,7 +22,7 @@ import { destroyContentPeerSockets } from './content-swarm.js'
 import { record } from '../audit/audit-log.js'
 import { peerLeft } from '../audit/network-watch.js'
 import { markLeft } from '../spaces/member-registry.js'
-import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers } from './swarm-registries.js'
+import { connectedPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, authorizedOn, detachPeerFromSpace, forgetPeerOnSocket } from './swarm-registries.js'
 import { ACTOR_TYPE } from '../contract/audit-kinds.js'
 
 let presence = null
@@ -82,7 +82,7 @@ export async function handleLeaveFrame(socket, peerInfo, msg) {
   // per-socket auth index; the robust path is the frame's identity binding, which survives the
   // teardown/reconnect race that clears or has-not-yet-populated that index. Additive — the binding
   // proof is strictly stronger than the index, so a third party still cannot evict a member.
-  const onSocket = socketToPeers.get(socket)?.has(profileKey) || false
+  const onSocket = authorizedOn(socket, profileKey)
   if (!onSocket && !leaveFrameBound(peerInfo, msg)) {
     log.warn('leave frame rejected — sender not authenticated on socket and no valid binding')
     return
@@ -146,20 +146,12 @@ export async function handleLeaveFrame(socket, peerInfo, msg) {
   peerLeft(profileKey, spaceId)         // ...but that is a LEAVE; member.left carries it
 
   const peer = connectedPeers.get(profileKey)
-  if (peer) {
-    peer.spaces.delete(spaceId)
-    peer.looseCatalogKeys?.delete(spaceId)
-    if (peer.spaces.size === 0) {
-      connectedPeers.delete(profileKey)
-      const set = socketToPeers.get(peer.socket)
-      if (set) {
-        set.delete(profileKey)
-        if (set.size === 0) socketToPeers.delete(peer.socket)
-      }
-      // The overlay content channel rides the CONTENT socket, not this one: a peer we no longer
-      // share any space with must lose that socket too, or we keep serving it bulk bytes.
-      try { destroyContentPeerSockets(profileKey) } catch {}
-    }
+  if (peer && detachPeerFromSpace(peer, spaceId)) {
+    connectedPeers.delete(profileKey)
+    forgetPeerOnSocket(peer.socket, profileKey)
+    // The overlay content channel rides the CONTENT socket, not this one: a peer we no longer
+    // share any space with must lose that socket too, or we keep serving it bulk bytes.
+    try { destroyContentPeerSockets(profileKey) } catch {}
   }
   // Their leave revokes our serve grants for this space: the grant is cached per (peer, path) at
   // request time and re-checked against that cache only, so a membership change has to invalidate
@@ -314,7 +306,7 @@ export function handleLeaveAckFrame(socket, msg) {
   }
   // Only count an ack from a peer that authenticated as this profileKey on this socket, so a peer
   // can't forge acks for other members and collapse the leaver's flush wait early.
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  if (!authorizedOn(socket, profileKey)) return
   leaveAcks.get(spaceId)?.add(profileKey)
 }
 

--- a/src/shared/transfer/presence-broadcast.js
+++ b/src/shared/transfer/presence-broadcast.js
@@ -11,7 +11,7 @@ import { LOOSE_SHARE_ID } from './transfer-id.js'
 import { shareDecoKey } from '../contract/decoration-key.js'
 import { peerSeen } from '../audit/network-watch.js'
 import { presenceFrameKind } from '../state/presence.js'
-import { connectedPeers, socketToPeers, spaceTopics, socketMsgHandlers } from './swarm-registries.js'
+import { spaceTopics, socketMsgHandlers, authorizedOn, broadcastToSpace } from './swarm-registries.js'
 
 let presence = null
 let membersPoke = null
@@ -63,11 +63,7 @@ function broadcastPresence() {
   if (socketMsgHandlers.size === 0) return
   const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
   for (const [spaceId, topicHex] of spaceTopics) {
-    for (const [, peer] of connectedPeers) {
-      if (!peer.spaces.has(spaceId)) continue
-      const handler = socketMsgHandlers.get(peer.socket)
-      if (handler) { try { handler.send(JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex })) } catch {} }
-    }
+    broadcastToSpace(spaceId, JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex }))
   }
 }
 
@@ -82,11 +78,7 @@ export function broadcastDeparture() {
   if (!getSwarm() || socketMsgHandlers.size === 0) return
   const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
   for (const [spaceId, topicHex] of spaceTopics) {
-    for (const [, peer] of connectedPeers) {
-      if (!peer.spaces.has(spaceId)) continue
-      const handler = socketMsgHandlers.get(peer.socket)
-      if (handler) { try { handler.send(JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex, offline: true })) } catch {} }
-    }
+    broadcastToSpace(spaceId, JSON.stringify({ type: 'presence', profileKey: profileKeyHex, spaceTopic: topicHex, offline: true }))
   }
 }
 
@@ -95,12 +87,7 @@ export function broadcastDeparture() {
 export function broadcastSharePrepareProgress(spaceId, payload) {
   if (socketMsgHandlers.size === 0) return
   const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
-  const frame = JSON.stringify({ type: 'share-prepare-progress', profileKey: profileKeyHex, spaceId, ...payload })
-  for (const [, peer] of connectedPeers) {
-    if (!peer.spaces.has(spaceId)) continue
-    const handler = socketMsgHandlers.get(peer.socket)
-    if (handler) { try { handler.send(frame) } catch {} }
-  }
+  broadcastToSpace(spaceId, JSON.stringify({ type: 'share-prepare-progress', profileKey: profileKeyHex, spaceId, ...payload }))
 }
 
 // A share is admission-gated at 5k files and a folder that grows past it keeps publishing, so this
@@ -114,12 +101,7 @@ const MAX_WIRE_COUNT = 1_000_000
 export function broadcastShareIndexProgress(spaceId, payload) {
   if (socketMsgHandlers.size === 0) return
   const profileKeyHex = b4a.toString(getProfileKey(), 'hex')
-  const frame = JSON.stringify({ type: 'share-index-progress', profileKey: profileKeyHex, spaceId, ...payload })
-  for (const [, peer] of connectedPeers) {
-    if (!peer.spaces.has(spaceId)) continue
-    const handler = socketMsgHandlers.get(peer.socket)
-    if (handler) { try { handler.send(frame) } catch {} }
-  }
+  broadcastToSpace(spaceId, JSON.stringify({ type: 'share-index-progress', profileKey: profileKeyHex, spaceId, ...payload }))
 }
 
 // Re-surface an owner's queue depth to our renderer. Same anti-spoof guard as the prepare frame:
@@ -130,7 +112,7 @@ export function broadcastShareIndexProgress(spaceId, payload) {
 export function handleShareIndexProgressFrame(socket, msg) {
   const { profileKey, spaceId, shareId, adding, bytesQueued } = msg
   if (typeof profileKey !== 'string' || typeof spaceId !== 'string' || typeof shareId !== 'string') return
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  if (!authorizedOn(socket, profileKey)) return
   // The sender is carried through as `ownerKey` so the consumer can require it to be the share's
   // actual owner. Authentication proves only WHO is speaking: without this any approved co-member
   // could describe someone else's share, and the notice names that someone by display name.
@@ -151,7 +133,7 @@ export function handlePresenceFrame(socket, msg) {
   const kind = presenceFrameKind(msg)
   if (kind === 'ignore') return
   const { profileKey, spaceTopic } = msg
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  if (!authorizedOn(socket, profileKey)) return
   const spaceId = resolveSpaceIdForTopic(spaceTopic)
   if (!spaceId) return
   if (kind === 'clear') {
@@ -181,7 +163,7 @@ export function handleSharePrepareProgressFrame(socket, msg) {
   const { profileKey, spaceId, shareId, relPath, bytes, total, eta } = msg
   if (typeof profileKey !== 'string' || typeof spaceId !== 'string') return
   if (typeof shareId !== 'string' || typeof relPath !== 'string') return
-  if (!socketToPeers.get(socket)?.has(profileKey)) return
+  if (!authorizedOn(socket, profileKey)) return
   const key = shareId === LOOSE_SHARE_ID ? '/' + relPath : shareDecoKey(shareId, relPath)
   // The owner finished (or abandoned) the hash. Decorations are cleared only by this frame, so
   // without it the bar sits at ~100% and repaints stale on the next re-hash of the same path. It

--- a/src/shared/transfer/swarm-registries.js
+++ b/src/shared/transfer/swarm-registries.js
@@ -35,3 +35,72 @@ const ALL = [connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socke
 export function resetRegistries() {
   for (const m of ALL) m.clear()
 }
+
+// === Reading the indexes ===
+//
+// The questions the swarm asks of these Maps. Each rule has one implementation, so every caller
+// gets the same answer.
+
+// True when this identity passed the identity binding on THIS socket. Answers both "is the
+// requester admitted here?" (owner side) and "did this reply come from the owner?" (consumer
+// side). Deliberately per socket rather than per peer: a draining socket keeps its entry until
+// close, so during an owner reconnect both sockets are authorized rather than neither.
+export function authorizedOn(socket, profileKeyHex) {
+  return !!socketToPeers.get(socket)?.has(profileKeyHex)
+}
+
+// The peers sharing this space with us, as [profileKey, entry].
+export function* peersInSpace(spaceId) {
+  for (const [profileKey, peer] of connectedPeers) {
+    if (peer.spaces.has(spaceId)) yield [profileKey, peer]
+  }
+}
+
+// Send one frame to one peer. Best-effort: a socket mid-close must not abort a fan-out, so a
+// failed send is reported rather than thrown. Returns whether the frame reached a channel.
+export function safeSend(peer, frame) {
+  const handler = socketMsgHandlers.get(peer.socket)
+  if (!handler) return false
+  try {
+    handler.send(frame)
+    return true
+  } catch {
+    return false
+  }
+}
+
+// Fan one frame out to a space. The caller serializes it once: every recipient gets the same
+// bytes. Returns how many peers it reached.
+export function broadcastToSpace(spaceId, frame) {
+  let sent = 0
+  for (const [, peer] of peersInSpace(spaceId)) {
+    if (safeSend(peer, frame)) sent++
+  }
+  return sent
+}
+
+// === Detaching a peer from a space ===
+
+// Remove one space from a peer's membership, with the loose catalog key that belongs to it.
+// Returns true when the peer is left in no space at all — the condition for forgetting the peer
+// itself.
+//
+// What follows that `true` belongs to the caller, because it differs by event. When WE leave a
+// space the control socket is destroyed and its close handler completes the teardown; when THEY
+// leave, the socket stays up — they remain a peer, just not here — so that path unwinds
+// socketToPeers itself.
+export function detachPeerFromSpace(peer, spaceId) {
+  peer.spaces.delete(spaceId)
+  peer.looseCatalogKeys?.delete(spaceId)
+  return peer.spaces.size === 0
+}
+
+// Remove one identity from a socket's set, and the socket once no identity rides it. The
+// disconnect path does not use this: there the socket itself is gone, so its whole entry goes at
+// once.
+export function forgetPeerOnSocket(socket, profileKey) {
+  const set = socketToPeers.get(socket)
+  if (!set) return
+  set.delete(profileKey)
+  if (set.size === 0) socketToPeers.delete(socket)
+}

--- a/src/shared/transfer/swarm.js
+++ b/src/shared/transfer/swarm.js
@@ -40,7 +40,7 @@ import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { createSwarmDiagnostics } from './swarm-diagnostics.js'
 import { createAdmissionGates } from './admission-gates.js'
-import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, announceLedger, resetRegistries } from './swarm-registries.js'
+import { connectedPeers, socketToPeers, spaceTopics, spaceDiscoveries, socketMsgHandlers, pendingRequesters, boundSignerKeys, announceLedger, resetRegistries, authorizedOn, detachPeerFromSpace } from './swarm-registries.js'
 import {
   initPresenceBroadcast, startPresenceHeartbeat, stopPresenceHeartbeat, resolveSpaceIdForTopic,
   handlePresenceFrame, handleShareIndexProgressFrame, handleSharePrepareProgressFrame,
@@ -342,15 +342,21 @@ function initSwarm(_ipc, relaySeedHex = null) {
         // connection's Noise key. Gated before pendingRequesters.set so a spoofed request can't
         // capture a grant.
         if ((msg.type === 'handshake' || msg.type === 'membership:request') &&
-            !admitIdentityFrame(socket, peerInfo, remoteKey, msg)) return
+            !admitIdentityFrame(conn, msg)) return
 
         try {
-          dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler)
+          dispatchFrame(conn, msg)
         } catch (err) {
           log.error('handshake dispatch error:', err)
         }
       },
     })
+
+    // One live control connection: the socket, who is on the other end, the Noise key they are
+    // reached by, and the channel frames go out on. The frame path takes this whole rather than its
+    // fields. Declared after the channel because it carries the channel's handler; onmessage above
+    // closes over it and cannot run before channel.open() below.
+    const conn = { socket, peerInfo, remoteKey, msgHandler }
 
     // Let content backends bind extra protocol channels on THIS mux (overlay's
     // hyper-overlay/v2). Synchronous + before channel.open() — protomux won't pair
@@ -392,7 +398,8 @@ function initSwarm(_ipc, relaySeedHex = null) {
 // never starve the shared-space frame. Only matched frames pay for signature verification and
 // reach dispatch. Both lanes ban on a sustained flood. Returns false if the frame was
 // dropped/rejected.
-function admitIdentityFrame(socket, peerInfo, remoteKey, msg) {
+function admitIdentityFrame(conn, msg) {
+  const { socket, peerInfo, remoteKey } = conn
   if (testDrop) {
     const i = testDrop.seen++
     if (i >= testDrop.after && i < testDrop.after + testDrop.count) {
@@ -435,7 +442,8 @@ function admitIdentityFrame(socket, peerInfo, remoteKey, msg) {
 
 // A pending joiner has no drive/handshake yet, so remember its socket to deliver a grant later.
 // Bounded by the pendingRequesters cap; an already-tracked requester re-registering is allowed.
-function registerPendingRequester(socket, remoteKey, msg) {
+function registerPendingRequester(conn, msg) {
+  const { socket, remoteKey } = conn
   const cap = getResourceCaps().pendingRequesters
   if (!cap || pendingRequesters.size < cap || pendingRequesters.has(msg.profileKey)) {
     pendingRequesters.set(msg.profileKey, socket)
@@ -469,7 +477,8 @@ function registerPendingRequester(socket, remoteKey, msg) {
 // identity instead, and the membership control handler verifies it, because a grant arrives on the
 // connection the joiner opened. The content plane runs its own channel with one frame,
 // content-hello (content-swarm.js).
-function dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler) {
+function dispatchFrame(conn, msg) {
+  const { socket, peerInfo, msgHandler } = conn
   const reply = (payload) => { try { msgHandler.send(JSON.stringify(payload)) } catch {} }
   if (msg.type === 'handshake') {
     // Fire-and-forget: handleHandshake is async, so the synchronous try/catch around
@@ -489,7 +498,7 @@ function dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler) {
   } else if (msg.type === 'share-prepare-progress') {
     handleSharePrepareProgressFrame(socket, msg)
   } else if (msg.type.startsWith('membership:')) {
-    if (msg.type === 'membership:request' && msg.profileKey) registerPendingRequester(socket, remoteKey, msg)
+    if (msg.type === 'membership:request' && msg.profileKey) registerPendingRequester(conn, msg)
     membershipControlHandler?.(msg, { socket, peerInfo, reply })  // handler verifies a grant's identity binding + asserted root
   } else {
     countDroppedFrame('unknown')
@@ -943,15 +952,12 @@ export async function leaveSpaceTopic(spaceId) {
 function disconnectPeersFromSpace(spaceId) {
   for (const [key, peer] of connectedPeers) {
     if (!peer.spaces.has(spaceId)) continue
-    peer.spaces.delete(spaceId)
-    peer.looseCatalogKeys?.delete(spaceId)
-    if (peer.spaces.size === 0) {
-      try { peer.socket.destroy() } catch {}
-      // The overlay content channel rides the CONTENT socket, not this one. Dropping only the
-      // control socket leaves the bulk plane serving a space we have just left.
-      try { destroyContentPeerSockets(key) } catch {}
-      connectedPeers.delete(key)
-    }
+    if (!detachPeerFromSpace(peer, spaceId)) continue
+    try { peer.socket.destroy() } catch {}
+    // The overlay content channel rides the CONTENT socket, not this one. Dropping only the
+    // control socket leaves the bulk plane serving a space we have just left.
+    try { destroyContentPeerSockets(key) } catch {}
+    connectedPeers.delete(key)
   }
 }
 
@@ -1061,14 +1067,10 @@ export function getConnectedMemberMeta(spaceId, profileKeyHex) {
   return { driveKey: peer.spaces.get(spaceId) || null, looseCatalogKey: loose?.key || null, looseCatalogKeyEnc: loose?.keyEnc || null, displayName: peer.displayName, avatar: peer.avatar }
 }
 
-// The serve-authorization primitive, single-sourced so every serve path (the overlay's
-// authorizer) reuses it. socketToPeers holds only identities that passed the identity binding on
-// this socket, so this answers both "is the requester admitted here?" (owner side) and "did this
-// reply come from the owner?" (consumer side) — and it survives an owner reconnect because the
-// draining old socket keeps its entry until close, unlike a check against the single latest
-// connectedPeers socket.
+// The name the overlay's authorizer imports for authorizedOn (swarm-registries.js), which is where
+// the rule lives.
 export function senderAuthorizedOnSocket(socket, profileKeyHex) {
-  return !!socketToPeers.get(socket)?.has(profileKeyHex)
+  return authorizedOn(socket, profileKeyHex)
 }
 // The bound signer key a connected peer last asserted, for sealing a membership:grant to it.
 export function getBoundSignerKey(profileKeyHex) {

--- a/test/unit/swarm-registries.test.js
+++ b/test/unit/swarm-registries.test.js
@@ -1,0 +1,166 @@
+import test from 'brittle'
+import { readFileSync, readdirSync, statSync } from 'fs'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import {
+  connectedPeers,
+  socketToPeers,
+  socketMsgHandlers,
+  resetRegistries,
+  authorizedOn,
+  peersInSpace,
+  safeSend,
+  broadcastToSpace,
+  detachPeerFromSpace,
+  forgetPeerOnSocket,
+} from '../../src/shared/transfer/swarm-registries.js'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+
+function peer(socket, spaces, loose = []) {
+  return {
+    socket,
+    spaces: new Map(spaces.map((s) => [s, 'drive-' + s])),
+    looseCatalogKeys: new Map(loose.map((s) => [s, { key: 'k', keyEnc: 'e' }])),
+  }
+}
+
+function channel(sent, throws = false) {
+  return { send: (frame) => { if (throws) throw new Error('socket closing'); sent.push(frame) } }
+}
+
+test('authorizedOn answers only for an identity bound on THAT socket', (t) => {
+  resetRegistries()
+  const a = { id: 'a' }
+  const b = { id: 'b' }
+  socketToPeers.set(a, new Set(['key1']))
+
+  t.ok(authorizedOn(a, 'key1'), 'bound on this socket')
+  t.absent(authorizedOn(a, 'key2'), 'a different identity on the same socket')
+  t.absent(authorizedOn(b, 'key1'), 'the same identity on a different socket')
+  t.absent(authorizedOn(undefined, 'key1'), 'no socket is not authorized')
+})
+
+// An owner reconnect leaves two sockets carrying the same identity until the old one closes, and
+// both must answer true — a check against one current socket would deny the live one.
+test('authorizedOn stays true on a draining socket after a reconnect', (t) => {
+  resetRegistries()
+  const oldSock = { id: 'old' }
+  const newSock = { id: 'new' }
+  socketToPeers.set(oldSock, new Set(['owner']))
+  socketToPeers.set(newSock, new Set(['owner']))
+
+  t.ok(authorizedOn(oldSock, 'owner'), 'the draining socket still answers')
+  t.ok(authorizedOn(newSock, 'owner'), 'and so does the fresh one')
+})
+
+test('peersInSpace yields only the peers that share that space', (t) => {
+  resetRegistries()
+  connectedPeers.set('p1', peer({ id: 's1' }, ['space-a']))
+  connectedPeers.set('p2', peer({ id: 's2' }, ['space-a', 'space-b']))
+  connectedPeers.set('p3', peer({ id: 's3' }, ['space-b']))
+
+  t.alike([...peersInSpace('space-a')].map(([k]) => k), ['p1', 'p2'])
+  t.alike([...peersInSpace('space-b')].map(([k]) => k), ['p2', 'p3'])
+  t.alike([...peersInSpace('space-c')].map(([k]) => k), [], 'a space nobody is in')
+})
+
+test('safeSend reports whether a frame reached a channel', (t) => {
+  resetRegistries()
+  const sock = { id: 's1' }
+  const sent = []
+  const p = peer(sock, ['space-a'])
+
+  t.absent(safeSend(p, 'frame'), 'no channel for this socket yet')
+  socketMsgHandlers.set(sock, channel(sent))
+  t.ok(safeSend(p, 'frame'), 'sent once the channel is registered')
+  t.alike(sent, ['frame'])
+})
+
+// One unreachable peer must not cost the rest of the space its frame.
+test('a throwing channel does not abort the broadcast', (t) => {
+  resetRegistries()
+  const good = { id: 'good' }
+  const bad = { id: 'bad' }
+  const sent = []
+  connectedPeers.set('bad', peer(bad, ['space-a']))
+  connectedPeers.set('good', peer(good, ['space-a']))
+  socketMsgHandlers.set(bad, channel(sent, true))
+  socketMsgHandlers.set(good, channel(sent))
+
+  t.is(broadcastToSpace('space-a', 'frame'), 1, 'one of two reached a channel')
+  t.alike(sent, ['frame'], 'the healthy peer still got it')
+})
+
+test('broadcastToSpace sends once per peer in the space and to nobody else', (t) => {
+  resetRegistries()
+  const s1 = { id: 's1' }
+  const s2 = { id: 's2' }
+  const sent1 = []
+  const sent2 = []
+  connectedPeers.set('p1', peer(s1, ['space-a']))
+  connectedPeers.set('p2', peer(s2, ['space-b']))
+  socketMsgHandlers.set(s1, channel(sent1))
+  socketMsgHandlers.set(s2, channel(sent2))
+
+  t.is(broadcastToSpace('space-a', 'frame'), 1)
+  t.alike(sent1, ['frame'])
+  t.alike(sent2, [], 'a peer in another space is not a recipient')
+})
+
+test('detachPeerFromSpace drops the space and reports when none is left', (t) => {
+  resetRegistries()
+  const p = peer({ id: 's1' }, ['space-a', 'space-b'], ['space-a', 'space-b'])
+
+  t.absent(detachPeerFromSpace(p, 'space-a'), 'still in space-b')
+  t.absent(p.spaces.has('space-a'))
+  t.absent(p.looseCatalogKeys.has('space-a'), 'the loose catalog key goes with the space')
+
+  t.ok(detachPeerFromSpace(p, 'space-b'), 'now in no space at all')
+  t.is(p.spaces.size, 0)
+})
+
+test('detachPeerFromSpace tolerates a peer with no loose catalog map', (t) => {
+  const p = { socket: { id: 's1' }, spaces: new Map([['space-a', 'drive']]) }
+  t.ok(detachPeerFromSpace(p, 'space-a'))
+})
+
+test('forgetPeerOnSocket drops the socket entry only once no identity rides it', (t) => {
+  resetRegistries()
+  const sock = { id: 's1' }
+  socketToPeers.set(sock, new Set(['key1', 'key2']))
+
+  forgetPeerOnSocket(sock, 'key1')
+  t.ok(socketToPeers.has(sock), 'a second identity still rides this socket')
+  t.absent(authorizedOn(sock, 'key1'))
+
+  forgetPeerOnSocket(sock, 'key2')
+  t.absent(socketToPeers.has(sock), 'the last identity takes the entry with it')
+  forgetPeerOnSocket(sock, 'key2')
+  t.absent(socketToPeers.has(sock), 'and forgetting an unknown socket is a no-op')
+})
+
+// The authorization rule has one implementation. content-peer-sockets.js is exempt on purpose: the
+// identical-looking line there reads its OWN private socket→identities map for the content plane,
+// not the swarm's.
+test('no module re-inlines the authorization test', (t) => {
+  const root = path.join(here, '..', '..', 'src', 'shared')
+  const exempt = ['swarm-registries.js', 'content-peer-sockets.js']
+
+  const files = []
+  const walk = (dir) => {
+    for (const name of readdirSync(dir)) {
+      const p = path.join(dir, name)
+      if (statSync(p).isDirectory()) { if (name !== 'vendor') walk(p) }
+      else if (name.endsWith('.js') && !exempt.includes(name)) files.push(p)
+    }
+  }
+  walk(root)
+  t.ok(files.length > 50, `walked ${files.length} modules`)
+
+  for (const file of files) {
+    const src = readFileSync(file, 'utf8')
+    t.absent(/socketToPeers\.get\([^)]*\)\?\.has\(/.test(src),
+      `${path.relative(root, file)} calls authorizedOn rather than re-testing socketToPeers`)
+  }
+})


### PR DESCRIPTION
Box 2.7 of #233. Three of the requested names landed, three did not, and the box's central premise
turned out to be wrong — details below, because it changes what #233 should still claim.

**Landed in `swarm-registries.js`:** `authorizedOn`, `peersInSpace` + `safeSend` + `broadcastToSpace`,
`detachPeerFromSpace` + `forgetPeerOnSocket`. Plus a `conn` object for the control frame path,
collapsing `dispatchFrame(socket, peerInfo, remoteKey, msg, msgHandler)` and its two 3–4 positional
relatives to `(conn, msg)`.

### The three evictions should not be merged

The box reads them as "three different answers to what else must be forgotten". They are three
different **events**: the socket died, WE left a space, THEY left a space. Merging the follow-through
would either destroy a socket that is still carrying another space or leave a dead one indexed. What
they genuinely share is the index mutation, which is now `detachPeerFromSpace`; each caller keeps its
own follow-through, and the reason is stated next to it.

Worth knowing while reading that: when we leave a space and a peer becomes spaceless,
`disconnectPeersFromSpace` deletes it from `connectedPeers` **before** destroying the socket, so
`handleDisconnect` hits `if (!peer) continue` and its `presence.clear` / `boundSignerKeys.delete`
never run for that peer. Presence self-heals on its 15s lease; a `boundSignerKeys` entry survives
until that peer reconnects. Deliberately **not** changed here — behaviour is identical to `staging`,
and a fix belongs in its own red-first PR.

### Corrected counts

- **Auth guards: 5 inlined copies, not 7.** Of the seven, one was already the canonical
  `senderAuthorizedOnSocket` and one is `content-peer-sockets.js` — which reads its **own private**
  socket→identities map for the content plane. It looks identical and is not a duplicate; the ratchet
  exempts it and says why.
- **Fan-out loops: 4 collapse, not 9.** The other five iterate `socketMsgHandlers` — every connected
  socket, not a space's members — and each needs the socket identity to record per-socket ack
  eligibility or send handshakes. Different shape; a helper would not serve them.
- **`peerEntryFor` not added.** It would be a wrapper over `connectedPeers.get` that adds nothing.
- **`handlersInSpace` not added.** `broadcastToSpace` is what its callers wanted.
- **`forgetPeerInSpace` not added**, per the eviction finding above.

### Verification

No behaviour change intended. `tsc` + `lint:ci` clean; 10 new unit tests (209 asserts) and the seven
existing presence/leave/swarm unit files pass. Flow, targeted: `membership-presence`,
`share-index-progress`, `share-prepare-progress`, `membership-approval`, `identity-binding`,
`leave-drops-coapproved-member`, `leave-multi-space-content-plane`, `quit-announces-offline` — all
pass, each run checked for planned-vs-executed count.

The ratchet was verified by re-inlining a guard and watching it fail. (My first attempt to break it
used a `sed` that silently changed nothing and the test passed — worth knowing that a
"guard didn't fire" result needs the file diffed before it is believed.)
