### PR TITLE
[fix] Show one folder state, not two

### DIFF
--- a/src/renderer/folderStatus.d.ts
+++ b/src/renderer/folderStatus.d.ts
@@ -4,7 +4,7 @@ export interface FolderStatusInput {
   role: ShareRole
   sourceMissing: boolean
   fault: boolean
-  indexPaused: boolean
+  paused: boolean
   mirrorEnabled: boolean
   indexing: boolean
   mirrorSyncing: boolean

--- a/src/renderer/folderStatus.js
+++ b/src/renderer/folderStatus.js
@@ -9,12 +9,12 @@
 // second announcement from the tile would read the same change twice.
 
 export function deriveFolderStatus(input) {
-  const { role, sourceMissing, fault, indexPaused, mirrorEnabled, indexing, mirrorSyncing, ownerOnline, incomplete } = input
+  const { role, sourceMissing, fault, paused, mirrorEnabled, indexing, mirrorSyncing, ownerOnline, incomplete } = input
   if (sourceMissing) return { labelKey: 'folder.statusMissing', badge: 'paused' }
   // Above both pauses, for the same reason the fault strip is: an auto-paused mirror is
   // enabled === false, so without this the tile calls a stopped folder "Paused".
   if (fault) return { labelKey: 'folder.statusFault', badge: 'error' }
-  if (role === 'mine' && indexPaused) return { labelKey: 'folder.statusPaused', badge: 'paused' }
+  if (role === 'mine' && paused) return { labelKey: 'folder.statusPaused', badge: 'paused' }
   if (role === 'mirrored' && mirrorEnabled === false) return { labelKey: 'folder.statusPaused', badge: 'paused' }
   if (role === 'mine' && indexing) return { labelKey: 'folder.statusAdding', badge: 'publishing' }
   if (role === 'mirrored' && mirrorSyncing) return { labelKey: 'folder.statusSyncing', badge: 'downloading' }

--- a/src/renderer/folderStrips.js
+++ b/src/renderer/folderStrips.js
@@ -31,8 +31,10 @@ function faultStrip(input) {
   }
 }
 
+// A folder shows one state, and both a fault and a missing source outrank a pause: each carries the
+// action the user can actually take, and the pause is still recorded underneath.
 function isPaused(input) {
-  if (input.fault) return false
+  if (input.fault || input.sourceMissing) return false
   if (input.isYou) return !!input.indexing?.paused
   return input.role === 'mirrored' && input.foreignEnabled === false
 }

--- a/src/renderer/indexSummary.d.ts
+++ b/src/renderer/indexSummary.d.ts
@@ -21,5 +21,5 @@ export interface IndexSummary {
 
 export function deriveIndexSummary(
   status: IndexStatus | null | undefined,
-  mount?: { indexPaused?: boolean; scanning?: boolean } | null,
+  mount?: { paused?: boolean; scanning?: boolean } | null,
 ): IndexSummary

--- a/src/renderer/indexSummary.js
+++ b/src/renderer/indexSummary.js
@@ -11,13 +11,12 @@
 
 const count = (n) => (Number.isFinite(n) && n > 0 ? n : 0)
 
-// The mount carries the durable pause. A paused index has an EMPTY queue — pausing drops it, and
-// rebuilding it costs one walk because a published file is never re-hashed — so `paused` is
-// deliberately independent of `active`: a paused folder reports the same zero a finished one does,
-// and only the mount tells them apart.
+// A paused index has an EMPTY queue — pausing drops it, and rebuilding it costs one walk because a
+// published file is never re-hashed — so `paused` is deliberately independent of `active`: a paused
+// folder reports the same zero a finished one does, and only the mount tells them apart.
 export function deriveIndexSummary(status, mount) {
   const files = count(status?.adding)
-  const paused = !!mount?.indexPaused
+  const paused = !!mount?.paused
   // The scan's first phase walks the disk and fills no queue, so `adding` is 0 for the whole of it
   // — minutes on a large folder, during which the notice would otherwise show nothing and offer no
   // way to stop. That is exactly when a user reaches for one, so the phase counts as active.

--- a/src/renderer/ownedMount.d.ts
+++ b/src/renderer/ownedMount.d.ts
@@ -9,7 +9,7 @@ export interface OwnedMountState {
    *  it means "not read yet", and a caller that cannot tell them apart falls back to a frozen
    *  navigation snapshot forever. */
   loaded: boolean
-  indexPaused: boolean
+  paused: boolean
   /** The scan is walking the disk. It fills no queue, so nothing else can report that phase. */
   scanning: boolean
   mountPath: string | null

--- a/src/renderer/ownedMount.js
+++ b/src/renderer/ownedMount.js
@@ -2,16 +2,13 @@
 // projections live here rather than in the hook so they are one declaration for two screens — and
 // so the precedence below is testable without React.
 
-// The badge projection of an owned mount's durable state: a live missing path wins, then any
-// persisted non-healthy status (paused-error / mount-point-gone survive a restart); healthy states
-// (active / scanning) render no badge.
+import { MOUNT_STATUS } from '../shared/contract/statuses.js'
+import { ownedMountStatus, isHealthyOwnedStatus } from '../shared/contract/mount-precedence.js'
 
-import { MOUNT_STATUS, HEALTHY_OWNED_STATUSES } from '../shared/contract/statuses.js'
+// Which states deserve a badge: the resolved status, unless it is one nothing is wrong with.
 export function unhealthyOwnedStatus(m) {
-  if (!m) return null
-  if (m.mountPointMissing) return MOUNT_STATUS.MOUNT_POINT_GONE
-  if (m.status && !HEALTHY_OWNED_STATUSES.includes(m.status)) return m.status
-  return null
+  const status = ownedMountStatus(m)
+  return status && !isHealthyOwnedStatus(status) ? status : null
 }
 
 // Settled means an answer LANDED — data or error — not `!loading`: the store settles an entry on an
@@ -33,20 +30,18 @@ export function ownedMountSettled(enabled, rows) {
 export function projectOwnedMount(rows, spaceId, shareId, settled) {
   if (!settled || !spaceId || !shareId) return NO_OWNED_MOUNT
   const m = (rows || []).find((x) => x.spaceId === spaceId && x.shareId === shareId)
-  // Both from one row: the badge projection AND the durable intent behind it. The status alone
-  // cannot carry the pause — a scan settle overwrites it, and 'mount-point-gone' legitimately
-  // outranks it while the source is missing.
+  const resolved = ownedMountStatus(m)
   return {
     status: unhealthyOwnedStatus(m),
     lastError: m?.lastError ?? null,
     loaded: true,
-    indexPaused: !!m?.indexPaused,
-    scanning: m?.status === 'scanning',
+    paused: resolved === MOUNT_STATUS.PAUSED,
+    scanning: resolved === MOUNT_STATUS.SCANNING,
     mountPath: m?.mountPath ?? null,
   }
 }
 
 // test seam
 export const NO_OWNED_MOUNT = Object.freeze({
-  status: null, lastError: null, loaded: false, indexPaused: false, scanning: false, mountPath: null,
+  status: null, lastError: null, loaded: false, paused: false, scanning: false, mountPath: null,
 })

--- a/src/renderer/screens/FolderView.tsx
+++ b/src/renderer/screens/FolderView.tsx
@@ -180,7 +180,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   const manualControls = share.role === 'browse'
   // Live while mounted: owned-folder:list-all (a live mountRootAvailable check) re-derives on every
   // mount-status event; the useShares projection covers SpaceView only.
-  const { status: ownedStatus, lastError: ownedError, loaded: ownedLoaded, indexPaused, scanning, mountPath: ownedPath } = useOwnedMount(spaceId, isYou ? share.id : '')
+  const { status: ownedStatus, lastError: ownedError, loaded: ownedLoaded, paused: ownedPaused, scanning, mountPath: ownedPath } = useOwnedMount(spaceId, isYou ? share.id : '')
   // The scan's queue depth, which the file rows cannot show: a queued file has no catalog entry
   // yet, so it has no row. Ours reports locally; a peer's is re-announced by its owner, so it is
   // only meaningful while they are reachable — an owner that drops mid-scan sends no final frame.
@@ -192,8 +192,8 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
   // Memoised on its inputs: deriveIndexSummary returns a fresh object every call, and an unstable
   // `indexing` would make every downstream useMemo that depends on it miss on every render.
   const indexing = useMemo(
-    () => deriveIndexSummary(indexProgress, { indexPaused, scanning }),
-    [indexProgress, indexPaused, scanning],
+    () => deriveIndexSummary(indexProgress, { paused: ownedPaused, scanning }),
+    [indexProgress, ownedPaused, scanning],
   )
   // Live read wins once loaded, including "healthy": the hook returns null for a healthy mount, so
   // `??` would resurrect the snapshot.
@@ -265,7 +265,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
     role: share.role,
     sourceMissing,
     fault: !!fault,
-    indexPaused,
+    paused: ownedPaused,
     mirrorEnabled: foreignEnabled,
     indexing: indexing.active,
     // Same rule the strip applies: with the owner away nothing is being fetched, so the tile must
@@ -336,7 +336,7 @@ export default function FolderView({ spaceId, share, onBack, onMirror, onUnmount
     else void setPaused(action === 'pause')
   }
 
-  const paused = isYou ? indexPaused : !foreignEnabled
+  const paused = isYou ? ownedPaused : !foreignEnabled
   // The same acts the header offers, reachable from the command palette while this folder is on
   // screen. Deliberately not the destructive pair: Delete and Unmount are gated on work that is
   // still running, and an Enter keypress in a search field is the wrong place to confirm either.

--- a/test/frontend/run.mjs
+++ b/test/frontend/run.mjs
@@ -139,6 +139,7 @@ import s138 from './scenarios/s138-mirror-offline-quiet.mjs'
 import s139 from './scenarios/s139-mirror-offline-incomplete.mjs'
 import s140 from './scenarios/s140-modal-failure-escape-routes.mjs'
 import s141 from './scenarios/s141-scan-preview-singular.mjs'
+import s142 from './scenarios/s142-paused-and-missing-one-state.mjs'
 
 const REPO = path.resolve(import.meta.dirname, '../..')
 const runDir = path.join(REPO, 'test/frontend/evidence', new Date().toISOString().replace(/[:.]/g, '-'))
@@ -198,7 +199,7 @@ function pruneAgentDesktopStore() {
   if (stale) console.error(`pruned ${stale} stale agent-desktop snapshot(s)`)
 }
 
-const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140, s141 }
+const ALL = { s1, s2, s3, s4, s5, s6, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22, s23, s24, s25, s26, s27, s28, s29, s30, s31, s32, s33, s34, s35, s36, s37, s38, s39, s40, s41, s42, s48, s49, s50, s51, s52, s54, s55, s56, s57, s58, s59, s60, s61, s62, s63, s64, s65, s66, s67, s68, s69, s70, s71, s73, s74, s75, s76, s77, s78, s79, s80, s81, s82, s83, s84, s85, s86, s87, s88, s89, s90, s91, s92, s93, s94, s95, s96, s97, s98, s99, s100, s101, s102, s103, s104, s105, s106, s107, s108, s109, s110, s111, s112, s113, s114, s115, s116, s117, s118, s119, s120, s121, s122, s123, s124, s125, s126, s127, s128, s129, s130, s131, s132, s133, s134, s135, s136, s137, s138, s139, s140, s141, s142 }
 const pick = args.filter((a) => !a.startsWith('--'))
 const keys = pick.length ? pick : Object.keys(ALL)
 

--- a/test/frontend/scenarios/s142-paused-and-missing-one-state.mjs
+++ b/test/frontend/scenarios/s142-paused-and-missing-one-state.mjs
@@ -1,0 +1,99 @@
+import { mkdirSync, writeFileSync, renameSync } from 'node:fs'
+import path from 'node:path'
+import { Instance } from '../instance.mjs'
+import { makeReport, assert, waitFor } from '../assert.mjs'
+import { allText, flatten } from '../tree.mjs'
+import { workDir } from '../paths.mjs'
+
+// REGRESSION (A.4: a paused folder whose source went missing showed both states at once — the
+// "Locate folder…" strip stacked above a "Resume" strip — and the header menu still offered Resume
+// syncing, which the worker refuses with SOURCE_FOLDER_MISSING. The pause and the last pass's
+// outcome are two facts; the screen shows the one the user can act on, and the pause resurfaces
+// once the source is back.)
+//
+// The restore step waits past the 60s mount-point probe interval: the folder coming back is not the
+// user pressing Resume, so nothing else re-derives the status.
+export default async function s142({ runDir }) {
+  mkdirSync(runDir, { recursive: true })
+  const r = makeReport()
+  const A = new Instance({ name: 'Alice', slot: 0, total: 1 })
+
+  const parent = workDir('own-')
+  const ownDir = path.join(parent, 'Ledger')
+  const movedDir = path.join(parent, 'Ledger-moved')
+  mkdirSync(ownDir, { recursive: true })
+  writeFileSync(path.join(ownDir, 'q1.txt'), 'numbers')
+
+  const menuLabels = async () => {
+    const nodes = flatten(await A.snap())
+    return nodes.filter((n) => n.role === 'menuitem').map((n) => n.label || '')
+  }
+
+  try {
+    await r.ok('A shares "Ledger" and pauses it from the folder menu', async () => {
+      await A.launch()
+      await A.createSpaceOnly('Aurora')
+      await A.addOwnedFolder(ownDir)
+      await A.waitText('Ledger', 60000)
+      await A.openFolder('Ledger')
+      await A.waitText('q1.txt', 20000)
+
+      await A.click({ name: 'More', last: true })
+      await A.click({ name: 'Pause syncing' })
+      await A.waitText('Adding files is paused', 60000)
+      await A.shot('s142-paused', runDir)
+    })
+
+    await r.ok('the source goes missing, and the screen shows ONE state', async () => {
+      renameSync(ownDir, movedDir)
+      await waitFor(async () => /source folder moved or unavailable/i.test(allText(await A.snap())),
+        90000, 'the missing-source strip appears')
+
+      const text = allText(await A.snap())
+      assert(!/adding files is paused/i.test(text),
+        'and the paused strip is gone — the missing source is the state the user can act on')
+      assert(await A.hasText('Missing'), 'the tile pill agrees with the strip')
+
+      const buttons = flatten(await A.snap()).filter((n) => n.role === 'button')
+      assert(buttons.some((b) => /locate folder/i.test(b.label || '')), 'the strip carries Locate folder…')
+      assert(!buttons.some((b) => /^resume$/i.test(b.label || '')), 'and no Resume the worker would refuse')
+      await A.shot('s142-missing-not-paused', runDir)
+    })
+
+    await r.ok('the header menu offers Pause, never a Resume that cannot run', async () => {
+      await A.click({ name: 'More', last: true })
+      const labels = await menuLabels()
+      assert(labels.some((l) => /pause syncing/i.test(l)),
+        'the folder is not presented as paused while it is missing')
+      assert(!labels.some((l) => /resume syncing/i.test(l)),
+        'so the menu cannot raise SOURCE_FOLDER_MISSING')
+      await A.shot('s142-menu-offers-pause', runDir)
+      await A.press('escape')
+    })
+
+    // Split rather than compound: the two halves fail for different reasons — the first if the
+    // probe's return edge never reached the UI, the second if it reached it as the wrong state —
+    // and one timeout covering both names neither. The budget is three probe intervals.
+    await r.ok('the returning source clears the missing state', async () => {
+      // The strip above can appear from the listing's own live mountRootAvailable, before the 60s
+      // mount-point probe has recorded anything. The probe reports a TRANSITION, so a folder that
+      // leaves and returns inside one interval leaves it with nothing to report and the screen keeps
+      // the stale listing. Wait out a full interval here so the departure is recorded first.
+      await new Promise((done) => setTimeout(done, 70000))
+      renameSync(movedDir, ownDir)
+      await waitFor(async () => !/source folder moved or unavailable/i.test(allText(await A.snap())),
+        190000, 'the missing-source strip goes when the folder comes back')
+      await A.shot('s142-source-returned', runDir)
+    })
+
+    await r.ok('and the pause the user set is what it returns to', async () => {
+      await waitFor(async () => /adding files is paused/i.test(allText(await A.snap())),
+        30000, 'a folder coming back is not a Resume')
+      assert(!(await A.hasText('Missing')), 'and the tile pill follows it back')
+      const buttons = flatten(await A.snap()).filter((n) => n.role === 'button')
+      assert(buttons.some((b) => /^resume$/i.test(b.label || '')), 'the way back is offered again')
+      await A.shot('s142-paused-again', runDir)
+    })
+  } catch {}
+  return { pass: r.summary(), instances: [A] }
+}

--- a/test/unit/folder-status.test.js
+++ b/test/unit/folder-status.test.js
@@ -7,24 +7,24 @@ const BASE = {
   role: 'mine',
   sourceMissing: false,
   fault: false,
-  indexPaused: false,
+  paused: false,
   mirrorEnabled: true,
   indexing: false,
   mirrorSyncing: false,
 }
 
 test('a missing source outranks every other state', (t) => {
-  const status = deriveFolderStatus({ ...BASE, sourceMissing: true, indexPaused: true, indexing: true })
+  const status = deriveFolderStatus({ ...BASE, sourceMissing: true, paused: true, indexing: true })
   t.is(status.labelKey, 'folder.statusMissing')
 })
 
 test('a paused index outranks an active one', (t) => {
-  const status = deriveFolderStatus({ ...BASE, indexPaused: true, indexing: true })
+  const status = deriveFolderStatus({ ...BASE, paused: true, indexing: true })
   t.is(status.labelKey, 'folder.statusPaused')
 })
 
 test('a paused mirror reads the same as a paused index', (t) => {
-  const owner = deriveFolderStatus({ ...BASE, indexPaused: true })
+  const owner = deriveFolderStatus({ ...BASE, paused: true })
   const mirror = deriveFolderStatus({ ...BASE, role: 'mirrored', mirrorEnabled: false })
   t.is(mirror.labelKey, owner.labelKey, 'one word for one state, both roles')
   t.is(mirror.badge, owner.badge, 'and one colour')
@@ -47,7 +47,7 @@ test('browse is passive', (t) => {
 // The strip above the listing announces every state worth announcing, so the tile is a label and a
 // colour and nothing more — anything else here would read the same change twice.
 test('the status is exactly a label and a badge', (t) => {
-  for (const input of [{ ...BASE, sourceMissing: true }, { ...BASE, indexPaused: true }, { ...BASE, indexing: true }, BASE]) {
+  for (const input of [{ ...BASE, sourceMissing: true }, { ...BASE, paused: true }, { ...BASE, indexing: true }, BASE]) {
     t.alike(Object.keys(deriveFolderStatus(input)).sort(), ['badge', 'labelKey'])
   }
 })
@@ -62,7 +62,7 @@ test('an idle folder is up to date', (t) => {
 test('every badge names a real style in the shared table', (t) => {
   const cases = [
     { ...BASE, sourceMissing: true },
-    { ...BASE, indexPaused: true },
+    { ...BASE, paused: true },
     { ...BASE, indexing: true },
     { ...BASE, role: 'mirrored', mirrorSyncing: true },
     { ...BASE, role: 'browse' },
@@ -77,7 +77,7 @@ test('every badge names a real style in the shared table', (t) => {
 // An auto-paused mirror is enabled === false, so without the fault outranking the pause the tile
 // called a folder stopped by a full disk "Paused" — the user's own doing, as far as it read.
 test('a fault outranks both pauses and reads as an error', (t) => {
-  const owner = deriveFolderStatus({ ...BASE, fault: true, indexPaused: true })
+  const owner = deriveFolderStatus({ ...BASE, fault: true, paused: true })
   t.is(owner.labelKey, 'folder.statusFault')
   t.is(owner.badge, 'error')
 

--- a/test/unit/folder-strips.test.js
+++ b/test/unit/folder-strips.test.js
@@ -148,3 +148,15 @@ test('a faulted owner can still be working — the fault describes the last pass
   })
   t.alike(ids(strips), ['fault', 'working'])
 })
+
+// REGRESSION (A.4-D1): a paused folder whose source went missing rendered both strips, stacked —
+// "Locate folder…" above "Resume" — offering a Resume that cannot run. One state, one strip.
+test('REGRESSION (A.4-D1): a missing source outranks a pause, as a fault already does', (t) => {
+  const paused = { ...OWNER, indexing: { ...IDLE_INDEX, paused: true } }
+  t.alike(ids(deriveStrips(paused)), ['paused'], 'precondition: a plain pause still shows')
+
+  t.alike(ids(deriveStrips({ ...paused, sourceMissing: true })), ['source-missing'],
+    'the missing source is the one the user can act on')
+  t.alike(ids(deriveStrips({ ...paused, fault: { status: 'paused-error', code: 'EACCES' } })), ['fault'],
+    'and a fault still outranks it too')
+})

--- a/test/unit/index-summary.test.js
+++ b/test/unit/index-summary.test.js
@@ -44,16 +44,16 @@ test('wire numbers are clamped', (t) => {
 // re-hashed), so a paused folder reports the same adding: 0 a finished one reports. Only the mount
 // tells them apart — which is why `paused` is independent of `active` rather than derived from it.
 test('a paused index renders as paused, not as idle', (t) => {
-  const s = deriveIndexSummary({ adding: 0, bytesQueued: 0 }, { indexPaused: true })
+  const s = deriveIndexSummary({ adding: 0, bytesQueued: 0 }, { paused: true })
   t.absent(s.active, 'no work is queued')
   t.ok(s.paused, 'but the folder is paused, and the notice must say so')
 })
 
 test('pausing is not the same as finishing', (t) => {
-  t.absent(deriveIndexSummary({ adding: 0 }, { indexPaused: false }).paused)
+  t.absent(deriveIndexSummary({ adding: 0 }, { paused: false }).paused)
   t.absent(deriveIndexSummary({ adding: 0 }, null).paused, 'no mount yet is not a pause')
   t.absent(deriveIndexSummary({ adding: 0 }, undefined).paused)
-  t.ok(deriveIndexSummary({ adding: 12 }, { indexPaused: true }).paused, 'a pause mid-queue still reads paused')
+  t.ok(deriveIndexSummary({ adding: 12 }, { paused: true }).paused, 'a pause mid-queue still reads paused')
 })
 
 test('the summary is unchanged when no mount is passed', (t) => {
@@ -84,7 +84,7 @@ test('a filled queue supersedes the walk phase', (t) => {
 test('a paused index is never reported as scanning', (t) => {
   // Pause cancels the pass, so a stale 'scanning' status must not outrank the durable pause and
   // put the folder back into the busy notice.
-  const s = deriveIndexSummary({ adding: 0 }, { indexPaused: true, scanning: true })
+  const s = deriveIndexSummary({ adding: 0 }, { paused: true, scanning: true })
   t.ok(s.paused)
   t.absent(s.scanning)
   t.absent(s.active, 'the paused banner renders instead of the busy one')

--- a/test/unit/owned-mount-projection.test.js
+++ b/test/unit/owned-mount-projection.test.js
@@ -27,7 +27,7 @@ test('an unsettled read is distinguishable from a share with no row', (t) => {
   // so reporting it for a folder that simply was never mounted would freeze that folder forever.
   t.alike(
     projectOwnedMount([], 'sp1', 'sh1', true),
-    { status: null, lastError: null, loaded: true, indexPaused: false, scanning: false, mountPath: null },
+    { status: null, lastError: null, loaded: true, paused: false, scanning: false, mountPath: null },
     'settled with no row → loaded:true, healthy',
   )
 })
@@ -72,17 +72,33 @@ test('every field is read from the row, so nothing latches across a share change
     row({ shareId: 'sh2', status: 'scanning', mountPath: '/b' }),
   ]
 
+  // REGRESSION (A.4): the row holds both facts and the projection resolves them — the fault is what
+  // shows, and `paused` is false while it does.
   t.alike(projectOwnedMount(rows, 'sp1', 'sh1', true), {
-    status: 'paused-error', lastError: 'ENOSPC', loaded: true, indexPaused: true, scanning: false, mountPath: '/a',
+    status: 'paused-error', lastError: 'ENOSPC', loaded: true, paused: false, scanning: false, mountPath: '/a',
   })
   // The same call for the sibling share carries none of sh1's state — the leak the hand-rolled
   // hook had, where `loaded` and `status` survived a navigation because only the effect reset them.
   t.alike(projectOwnedMount(rows, 'sp1', 'sh2', true), {
-    status: null, lastError: null, loaded: true, indexPaused: false, scanning: true, mountPath: '/b',
+    status: null, lastError: null, loaded: true, paused: false, scanning: true, mountPath: '/b',
   })
 })
 
 test('rows from another space are never matched', (t) => {
   const rows = [row({ spaceId: 'sp2', status: 'paused-error' })]
   t.is(projectOwnedMount(rows, 'sp1', 'sh1', true).status, null, 'same shareId, different space')
+})
+
+test('REGRESSION (A.4): a paused row projects paused, and the fault over it projects the fault', (t) => {
+  const paused = [row({ status: 'active', indexPaused: true })]
+  t.is(projectOwnedMount(paused, 'sp1', 'sh1', true).status, 'paused', 'the pause shows')
+  t.ok(projectOwnedMount(paused, 'sp1', 'sh1', true).paused)
+
+  const faulted = [row({ status: 'paused-enospc', indexPaused: true })]
+  t.is(projectOwnedMount(faulted, 'sp1', 'sh1', true).status, 'paused-enospc', 'the fault outranks it')
+  t.absent(projectOwnedMount(faulted, 'sp1', 'sh1', true).paused, 'so the screen offers Try again, not Resume')
+
+  const missing = [row({ status: 'active', indexPaused: true, mountPointMissing: true })]
+  t.is(projectOwnedMount(missing, 'sp1', 'sh1', true).status, 'mount-point-gone', 'and a missing source outranks both')
+  t.absent(projectOwnedMount(missing, 'sp1', 'sh1', true).paused)
 })


### PR DESCRIPTION
Second of two for A.4. **Stacked on #288** — merge that one first (or this one into it), never this
one alone: `ownedMount.js` imports the derivation #288 adds.

This is the half with the user-visible fixes.

### The two defects

**A folder that was paused and then lost its source rendered both states at once** — "Locate
folder…" stacked above "Resume". `folderStrips.js` suppressed the paused strip for a fault but not
for a missing source.

**The header menu and the command palette offered "Resume syncing" on a faulted or missing folder**,
and clicking it called `owned-folder:resume-index`, which the worker refuses with
`SOURCE_FOLDER_MISSING` — an error toast for an action the UI itself offered. `FolderView` derived
`paused` from the raw flag, ignoring fault and missing entirely.

Both come from the same cause: five hand-written copies of the precedence, two of which disagreed
with the other three. The renderer now reads the resolved status instead of the raw flag, so
`OwnedMountState` carries `paused` — already resolved — rather than `indexPaused`.

`unhealthyOwnedStatus` stays, rebuilt on the derivation: it answers a different question ("anything
to badge?") and has two production callers, including the space-screen card's `mountStatus`.

`types.ts` keeps `indexPaused` — it is the wire shape of the record, and the worker still sends it.

### Verification

`tsc` and `lint:ci` clean; unit 71/71 across 6 files.

**Frontend, all three run locally — 15/15 steps:**

- **s121** (pause/resume, survives restart) 5/5 — unchanged behaviour intact
- **s127** (fault strip, survives restart) 5/5 — unchanged behaviour intact
- **s142** (new, `s142-paused-and-missing-one-state.mjs`) 5/5 — pauses a folder, takes its source
  away, asserts **one** strip, the Missing pill and a menu offering **Pause**; then restores the
  source and asserts the folder returns to **paused** with no explicit resume

s142's fourth step waits out a full mount-point probe interval before restoring the folder. That is
deliberate and commented: the strip can appear from the listing's own live `mountRootAvailable`
before the probe has recorded anything, and the probe reports a transition — so a folder that leaves
and returns inside one interval leaves it with nothing to report. That is **#287**, pre-existing and
filed separately; when it is fixed, the wait can go and its removal is the end-to-end proof.

Accessibility: strip roles unchanged (`source-missing`/`fault` are `role="alert"`, `paused` is
`role="status"`), the tile pill's name still flows through `folder.statusLabel`, and the pause control
stays a command with a swinging label rather than a toggle. Collapsing two strips to one reduces the
announcement from two regions to one alert, which is the intended direction. `jsx-a11y` passes.
