### PR TITLE
[chore] Give the status vocabularies a name for each value

### DIFF
--- a/src/renderer/mirrorSync.js
+++ b/src/renderer/mirrorSync.js
@@ -8,7 +8,9 @@
 // The percentage is dropped when the listing is truncated: past the cap the rows are a capped
 // sample, so bytes-on-device over bytes-total would be computed from a subset and read low.
 
-const ON_DEVICE = new Set(['downloaded', 'synced'])
+import { ON_DEVICE_STATUSES } from '../shared/contract/statuses.js'
+
+const ON_DEVICE = new Set(ON_DEVICE_STATUSES)
 
 export function deriveMirrorSync(files, opts = {}) {
   const truncated = !!opts.truncated

--- a/src/renderer/ownedMount.js
+++ b/src/renderer/ownedMount.js
@@ -5,10 +5,12 @@
 // The badge projection of an owned mount's durable state: a live missing path wins, then any
 // persisted non-healthy status (paused-error / mount-point-gone survive a restart); healthy states
 // (active / scanning) render no badge.
+
+import { MOUNT_STATUS, HEALTHY_OWNED_STATUSES } from '../shared/contract/statuses.js'
 export function unhealthyOwnedStatus(m) {
   if (!m) return null
-  if (m.mountPointMissing) return 'mount-point-gone'
-  if (m.status && m.status !== 'active' && m.status !== 'scanning') return m.status
+  if (m.mountPointMissing) return MOUNT_STATUS.MOUNT_POINT_GONE
+  if (m.status && !HEALTHY_OWNED_STATUSES.includes(m.status)) return m.status
   return null
 }
 

--- a/src/renderer/rowView.js
+++ b/src/renderer/rowView.js
@@ -9,14 +9,15 @@
 // count.
 //
 // Status is worker-derived; this only decorates. It never reads or writes IPC.
+
+import { ON_DEVICE_STATUSES } from '../shared/contract/statuses.js'
 import { badgeStyle, fileStatusToBadge, shareFileStatusToBadge } from './statusBadge.js'
 
 const pct = (bytes, total) => (total > 0 ? Math.min(100, Math.round((bytes / total) * 100)) : 0)
 
-// "The bytes are on this device." 'downloaded' is on both vocabularies; 'synced' is share-only and
-// is a mirror's terminal state. Naming both here is what lets ONE showVerified rule serve both
-// kinds — gating on 'downloaded' alone would hide the check on every mirrored row.
-const ON_DEVICE = new Set(['downloaded', 'synced'])
+// One showVerified rule serves both vocabularies: gating on 'downloaded' alone would hide the check
+// on every mirrored row, whose terminal state is 'synced'.
+const ON_DEVICE = new Set(ON_DEVICE_STATUSES)
 
 // The stand-in frame for a row whose download was just requested and whose first real frame has not
 // arrived. Shaped exactly like a decoration — `eta: null` above all, which is what makes the bar

--- a/src/renderer/types.ts
+++ b/src/renderer/types.ts
@@ -1,4 +1,4 @@
-import type { FILE_STATUS, BADGE_STATUS, SHARE_FILE_STATUS, OWNED_MOUNT_STATUS, FOREIGN_MOUNT_STATUS } from '../shared/contract/statuses.js'
+import type { FILE_STATUSES, BADGE_STATUSES, SHARE_FILE_STATUSES, OWNED_MOUNT_STATUSES, FOREIGN_MOUNT_STATUSES, MIRROR_STATES } from '../shared/contract/statuses.js'
 import type { CATEGORIES, OUTCOMES, ACTOR_TYPES, TARGET_KINDS } from '../shared/contract/audit-kinds.js'
 export interface Profile {
   displayName: string
@@ -52,9 +52,9 @@ export interface Space {
   downloadFolder?: string
 }
 
-export type FileStatus = (typeof FILE_STATUS)[number]
+export type FileStatus = (typeof FILE_STATUSES)[number]
 
-export type BadgeStatus = (typeof BADGE_STATUS)[number]
+export type BadgeStatus = (typeof BADGE_STATUSES)[number]
 
 export interface FileEntry {
   path: string
@@ -99,7 +99,7 @@ export interface PeerDownloadPeer {
 export interface MirrorParticipant {
   mirrorer: string
   shareId: string
-  state: 'syncing' | 'synced' | 'paused'
+  state: (typeof MIRROR_STATES)[number]
   mountedAt: number
 }
 
@@ -120,7 +120,7 @@ export interface Share {
   deletedAt?: number
 }
 
-type OwnedMountStatus = (typeof OWNED_MOUNT_STATUS)[number]
+type OwnedMountStatus = (typeof OWNED_MOUNT_STATUSES)[number]
 
 export interface OwnedFolderMount {
   spaceId: string
@@ -134,7 +134,7 @@ export interface OwnedFolderMount {
   indexPaused?: boolean
 }
 
-export type ForeignMountStatus = (typeof FOREIGN_MOUNT_STATUS)[number]
+export type ForeignMountStatus = (typeof FOREIGN_MOUNT_STATUSES)[number]
 
 export interface ForeignFolderMount {
   spaceId: string
@@ -147,7 +147,7 @@ export interface ForeignFolderMount {
   lastError?: string | null
 }
 
-export type ShareFileStatus = (typeof SHARE_FILE_STATUS)[number]
+export type ShareFileStatus = (typeof SHARE_FILE_STATUSES)[number]
 
 export interface ShareFileEntry {
   relPath: string

--- a/src/shared/contract/mount-fault.js
+++ b/src/shared/contract/mount-fault.js
@@ -5,11 +5,12 @@
 //
 // The errno half (which errno IS a fault) stays in the worker: it needs core/errors.js, and this
 // package imports nothing outside itself.
+import { MOUNT_STATUS } from './statuses.js'
 import { CODES } from './errors.js'
 
-const STATUS_ENOSPC = 'paused-enospc'
-const STATUS_IO_ERROR = 'paused-error'
-export const STATUS_MOUNT_GONE = 'mount-point-gone'
+const STATUS_ENOSPC = MOUNT_STATUS.PAUSED_ENOSPC
+const STATUS_IO_ERROR = MOUNT_STATUS.PAUSED_ERROR
+export const STATUS_MOUNT_GONE = MOUNT_STATUS.MOUNT_POINT_GONE
 
 // The automatic (recoverable) pause statuses. A user pause ('paused') is deliberately absent: it
 // is a decision, and nothing but an explicit resume may lift it.

--- a/src/shared/contract/statuses.d.ts
+++ b/src/shared/contract/statuses.d.ts
@@ -1,8 +1,16 @@
 // Literal tuples, not string[]: the renderer derives its unions from these with (typeof X)[number],
 // so a widened declaration would silently turn an exhaustive switch into `string`.
 // Generated from statuses.js — contract-declarations.test.js asserts the two agree.
-export declare const FILE_STATUS: readonly ['mine', 'downloaded', 'remote', 'preparing', 'downloading', 'verifying', 'publishing', 'paused-interrupted', 'paused-offline', 'unavailable', 'error']
-export declare const BADGE_STATUS: readonly ['mine', 'on-device', 'available', 'downloading', 'verifying', 'preparing', 'publishing', 'paused', 'owner-offline', 'unavailable', 'error']
-export declare const SHARE_FILE_STATUS: readonly ['remote', 'preparing', 'downloading', 'verifying', 'publishing', 'downloaded', 'synced', 'unavailable', 'paused-interrupted', 'paused-offline', 'error']
-export declare const OWNED_MOUNT_STATUS: readonly ['scanning', 'active', 'paused', 'paused-enospc', 'paused-error', 'mount-point-gone']
-export declare const FOREIGN_MOUNT_STATUS: readonly ['idle', 'scanning', 'active', 'paused', 'paused-enospc', 'paused-error', 'mount-point-gone']
+export declare const FILE_STATUS: Readonly<{ MINE: 'mine'; DOWNLOADED: 'downloaded'; REMOTE: 'remote'; PREPARING: 'preparing'; DOWNLOADING: 'downloading'; VERIFYING: 'verifying'; PUBLISHING: 'publishing'; PAUSED_INTERRUPTED: 'paused-interrupted'; PAUSED_OFFLINE: 'paused-offline'; UNAVAILABLE: 'unavailable'; ERROR: 'error' }>
+export declare const BADGE_STATUS: Readonly<{ MINE: 'mine'; ON_DEVICE: 'on-device'; AVAILABLE: 'available'; DOWNLOADING: 'downloading'; VERIFYING: 'verifying'; PREPARING: 'preparing'; PUBLISHING: 'publishing'; PAUSED: 'paused'; OWNER_OFFLINE: 'owner-offline'; UNAVAILABLE: 'unavailable'; ERROR: 'error' }>
+export declare const SHARE_FILE_STATUS: Readonly<{ REMOTE: 'remote'; PREPARING: 'preparing'; DOWNLOADING: 'downloading'; VERIFYING: 'verifying'; PUBLISHING: 'publishing'; DOWNLOADED: 'downloaded'; SYNCED: 'synced'; UNAVAILABLE: 'unavailable'; PAUSED_INTERRUPTED: 'paused-interrupted'; PAUSED_OFFLINE: 'paused-offline'; ERROR: 'error' }>
+export declare const MOUNT_STATUS: Readonly<{ IDLE: 'idle'; SCANNING: 'scanning'; ACTIVE: 'active'; PAUSED: 'paused'; PAUSED_ENOSPC: 'paused-enospc'; PAUSED_ERROR: 'paused-error'; MOUNT_POINT_GONE: 'mount-point-gone' }>
+export declare const MIRROR_STATE: Readonly<{ SYNCING: 'syncing'; SYNCED: 'synced'; PAUSED: 'paused' }>
+export declare const FILE_STATUSES: readonly ['mine', 'downloaded', 'remote', 'preparing', 'downloading', 'verifying', 'publishing', 'paused-interrupted', 'paused-offline', 'unavailable', 'error']
+export declare const BADGE_STATUSES: readonly ['mine', 'on-device', 'available', 'downloading', 'verifying', 'preparing', 'publishing', 'paused', 'owner-offline', 'unavailable', 'error']
+export declare const SHARE_FILE_STATUSES: readonly ['remote', 'preparing', 'downloading', 'verifying', 'publishing', 'downloaded', 'synced', 'unavailable', 'paused-interrupted', 'paused-offline', 'error']
+export declare const OWNED_MOUNT_STATUSES: readonly ['scanning', 'active', 'paused', 'paused-enospc', 'paused-error', 'mount-point-gone']
+export declare const FOREIGN_MOUNT_STATUSES: readonly ['idle', 'scanning', 'active', 'paused', 'paused-enospc', 'paused-error', 'mount-point-gone']
+export declare const MIRROR_STATES: readonly ['syncing', 'synced', 'paused']
+export declare const ON_DEVICE_STATUSES: readonly ['downloaded', 'synced']
+export declare const HEALTHY_OWNED_STATUSES: readonly ['active', 'scanning']

--- a/src/shared/contract/statuses.js
+++ b/src/shared/contract/statuses.js
@@ -1,47 +1,68 @@
-// The status vocabularies the worker produces and the renderer renders. Frozen arrays rather than
-// TypeScript unions so all three runtimes can read them; types.ts derives its unions from these.
+// The status vocabularies the worker produces and the renderer renders. Each is a name→value
+// object so a producer imports the spelling instead of writing it, beside a frozen tuple that is
+// Object.values of that object — the tuple is what types.ts derives its unions from, and deriving
+// it here is what keeps the two from disagreeing.
 
-export const FILE_STATUS = Object.freeze([
-  'mine',
-  'downloaded',
-  'remote',
-  'preparing',
-  'downloading',
-  'verifying',
-  'publishing',
-  'paused-interrupted',
-  'paused-offline',
-  'unavailable',
-  'error',
-])
+export const FILE_STATUS = Object.freeze({
+  MINE: 'mine',
+  DOWNLOADED: 'downloaded',
+  REMOTE: 'remote',
+  PREPARING: 'preparing',
+  DOWNLOADING: 'downloading',
+  VERIFYING: 'verifying',
+  PUBLISHING: 'publishing',
+  PAUSED_INTERRUPTED: 'paused-interrupted',
+  PAUSED_OFFLINE: 'paused-offline',
+  UNAVAILABLE: 'unavailable',
+  ERROR: 'error',
+})
 
-export const BADGE_STATUS = Object.freeze([
-  'mine',
-  'on-device',
-  'available',
-  'downloading',
-  'verifying',
-  'preparing',
-  'publishing',
-  'paused',
-  'owner-offline',
-  'unavailable',
-  'error',
-])
+export const BADGE_STATUS = Object.freeze({
+  MINE: 'mine',
+  ON_DEVICE: 'on-device',
+  AVAILABLE: 'available',
+  DOWNLOADING: 'downloading',
+  VERIFYING: 'verifying',
+  PREPARING: 'preparing',
+  PUBLISHING: 'publishing',
+  PAUSED: 'paused',
+  OWNER_OFFLINE: 'owner-offline',
+  UNAVAILABLE: 'unavailable',
+  ERROR: 'error',
+})
 
-export const SHARE_FILE_STATUS = Object.freeze([
-  'remote',
-  'preparing',
-  'downloading',
-  'verifying',
-  'publishing',
-  'downloaded',
-  'synced',
-  'unavailable',
-  'paused-interrupted',
-  'paused-offline',
-  'error',
-])
+export const SHARE_FILE_STATUS = Object.freeze({
+  REMOTE: 'remote',
+  PREPARING: 'preparing',
+  DOWNLOADING: 'downloading',
+  VERIFYING: 'verifying',
+  PUBLISHING: 'publishing',
+  DOWNLOADED: 'downloaded',
+  SYNCED: 'synced',
+  UNAVAILABLE: 'unavailable',
+  PAUSED_INTERRUPTED: 'paused-interrupted',
+  PAUSED_OFFLINE: 'paused-offline',
+  ERROR: 'error',
+})
+
+export const FILE_STATUSES = Object.freeze(Object.values(FILE_STATUS))
+export const BADGE_STATUSES = Object.freeze(Object.values(BADGE_STATUS))
+export const SHARE_FILE_STATUSES = Object.freeze(Object.values(SHARE_FILE_STATUS))
+
+// The file statuses that mean the bytes are on this disk. A caller asking "is it here?" asks this
+// rather than naming the two members, which is how the renderer came to hold two copies of the set.
+export const ON_DEVICE_STATUSES = Object.freeze([SHARE_FILE_STATUS.DOWNLOADED, SHARE_FILE_STATUS.SYNCED])
+
+// A mirror record's sync state, which is not a mount status: it is what the OWNER and every member
+// see about a mirror, replicated in the mirror record, while a mount status is local to the device
+// that holds the mount.
+export const MIRROR_STATE = Object.freeze({
+  SYNCING: 'syncing',
+  SYNCED: 'synced',
+  PAUSED: 'paused',
+})
+
+export const MIRROR_STATES = Object.freeze(Object.values(MIRROR_STATE))
 
 // A mount's durable status, per role. Two vocabularies rather than one: 'idle' is a mirror-only
 // state, and the two roles mean different things by a fault — a mirror's pause stops its loop,
@@ -62,21 +83,29 @@ export const SHARE_FILE_STATUS = Object.freeze([
 // recorded there would be lost at the next settle — and `lastError` is the code a fault status
 // names itself by. folders/mount-store.js is the only write path; folders/foreign-folders.js and
 // worker/mounts-runtime.js are the callers that decide.
-export const OWNED_MOUNT_STATUS = Object.freeze([
-  'scanning',
-  'active',
-  'paused',
-  'paused-enospc',
-  'paused-error',
-  'mount-point-gone',
+export const MOUNT_STATUS = Object.freeze({
+  IDLE: 'idle',
+  SCANNING: 'scanning',
+  ACTIVE: 'active',
+  PAUSED: 'paused',
+  PAUSED_ENOSPC: 'paused-enospc',
+  PAUSED_ERROR: 'paused-error',
+  MOUNT_POINT_GONE: 'mount-point-gone',
+})
+
+// Listed rather than derived: 'idle' is mirror-only, so the owned tuple is a deliberate subset of
+// the object above and not all of it.
+export const OWNED_MOUNT_STATUSES = Object.freeze([
+  MOUNT_STATUS.SCANNING,
+  MOUNT_STATUS.ACTIVE,
+  MOUNT_STATUS.PAUSED,
+  MOUNT_STATUS.PAUSED_ENOSPC,
+  MOUNT_STATUS.PAUSED_ERROR,
+  MOUNT_STATUS.MOUNT_POINT_GONE,
 ])
 
-export const FOREIGN_MOUNT_STATUS = Object.freeze([
-  'idle',
-  'scanning',
-  'active',
-  'paused',
-  'paused-enospc',
-  'paused-error',
-  'mount-point-gone',
-])
+export const FOREIGN_MOUNT_STATUSES = Object.freeze(Object.values(MOUNT_STATUS))
+
+// The owned statuses that mean nothing is wrong. A row shows a status only when it is not one of
+// these, so the pair is a vocabulary rather than two comparisons at each caller.
+export const HEALTHY_OWNED_STATUSES = Object.freeze([MOUNT_STATUS.ACTIVE, MOUNT_STATUS.SCANNING])

--- a/src/shared/folders/foreign-folders.js
+++ b/src/shared/folders/foreign-folders.js
@@ -4,6 +4,7 @@
 // the overlay backend and land as partials that rename into place; deletions are
 // honored only for files the mirror itself wrote (syncedPaths) and only while the
 // owner is provably online, so a lagged replica or a user's own files are never wiped.
+import { MOUNT_STATUS, MIRROR_STATE } from '../contract/statuses.js'
 import fs from 'bare-fs'
 import path from 'bare-path'
 import { shouldHonorDeletions, relKeyEscapes, dropUnsafeEntries, conflictCopyName, driveKeyToSegments } from './path-keys.js'
@@ -163,7 +164,7 @@ async function pauseMount(mount, status, reason) {
   // generation is bumped — the last point lets an in-progress scan bail before it would
   // otherwise overwrite this pause with a trailing status:'active'.
   stopForeignLoop(mount.spaceId, mount.shareId)
-  await syncMirrorRecord(mount.spaceId, mount.shareId, () => setMirrorState(mount.spaceId, mount.shareId, 'paused'))
+  await syncMirrorRecord(mount.spaceId, mount.shareId, () => setMirrorState(mount.spaceId, mount.shareId, MIRROR_STATE.PAUSED))
   emitStatus(mount.spaceId, mount.shareId, status, reason ? { error: reason } : null)
 }
 
@@ -708,17 +709,17 @@ async function initialMaterializeScanCatalog(mount, share) {
     for (const ownerKey of [...synced]) if (!listed.has(ownerKey)) state.forgetSynced(key, synced, ownerKey)
     mount.initialScanCompletedAt = Date.now()
   }
-  mount.status = 'active'
+  mount.status = MOUNT_STATUS.ACTIVE
   await patchForeignMount(mount.spaceId, mount.shareId, {
     ...state.syncFields(mount),
-    status: 'active',
+    status: MOUNT_STATUS.ACTIVE,
     // A pass that got through clears the reason with the status: a stale one would name the next
     // fault that records none.
     lastError: null,
     ...(listingComplete ? { initialScanCompletedAt: mount.initialScanCompletedAt } : {}),
   })
   state.markClean(key)
-  emitStatus(mount.spaceId, mount.shareId, 'active')
+  emitStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.ACTIVE)
   // Skip the terminal state on an empty or partial listing: at mount the owner's catalog may not
   // have replicated yet, and publishing 'synced' with zero (or truncated) entries would falsely
   // show a fully-merged mirror. A genuinely-empty share settles to 'synced' on a later tick. The
@@ -995,7 +996,7 @@ export async function unmountForeignFolder(spaceId, shareId) {
   await deleteForeignMount(spaceId, shareId)
   resetForeignSyncState(spaceId, shareId)
   await syncMirrorRecord(spaceId, shareId, () => tombstoneMirror(spaceId, shareId))
-  emitStatus(spaceId, shareId, 'idle')
+  emitStatus(spaceId, shareId, MOUNT_STATUS.IDLE)
   ipcRef?.emit('event:share-files-updated', { spaceId, shareId })
 }
 
@@ -1015,7 +1016,7 @@ export async function relocateForeignFolder(spaceId, shareId, mountPath) {
   // ('mount-point-gone', 'paused-enospc') into a plain user 'paused' would take it out of the
   // auto-pause set and permanently disable the auto-resume that exists to rescue exactly the
   // mirrors this verb is used on.
-  const status = enabled ? 'scanning' : (mount.status ?? 'paused')
+  const status = enabled ? MOUNT_STATUS.SCANNING : (mount.status ?? MOUNT_STATUS.PAUSED)
   // A read-merge, never a whole-object write-back: the snapshot above predates this await, so
   // putting it back would resurrect an `enabled`/`status` a concurrent pause had already written.
   const patched = await patchForeignMount(spaceId, shareId, { mountPath, status, syncedPaths: [], renamedPaths: {} })
@@ -1044,12 +1045,12 @@ export async function setForeignEnabled(spaceId, shareId, enabled) {
   if (!mount) throw new AppError(CODES.MOUNT_NOT_ON_DEVICE, 'Mount not found')
   const wasEnabled = mount.enabled !== false
   mount.enabled = enabled
-  mount.status = enabled ? 'active' : 'paused'
+  mount.status = enabled ? MOUNT_STATUS.ACTIVE : MOUNT_STATUS.PAUSED
   if (enabled) mount.lastError = null
   await mutateForeignMount(spaceId, shareId, (m) => ({
     ...m,
     enabled,
-    status: enabled ? 'active' : 'paused',
+    status: enabled ? MOUNT_STATUS.ACTIVE : MOUNT_STATUS.PAUSED,
     ...(enabled ? { lastError: null } : {}),
     ...state.syncFields(m),
   }))
@@ -1065,7 +1066,7 @@ export async function setForeignEnabled(spaceId, shareId, enabled) {
     }
   } else {
     stopForeignLoop(spaceId, shareId)
-    await syncMirrorRecord(spaceId, shareId, () => setMirrorState(spaceId, shareId, 'paused'))
+    await syncMirrorRecord(spaceId, shareId, () => setMirrorState(spaceId, shareId, MIRROR_STATE.PAUSED))
   }
   emitStatus(spaceId, shareId, mount.status)
   return mount

--- a/src/shared/folders/mirror-records.js
+++ b/src/shared/folders/mirror-records.js
@@ -4,6 +4,7 @@
 // a durable, replicated fact that survives the owner being offline. Removal is a soft tombstone
 // (unmirroredAt) so a reader tells "stopped mirroring" apart from "not replicated yet". Peers' rows
 // are read cap-gated with bounded reads, so an offline member can't stall a caller.
+import { MIRROR_STATE } from '../contract/statuses.js'
 import { getProfileBee, withPeerBee } from '../spaces/profile.js'
 import { withReadTimeout, peerReadTimeoutMs } from '../core/with-timeout.js'
 import { createLogger } from '../core/logger.js'
@@ -34,7 +35,7 @@ export async function ensureFolderMirrorsCap() {
   if (!entry?.value) await bee.put(MIRRORS_CAP, true)
 }
 
-export function publishMirror(spaceId, shareId, { state = 'syncing', mountedAt = Date.now() } = {}) {
+export function publishMirror(spaceId, shareId, { state = MIRROR_STATE.SYNCING, mountedAt = Date.now() } = {}) {
   const key = keyFor(spaceId, shareId)
   return serialize(key, async () => {
     await ensureFolderMirrorsCap()
@@ -46,7 +47,7 @@ export function publishMirror(spaceId, shareId, { state = 'syncing', mountedAt =
 // Create the record only if it is absent or tombstoned — used by boot resume so a mount that
 // predates this feature (or whose mount-time publish failed) still gains a participation record,
 // without re-stamping (and re-broadcasting) a healthy one on every restart.
-export function ensureMirror(spaceId, shareId, { state = 'syncing', mountedAt = Date.now() } = {}) {
+export function ensureMirror(spaceId, shareId, { state = MIRROR_STATE.SYNCING, mountedAt = Date.now() } = {}) {
   const key = keyFor(spaceId, shareId)
   return serialize(key, async () => {
     const bee = getProfileBee()

--- a/src/shared/folders/owned-folders.js
+++ b/src/shared/folders/owned-folders.js
@@ -3,6 +3,7 @@
 // periodic reconcile — computes a diff and enqueues work items on the shared publish service; the
 // folder channel registered here resolves, publishes and retires them. A missing mount root always
 // pauses publishing instead of tombstoning the catalog.
+import { MOUNT_STATUS } from '../contract/statuses.js'
 import path from 'bare-path'
 import { ignorePathsFor, clearShareGuards } from './echo-guard.js'
 import { getOwnedMount, touchOwnedMountScan, findOwnedMountByShareId } from './mount-store.js'
@@ -312,7 +313,7 @@ export async function onFsEvent(spaceId, shareId, action, relPath, absPath) {
   })
   const outcome = await settled
   if (outcome.result?.outcome === 'skipped-root-gone') {
-    ipcRef?.emit('event:owned-folder-mount-status', { spaceId, shareId, status: 'mount-point-gone' })
+    ipcRef?.emit('event:owned-folder-mount-status', { spaceId, shareId, status: MOUNT_STATUS.MOUNT_POINT_GONE })
   }
   return outcome
 }
@@ -436,8 +437,8 @@ async function diffAndEnqueue(spaceId, shareId, { mountPath, ignore, deep, defer
   // loop restarts us when the path returns.
   if (!mountRootAvailable(mountPath)) {
     log.warn('mount path unavailable, skipping reconcile:', mountPath)
-    ipcRef?.emit('event:owned-folder-mount-status', { spaceId, shareId, status: 'mount-point-gone' })
-    return { skipped: 'mount-point-gone', totalOnDisk: 0 }
+    ipcRef?.emit('event:owned-folder-mount-status', { spaceId, shareId, status: MOUNT_STATUS.MOUNT_POINT_GONE })
+    return { skipped: MOUNT_STATUS.MOUNT_POINT_GONE, totalOnDisk: 0 }
   }
   if (isUnsupportedShare(share)) {
     log.warn('skipping scan for unsupported content mode:', share.contentMode, shareId)

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -9,6 +9,7 @@
 // resume passes and the periodic backstops — is constructed and started by the composition root
 // in ./boot.js, whose returned `root.close()` is the whole stop sequence. ipc.start() runs after
 // every handler is registered, so no frame is dispatched before its handler exists.
+import { MOUNT_STATUS } from '../shared/contract/statuses.js'
 import os from 'bare-os'
 import b4a from 'b4a'
 import crypto from 'hypercore-crypto'
@@ -1037,7 +1038,7 @@ async function mountOwnedShare(spaceId, share, validated, requestedIgnore) {
   // Seed the probe baseline so the first mount-point tick doesn't read this brand-new mount as a
   // gone→present transition (which would otherwise run against an unseeded key).
   mounts.lastMountPointStatus.set('owned-folder:' + shareId, mountRootAvailable(mountPath))
-  await mounts.setOwnedStatus(spaceId, shareId, 'scanning')
+  await mounts.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.SCANNING)
 
   ipc.emit(MAIN_REQUEST_FRAME, {
     command: MAIN_REQUEST.OWNED_FOLDER_START_WATCHER,
@@ -1116,7 +1117,7 @@ ipc.handle('owned-folder:relocate', async (msg) => {
   mount.mountPath = mountPath
   mounts.lastMountPointStatus.set('owned-folder:' + msg.shareId, true)
 
-  await mounts.setOwnedStatus(msg.spaceId, msg.shareId, mount.indexPaused ? 'paused' : 'scanning')
+  await mounts.setOwnedStatus(msg.spaceId, msg.shareId, mount.indexPaused ? MOUNT_STATUS.PAUSED : MOUNT_STATUS.SCANNING)
   ipc.emit(MAIN_REQUEST_FRAME, {
     command: MAIN_REQUEST.OWNED_FOLDER_START_WATCHER,
     args: { shareId: msg.shareId, mountPath, ignore: mount.ignore },
@@ -1228,10 +1229,10 @@ ipc.handle('foreign-folder:mount', async (msg) => {
     mountPath,
     enabled: true,
     attachedAt: Date.now(),
-    status: 'scanning',
+    status: MOUNT_STATUS.SCANNING,
   }
   await persistForeignMount(mount)
-  ipc.emit('event:foreign-folder-mount-status', { spaceId: msg.spaceId, shareId: msg.shareId, status: 'scanning' })
+  ipc.emit('event:foreign-folder-mount-status', { spaceId: msg.spaceId, shareId: msg.shareId, status: MOUNT_STATUS.SCANNING })
   try { await publishMirror(msg.spaceId, msg.shareId, { state: 'syncing' }) }
   catch (err) { log.warn('mirror record publish failed:', msg.shareId, '-', err.message) }
   ipc.emit('event:mirrors-updated', { spaceId: msg.spaceId, shareId: msg.shareId })

--- a/src/worker/mounts-runtime.js
+++ b/src/worker/mounts-runtime.js
@@ -3,6 +3,7 @@
 // timers, the resume passes for both mount kinds, and the probe that notices a mount point or a
 // download root appearing or disappearing. A Subsystem: the maps are instance state, the probe
 // rides `this.timers`, and _close is the bulk stop.
+import { MOUNT_STATUS, MIRROR_STATE } from '../shared/contract/statuses.js'
 import fs from 'bare-fs'
 import { Subsystem } from '../shared/core/subsystem.js'
 import { getDeepReconcileEvery } from '../shared/core/runtime-config.js'
@@ -66,7 +67,7 @@ export class MountsRuntime extends Subsystem {
         if (!mountRootAvailable(mount.mountPath)) {
           this.log.warn('owned mount path missing at startup:', mount.mountPath)
           this.lastMountPointStatus.set('owned-folder:' + mount.shareId, false)
-          await this.setOwnedStatus(mount.spaceId, mount.shareId, 'mount-point-gone')
+          await this.setOwnedStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
           continue
         }
         this.lastMountPointStatus.set('owned-folder:' + mount.shareId, true)
@@ -80,7 +81,7 @@ export class MountsRuntime extends Subsystem {
         // The scan would decline itself anyway, but an interval that can never do work reads as a
         // bug later. Re-assert the status so a restart repaints the badge from the durable record.
         if (mount.indexPaused) {
-          await this.setOwnedStatus(mount.spaceId, mount.shareId, 'paused')
+          await this.setOwnedStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.PAUSED)
           continue
         }
         this.armCatchUpScan(mount.spaceId, mount.shareId, mount)
@@ -103,7 +104,7 @@ export class MountsRuntime extends Subsystem {
         // Backfill a participation record for a mount that predates this feature (or whose mount-time
         // publish failed): only the fresh-mount handler publishes, and setMirrorState can't create one,
         // so without this a restored mirror stays invisible to owners forever.
-        await ensureMirror(mount.spaceId, mount.shareId, { state: mount.enabled === false ? 'paused' : 'syncing' })
+        await ensureMirror(mount.spaceId, mount.shareId, { state: mount.enabled === false ? MIRROR_STATE.PAUSED : MIRROR_STATE.SYNCING })
           .catch((err) => this.log.debug('mirror record ensure at boot failed for', mount.shareId, '-', err.message))
         if (!mount.enabled) {
           // Auto-paused mirrors (mount-point-gone / enospc / perm) recover at boot if the
@@ -164,7 +165,7 @@ export class MountsRuntime extends Subsystem {
     this.cancelPeriodicReconcile(spaceId, shareId)
     // A vanished root makes chokidar emit one unlink per file; every queued retire dies with it.
     stopOwnedFolder(spaceId, shareId)
-    await this.setOwnedStatus(spaceId, shareId, 'mount-point-gone')
+    await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
   }
 
   // Map a reconcile/scan outcome to the durable owned-mount status. A scan RESOLVES (not rejects)
@@ -178,16 +179,16 @@ export class MountsRuntime extends Subsystem {
     try {
       const result = await promise
       if (result?.cancelled) return result
-      if (result?.skipped === 'mount-point-gone') await this.handleOwnedMountGone(spaceId, shareId)
+      if (result?.skipped === MOUNT_STATUS.MOUNT_POINT_GONE) await this.handleOwnedMountGone(spaceId, shareId)
       // A paused index is a decision, not a fault: it carries no lastError and must not reach the
       // paused-error branch below, which raises an error toast and an unhealthy badge.
-      else if (result?.skipped === 'index-paused') await this.setOwnedStatus(spaceId, shareId, 'paused')
-      else if (result?.skipped) await this.setOwnedStatus(spaceId, shareId, 'paused-error', result.skipped)
+      else if (result?.skipped === 'index-paused') await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.PAUSED)
+      else if (result?.skipped) await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.PAUSED_ERROR, result.skipped)
       // A pass whose items failed on a classified fault is not a healthy scan. The pass resolving
       // does not mean its files reached the catalog — publish failures are per item — and reading
       // that resolution as 'active' is what made a full disk invisible to the owner.
       else if (result?.faultCode) await this.setOwnedStatus(spaceId, shareId, statusForFaultCode(result.faultCode), result.faultCode)
-      else await this.setOwnedStatus(spaceId, shareId, 'active')
+      else await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.ACTIVE)
       return result
     } catch (err) {
       this.log.warn('owned reconcile failed for', shareId, '-', err.message)
@@ -215,7 +216,7 @@ export class MountsRuntime extends Subsystem {
         return
       }
     }
-    await this.setOwnedStatus(spaceId, shareId, 'paused-error', err.message)
+    await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.PAUSED_ERROR, err.message)
   }
 
   // One catch-up pass for an owned mount, honouring any deep-scan debt a relocate left behind: the
@@ -283,7 +284,7 @@ export class MountsRuntime extends Subsystem {
     // A missing source folder outranks the pause as a status — but the event must fire either way:
     // it is the only thing that tells the renderer to re-read the mount.
     const gone = !mountRootAvailable(mount.mountPath)
-    await this.setOwnedStatus(spaceId, shareId, gone ? 'mount-point-gone' : 'paused')
+    await this.setOwnedStatus(spaceId, shareId, gone ? MOUNT_STATUS.MOUNT_POINT_GONE : MOUNT_STATUS.PAUSED)
     return { cancelled, paused: true, mountPointGone: gone }
   }
 
@@ -303,7 +304,7 @@ export class MountsRuntime extends Subsystem {
     const deep = !!mount.deepScanOwed
     // Before the pass, not after: on a large folder the walk is minutes, and a badge still reading
     // 'paused' makes the click look ignored.
-    await this.setOwnedStatus(spaceId, shareId, 'scanning')
+    await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.SCANNING)
     this.armCatchUpScan(spaceId, shareId, mount)
     this.schedulePeriodicReconcile(spaceId, shareId, mount.mountPath, mount.ignore)
     return { resumed: true, deep }
@@ -338,7 +339,7 @@ export class MountsRuntime extends Subsystem {
           // handleOwnedMountGone overwrote it when the path vanished.
           const paused = (await getOwnedMount(mount.spaceId, mount.shareId))?.indexPaused
           if (paused) {
-            await this.setOwnedStatus(mount.spaceId, mount.shareId, 'paused')
+            await this.setOwnedStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.PAUSED)
             continue
           }
           this.armCatchUpScan(mount.spaceId, mount.shareId, mount)
@@ -366,7 +367,7 @@ export class MountsRuntime extends Subsystem {
         this.deps.ipc.emit('event:foreign-folder-mount-status', {
           spaceId: mount.spaceId,
           shareId: mount.shareId,
-          status: current ? (current.status || 'active') : 'mount-point-gone',
+          status: current ? (current.status || MOUNT_STATUS.ACTIVE) : MOUNT_STATUS.MOUNT_POINT_GONE,
         })
       }
     }

--- a/test/unit/README.md
+++ b/test/unit/README.md
@@ -33,7 +33,7 @@ Pure-logic tests of `src/shared/*` and `src/renderer/*` helpers — **no I/O, no
 |------|-----------|
 | `errors.test.js` | `classifyLocalIoFault`: ENOSPC → disk-full, EACCES/EPERM/EROFS → permission, `null` for ENOENT and anything unnamed (one classifier for both folder roles). `classifyTransferError`: fs codes (`ENOSPC`→disk-full, `EACCES`/`EPERM`→permission); message substrings, case-insensitive (checksum / signature / "block not available" / "not found"); falls back to `NETWORK`; tolerates `null`/`undefined`/missing message; `code` beats `message`. `isRetryableTransferError` true only for `NETWORK`. |
 | `mount-fault.test.js` | `isMountFault` / `mountFault`: the two fault statuses and nothing else; a missing source and a user pause are not faults; the reason travels as a code; a fault with no recorded reason still names itself where the status can (`paused-enospc` → `TRANSFER_DISK_FULL`); both statuses exist in both roles' contract vocabularies. |
-| `mount-status-vocabulary.test.js` | Source-scanned ratchet: every status-shaped literal in `foreign-folders.js`, `mounts-runtime.js` and `mountFault.js` is one `OWNED_MOUNT_STATUS`/`FOREIGN_MOUNT_STATUS` declares — the drift that let the mirror write `paused-enospc` while the owned union had never heard of it. |
+| `mount-status-vocabulary.test.js` | Source-scanned ratchet over the mount-status writers: every status-shaped literal is one `OWNED_MOUNT_STATUSES`/`FOREIGN_MOUNT_STATUSES` declares, and every writer imports `MOUNT_STATUS` — the drift that let the mirror write `paused-enospc` while the owned union had never heard of it. |
 
 ### E. Publish loop-prevention (echo-guard)
 | File | Scenarios |

--- a/test/unit/contract-declarations.test.js
+++ b/test/unit/contract-declarations.test.js
@@ -97,7 +97,7 @@ test('the declared status tuples match the runtime arrays exactly', (t) => {
 // exactly the twin this package exists to delete.
 test('the renderer derives its status unions instead of re-listing them', (t) => {
   const types = readFileSync(path.join(dir, '..', '..', 'renderer', 'types.ts'), 'utf8')
-  for (const [type, konst] of [['FileStatus', 'FILE_STATUS'], ['BadgeStatus', 'BADGE_STATUS'], ['ShareFileStatus', 'SHARE_FILE_STATUS'], ['AuditCategory', 'CATEGORIES']]) {
+  for (const [type, konst] of [['FileStatus', 'FILE_STATUSES'], ['BadgeStatus', 'BADGE_STATUSES'], ['ShareFileStatus', 'SHARE_FILE_STATUSES'], ['AuditCategory', 'CATEGORIES']]) {
     t.ok(new RegExp(`export type ${type} = \\(typeof ${konst}\\)\\[number\\]`).test(types),
       `${type} is derived from the contract`)
   }

--- a/test/unit/file-dedupe.test.js
+++ b/test/unit/file-dedupe.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
 import { dedupeFileRows, STATUS_RANK } from '../../src/shared/transfer/file-dedupe.js'
-import { FILE_STATUS } from '../../src/shared/contract/statuses.js'
+import { FILE_STATUSES } from '../../src/shared/contract/statuses.js'
 
 const candidate = (over = {}) => ({
   path: '/a.txt', size: 1, hash: 'h-a', inPlace: true, status: 'remote',
@@ -9,8 +9,8 @@ const candidate = (over = {}) => ({
 
 test('every file status has a rank and every rank names a file status', (t) => {
   const ranked = Object.keys(STATUS_RANK).sort()
-  t.alike(ranked, [...FILE_STATUS].sort(), 'the rank table and FILE_STATUS name the same statuses')
-  for (const status of FILE_STATUS) t.is(typeof STATUS_RANK[status], 'number', status + ' has a numeric rank')
+  t.alike(ranked, [...FILE_STATUSES].sort(), 'the rank table and FILE_STATUSES name the same statuses')
+  for (const status of FILE_STATUSES) t.is(typeof STATUS_RANK[status], 'number', status + ' has a numeric rank')
 })
 
 test('the same content held by several peers folds into one row with a sharedByCount', (t) => {

--- a/test/unit/folder-status.test.js
+++ b/test/unit/folder-status.test.js
@@ -1,7 +1,7 @@
 import test from 'brittle'
 import { deriveFolderStatus } from '../../src/renderer/folderStatus.js'
 import { badgeStyle } from '../../src/renderer/statusBadge.js'
-import { BADGE_STATUS } from '../../src/shared/contract/statuses.js'
+import { BADGE_STATUSES } from '../../src/shared/contract/statuses.js'
 
 const BASE = {
   role: 'mine',
@@ -138,8 +138,8 @@ test('the offline state is still exactly a label and a badge', (t) => {
   t.alike(Object.keys(deriveFolderStatus(MIRROR_OFFLINE)).sort(), ['badge', 'labelKey'])
 })
 
-test('every badge deriveFolderStatus can return is a legal BADGE_STATUS token', (t) => {
+test('every badge deriveFolderStatus can return is a legal BADGE_STATUSES token', (t) => {
   const cases = [MIRROR_OFFLINE, { ...BASE, sourceMissing: true }, { ...BASE, fault: true },
     { ...BASE, role: 'mirrored', mirrorSyncing: true }, { ...BASE, role: 'browse' }, BASE]
-  for (const c of cases) t.ok(BADGE_STATUS.includes(deriveFolderStatus(c).badge), `${deriveFolderStatus(c).badge} is a BADGE_STATUS`)
+  for (const c of cases) t.ok(BADGE_STATUSES.includes(deriveFolderStatus(c).badge), `${deriveFolderStatus(c).badge} is a BADGE_STATUSES`)
 })

--- a/test/unit/mount-fault.test.js
+++ b/test/unit/mount-fault.test.js
@@ -1,6 +1,6 @@
 import test from 'brittle'
 import { isMountFault, mountFault } from '../../src/shared/contract/mount-fault.js'
-import { OWNED_MOUNT_STATUS, FOREIGN_MOUNT_STATUS } from '../../src/shared/contract/statuses.js'
+import { OWNED_MOUNT_STATUSES, FOREIGN_MOUNT_STATUSES } from '../../src/shared/contract/statuses.js'
 
 // The projection that decides whether a folder screen shows a fault at all. Before it, both fault
 // statuses were durably recorded and rendered nowhere: every consumer of mount.status compared
@@ -36,7 +36,7 @@ test('a fault with no recorded reason still names itself where the status can', 
 
 test('every fault status is one both roles can actually record', (t) => {
   for (const status of ['paused-error', 'paused-enospc']) {
-    t.ok(OWNED_MOUNT_STATUS.includes(status), `an owned mount can record ${status}`)
-    t.ok(FOREIGN_MOUNT_STATUS.includes(status), `a mirror can record ${status}`)
+    t.ok(OWNED_MOUNT_STATUSES.includes(status), `an owned mount can record ${status}`)
+    t.ok(FOREIGN_MOUNT_STATUSES.includes(status), `a mirror can record ${status}`)
   }
 })

--- a/test/unit/mount-status-vocabulary.test.js
+++ b/test/unit/mount-status-vocabulary.test.js
@@ -2,7 +2,7 @@ import test from 'brittle'
 import fs from 'fs'
 import path from 'path'
 import { fileURLToPath } from 'url'
-import { OWNED_MOUNT_STATUS, FOREIGN_MOUNT_STATUS } from '../../src/shared/contract/statuses.js'
+import { OWNED_MOUNT_STATUSES, FOREIGN_MOUNT_STATUSES } from '../../src/shared/contract/statuses.js'
 import { CODES } from '../../src/shared/contract/errors.js'
 import {
   AUTO_PAUSE_STATUSES, statusForFaultCode, faultFromError, isAutoPauseStatus, mountFault, isMountFault,
@@ -33,21 +33,38 @@ const WRITERS = [
   'shared/contract/mount-fault.js',
 ]
 
-const declared = new Set([...OWNED_MOUNT_STATUS, ...FOREIGN_MOUNT_STATUS])
+const declared = new Set([...OWNED_MOUNT_STATUSES, ...FOREIGN_MOUNT_STATUSES])
+
+// The pattern is guarded against its own rot here rather than by requiring each writer to still
+// contain a literal — a writer that names every status through MOUNT_STATUS holds none, and that is
+// the desired end state, not a broken scan.
+test('the status-shaped pattern still matches a status', (t) => {
+  const found = [..."const a = 'paused-error'; const b = 'idle'".matchAll(STATUS_SHAPED)].map((m) => m[1])
+  t.alike(found, ['paused-error', 'idle'], 'the scan pattern matches status-shaped literals')
+})
 
 for (const file of WRITERS) {
   test(`every mount status ${file} names is one the contract declares`, (t) => {
     const found = new Set([...read(file).matchAll(STATUS_SHAPED)].map((m) => m[1]))
-    t.ok(found.size > 0, 'the scan found statuses at all (guards the pattern itself)')
     for (const status of found) t.ok(declared.has(status), `'${status}' is in the contract vocabulary`)
+    t.pass(`${found.size} status-shaped literal(s) scanned`)
   })
 }
 
+// A writer that spells a status itself can still be caught by the scan above, but only for a
+// spelling the pattern anticipates. Importing the vocabulary is what makes a new status reach the
+// contract first.
+test('every mount-status writer imports the vocabulary', (t) => {
+  for (const file of WRITERS) {
+    t.ok(/MOUNT_STATUS/.test(read(file)), `${file} names statuses through MOUNT_STATUS`)
+  }
+})
+
 test('the fault statuses both roles share are declared for both', (t) => {
-  t.ok(OWNED_MOUNT_STATUS.includes('paused-enospc'), 'the drift this test exists for: the owned union lacked it')
-  t.ok(FOREIGN_MOUNT_STATUS.includes('paused-enospc'))
-  t.ok(FOREIGN_MOUNT_STATUS.includes('idle'), "and 'idle' stays mirror-only, which is why there are two")
-  t.absent(OWNED_MOUNT_STATUS.includes('idle'))
+  t.ok(OWNED_MOUNT_STATUSES.includes('paused-enospc'), 'the drift this test exists for: the owned union lacked it')
+  t.ok(FOREIGN_MOUNT_STATUSES.includes('paused-enospc'))
+  t.ok(FOREIGN_MOUNT_STATUSES.includes('idle'), "and 'idle' stays mirror-only, which is why there are two")
+  t.absent(OWNED_MOUNT_STATUSES.includes('idle'))
 })
 
 // The promise the source scan could only approximate. Importable now that one bare-*-free module
@@ -61,8 +78,8 @@ test('every status mount-fault.js can produce is declared for both roles', (t) =
   ])
   t.ok(produced.size >= 3, 'the set is non-trivial (guards the assertion itself)')
   for (const status of produced) {
-    t.ok(OWNED_MOUNT_STATUS.includes(status), `owned declares '${status}'`)
-    t.ok(FOREIGN_MOUNT_STATUS.includes(status), `foreign declares '${status}'`)
+    t.ok(OWNED_MOUNT_STATUSES.includes(status), `owned declares '${status}'`)
+    t.ok(FOREIGN_MOUNT_STATUSES.includes(status), `foreign declares '${status}'`)
   }
 })
 

--- a/test/unit/state-conveyance-review-fixes.test.js
+++ b/test/unit/state-conveyance-review-fixes.test.js
@@ -31,7 +31,7 @@ test('REGRESSION (C2: the offline-deny re-send excludes a knock backed by a vali
 
 test('REGRESSION (FIX-6/7/8: scan outcomes drive owned status; probe never blanket-writes active)', (t) => {
   t.ok(/async settleScanStatus\(/.test(mountsRuntime), 'the settleScanStatus method exists')
-  t.ok(/result\?\.skipped === 'mount-point-gone'/.test(mountsRuntime) && /else if \(result\?\.skipped\)/.test(mountsRuntime),
+  t.ok(/result\?\.skipped === MOUNT_STATUS\.MOUNT_POINT_GONE/.test(mountsRuntime) && /else if \(result\?\.skipped\)/.test(mountsRuntime),
     'a skipped scan is not recorded as active')
   // The probe's owned branch must not assert a durable status purely from path presence.
   t.absent(/setOwnedStatus\(mount\.spaceId, mount\.shareId, exists \? 'active'/.test(mountsRuntime),

--- a/test/unit/status-badge.test.js
+++ b/test/unit/status-badge.test.js
@@ -5,15 +5,9 @@ import {
   badgeStyle,
   roleBadge,
 } from '../../src/renderer/statusBadge.js'
+import { FILE_STATUSES, SHARE_FILE_STATUSES } from '../../src/shared/contract/statuses.js'
 
-const FILE_STATUSES = [
-  'mine', 'downloaded', 'remote', 'preparing', 'downloading', 'verifying', 'publishing',
-  'paused-interrupted', 'paused-offline', 'unavailable', 'error',
-]
-const SHARE_STATUSES = [
-  'remote', 'preparing', 'downloading', 'verifying', 'publishing', 'downloaded', 'synced',
-  'unavailable', 'paused-interrupted', 'paused-offline',
-]
+const SHARE_STATUSES = SHARE_FILE_STATUSES
 const ROLES = ['mine', 'browse', 'mirrored']
 
 const ALLOWED_BG = [


### PR DESCRIPTION
Box 2.1 of #233. A.4 (the single `status` field with precedence) is **not** here — you split it into
its own box, and this stays a rename-and-import change with no behaviour in it.

- `statuses.js` exports a name→value object per vocabulary (`FILE_STATUS`, `BADGE_STATUS`,
  `SHARE_FILE_STATUS`, `MOUNT_STATUS`, `MIRROR_STATE`), with each frozen tuple derived from its
  object via `Object.values`. The tuples keep their old values exactly; they take the plural name
  (`FILE_STATUSES`, …), which is the convention `OUTCOME`/`OUTCOMES` and `TARGET_KIND`/`TARGET_KINDS`
  already set.
- `MIRROR_STATE` declares `syncing | synced | paused`, which was written out at its defaults and
  typed as a hand-written union in `types.ts`.
- `ON_DEVICE_STATUSES` and `HEALTHY_OWNED_STATUSES` name two sets that were spelled at their callers
  — the first was a `new Set(['downloaded', 'synced'])` in **two** renderer files.
- The mount-status writers (`mounts-runtime.js`, `worker/main.js`, `foreign-folders.js`,
  `owned-folders.js`, `contract/mount-fault.js`) import `MOUNT_STATUS`.

### The regex test is kept, and the box is wrong that it becomes redundant

2.1 says importing the objects retires `mount-status-vocabulary.test.js`. It does not: the writers are
**untyped Bare `.js`**, so `MOUNT_STATUS.TYPO` is silently `undefined` rather than a compile error —
unlike the renderer, whose literals are already checked against the derived unions. The scan is still
the only thing that catches a stray spelling, so it stays, with two changes:

- its per-file "the scan found statuses at all" self-guard moves to a fixture, because a writer that
  names every status through `MOUNT_STATUS` legitimately contains no literal;
- a new assertion that every writer imports the vocabulary.

The real fix for `undefined` is validation in the write path, and that belongs with **A.4**, which has
to funnel all four blind-assigning writers through one setter anyway. Noted there rather than bolted
on here.

### Also found

`test/unit/status-badge.test.js` held its own copy of the file-status lists, and the share copy had
already drifted — it was missing `'error'`, so `shareFileStatusToBadge('error')` was never exercised.
Both now come from the contract. The widened list passes, so the drift was latent, not a live bug.

Not done: converting the ~47 inline `status === '<literal>'` comparisons. In the renderer they are
already checked against the derived unions, and in the worker replacing a literal with a constant
that can be `undefined` trades a visible spelling for an invisible one. The scan is the better guard
there.

Verified: `tsc` + `lint:ci` clean; the status, mount-fault, row-view, badge, mirror-sync and
owned-mount unit files pass; integration `mount-validate`, `foreign-mirror-sync-state`,
`foreign-unmount`, `owned-folder-publish`, `owned-folder-edge`, `foreign-mirror-offline-gate` pass.
