### PR TITLE
[refactor] Derive an owned mount's status from its two facts

### DIFF
--- a/.claude/solution-architecture.md
+++ b/.claude/solution-architecture.md
@@ -1181,6 +1181,7 @@ Behaviour worth knowing (styling → `design.md`):
 | `src/shared/contract/statuses.js` | The status tuples the worker produces and the renderer derives its unions from (§3.5, §7.3) |
 | `src/shared/contract/events.js` | Every `event:*` name; emit sites stay the source of truth and `contract-declarations.test.js` compares both directions |
 | `src/shared/contract/mount-fault.js` | Fault code ↔ mount status bridge (the errno half lives in `folders/mount-fault.js`) |
+| `src/shared/contract/mount-precedence.js` | The order an owned mount's two facts resolve in: `mount-point-gone` > fault > `paused` > `scanning` > `active`. `status` is derived from it, never assigned |
 | `src/shared/contract/scope.js` | `Scope` constructors + `scopeMatches` — the identity of a re-derivable view (§4.7) |
 | `src/shared/contract/main-requests.js` | Every worker→main control frame name (`MAIN_REQUEST`, `MAIN_REQUEST_FRAME`) |
 | `src/shared/contract/frames.js` | The non-request frames: `bootstrap`, `response`, `cancel` |

--- a/src/renderer/folderStatus.d.ts
+++ b/src/renderer/folderStatus.d.ts
@@ -4,7 +4,7 @@ export interface FolderStatusInput {
   role: ShareRole
   sourceMissing: boolean
   fault: boolean
-  indexPaused: boolean
+  paused: boolean
   mirrorEnabled: boolean
   indexing: boolean
   mirrorSyncing: boolean

--- a/src/renderer/folderStatus.js
+++ b/src/renderer/folderStatus.js
@@ -9,12 +9,12 @@
 // second announcement from the tile would read the same change twice.
 
 export function deriveFolderStatus(input) {
-  const { role, sourceMissing, fault, indexPaused, mirrorEnabled, indexing, mirrorSyncing, ownerOnline, incomplete } = input
+  const { role, sourceMissing, fault, paused, mirrorEnabled, indexing, mirrorSyncing, ownerOnline, incomplete } = input
   if (sourceMissing) return { labelKey: 'folder.statusMissing', badge: 'paused' }
   // Above both pauses, for the same reason the fault strip is: an auto-paused mirror is
   // enabled === false, so without this the tile calls a stopped folder "Paused".
   if (fault) return { labelKey: 'folder.statusFault', badge: 'error' }
-  if (role === 'mine' && indexPaused) return { labelKey: 'folder.statusPaused', badge: 'paused' }
+  if (role === 'mine' && paused) return { labelKey: 'folder.statusPaused', badge: 'paused' }
   if (role === 'mirrored' && mirrorEnabled === false) return { labelKey: 'folder.statusPaused', badge: 'paused' }
   if (role === 'mine' && indexing) return { labelKey: 'folder.statusAdding', badge: 'publishing' }
   if (role === 'mirrored' && mirrorSyncing) return { labelKey: 'folder.statusSyncing', badge: 'downloading' }

--- a/src/renderer/folderStrips.js
+++ b/src/renderer/folderStrips.js
@@ -31,8 +31,10 @@ function faultStrip(input) {
   }
 }
 
+// A folder shows one state, and both a fault and a missing source outrank a pause: each carries the
+// action the user can actually take, and the pause is still recorded underneath.
 function isPaused(input) {
-  if (input.fault) return false
+  if (input.fault || input.sourceMissing) return false
   if (input.isYou) return !!input.indexing?.paused
   return input.role === 'mirrored' && input.foreignEnabled === false
 }

--- a/src/renderer/indexSummary.d.ts
+++ b/src/renderer/indexSummary.d.ts
@@ -21,5 +21,5 @@ export interface IndexSummary {
 
 export function deriveIndexSummary(
   status: IndexStatus | null | undefined,
-  mount?: { indexPaused?: boolean; scanning?: boolean } | null,
+  mount?: { paused?: boolean; scanning?: boolean } | null,
 ): IndexSummary

--- a/src/renderer/indexSummary.js
+++ b/src/renderer/indexSummary.js
@@ -11,13 +11,12 @@
 
 const count = (n) => (Number.isFinite(n) && n > 0 ? n : 0)
 
-// The mount carries the durable pause. A paused index has an EMPTY queue — pausing drops it, and
-// rebuilding it costs one walk because a published file is never re-hashed — so `paused` is
-// deliberately independent of `active`: a paused folder reports the same zero a finished one does,
-// and only the mount tells them apart.
+// A paused index has an EMPTY queue — pausing drops it, and rebuilding it costs one walk because a
+// published file is never re-hashed — so `paused` is deliberately independent of `active`: a paused
+// folder reports the same zero a finished one does, and only the mount tells them apart.
 export function deriveIndexSummary(status, mount) {
   const files = count(status?.adding)
-  const paused = !!mount?.indexPaused
+  const paused = !!mount?.paused
   // The scan's first phase walks the disk and fills no queue, so `adding` is 0 for the whole of it
   // — minutes on a large folder, during which the notice would otherwise show nothing and offer no
   // way to stop. That is exactly when a user reaches for one, so the phase counts as active.

--- a/src/renderer/ownedMount.d.ts
+++ b/src/renderer/ownedMount.d.ts
@@ -9,7 +9,7 @@ export interface OwnedMountState {
    *  it means "not read yet", and a caller that cannot tell them apart falls back to a frozen
    *  navigation snapshot forever. */
   loaded: boolean
-  indexPaused: boolean
+  paused: boolean
   /** The scan is walking the disk. It fills no queue, so nothing else can report that phase. */
   scanning: boolean
   mountPath: string | null

--- a/src/renderer/ownedMount.js
+++ b/src/renderer/ownedMount.js
@@ -2,16 +2,13 @@
 // projections live here rather than in the hook so they are one declaration for two screens — and
 // so the precedence below is testable without React.
 
-// The badge projection of an owned mount's durable state: a live missing path wins, then any
-// persisted non-healthy status (paused-error / mount-point-gone survive a restart); healthy states
-// (active / scanning) render no badge.
+import { MOUNT_STATUS } from '../shared/contract/statuses.js'
+import { ownedMountStatus, isHealthyOwnedStatus } from '../shared/contract/mount-precedence.js'
 
-import { MOUNT_STATUS, HEALTHY_OWNED_STATUSES } from '../shared/contract/statuses.js'
+// Which states deserve a badge: the resolved status, unless it is one nothing is wrong with.
 export function unhealthyOwnedStatus(m) {
-  if (!m) return null
-  if (m.mountPointMissing) return MOUNT_STATUS.MOUNT_POINT_GONE
-  if (m.status && !HEALTHY_OWNED_STATUSES.includes(m.status)) return m.status
-  return null
+  const status = ownedMountStatus(m)
+  return status && !isHealthyOwnedStatus(status) ? status : null
 }
 
 // Settled means an answer LANDED — data or error — not `!loading`: the store settles an entry on an
@@ -33,20 +30,18 @@ export function ownedMountSettled(enabled, rows) {
 export function projectOwnedMount(rows, spaceId, shareId, settled) {
   if (!settled || !spaceId || !shareId) return NO_OWNED_MOUNT
   const m = (rows || []).find((x) => x.spaceId === spaceId && x.shareId === shareId)
-  // Both from one row: the badge projection AND the durable intent behind it. The status alone
-  // cannot carry the pause — a scan settle overwrites it, and 'mount-point-gone' legitimately
-  // outranks it while the source is missing.
+  const resolved = ownedMountStatus(m)
   return {
     status: unhealthyOwnedStatus(m),
     lastError: m?.lastError ?? null,
     loaded: true,
-    indexPaused: !!m?.indexPaused,
-    scanning: m?.status === 'scanning',
+    paused: resolved === MOUNT_STATUS.PAUSED,
+    scanning: resolved === MOUNT_STATUS.SCANNING,
     mountPath: m?.mountPath ?? null,
   }
 }
 
 // test seam
 export const NO_OWNED_MOUNT = Object.freeze({
-  status: null, lastError: null, loaded: false, indexPaused: false, scanning: false, mountPath: null,
+  status: null, lastError: null, loaded: false, paused: false, scanning: false, mountPath: null,
 })

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -180,7 +180,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   const manualControls = share.role === 'browse'
   // Live while mounted: owned-folder:list-all (a live mountRootAvailable check) re-derives on every
   // mount-status event; the useShares projection covers SpaceView only.
-  const { status: ownedStatus, lastError: ownedError, loaded: ownedLoaded, indexPaused, scanning, mountPath: ownedPath } = useOwnedMount(spaceId, isYou ? share.id : '')
+  const { status: ownedStatus, lastError: ownedError, loaded: ownedLoaded, paused: ownedPaused, scanning, mountPath: ownedPath } = useOwnedMount(spaceId, isYou ? share.id : '')
   // The scan's queue depth, which the file rows cannot show: a queued file has no catalog entry
   // yet, so it has no row. Ours reports locally; a peer's is re-announced by its owner, so it is
   // only meaningful while they are reachable — an owner that drops mid-scan sends no final frame.
@@ -192,8 +192,8 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   // Memoised on its inputs: deriveIndexSummary returns a fresh object every call, and an unstable
   // `indexing` would make every downstream useMemo that depends on it miss on every render.
   const indexing = useMemo(
-    () => deriveIndexSummary(indexProgress, { indexPaused, scanning }),
-    [indexProgress, indexPaused, scanning],
+    () => deriveIndexSummary(indexProgress, { paused: ownedPaused, scanning }),
+    [indexProgress, ownedPaused, scanning],
   )
   // Live read wins once loaded, including "healthy": the hook returns null for a healthy mount, so
   // `??` would resurrect the snapshot.
@@ -265,7 +265,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
     role: share.role,
     sourceMissing,
     fault: !!fault,
-    indexPaused,
+    paused: ownedPaused,
     mirrorEnabled: foreignEnabled,
     indexing: indexing.active,
     // Same rule the strip applies: with the owner away nothing is being fetched, so the tile must
@@ -336,7 +336,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
     else void setPaused(action === 'pause')
   }
 
-  const paused = isYou ? indexPaused : !foreignEnabled
+  const paused = isYou ? ownedPaused : !foreignEnabled
   // The same acts the header offers, reachable from the command palette while this folder is on
   // screen. Deliberately not the destructive pair: Delete and Unmount are gated on work that is
   // still running, and an Enter keypress in a search field is the wrong place to confirm either.

--- a/src/shared/contract/mount-precedence.d.ts
+++ b/src/shared/contract/mount-precedence.d.ts
@@ -1,0 +1,15 @@
+// Generated from mount-precedence.js — contract-declarations.test.js asserts the two agree.
+import type { OWNED_MOUNT_STATUSES } from './statuses.js'
+
+export type OwnedMountStatusValue = (typeof OWNED_MOUNT_STATUSES)[number]
+
+export interface OwnedMountFacts {
+  status?: string | null
+  indexPaused?: boolean
+  mountPointMissing?: boolean
+}
+
+export declare function isFaultStatus(status: string | null | undefined): boolean
+export declare function ownedMountStatus(record: OwnedMountFacts | null | undefined): OwnedMountStatusValue | null
+export declare function isHealthyOwnedStatus(status: string | null | undefined): boolean
+export declare const _rankForTests: Readonly<Record<string, number>>

--- a/src/shared/contract/mount-precedence.js
+++ b/src/shared/contract/mount-precedence.js
@@ -1,0 +1,40 @@
+// An owned mount holds two independent facts — the last pass's outcome and the user's pause — and
+// shows exactly one of them. This is the order they resolve in.
+//
+// mount-point-gone tops it because its remedy is a different verb: "Locate folder…", not "Try
+// again". A fault outranks a pause because the fault is the one the user can act on; the pause is
+// kept in its own field, so it resurfaces when the fault clears.
+import { MOUNT_STATUS, HEALTHY_OWNED_STATUSES } from './statuses.js'
+
+const RANK = Object.freeze({
+  [MOUNT_STATUS.MOUNT_POINT_GONE]: 5,
+  [MOUNT_STATUS.PAUSED_ENOSPC]: 4,
+  [MOUNT_STATUS.PAUSED_ERROR]: 4,
+  [MOUNT_STATUS.PAUSED]: 3,
+  [MOUNT_STATUS.SCANNING]: 2,
+  [MOUNT_STATUS.ACTIVE]: 1,
+  [MOUNT_STATUS.IDLE]: 0,
+})
+
+// A status no writer may clear by asserting activity alone — only a pass that ran, a probe or a
+// relocate clears it.
+export function isFaultStatus(status) {
+  return RANK[status] >= RANK[MOUNT_STATUS.PAUSED_ENOSPC]
+}
+
+// `mountPointMissing` is the live probe result and outranks the record, which can still read
+// 'active' between the path vanishing and the next probe.
+export function ownedMountStatus(record) {
+  if (!record) return null
+  if (record.mountPointMissing) return MOUNT_STATUS.MOUNT_POINT_GONE
+  if (isFaultStatus(record.status)) return record.status
+  if (record.indexPaused) return MOUNT_STATUS.PAUSED
+  return record.status ?? MOUNT_STATUS.SCANNING
+}
+
+export function isHealthyOwnedStatus(status) {
+  return HEALTHY_OWNED_STATUSES.includes(status)
+}
+
+// test seam — the ordering test reads the table rather than re-listing it
+export const _rankForTests = RANK

--- a/src/shared/contract/statuses.js
+++ b/src/shared/contract/statuses.js
@@ -77,12 +77,11 @@ export const MIRROR_STATES = Object.freeze(Object.values(MIRROR_STATE))
 //   owner   scanning → active on a clean pass, scanning → paused-* when the pass hit a fault. The
 //           cadence keeps retrying either way.
 //
-// Three fields sit beside `status`, and none is derivable from it: `enabled` is the mirror's loop
-// switch (false plus an auto-pause status is what isAutoPaused reads), `indexPaused` is the owner's
-// durable pause — a field rather than a status, because four writers overwrite status and a pause
-// recorded there would be lost at the next settle — and `lastError` is the code a fault status
-// names itself by. folders/mount-store.js is the only write path; folders/foreign-folders.js and
-// worker/mounts-runtime.js are the callers that decide.
+// The two roles' status fields are differently authoritative. A MIRROR's is assigned: `enabled` is
+// its loop switch, and false plus an auto-pause status is what isAutoPaused reads. An OWNER's is
+// derived by contract/mount-precedence.js from the two facts beside it — `indexPaused`, the user's
+// durable pause, and `lastError`, the code a fault status names itself by — so an owner's pause and
+// its fault are both recorded while only one of them shows.
 export const MOUNT_STATUS = Object.freeze({
   IDLE: 'idle',
   SCANNING: 'scanning',

--- a/src/shared/folders/mount-store.js
+++ b/src/shared/folders/mount-store.js
@@ -13,6 +13,9 @@ import { createRecordWriter } from '../core/bee-writer.js'
 import { createLogger } from '../core/logger.js'
 import { Subsystem } from '../core/subsystem.js'
 import { prefixRange } from '../core/bee-keys.js'
+import { ownedMountStatus } from '../contract/mount-precedence.js'
+import { AppError } from '../core/errors.js'
+import { CODES } from '../contract/errors.js'
 
 const log = createLogger('mount-store')
 
@@ -62,25 +65,46 @@ export async function deleteOwnedMount(spaceId, shareId) {
   await records.del(ownedKey(spaceId, shareId))
 }
 
-// Durable status for an owned mount (mirrors the foreign mount.status field): the boot
-// loop and probe read/write it so a scan failure survives a restart instead of living
-// only in a transient renderer event. No-op when the mount record is gone (unmounted).
-export function setOwnedMountStatus(spaceId, shareId, status, lastError = null) {
-  return mutateOwned(spaceId, shareId, (m) =>
-    (m.status === status && (m.lastError ?? null) === lastError) ? null : { ...m, status, lastError })
+// `status` is derived from the two facts beside it, never assigned: the three setters below name a
+// fact and this resolves it. No-op when nothing changed, so a probe tick that re-asserts the same
+// state appends no block.
+function applied(m, patch) {
+  const next = { ...m, ...patch }
+  next.status = ownedMountStatus(next)
+  next.lastError = next.lastError ?? null
+  const same = m.status === next.status
+    && (m.lastError ?? null) === (next.lastError ?? null)
+    && !!m.indexPaused === !!next.indexPaused
+  return same ? null : next
 }
 
-// Durable user intent: this folder's index is paused until an explicit resume. A FIELD, not a
-// status, because four writers overwrite status (a scan settle, the mount-gone path, mount,
-// relocate) and a pause recorded only there is lost at the next settle. No-op (false) when the
-// record is gone.
-export function setOwnedIndexPaused(spaceId, shareId, paused) {
-  return mutateOwned(spaceId, shareId, (m) =>
-    (!!m.indexPaused === !!paused) ? null : { ...m, indexPaused: !!paused })
+// A pass reached a conclusion about the source: it is readable, and this is where it got to.
+// Clears a recorded fault — a pass that ran is the evidence it is gone — and cannot disturb a pause.
+export function setOwnedActivity(spaceId, shareId, activity) {
+  return mutateOwned(spaceId, shareId, (m) => applied(m, { status: activity, lastError: null }))
 }
+
+// A pass could not finish, and this is why. Outranks a pause without erasing it.
+export function setOwnedFault(spaceId, shareId, faultStatus, code = null) {
+  return mutateOwned(spaceId, shareId, (m) => applied(m, { status: faultStatus, lastError: code }))
+}
+
+// Durable user intent: this folder's index is paused until an explicit resume. Kept beside `status`
+// rather than in it, so a fault showing over the pause does not erase it.
+export function setOwnedIndexPaused(spaceId, shareId, paused) {
+  return mutateOwned(spaceId, shareId, (m) => applied(m, { indexPaused: !!paused }))
+}
+
+const DERIVED_FIELDS = ['status', 'indexPaused']
 
 // Patch an owned mount's bookkeeping. No-op (false) when the record is gone.
 export function patchOwnedMount(spaceId, shareId, patch) {
+  for (const field of DERIVED_FIELDS) {
+    if (field in patch) {
+      throw new AppError(CODES.INVALID_ARGUMENT,
+        `mount ${field} is derived — use setOwnedActivity, setOwnedFault or setOwnedIndexPaused`)
+    }
+  }
   return mutateOwned(spaceId, shareId, (m) => ({ ...m, ...patch }))
 }
 

--- a/src/worker/main.js
+++ b/src/worker/main.js
@@ -1038,7 +1038,7 @@ async function mountOwnedShare(spaceId, share, validated, requestedIgnore) {
   // Seed the probe baseline so the first mount-point tick doesn't read this brand-new mount as a
   // gone→present transition (which would otherwise run against an unseeded key).
   mounts.lastMountPointStatus.set('owned-folder:' + shareId, mountRootAvailable(mountPath))
-  await mounts.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.SCANNING)
+  await mounts.recordActivity(spaceId, shareId, MOUNT_STATUS.SCANNING)
 
   ipc.emit(MAIN_REQUEST_FRAME, {
     command: MAIN_REQUEST.OWNED_FOLDER_START_WATCHER,
@@ -1117,7 +1117,9 @@ ipc.handle('owned-folder:relocate', async (msg) => {
   mount.mountPath = mountPath
   mounts.lastMountPointStatus.set('owned-folder:' + msg.shareId, true)
 
-  await mounts.setOwnedStatus(msg.spaceId, msg.shareId, mount.indexPaused ? MOUNT_STATUS.PAUSED : MOUNT_STATUS.SCANNING)
+  // Locate Folder clears the gone fault; a paused index is still paused, which the precedence
+  // decides rather than this call site.
+  await mounts.recordActivity(msg.spaceId, msg.shareId, MOUNT_STATUS.SCANNING)
   ipc.emit(MAIN_REQUEST_FRAME, {
     command: MAIN_REQUEST.OWNED_FOLDER_START_WATCHER,
     args: { shareId: msg.shareId, mountPath, ignore: mount.ignore },
@@ -1135,7 +1137,10 @@ ipc.handle('owned-folder:relocate', async (msg) => {
   // below, which runs in a floating promise a quit mid-walk can end.
   await patchOwnedMount(msg.spaceId, msg.shareId, { deepScanOwed: true })
 
-  if (!mount.indexPaused) {
+  // Re-read: `mount` predates validateMountPath and two awaits, so a pause landing in between would
+  // be missed and this would arm a pass the user had stopped.
+  const current = await getOwnedMount(msg.spaceId, msg.shareId)
+  if (!current?.indexPaused) {
     mounts.settleScanStatus(initialPublishScan(msg.spaceId, msg.shareId, mountPath, mount.ignore, { deep: true }), msg.spaceId, msg.shareId)
       .then(async (result) => {
         if (result?.cancelled) return

--- a/src/worker/mounts-runtime.js
+++ b/src/worker/mounts-runtime.js
@@ -12,7 +12,7 @@ import { AppError } from '../shared/core/errors.js'
 import { CODES } from '../shared/contract/errors.js'
 import { MAIN_REQUEST_FRAME, MAIN_REQUEST } from '../shared/contract/main-requests.js'
 import { faultFromError, statusForFaultCode } from '../shared/folders/mount-fault.js'
-import { setOwnedMountStatus, setOwnedIndexPaused, patchOwnedMount, listOwnedMounts, listAllMounts, listForeignMounts, getOwnedMount, getForeignMount } from '../shared/folders/mount-store.js'
+import { setOwnedActivity, setOwnedFault, setOwnedIndexPaused, patchOwnedMount, listOwnedMounts, listAllMounts, listForeignMounts, getOwnedMount, getForeignMount } from '../shared/folders/mount-store.js'
 import { periodicReconcile, stopOwnedFolder, cancelIndex } from '../shared/folders/owned-folders.js'
 import { mountRootAvailable } from '../shared/folders/publish-runner.js'
 import { startForeignLoop, initialMaterializeScan, resumeAutoPausedForeignMount, autoPauseForeignMountGone } from '../shared/folders/foreign-folders.js'
@@ -67,7 +67,7 @@ export class MountsRuntime extends Subsystem {
         if (!mountRootAvailable(mount.mountPath)) {
           this.log.warn('owned mount path missing at startup:', mount.mountPath)
           this.lastMountPointStatus.set('owned-folder:' + mount.shareId, false)
-          await this.setOwnedStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
+          await this.recordFault(mount.spaceId, mount.shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
           continue
         }
         this.lastMountPointStatus.set('owned-folder:' + mount.shareId, true)
@@ -81,7 +81,7 @@ export class MountsRuntime extends Subsystem {
         // The scan would decline itself anyway, but an interval that can never do work reads as a
         // bug later. Re-assert the status so a restart repaints the badge from the durable record.
         if (mount.indexPaused) {
-          await this.setOwnedStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.PAUSED)
+          await this.recordPause(mount.spaceId, mount.shareId, true)
           continue
         }
         this.armCatchUpScan(mount.spaceId, mount.shareId, mount)
@@ -143,14 +143,30 @@ export class MountsRuntime extends Subsystem {
     this.reconcileCounters.clear()
   }
 
-  // Persist + announce an owned mount's status in one step. The durable field is what a
-  // boot or refresh re-derives the badge from — a transient-only event vanishes on reload —
-  // and the event stays as the live decoration.
-  async setOwnedStatus(spaceId, shareId, status, error) {
-    try { await setOwnedMountStatus(spaceId, shareId, status, error ?? null) } catch (err) {
+  // Persist + announce in one step. The durable field is what a boot or refresh re-derives the badge
+  // from — a transient-only event vanishes on reload — and the event stays as the live decoration.
+  // The event carries what the RECORD says, which after the precedence is applied is not always
+  // what the caller named.
+  async _announce(spaceId, shareId, write) {
+    try { await write() } catch (err) {
       this.log.debug('owned mount status persist failed:', shareId, '-', err.message)
     }
-    this.deps.ipc.emit('event:owned-folder-mount-status', { spaceId, shareId, status, ...(error ? { error } : {}) })
+    const mount = await getOwnedMount(spaceId, shareId)
+    if (!mount) return
+    this.deps.ipc.emit('event:owned-folder-mount-status',
+      { spaceId, shareId, status: mount.status, ...(mount.lastError ? { error: mount.lastError } : {}) })
+  }
+
+  recordActivity(spaceId, shareId, activity) {
+    return this._announce(spaceId, shareId, () => setOwnedActivity(spaceId, shareId, activity))
+  }
+
+  recordFault(spaceId, shareId, status, code) {
+    return this._announce(spaceId, shareId, () => setOwnedFault(spaceId, shareId, status, code ?? null))
+  }
+
+  recordPause(spaceId, shareId, paused) {
+    return this._announce(spaceId, shareId, () => setOwnedIndexPaused(spaceId, shareId, paused))
   }
 
   // Everything that must happen once an owned source folder is known to be missing, from whichever
@@ -165,7 +181,7 @@ export class MountsRuntime extends Subsystem {
     this.cancelPeriodicReconcile(spaceId, shareId)
     // A vanished root makes chokidar emit one unlink per file; every queued retire dies with it.
     stopOwnedFolder(spaceId, shareId)
-    await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
+    await this.recordFault(spaceId, shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
   }
 
   // Map a reconcile/scan outcome to the durable owned-mount status. A scan RESOLVES (not rejects)
@@ -182,13 +198,13 @@ export class MountsRuntime extends Subsystem {
       if (result?.skipped === MOUNT_STATUS.MOUNT_POINT_GONE) await this.handleOwnedMountGone(spaceId, shareId)
       // A paused index is a decision, not a fault: it carries no lastError and must not reach the
       // paused-error branch below, which raises an error toast and an unhealthy badge.
-      else if (result?.skipped === 'index-paused') await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.PAUSED)
-      else if (result?.skipped) await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.PAUSED_ERROR, result.skipped)
+      else if (result?.skipped === 'index-paused') await this.recordActivity(spaceId, shareId, MOUNT_STATUS.SCANNING)
+      else if (result?.skipped) await this.recordFault(spaceId, shareId, MOUNT_STATUS.PAUSED_ERROR, result.skipped)
       // A pass whose items failed on a classified fault is not a healthy scan. The pass resolving
       // does not mean its files reached the catalog — publish failures are per item — and reading
       // that resolution as 'active' is what made a full disk invisible to the owner.
-      else if (result?.faultCode) await this.setOwnedStatus(spaceId, shareId, statusForFaultCode(result.faultCode), result.faultCode)
-      else await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.ACTIVE)
+      else if (result?.faultCode) await this.recordFault(spaceId, shareId, statusForFaultCode(result.faultCode), result.faultCode)
+      else await this.recordActivity(spaceId, shareId, MOUNT_STATUS.ACTIVE)
       return result
     } catch (err) {
       this.log.warn('owned reconcile failed for', shareId, '-', err.message)
@@ -204,7 +220,7 @@ export class MountsRuntime extends Subsystem {
   async recordScanFault(spaceId, shareId, err) {
     const fault = faultFromError(err)
     if (fault) {
-      await this.setOwnedStatus(spaceId, shareId, fault.status, fault.code)
+      await this.recordFault(spaceId, shareId, fault.status, fault.code)
       return
     }
     // A root that vanished mid-pass: the probe would notice within its interval anyway, but going
@@ -216,7 +232,7 @@ export class MountsRuntime extends Subsystem {
         return
       }
     }
-    await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.PAUSED_ERROR, err.message)
+    await this.recordFault(spaceId, shareId, MOUNT_STATUS.PAUSED_ERROR, err.message)
   }
 
   // One catch-up pass for an owned mount, honouring any deep-scan debt a relocate left behind: the
@@ -278,13 +294,11 @@ export class MountsRuntime extends Subsystem {
     if (!mount) throw new AppError(CODES.MOUNT_NOT_ON_DEVICE, 'Folder is not mounted on this device')
     // The flag first: an item enqueued between the cancel and the write must be declined by the
     // publish channel rather than published.
-    await setOwnedIndexPaused(spaceId, shareId, true)
+    await this.recordPause(spaceId, shareId, true)
     const cancelled = cancelIndex(spaceId, shareId)
     this.cancelPeriodicReconcile(spaceId, shareId)
-    // A missing source folder outranks the pause as a status — but the event must fire either way:
-    // it is the only thing that tells the renderer to re-read the mount.
     const gone = !mountRootAvailable(mount.mountPath)
-    await this.setOwnedStatus(spaceId, shareId, gone ? MOUNT_STATUS.MOUNT_POINT_GONE : MOUNT_STATUS.PAUSED)
+    if (gone) await this.recordFault(spaceId, shareId, MOUNT_STATUS.MOUNT_POINT_GONE)
     return { cancelled, paused: true, mountPointGone: gone }
   }
 
@@ -298,13 +312,13 @@ export class MountsRuntime extends Subsystem {
       await this.handleOwnedMountGone(spaceId, shareId)
       throw new AppError(CODES.SOURCE_FOLDER_MISSING, 'Source folder is missing — locate it before resuming')
     }
-    await setOwnedIndexPaused(spaceId, shareId, false)
+    await this.recordPause(spaceId, shareId, false)
     // A relocate that landed while this was paused recorded a debt: its deep pass never ran, and
     // the fast diff would re-advertise every entry on the new tree's fresh mtimes.
     const deep = !!mount.deepScanOwed
     // Before the pass, not after: on a large folder the walk is minutes, and a badge still reading
     // 'paused' makes the click look ignored.
-    await this.setOwnedStatus(spaceId, shareId, MOUNT_STATUS.SCANNING)
+    await this.recordActivity(spaceId, shareId, MOUNT_STATUS.SCANNING)
     this.armCatchUpScan(spaceId, shareId, mount)
     this.schedulePeriodicReconcile(spaceId, shareId, mount.mountPath, mount.ignore)
     return { resumed: true, deep }
@@ -334,14 +348,10 @@ export class MountsRuntime extends Subsystem {
             command: MAIN_REQUEST.OWNED_FOLDER_START_WATCHER,
             args: { shareId: mount.shareId, mountPath: mount.mountPath, ignore: mount.ignore },
           })
-          // A path coming back is not the user pressing Resume, so a paused index stays paused —
-          // without this, unplug + replug is a silent resume. The status is re-asserted because
-          // handleOwnedMountGone overwrote it when the path vanished.
-          const paused = (await getOwnedMount(mount.spaceId, mount.shareId))?.indexPaused
-          if (paused) {
-            await this.setOwnedStatus(mount.spaceId, mount.shareId, MOUNT_STATUS.PAUSED)
-            continue
-          }
+          // A path coming back is not the user pressing Resume: clearing the gone fault returns the
+          // mount to whatever it was, which for a paused index is still paused.
+          await this.recordActivity(mount.spaceId, mount.shareId, MOUNT_STATUS.SCANNING)
+          if ((await getOwnedMount(mount.spaceId, mount.shareId))?.indexPaused) continue
           this.armCatchUpScan(mount.spaceId, mount.shareId, mount)
           this.schedulePeriodicReconcile(mount.spaceId, mount.shareId, mount.mountPath, mount.ignore)
         }

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -139,6 +139,7 @@ import s138 from './scenarios/s138-mirror-offline-quiet.mjs'
 import s139 from './scenarios/s139-mirror-offline-incomplete.mjs'
 import s140 from './scenarios/s140-modal-failure-escape-routes.mjs'
 import s141 from './scenarios/s141-scan-preview-singular.mjs'
+import s142 from './scenarios/s142-paused-and-missing-one-state.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -198,7 +199,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140, s141 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140, s141, s142 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s142-paused-and-missing-one-state.mjs
+++ b/test/frontend/scenarios/s142-paused-and-missing-one-state.mjs
@@ -1,0 +1,99 @@
+import { mkdirSync, writeFileSync, renameSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { allText, flatten } from '../tree.mjs'
+import { workDir } from '../paths.mjs'
+
+// REGRESSION (A.4: a paused folder whose source went missing showed both states at once — the
+// "Locate folder…" strip stacked above a "Resume" strip — and the header menu still offered Resume
+// syncing, which the worker refuses with SOURCE_FOLDER_MISSING. The pause and the last pass's
+// outcome are two facts; the screen shows the one the user can act on, and the pause resurfaces
+// once the source is back.)
+//
+// The restore step waits past the 60s mount-point probe interval: the folder coming back is not the
+// user pressing Resume, so nothing else re-derives the status.
+export default async function s142({ runDir }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', slot: 0, total: 1 })
+
+  const parent = workDir('own-')
+  const ownDir = path.join(parent, 'Ledger')
+  const movedDir = path.join(parent, 'Ledger-moved')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'q1.txt'), 'numbers')
+
+  const menuLabels = async () => {
+    const nodes = flatten(await A.snap())
+    return nodes.filter((n) => n.role === 'menuitem').map((n) => n.label || '')
+  }
+
+  try {
+    await r.ok('A shares "Ledger" and pauses it from the folder menu', async () => {
+      await A.launch()
+      await A.createSpaceOnly('Aurora')
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Ledger', 60000)
+      await A.openFolder('Ledger')
+      await A.waitText('q1.txt', 20000)
+
+      await A.click({ name: 'More', last: true })
+      await A.click({ name: 'Pause syncing' })
+      await A.waitText('Adding files is paused', 60000)
+      await A.shot('s142-paused', runDir)
+    })
+
+    await r.ok('the source goes missing, and the screen shows ONE state', async () => {
+      renameSync(ownDir, movedDir)
+      await waitFor(async () => /source folder moved or unavailable/i.test(allText(await A.snap())),
+        90000, 'the missing-source strip appears')
+
+      const text = allText(await A.snap())
+      assert(!/adding files is paused/i.test(text),
+        'and the paused strip is gone — the missing source is the state the user can act on')
+      assert(await A.hasText('Missing'), 'the tile pill agrees with the strip')
+
+      const buttons = flatten(await A.snap()).filter((n) => n.role === 'button')
+      assert(buttons.some((b) => /locate folder/i.test(b.label || '')), 'the strip carries Locate folder…')
+      assert(!buttons.some((b) => /^resume$/i.test(b.label || '')), 'and no Resume the worker would refuse')
+      await A.shot('s142-missing-not-paused', runDir)
+    })
+
+    await r.ok('the header menu offers Pause, never a Resume that cannot run', async () => {
+      await A.click({ name: 'More', last: true })
+      const labels = await menuLabels()
+      assert(labels.some((l) => /pause syncing/i.test(l)),
+        'the folder is not presented as paused while it is missing')
+      assert(!labels.some((l) => /resume syncing/i.test(l)),
+        'so the menu cannot raise SOURCE_FOLDER_MISSING')
+      await A.shot('s142-menu-offers-pause', runDir)
+      await A.press('escape')
+    })
+
+    // Split rather than compound: the two halves fail for different reasons — the first if the
+    // probe's return edge never reached the UI, the second if it reached it as the wrong state —
+    // and one timeout covering both names neither. The budget is three probe intervals.
+    await r.ok('the returning source clears the missing state', async () => {
+      // The strip above can appear from the listing's own live mountRootAvailable, before the 60s
+      // mount-point probe has recorded anything. The probe reports a TRANSITION, so a folder that
+      // leaves and returns inside one interval leaves it with nothing to report and the screen keeps
+      // the stale listing. Wait out a full interval here so the departure is recorded first.
+      await new Promise((done) => setTimeout(done, 70000))
+      renameSync(movedDir, ownDir)
+      await waitFor(async () => !/source folder moved or unavailable/i.test(allText(await A.snap())),
+        190000, 'the missing-source strip goes when the folder comes back')
+      await A.shot('s142-source-returned', runDir)
+    })
+
+    await r.ok('and the pause the user set is what it returns to', async () => {
+      await waitFor(async () => /adding files is paused/i.test(allText(await A.snap())),
+        30000, 'a folder coming back is not a Resume')
+      assert(!(await A.hasText('Missing')), 'and the tile pill follows it back')
+      const buttons = flatten(await A.snap()).filter((n) => n.role === 'button')
+      assert(buttons.some((b) => /^resume$/i.test(b.label || '')), 'the way back is offered again')
+      await A.shot('s142-paused-again', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/integration/mount-store-write-path.test.js
+++ b/test/integration/mount-store-write-path.test.js
@@ -2,7 +2,7 @@ import test from 'brittle'
 import { freshPeer } from '../helpers/store.js'
 import {
   createOwnedMount, getOwnedMount, deleteOwnedMount,
-  patchOwnedMount, setOwnedMountStatus, setOwnedIndexPaused, touchOwnedMountScan,
+  patchOwnedMount, setOwnedActivity, setOwnedFault, setOwnedIndexPaused, touchOwnedMountScan,
 } from '../../src/shared/folders/mount-store.js'
 
 const KEY = { spaceId: 'sp-1', shareId: 'sh-1' }
@@ -21,7 +21,7 @@ test('REGRESSION (FIX-R05-2b): a relocate does not clobber a concurrent status w
 
   await Promise.all([
     patchOwnedMount(KEY.spaceId, KEY.shareId, { mountPath: '/new' }),
-    setOwnedMountStatus(KEY.spaceId, KEY.shareId, 'paused-error', 'ENOSPC'),
+    setOwnedFault(KEY.spaceId, KEY.shareId, 'paused-error', 'ENOSPC'),
   ])
 
   const mount = await getOwnedMount(KEY.spaceId, KEY.shareId)
@@ -51,7 +51,7 @@ test('an unmount racing a patch does not resurrect the record', async (t) => {
   await seed(t)
 
   await Promise.all([
-    patchOwnedMount(KEY.spaceId, KEY.shareId, { status: 'active' }),
+    patchOwnedMount(KEY.spaceId, KEY.shareId, { mountPath: '/new' }),
     deleteOwnedMount(KEY.spaceId, KEY.shareId),
   ])
 
@@ -60,8 +60,40 @@ test('an unmount racing a patch does not resurrect the record', async (t) => {
 
 test('the read-merge helpers still report a missing record rather than creating one', async (t) => {
   await freshPeer(t)
-  t.is(await patchOwnedMount('sp-x', 'sh-x', { status: 'active' }), false, 'patch declines')
-  t.is(await setOwnedMountStatus('sp-x', 'sh-x', 'active'), false, 'status declines')
+  t.is(await patchOwnedMount('sp-x', 'sh-x', { mountPath: '/x' }), false, 'patch declines')
+  t.is(await setOwnedActivity('sp-x', 'sh-x', 'active'), false, 'status declines')
   t.is(await setOwnedIndexPaused('sp-x', 'sh-x', true), false, 'pause declines')
   t.absent(await getOwnedMount('sp-x', 'sh-x'), 'and none of them created one')
+})
+
+// REGRESSION (A.4): `status` is resolved from the facts beside it, so a patch that assigns one would
+// be the blind write the precedence exists to remove — and `indexPaused` is one of those facts.
+test('REGRESSION (A.4): a patch cannot assign a derived field', async (t) => {
+  await seed(t)
+
+  await t.exception(() => patchOwnedMount(KEY.spaceId, KEY.shareId, { status: 'active' }), /derived/)
+  await t.exception(() => patchOwnedMount(KEY.spaceId, KEY.shareId, { indexPaused: true }), /derived/)
+
+  const mount = await getOwnedMount(KEY.spaceId, KEY.shareId)
+  t.absent(mount.status, 'neither reached the record')
+  t.absent(mount.indexPaused)
+})
+
+// REGRESSION (A.4): the pause and the fault are separate facts, so a fault landing over a pause
+// shows the fault and leaves the intent standing for the pass that clears it.
+test('REGRESSION (A.4): a fault over a pause hides it without erasing it', async (t) => {
+  await seed(t)
+
+  await setOwnedIndexPaused(KEY.spaceId, KEY.shareId, true)
+  t.is((await getOwnedMount(KEY.spaceId, KEY.shareId)).status, 'paused', 'the pause shows')
+
+  await setOwnedFault(KEY.spaceId, KEY.shareId, 'paused-enospc', 'TRANSFER_DISK_FULL')
+  const faulted = await getOwnedMount(KEY.spaceId, KEY.shareId)
+  t.is(faulted.status, 'paused-enospc', 'the fault outranks it')
+  t.ok(faulted.indexPaused, 'and the intent is still recorded')
+
+  await setOwnedActivity(KEY.spaceId, KEY.shareId, 'active')
+  const cleared = await getOwnedMount(KEY.spaceId, KEY.shareId)
+  t.is(cleared.status, 'paused', 'a clean pass clears the fault and the pause resurfaces')
+  t.is(cleared.lastError, null, 'with its reason')
 })

--- a/test/integration/overlay-backend.test.js
+++ b/test/integration/overlay-backend.test.js
@@ -5,7 +5,7 @@ import { freshPeer } from '../helpers/store.js'
 import { createSpace } from '../../src/shared/spaces/space.js'
 import { publishShare, generateShareId } from '../../src/shared/shares/shares.js'
 import { getLocalPublicKeyHex } from '../../src/shared/spaces/profile.js'
-import { createOwnedMount, patchOwnedMount } from '../../src/shared/folders/mount-store.js'
+import { createOwnedMount, setOwnedIndexPaused } from '../../src/shared/folders/mount-store.js'
 import { initialPublishScan } from '../../src/shared/folders/owned-folders.js'
 import { getOwnEntry, ownCatalog } from '../../src/shared/shares/share-catalog.js'
 import { createCatalogBatch } from '../../src/shared/shares/catalog-writer.js'
@@ -147,14 +147,14 @@ test('REGRESSION (FIX-PI1-4: an owned-folder file gone from disk is retired thro
   const abs = path.join(ctx.mountPath, 'a.txt')
   await overlayBackend.publishAdd(ctx.spaceId, ctx.share, 'a.txt', abs)
 
-  await patchOwnedMount(ctx.spaceId, ctx.share.id, { indexPaused: true })
+  await setOwnedIndexPaused(ctx.spaceId, ctx.share.id, true)
   fs.unlinkSync(abs)
   await overlaySweepPresence()
   await overlaySweepPresence()
   t.ok(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'),
     'a paused index publishes no deletions — the reclaim went through the lane and the lane declined it')
 
-  await patchOwnedMount(ctx.spaceId, ctx.share.id, { indexPaused: false })
+  await setOwnedIndexPaused(ctx.spaceId, ctx.share.id, false)
   await overlaySweepPresence()
   await overlaySweepPresence()
   t.absent(await getOwnEntry(ctx.spaceId, ctx.share.id, 'a.txt'), 'and once the index resumes, the same lane retires it')

--- a/test/integration/owned-index-pause-restart.test.js
+++ b/test/integration/owned-index-pause-restart.test.js
@@ -77,3 +77,55 @@ test('the pause survives a restart, and boot arms no cadence for it', async (t) 
     && e.payload.command === MAIN_REQUEST.OWNED_FOLDER_START_WATCHER && e.payload.args.shareId === share.id),
   'and the watcher is still started')
 })
+
+// REGRESSION (A.4): both facts are durable, so a restart re-derives the same one thing the screen
+// showed before it — the fault — and the pass that clears the fault returns the folder to paused.
+test('REGRESSION (A.4): a paused and faulted mount comes back showing the fault', async (t) => {
+  t.teardown(() => timers.restore())
+  const root = tmp('store2')
+  const storage = path.join(root, 'app-storage')
+  fs.mkdirSync(storage, { recursive: true })
+  const downloads = tmp('dl2')
+  t.teardown(() => {
+    for (const dir of [root, downloads]) { try { fs.rmSync(dir, { recursive: true, force: true }) } catch {} }
+  })
+  const config = { storage, appVersion: '0.0.0-test', dev: true, verbose: false, downloadFolder: downloads, overlayEnabled: true }
+  const masterSecret = crypto.randomBytes(32)
+
+  const first = await boot(config, { ipc: createFakeIpc().ipc, log: silentLog, swarm: false, masterSecret, memberRegistry: offlineMemberRegistry })
+  await setProfile({ displayName: 'Tester' })
+  const space = await createSpace('Aurora')
+  const share = {
+    id: generateShareId(),
+    type: 'owned-folder',
+    name: 'Vault',
+    owner: getLocalPublicKeyHex(),
+    contentMode: 'overlay',
+    catalogKeyEnc: await ownCatalogKeyHex(space.spaceId),
+    createdAt: Date.now(),
+  }
+  await publishShare(space.spaceId, share)
+  const mountPath = tmp('mount2')
+  t.teardown(() => { try { fs.rmSync(mountPath, { recursive: true, force: true }) } catch {} })
+  fs.writeFileSync(path.join(mountPath, 'a.txt'), 'x')
+  await createOwnedMount({ spaceId: space.spaceId, shareId: share.id, mountPath, ignore: [], createdAt: Date.now() })
+
+  await first.mounts.pauseIndex(space.spaceId, share.id)
+  await first.mounts.settleScanStatus(
+    Promise.reject(Object.assign(new Error('no space'), { code: 'ENOSPC' })), space.spaceId, share.id)
+  await first.close()
+
+  const fake = createFakeIpc()
+  const second = await boot(config, { ipc: fake.ipc, log: silentLog, swarm: false, masterSecret, memberRegistry: offlineMemberRegistry })
+  t.teardown(() => second.close())
+
+  const restored = await getOwnedMount(space.spaceId, share.id)
+  t.is(restored.status, 'paused-enospc', 'the fault is what a restart repaints')
+  t.ok(restored.indexPaused, 'and the pause is still recorded')
+  t.absent(second.mounts.periodicTimers.has(space.spaceId + ':' + share.id),
+    'boot still arms no reconcile for a paused index')
+
+  await second.mounts.settleScanStatus(Promise.resolve({}), space.spaceId, share.id)
+  t.is((await getOwnedMount(space.spaceId, share.id)).status, 'paused',
+    'and the pass that clears the fault returns it to the pause the user set')
+})

--- a/test/integration/owned-mount-fault.test.js
+++ b/test/integration/owned-mount-fault.test.js
@@ -2,7 +2,7 @@ import test from 'brittle'
 import fs from 'bare-fs'
 import path from 'bare-path'
 import { setupOwnedShare } from '../helpers/owned.js'
-import { getOwnedMount, patchOwnedMount } from '../../src/shared/folders/mount-store.js'
+import { getOwnedMount, setOwnedActivity, setOwnedIndexPaused } from '../../src/shared/folders/mount-store.js'
 import { initialPublishScan } from '../../src/shared/folders/owned-folders.js'
 import { overlayBackend } from '../../src/shared/transfer/backends/overlay/index.js'
 import { CODES } from '../../src/shared/contract/errors.js'
@@ -126,7 +126,7 @@ test('a root that vanished mid-pass settles as mount-point-gone, not as a fault'
 // catch and its success path. These are the guard on the distinctions, not on the new behaviour.
 test("a cancelled pass still records nothing", async (t) => {
   const ctx = await setupOwnedShare(t)
-  await patchOwnedMount(ctx.spaceId, ctx.share.id, { status: 'scanning' })
+  await setOwnedActivity(ctx.spaceId, ctx.share.id, 'scanning')
 
   await ctx.root.mounts.settleScanStatus(Promise.resolve({ cancelled: true, failed: 0 }), ctx.spaceId, ctx.share.id)
 
@@ -136,10 +136,15 @@ test("a cancelled pass still records nothing", async (t) => {
 
 test('an index-paused skip still records paused, not a fault', async (t) => {
   const ctx = await setupOwnedShare(t)
+  // The skip only arises because the flag is set — the scan reads it and declines — so the fixture
+  // sets it too. The settle records the activity it reached; the pause is what outranks it.
+  await setOwnedIndexPaused(ctx.spaceId, ctx.share.id, true)
 
   await ctx.root.mounts.settleScanStatus(Promise.resolve({ skipped: 'index-paused' }), ctx.spaceId, ctx.share.id)
 
-  t.is((await getOwnedMount(ctx.spaceId, ctx.share.id)).status, 'paused', 'a decision is not a fault')
+  const mount = await getOwnedMount(ctx.spaceId, ctx.share.id)
+  t.is(mount.status, 'paused', 'a decision is not a fault')
+  t.is(mount.lastError, null, 'and carries no reason')
 })
 
 test('a skip with any other reason still records paused-error carrying it', async (t) => {
@@ -185,14 +190,14 @@ test('REGRESSION (FIX-PI12-3: a pass that declined to run does not consume the p
   // A pause declines the next pass before it walks. The fault it would have reported was observed
   // by the watcher item above and is still unreported, so it must survive rather than die with the
   // pass that never ran.
-  await patchOwnedMount(ctx.spaceId, ctx.share.id, { indexPaused: true })
+  await setOwnedIndexPaused(ctx.spaceId, ctx.share.id, true)
   await ctx.root.mounts.settleScanStatus(
     initialPublishScan(ctx.spaceId, ctx.share.id, ctx.mountPath, []),
     ctx.spaceId, ctx.share.id,
   )
   t.is((await getOwnedMount(ctx.spaceId, ctx.share.id)).status, 'paused', 'precondition: the pass declined')
 
-  await patchOwnedMount(ctx.spaceId, ctx.share.id, { indexPaused: false })
+  await setOwnedIndexPaused(ctx.spaceId, ctx.share.id, false)
   await ctx.root.mounts.settleScanStatus(
     initialPublishScan(ctx.spaceId, ctx.share.id, ctx.mountPath, []),
     ctx.spaceId, ctx.share.id,
@@ -222,4 +227,36 @@ test('a fault recorded by a watcher item between passes is not lost', async (t) 
   )
   t.is((await getOwnedMount(ctx.spaceId, ctx.share.id)).status, 'paused-enospc',
     'the fault carries to the pass that settles next, rather than being cleared when it starts')
+})
+
+// REGRESSION (A.4): the pause and the last pass's outcome are separate facts. A fault outranks the
+// pause on screen and leaves it recorded, so the clean pass that clears the fault returns the folder
+// to paused rather than silently resuming it.
+test('REGRESSION (A.4): a fault over a pause resolves back to paused, with no explicit resume', async (t) => {
+  const ctx = await setupOwnedShare(t)
+  await ctx.root.mounts.pauseIndex(ctx.spaceId, ctx.share.id)
+  t.is((await getOwnedMount(ctx.spaceId, ctx.share.id)).status, 'paused', 'precondition: paused')
+
+  await ctx.root.mounts.settleScanStatus(Promise.reject(errno('ENOSPC', 'no space left')), ctx.spaceId, ctx.share.id)
+  const faulted = await getOwnedMount(ctx.spaceId, ctx.share.id)
+  t.is(faulted.status, 'paused-enospc', 'the fault is what shows')
+  t.ok(faulted.indexPaused, 'and the pause is still recorded underneath')
+
+  await ctx.root.mounts.settleScanStatus(Promise.resolve({}), ctx.spaceId, ctx.share.id)
+  const cleared = await getOwnedMount(ctx.spaceId, ctx.share.id)
+  t.is(cleared.status, 'paused', 'the pass that clears the fault does not resume the folder')
+  t.is(cleared.lastError, null)
+})
+
+// REGRESSION (A.4): a clean pass over a paused folder must not report it active — the settle names
+// the activity it reached, and the pause outranks it.
+test('REGRESSION (A.4): a pause survives a clean scan settle', async (t) => {
+  const ctx = await setupOwnedShare(t)
+  await ctx.root.mounts.pauseIndex(ctx.spaceId, ctx.share.id)
+
+  await ctx.root.mounts.settleScanStatus(Promise.resolve({}), ctx.spaceId, ctx.share.id)
+
+  const mount = await getOwnedMount(ctx.spaceId, ctx.share.id)
+  t.is(mount.status, 'paused', 'still paused')
+  t.ok(mount.indexPaused)
 })

--- a/test/integration/owned-mount-probe.test.js
+++ b/test/integration/owned-mount-probe.test.js
@@ -43,3 +43,26 @@ test('a mount path that is still a directory is left alone', async (t) => {
   t.not(read.status, 'mount-point-gone', 'a healthy mount is not torn down by the probe')
   t.is(ctx.root.mounts.lastMountPointStatus.get('owned-folder:' + mount.shareId), true)
 })
+
+// REGRESSION (A.4): the probe's return edge clears the gone fault, and a paused index returns to
+// paused rather than being silently resumed by a folder reappearing.
+test('REGRESSION (A.4): a paused mount returns to paused when its source comes back', async (t) => {
+  const { ctx, mount } = await plantedMount(t, {
+    makePath: (p) => fs.mkdirSync(p, { recursive: true }),
+  })
+  await ctx.root.mounts.pauseIndex(mount.spaceId, mount.shareId)
+  t.is((await getOwnedMount(mount.spaceId, mount.shareId)).status, 'paused', 'precondition: paused')
+
+  fs.rmSync(mount.mountPath, { recursive: true, force: true })
+  await ctx.root.mounts.probeMountPoints()
+  t.is((await getOwnedMount(mount.spaceId, mount.shareId)).status, 'mount-point-gone',
+    'the missing source outranks the pause')
+
+  fs.mkdirSync(mount.mountPath, { recursive: true })
+  await ctx.root.mounts.probeMountPoints()
+  const back = await getOwnedMount(mount.spaceId, mount.shareId)
+  t.is(back.status, 'paused', 'and the pause the user set is what it returns to')
+  t.ok(back.indexPaused)
+  t.absent(ctx.root.mounts.periodicTimers.has(mount.spaceId + ':' + mount.shareId),
+    'a returning folder is not a resume, so no cadence is armed')
+})

--- a/test/integration/owned-mount-status.test.js
+++ b/test/integration/owned-mount-status.test.js
@@ -1,7 +1,7 @@
 import test from 'brittle'
 import path from 'bare-path'
 import { freshPeer } from '../helpers/store.js'
-import { createOwnedMount, getOwnedMount, listOwnedMounts, setOwnedMountStatus, touchOwnedMountScan } from '../../src/shared/folders/mount-store.js'
+import { createOwnedMount, getOwnedMount, listOwnedMounts, setOwnedActivity, setOwnedFault, touchOwnedMountScan } from '../../src/shared/folders/mount-store.js'
 
 async function plantedMount(t) {
   const ctx = await freshPeer(t)
@@ -22,7 +22,7 @@ async function plantedMount(t) {
 test('REGRESSION (FIX-F1: an owned-mount scan failure persists on the mount record)', async (t) => {
   const mount = await plantedMount(t)
 
-  t.ok(await setOwnedMountStatus(mount.spaceId, mount.shareId, 'paused-error', 'EACCES: permission denied'),
+  t.ok(await setOwnedFault(mount.spaceId, mount.shareId, 'paused-error', 'EACCES: permission denied'),
     'status write lands on the existing record')
 
   const read = await getOwnedMount(mount.spaceId, mount.shareId)
@@ -36,9 +36,9 @@ test('REGRESSION (FIX-F1: an owned-mount scan failure persists on the mount reco
 
 test('a healthy transition clears the persisted error', async (t) => {
   const mount = await plantedMount(t)
-  await setOwnedMountStatus(mount.spaceId, mount.shareId, 'paused-error', 'boom')
+  await setOwnedFault(mount.spaceId, mount.shareId, 'paused-error', 'boom')
 
-  await setOwnedMountStatus(mount.spaceId, mount.shareId, 'active')
+  await setOwnedActivity(mount.spaceId, mount.shareId, 'active')
 
   const read = await getOwnedMount(mount.spaceId, mount.shareId)
   t.is(read.status, 'active')
@@ -48,7 +48,7 @@ test('a healthy transition clears the persisted error', async (t) => {
 test('a status write for an unmounted share is a no-op', async (t) => {
   await plantedMount(t)
 
-  t.absent(await setOwnedMountStatus('space1', 'no-such-share', 'active'), 'reports the miss')
+  t.absent(await setOwnedActivity('space1', 'no-such-share', 'active'), 'reports the miss')
   t.absent(await getOwnedMount('space1', 'no-such-share'), 'no record conjured for a deleted mount')
 })
 
@@ -60,7 +60,7 @@ test('REGRESSION (FIX-15: the scan stamp merge preserves a status written mid-sc
 
   // Simulate: the scan started (record read), then a probe persisted 'paused-error' mid-scan,
   // then the scan completes and stamps its scan time.
-  await setOwnedMountStatus(mount.spaceId, mount.shareId, 'paused-error', 'disk full')
+  await setOwnedFault(mount.spaceId, mount.shareId, 'paused-error', 'disk full')
   await touchOwnedMountScan(mount.spaceId, mount.shareId)
 
   const read = await getOwnedMount(mount.spaceId, mount.shareId)

--- a/test/integration/owned-source-return.test.js
+++ b/test/integration/owned-source-return.test.js
@@ -3,7 +3,7 @@ import fs from 'bare-fs'
 import path from 'bare-path'
 import { setupOwnedShare } from '../helpers/owned.js'
 import { initOwnedFolders, onFsEvent } from '../../src/shared/folders/owned-folders.js'
-import { setOwnedMountStatus, getOwnedMount } from '../../src/shared/folders/mount-store.js'
+import { setOwnedActivity, setOwnedFault, getOwnedMount } from '../../src/shared/folders/mount-store.js'
 import { scaled } from '../helpers/bare-timing.js'
 
 // A watcher event schedules a trailing catch-up reconcile (2s debounce). That reconcile used to
@@ -32,7 +32,8 @@ function recordingSettle(ctx) {
       status = 'paused-error'
       outcome = { spaceId, shareId, error: err }
     }
-    await setOwnedMountStatus(spaceId, shareId, status, null)
+    if (status === 'active') await setOwnedActivity(spaceId, shareId, status)
+    else await setOwnedFault(spaceId, shareId, status, null)
     ctx.fake.ipc.emit('event:owned-folder-mount-status', { spaceId, shareId, status })
     // Recorded last: waitForSettle keys off this array, so publishing the status first keeps
     // the assertions that follow it free of a race with our own settle.

--- a/test/integration/relocate-deep-debt.test.js
+++ b/test/integration/relocate-deep-debt.test.js
@@ -148,6 +148,9 @@ test('relocate records the debt on both paths, before either pass is armed', (t)
   const scanAt = handler.indexOf('initialPublishScan(')
   t.ok(debtAt > 0, 'it records the debt')
   t.ok(scanAt > debtAt, 'before it arms the pass — the flag is the durable fact, the running pass is not')
-  t.absent(/if \(mount\.indexPaused\)[^\n]*deepScanOwed: true/.test(handler),
+  const pauseGate = handler.search(/if \(!?\w+\??\.?indexPaused\)/)
+  t.ok(pauseGate > debtAt,
     'and unconditionally: the ACTIVE path owes it too, to whatever runs after a quit mid-walk')
+  // The gate reads a record fetched AFTER the awaits above it, not the one this handler opened with.
+  t.absent(/if \(!mount\.indexPaused\)/.test(handler), 'the pause gate does not read the stale snapshot')
 })

--- a/test/unit/folder-status.test.js
+++ b/test/unit/folder-status.test.js
@@ -7,24 +7,24 @@ const BASE = {
   role: 'mine',
   sourceMissing: false,
   fault: false,
-  indexPaused: false,
+  paused: false,
   mirrorEnabled: true,
   indexing: false,
   mirrorSyncing: false,
 }
 
 test('a missing source outranks every other state', (t) => {
-  const status = deriveFolderStatus({ ...BASE, sourceMissing: true, indexPaused: true, indexing: true })
+  const status = deriveFolderStatus({ ...BASE, sourceMissing: true, paused: true, indexing: true })
   t.is(status.labelKey, 'folder.statusMissing')
 })
 
 test('a paused index outranks an active one', (t) => {
-  const status = deriveFolderStatus({ ...BASE, indexPaused: true, indexing: true })
+  const status = deriveFolderStatus({ ...BASE, paused: true, indexing: true })
   t.is(status.labelKey, 'folder.statusPaused')
 })
 
 test('a paused mirror reads the same as a paused index', (t) => {
-  const owner = deriveFolderStatus({ ...BASE, indexPaused: true })
+  const owner = deriveFolderStatus({ ...BASE, paused: true })
   const mirror = deriveFolderStatus({ ...BASE, role: 'mirrored', mirrorEnabled: false })
   t.is(mirror.labelKey, owner.labelKey, 'one word for one state, both roles')
   t.is(mirror.badge, owner.badge, 'and one colour')
@@ -47,7 +47,7 @@ test('browse is passive', (t) => {
 // The strip above the listing announces every state worth announcing, so the tile is a label and a
 // colour and nothing more — anything else here would read the same change twice.
 test('the status is exactly a label and a badge', (t) => {
-  for (const input of [{ ...BASE, sourceMissing: true }, { ...BASE, indexPaused: true }, { ...BASE, indexing: true }, BASE]) {
+  for (const input of [{ ...BASE, sourceMissing: true }, { ...BASE, paused: true }, { ...BASE, indexing: true }, BASE]) {
     t.alike(Object.keys(deriveFolderStatus(input)).sort(), ['badge', 'labelKey'])
   }
 })
@@ -62,7 +62,7 @@ test('an idle folder is up to date', (t) => {
 test('every badge names a real style in the shared table', (t) => {
   const cases = [
     { ...BASE, sourceMissing: true },
-    { ...BASE, indexPaused: true },
+    { ...BASE, paused: true },
     { ...BASE, indexing: true },
     { ...BASE, role: 'mirrored', mirrorSyncing: true },
     { ...BASE, role: 'browse' },
@@ -77,7 +77,7 @@ test('every badge names a real style in the shared table', (t) => {
 // An auto-paused mirror is enabled === false, so without the fault outranking the pause the tile
 // called a folder stopped by a full disk "Paused" — the user's own doing, as far as it read.
 test('a fault outranks both pauses and reads as an error', (t) => {
-  const owner = deriveFolderStatus({ ...BASE, fault: true, indexPaused: true })
+  const owner = deriveFolderStatus({ ...BASE, fault: true, paused: true })
   t.is(owner.labelKey, 'folder.statusFault')
   t.is(owner.badge, 'error')
 

--- a/test/unit/folder-strips.test.js
+++ b/test/unit/folder-strips.test.js
@@ -148,3 +148,15 @@ test('a faulted owner can still be working — the fault describes the last pass
   })
   t.alike(ids(strips), ['fault', 'working'])
 })
+
+// REGRESSION (A.4-D1): a paused folder whose source went missing rendered both strips, stacked —
+// "Locate folder…" above "Resume" — offering a Resume that cannot run. One state, one strip.
+test('REGRESSION (A.4-D1): a missing source outranks a pause, as a fault already does', (t) => {
+  const paused = { ...OWNER, indexing: { ...IDLE_INDEX, paused: true } }
+  t.alike(ids(deriveStrips(paused)), ['paused'], 'precondition: a plain pause still shows')
+
+  t.alike(ids(deriveStrips({ ...paused, sourceMissing: true })), ['source-missing'],
+    'the missing source is the one the user can act on')
+  t.alike(ids(deriveStrips({ ...paused, fault: { status: 'paused-error', code: 'EACCES' } })), ['fault'],
+    'and a fault still outranks it too')
+})

--- a/test/unit/index-summary.test.js
+++ b/test/unit/index-summary.test.js
@@ -44,16 +44,16 @@ test('wire numbers are clamped', (t) => {
 // re-hashed), so a paused folder reports the same adding: 0 a finished one reports. Only the mount
 // tells them apart — which is why `paused` is independent of `active` rather than derived from it.
 test('a paused index renders as paused, not as idle', (t) => {
-  const s = deriveIndexSummary({ adding: 0, bytesQueued: 0 }, { indexPaused: true })
+  const s = deriveIndexSummary({ adding: 0, bytesQueued: 0 }, { paused: true })
   t.absent(s.active, 'no work is queued')
   t.ok(s.paused, 'but the folder is paused, and the notice must say so')
 })
 
 test('pausing is not the same as finishing', (t) => {
-  t.absent(deriveIndexSummary({ adding: 0 }, { indexPaused: false }).paused)
+  t.absent(deriveIndexSummary({ adding: 0 }, { paused: false }).paused)
   t.absent(deriveIndexSummary({ adding: 0 }, null).paused, 'no mount yet is not a pause')
   t.absent(deriveIndexSummary({ adding: 0 }, undefined).paused)
-  t.ok(deriveIndexSummary({ adding: 12 }, { indexPaused: true }).paused, 'a pause mid-queue still reads paused')
+  t.ok(deriveIndexSummary({ adding: 12 }, { paused: true }).paused, 'a pause mid-queue still reads paused')
 })
 
 test('the summary is unchanged when no mount is passed', (t) => {
@@ -84,7 +84,7 @@ test('a filled queue supersedes the walk phase', (t) => {
 test('a paused index is never reported as scanning', (t) => {
   // Pause cancels the pass, so a stale 'scanning' status must not outrank the durable pause and
   // put the folder back into the busy notice.
-  const s = deriveIndexSummary({ adding: 0 }, { indexPaused: true, scanning: true })
+  const s = deriveIndexSummary({ adding: 0 }, { paused: true, scanning: true })
   t.ok(s.paused)
   t.absent(s.scanning)
   t.absent(s.active, 'the paused banner renders instead of the busy one')

--- a/test/unit/mount-precedence.test.js
+++ b/test/unit/mount-precedence.test.js
@@ -1,0 +1,67 @@
+import test from 'brittle'
+import { ownedMountStatus, isFaultStatus, isHealthyOwnedStatus, _rankForTests } from '../../src/shared/contract/mount-precedence.js'
+import { MOUNT_STATUS, OWNED_MOUNT_STATUSES } from '../../src/shared/contract/statuses.js'
+
+test('the precedence resolves every combination to exactly one status', (t) => {
+  const cases = [
+    [{ status: MOUNT_STATUS.ACTIVE }, MOUNT_STATUS.ACTIVE],
+    [{ status: MOUNT_STATUS.SCANNING }, MOUNT_STATUS.SCANNING],
+    [{ status: MOUNT_STATUS.ACTIVE, indexPaused: true }, MOUNT_STATUS.PAUSED],
+    [{ status: MOUNT_STATUS.SCANNING, indexPaused: true }, MOUNT_STATUS.PAUSED],
+    [{ status: MOUNT_STATUS.PAUSED_ERROR, indexPaused: true }, MOUNT_STATUS.PAUSED_ERROR],
+    [{ status: MOUNT_STATUS.PAUSED_ENOSPC, indexPaused: true }, MOUNT_STATUS.PAUSED_ENOSPC],
+    [{ status: MOUNT_STATUS.MOUNT_POINT_GONE, indexPaused: true }, MOUNT_STATUS.MOUNT_POINT_GONE],
+    [{ status: MOUNT_STATUS.PAUSED_ERROR, mountPointMissing: true }, MOUNT_STATUS.MOUNT_POINT_GONE],
+    [{ status: MOUNT_STATUS.SCANNING, mountPointMissing: true }, MOUNT_STATUS.MOUNT_POINT_GONE],
+    [{ status: undefined }, MOUNT_STATUS.SCANNING],
+    [{}, MOUNT_STATUS.SCANNING],
+  ]
+  for (const [record, expected] of cases) {
+    t.is(ownedMountStatus(record), expected, JSON.stringify(record))
+  }
+  t.is(ownedMountStatus(null), null, 'no record is no status')
+})
+
+// REGRESSION (A.4): the fault is what the user can act on, so it shows — but the pause is a
+// separate fact and is still there when the fault clears.
+test('REGRESSION (A.4): a fault hides a pause without erasing it', (t) => {
+  const faulted = { status: MOUNT_STATUS.PAUSED_ERROR, indexPaused: true }
+  t.is(ownedMountStatus(faulted), MOUNT_STATUS.PAUSED_ERROR, 'the fault is what shows')
+  t.is(ownedMountStatus({ ...faulted, status: MOUNT_STATUS.ACTIVE }), MOUNT_STATUS.PAUSED,
+    'and the pause is what is left once a clean pass clears the fault')
+})
+
+test('a missing source outranks an I/O fault', (t) => {
+  t.is(ownedMountStatus({ status: MOUNT_STATUS.PAUSED_ENOSPC, mountPointMissing: true }),
+    MOUNT_STATUS.MOUNT_POINT_GONE, 'the remedy is Locate, not Try again')
+})
+
+test('isFaultStatus names the statuses only a fresh pass can clear', (t) => {
+  for (const s of [MOUNT_STATUS.MOUNT_POINT_GONE, MOUNT_STATUS.PAUSED_ENOSPC, MOUNT_STATUS.PAUSED_ERROR]) {
+    t.ok(isFaultStatus(s), `${s} is a fault`)
+  }
+  for (const s of [MOUNT_STATUS.PAUSED, MOUNT_STATUS.SCANNING, MOUNT_STATUS.ACTIVE, MOUNT_STATUS.IDLE]) {
+    t.absent(isFaultStatus(s), `${s} is not a fault`)
+  }
+  t.absent(isFaultStatus(undefined), 'an unwritten status is not a fault')
+})
+
+test('isHealthyOwnedStatus is the pair that renders no badge', (t) => {
+  t.ok(isHealthyOwnedStatus(MOUNT_STATUS.ACTIVE))
+  t.ok(isHealthyOwnedStatus(MOUNT_STATUS.SCANNING))
+  for (const s of [MOUNT_STATUS.PAUSED, MOUNT_STATUS.PAUSED_ERROR, MOUNT_STATUS.MOUNT_POINT_GONE]) {
+    t.absent(isHealthyOwnedStatus(s), `${s} deserves a badge`)
+  }
+})
+
+test('every owned status the contract declares has a rank', (t) => {
+  for (const status of OWNED_MOUNT_STATUSES) {
+    t.is(typeof _rankForTests[status], 'number', `${status} is ranked`)
+  }
+  t.ok(_rankForTests[MOUNT_STATUS.MOUNT_POINT_GONE] > _rankForTests[MOUNT_STATUS.PAUSED_ERROR],
+    'a missing source outranks a fault')
+  t.ok(_rankForTests[MOUNT_STATUS.PAUSED_ERROR] > _rankForTests[MOUNT_STATUS.PAUSED],
+    'a fault outranks a pause')
+  t.ok(_rankForTests[MOUNT_STATUS.PAUSED] > _rankForTests[MOUNT_STATUS.SCANNING],
+    'a pause outranks activity')
+})

--- a/test/unit/owned-mount-projection.test.js
+++ b/test/unit/owned-mount-projection.test.js
@@ -27,7 +27,7 @@ test('an unsettled read is distinguishable from a share with no row', (t) => {
   // so reporting it for a folder that simply was never mounted would freeze that folder forever.
   t.alike(
     projectOwnedMount([], 'sp1', 'sh1', true),
-    { status: null, lastError: null, loaded: true, indexPaused: false, scanning: false, mountPath: null },
+    { status: null, lastError: null, loaded: true, paused: false, scanning: false, mountPath: null },
     'settled with no row → loaded:true, healthy',
   )
 })
@@ -72,17 +72,33 @@ test('every field is read from the row, so nothing latches across a share change
     row({ shareId: 'sh2', status: 'scanning', mountPath: '/b' }),
   ]
 
+  // REGRESSION (A.4): the row holds both facts and the projection resolves them — the fault is what
+  // shows, and `paused` is false while it does.
   t.alike(projectOwnedMount(rows, 'sp1', 'sh1', true), {
-    status: 'paused-error', lastError: 'ENOSPC', loaded: true, indexPaused: true, scanning: false, mountPath: '/a',
+    status: 'paused-error', lastError: 'ENOSPC', loaded: true, paused: false, scanning: false, mountPath: '/a',
   })
   // The same call for the sibling share carries none of sh1's state — the leak the hand-rolled
   // hook had, where `loaded` and `status` survived a navigation because only the effect reset them.
   t.alike(projectOwnedMount(rows, 'sp1', 'sh2', true), {
-    status: null, lastError: null, loaded: true, indexPaused: false, scanning: true, mountPath: '/b',
+    status: null, lastError: null, loaded: true, paused: false, scanning: true, mountPath: '/b',
   })
 })
 
 test('rows from another space are never matched', (t) => {
   const rows = [row({ spaceId: 'sp2', status: 'paused-error' })]
   t.is(projectOwnedMount(rows, 'sp1', 'sh1', true).status, null, 'same shareId, different space')
+})
+
+test('REGRESSION (A.4): a paused row projects paused, and the fault over it projects the fault', (t) => {
+  const paused = [row({ status: 'active', indexPaused: true })]
+  t.is(projectOwnedMount(paused, 'sp1', 'sh1', true).status, 'paused', 'the pause shows')
+  t.ok(projectOwnedMount(paused, 'sp1', 'sh1', true).paused)
+
+  const faulted = [row({ status: 'paused-enospc', indexPaused: true })]
+  t.is(projectOwnedMount(faulted, 'sp1', 'sh1', true).status, 'paused-enospc', 'the fault outranks it')
+  t.absent(projectOwnedMount(faulted, 'sp1', 'sh1', true).paused, 'so the screen offers Try again, not Resume')
+
+  const missing = [row({ status: 'active', indexPaused: true, mountPointMissing: true })]
+  t.is(projectOwnedMount(missing, 'sp1', 'sh1', true).status, 'mount-point-gone', 'and a missing source outranks both')
+  t.absent(projectOwnedMount(missing, 'sp1', 'sh1', true).paused)
 })

--- a/test/unit/state-conveyance-review-fixes.test.js
+++ b/test/unit/state-conveyance-review-fixes.test.js
@@ -33,8 +33,9 @@ test('REGRESSION (FIX-6/7/8: scan outcomes drive owned status; probe never blank
   t.ok(/async settleScanStatus\(/.test(mountsRuntime), 'the settleScanStatus method exists')
   t.ok(/result\?\.skipped === MOUNT_STATUS\.MOUNT_POINT_GONE/.test(mountsRuntime) && /else if \(result\?\.skipped\)/.test(mountsRuntime),
     'a skipped scan is not recorded as active')
-  // The probe's owned branch must not assert a durable status purely from path presence.
-  t.absent(/setOwnedStatus\(mount\.spaceId, mount\.shareId, exists \? 'active'/.test(mountsRuntime),
+  // The probe's owned branch must not assert a durable status purely from path presence: it may
+  // clear the gone fault on the return edge, never write an outcome the pass has not reached.
+  t.absent(/record(Activity|Fault)\(mount\.spaceId, mount\.shareId, exists \?/.test(mountsRuntime),
     'the probe no longer blanket-writes active/gone from path presence')
 })
 


### PR DESCRIPTION
First of two for A.4 (#236), split out of #233 box 2.1 by your decision. **This half is
behaviour-neutral end to end** — the renderer keeps its own precedence copies and nothing visible
changes; PR 2 is where the two user-facing bugs get fixed.

Full plan and reasoning: `~/Projects/Mirall/plans/plan-a4-one-mount-status.md`.

### A.4 contradicted itself, and this resolves it

A.4 asked for `indexPaused` to disappear **and** for a pause to resurface once a fault clears. Those
cannot both hold: with the pause living only in `status`, a fault status overwrites it and there is
nowhere for it to resurface from. `mount-store.js` said so already, and the probe's `indexPaused`
re-read existed purely to restore a pause `handleOwnedMountGone` had destroyed.

So **the field stays and the blind assignment goes**. `status` is derived, by
`contract/mount-precedence.js`, from the two facts recorded beside it:

```
mount-point-gone  >  paused-enospc = paused-error  >  paused  >  scanning  >  active  >  idle
```

`mount-point-gone` tops it because its remedy is a different verb — "Locate folder…", not "Try
again" — which is also why `mountFault()` excludes it.

- Three concern-named setters replace the one assigning setter: `setOwnedActivity` (a pass reached a
  conclusion; clears a fault), `setOwnedFault`, `setOwnedIndexPaused`. Each recomputes the derived
  status, so no caller assigns one.
- **There is no "refuses to downgrade" rule**, despite A.4's wording. `paused-enospc → active` on a
  clean pass is a required downgrade, pinned by an existing test; the invariant A.4 was reaching for
  ("a pause must not be lost") is satisfied structurally by keeping the pause in its own field.
- The probe's `indexPaused` re-read is **deleted** — the clearest sign the model is right.
- `patchOwnedMount` throws on `status` or `indexPaused`, closing the only bypass.
- The status event now carries what the record settled on, not what the caller asked for.
- Relocate's deep-scan gate re-reads the record: it was deciding from a snapshot taken before two
  awaits, so a pause landing in that window was missed.

**No migration.** The persisted shape is unchanged — only who writes `status`. Absent fields were
already the norm (`createOwnedMount` writes neither `status` nor `indexPaused`).

### Verification

`tsc` and `lint:ci` clean. Unit 97/97 across 8 files — **including the renderer projection tests
unchanged**, which is the behaviour-neutrality claim in executable form. Integration 69/69 across 9
files, covering pause-survives-settle, fault-over-pause-and-back, the probe's return edge, restart
durability and relocate.

Two source-scanning ratchets went **vacuous** rather than red and are re-pointed:
`state-conveyance-review-fixes.test.js` (matched a function name that no longer exists) and
`relocate-deep-debt.test.js` (matched `mount.indexPaused` in the relocate handler).

One test fixture was fictional and is now real: `owned-mount-fault.test.js` fabricated a
`{ skipped: 'index-paused' }` settle without the mount being paused, which production cannot
produce — that skip only arises *because* the flag is set.

Found while verifying, filed separately, **pre-existing**: #287.
